### PR TITLE
MSBuild fix property multiple value & quotation

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -236,7 +236,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
 
                 // Then
                 fixture.ProcessRunner.Received(1).Start(Arg.Is<ProcessStartInfo>(
-                    p => p.Arguments == "/property:A=B;C=D /target:Build \"src/Solution.sln\""));
+                    p => p.Arguments == "/p:\"A\"=\"B\" /p:\"C\"=\"D\" /target:Build \"src/Solution.sln\""));
             }
 
             [Fact]
@@ -254,7 +254,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
 
                 // Then
                 fixture.ProcessRunner.Received(1).Start(Arg.Is<ProcessStartInfo>(
-                    p => p.Arguments == "/property:Configuration=Release /target:Build \"src/Solution.sln\""));
+                    p => p.Arguments == "/p:\"Configuration\"=\"Release\" /target:Build \"src/Solution.sln\""));
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsTests.cs
@@ -88,7 +88,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 var configuration = new MSBuildSettings(solution);
                 
                 // When
-                configuration.Properties.Add("THEKEY", "THEVALUE");
+                configuration.Properties.Add("THEKEY", new []{"THEVALUE"});
 
                 // Then
                 Assert.True(configuration.Properties.ContainsKey("thekey"));

--- a/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Extensions;
@@ -51,24 +53,28 @@ namespace Cake.Common.Tools.MSBuild
         private ProcessStartInfo GetProcessStartInfo(MSBuildSettings settings, FilePath msBuildPath)
         {
             var parameters = new List<string>();
-            var properties = new List<string>();
 
             // Got a specific configuration in mind?
             if (!string.IsNullOrWhiteSpace(settings.Configuration))
             {
                 // Add the configuration as a property.
                 var configuration = settings.Configuration;
-                properties.Add(string.Concat("Configuration", "=", configuration));
+                parameters.Add(string.Concat("/p:\"Configuration\"", "=", configuration.Quote()));
             }
 
             // Got any properties?
             if (settings.Properties.Count > 0)
             {
-                properties.AddRange(settings.Properties.Select(x => string.Concat(x.Key, "=", x.Value)));
-            }
-            if (properties.Count > 0)
-            {
-                parameters.Add(string.Concat("/property:", string.Join(";", properties)));
+                parameters.AddRange(
+                    from key in settings.Properties
+                    from value in key.Value
+                    select string.Concat(
+                        "/p:",
+                        key.Key.Quote(),
+                        "=",
+                        value.Quote()
+                        )
+                    );
             }
 
             // Got any targets?

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
@@ -8,7 +8,7 @@ namespace Cake.Common.Tools.MSBuild
     {
         private readonly FilePath _solution;
         private readonly HashSet<string> _targets;
-        private readonly Dictionary<string, string> _properties;        
+        private readonly Dictionary<string, IList<string>> _properties;        
 
         public FilePath Solution
         {
@@ -20,7 +20,7 @@ namespace Cake.Common.Tools.MSBuild
             get { return _targets; }
         }
 
-        public IDictionary<string, string> Properties
+        public IDictionary<string, IList<string>> Properties
         {
             get { return _properties; }
         }
@@ -38,7 +38,7 @@ namespace Cake.Common.Tools.MSBuild
             
             _solution = solution;
             _targets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            _properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            _properties = new Dictionary<string, IList<string>>(StringComparer.OrdinalIgnoreCase);
 
             PlatformTarget = PlatformTarget.MSIL;
             ToolVersion = MSBuildToolVersion.VS2013;

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
@@ -1,4 +1,8 @@
-﻿namespace Cake.Common.Tools.MSBuild
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Cake.Common.Tools.MSBuild
 {
     public static class MSBuildSettingsExtensions
     {
@@ -20,9 +24,16 @@
             return settings;
         }
 
-        public static MSBuildSettings WithProperty(this MSBuildSettings settings, string name, string value)
+        public static MSBuildSettings WithProperty(this MSBuildSettings settings, string name, params string[] values)
         {
-            settings.Properties.Add(name, value);
+            IList<string> currValue;
+            currValue = new List<string>(
+                settings.Properties.TryGetValue(name, out currValue) && currValue != null
+                    ? currValue.Concat(values)
+                    : values
+                );
+            
+            settings.Properties[name] = currValue;
             return settings;
         }
 


### PR DESCRIPTION
1.Added support for multiple values as some MSBuild properties require this
2.Addded quatation to property key / values to support values with spaces
3.Adjusted tests to pass with new sematics
This enables properties like ReferencePath to be used whith cake.
Example fluent:

```
MSBuild(solution, settings =>
    settings.SetPlatformTarget(PlatformTarget.MSIL)
        .UseToolVersion(MSBuildToolVersion.NET45)
        .WithProperty("ReferencePath", @"c:\temp\assemblies1")
        .WithProperty("ReferencePath", @"c:\temp\assemblies2")
        .WithTarget("Build")
        .SetConfiguration(configuration));
```

Example all att once:

```
MSBuild(solution, settings =>
    settings.SetPlatformTarget(PlatformTarget.MSIL)
        .UseToolVersion(MSBuildToolVersion.NET45)
        .WithProperty("ReferencePath", @"\temp\assemblies1", @"\temp\assemblies2")
        .WithTarget("Build")
        .SetConfiguration(configuration));
```
