### PR TITLE
Add quoutes to MSBuild solution FullName + fix related tests

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -198,7 +198,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
 
                 // Then
                 fixture.ProcessRunner.Received(1).Start(Arg.Is<ProcessStartInfo>(
-                    p => p.Arguments == "/target:Build src/Solution.sln"));
+                    p => p.Arguments == "/target:Build \"src/Solution.sln\""));
             }
 
             [Fact]
@@ -217,7 +217,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
 
                 // Then
                 fixture.ProcessRunner.Received(1).Start(Arg.Is<ProcessStartInfo>(
-                    p => p.Arguments == "/target:A;B src/Solution.sln"));
+                    p => p.Arguments == "/target:A;B \"src/Solution.sln\""));
             }
 
             [Fact]
@@ -236,7 +236,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
 
                 // Then
                 fixture.ProcessRunner.Received(1).Start(Arg.Is<ProcessStartInfo>(
-                    p => p.Arguments == "/property:A=B;C=D /target:Build src/Solution.sln"));
+                    p => p.Arguments == "/property:A=B;C=D /target:Build \"src/Solution.sln\""));
             }
 
             [Fact]
@@ -254,7 +254,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
 
                 // Then
                 fixture.ProcessRunner.Received(1).Start(Arg.Is<ProcessStartInfo>(
-                    p => p.Arguments == "/property:Configuration=Release /target:Build src/Solution.sln"));
+                    p => p.Arguments == "/property:Configuration=Release /target:Build \"src/Solution.sln\""));
             }
 
             [Fact]

--- a/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
@@ -83,7 +83,7 @@ namespace Cake.Common.Tools.MSBuild
             }
 
             // Add the solution as the last parameter.
-            parameters.Add(settings.Solution.FullPath);
+            parameters.Add(string.Concat("\"", settings.Solution.FullPath, "\""));
 
             return new ProcessStartInfo(msBuildPath.FullPath)
             {


### PR DESCRIPTION
MSBuild runner fails with solutions with spaces in their names
