### PR TITLE
Fixed issue with cleaning deep dir structures

### DIFF
--- a/src/Cake.Common/IO/DirectoryCleaner.cs
+++ b/src/Cake.Common/IO/DirectoryCleaner.cs
@@ -25,7 +25,7 @@ namespace Cake.Common.IO
 
             context.Log.Verbose("Deleting contents of {0}", path);
 
-            // Delete all files.
+            // Delete all directories.
             foreach (var directory in root.GetDirectories("*", SearchScope.Current))
             {
                 Clean(context, directory.Path.FullPath);


### PR DESCRIPTION
Order matters when recursively deleting directories, for one
project kept getting:
"An error occured in task The directory is not empty."
solved this by recursively deleting bottom up, it might be a bit
slower, but ensures delets are done in correct order.
