### PR TITLE
Support .Description on Task

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Task("Pack")
 });
 
 Task("NuGet")
+    .Description("Create NuGet package")
     .IsDependentOn("Pack")
     .Does(() =>
 {
@@ -103,3 +104,24 @@ RunTarget(target);
 ```
 C:\Project\Tools\Cake> Cake.exe ../../build.csx -verbosity=verbose -target=Pack
 ```
+
+
+###4. Task descriptions
+A Task can be given a description using ``.Description``
+```
+Task("Foo")
+    .Description("A description for task Foo")
+    .Does(() => {});
+```
+To get a list of tasks run
+```
+C:\Project\Tools\Cake> Cake.exe ../../build.csx -s
+```
+The output will look something like
+```
+Task                          Description
+===============================================================================
+Bar
+Foo                           A description for task Foo
+```
+Tasks without a description will be listed with a blank description.

--- a/src/Cake.Core/CakeTask.cs
+++ b/src/Cake.Core/CakeTask.cs
@@ -15,6 +15,8 @@ namespace Cake.Core
             get { return _name; }
         }
 
+        public string Description { get; set; }
+
         public IReadOnlyList<string> Dependencies
         {
             get { return _dependencies; }

--- a/src/Cake.Core/CakeTaskBuilderExtensions.cs
+++ b/src/Cake.Core/CakeTaskBuilderExtensions.cs
@@ -34,7 +34,8 @@ namespace Cake.Core
             return Does(builder, context => action());
         }
 
-        public static CakeTaskBuilder<ActionTask> Does(this CakeTaskBuilder<ActionTask> builder, Action<ICakeContext> action)
+        public static CakeTaskBuilder<ActionTask> Does(this CakeTaskBuilder<ActionTask> builder,
+            Action<ICakeContext> action)
         {
             builder.Task.AddAction(action);
             return builder;
@@ -43,6 +44,13 @@ namespace Cake.Core
         public static CakeTaskBuilder<ActionTask> ContinueOnError(this CakeTaskBuilder<ActionTask> builder)
         {
             builder.Task.ContinueOnError = true;
+            return builder;
+        }
+
+        public static CakeTaskBuilder<T> Description<T>(this CakeTaskBuilder<T> builder, string description)
+            where T : CakeTask
+        {
+            builder.Task.Description = description;
             return builder;
         }
 

--- a/src/Cake.Core/ICakeEngine.cs
+++ b/src/Cake.Core/ICakeEngine.cs
@@ -1,7 +1,10 @@
-﻿namespace Cake.Core
+﻿using System.Collections.Generic;
+
+namespace Cake.Core
 {
     public interface ICakeEngine : ICakeContext
     {
+        IReadOnlyList<CakeTask> Tasks { get; }
         CakeTaskBuilder<ActionTask> Task(string name);
         CakeReport RunTarget(string target);
     }

--- a/src/Cake.Tests/Cake.Tests.csproj
+++ b/src/Cake.Tests/Cake.Tests.csproj
@@ -56,12 +56,14 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Fixtures\DescriptionScriptHostFixture.cs" />
     <Compile Include="Unit\Arguments\ArgumentParserTests.cs" />
     <Compile Include="Unit\Bootstrapper\CakeBootstrapperTests.cs" />
     <Compile Include="Unit\CakeApplicationTests.cs" />
     <Compile Include="Unit\CakeOptionsTests.cs" />
     <Compile Include="Unit\Diagnostics\CakeLogAdapterTests.cs" />
     <Compile Include="Unit\Diagnostics\FormatParserTests.cs" />
+    <Compile Include="Unit\Scripting\DescriptionScriptHostTests.cs" />
     <Compile Include="Unit\Scripting\RoslynScriptSessionTests.cs" />
     <Compile Include="Unit\Scripting\ScriptCodeGeneratorTests.cs" />
     <Compile Include="Unit\Scripting\ScriptHostTests.cs" />

--- a/src/Cake.Tests/Fixtures/CakeApplicationFixture.cs
+++ b/src/Cake.Tests/Fixtures/CakeApplicationFixture.cs
@@ -11,6 +11,7 @@ namespace Cake.Tests.Fixtures
     public sealed class CakeApplicationFixture
     {
         private readonly string _scriptPath;
+        private readonly bool _showDescription;
 
         public ICakeBootstrapper Bootstrapper { get; set; }
         public IFileSystem FileSystem { get; set; }
@@ -19,9 +20,10 @@ namespace Cake.Tests.Fixtures
         public ICakeLog Log { get; set; }
         public IScriptRunner ScriptRunner { get; set; }
 
-        public CakeApplicationFixture(string scriptPath = "/Build/script.csx")
+        public CakeApplicationFixture(string scriptPath = "/Build/script.csx", bool showDescription = false)
         {
             _scriptPath = scriptPath;
+            _showDescription = showDescription;
 
             Bootstrapper = Substitute.For<ICakeBootstrapper>();
 
@@ -56,7 +58,7 @@ namespace Cake.Tests.Fixtures
 
         public void Run()
         {           
-            CreateApplication().Run(new CakeOptions { Script = _scriptPath });
+            CreateApplication().Run(new CakeOptions { Script = _scriptPath, ShowDescription = _showDescription});
         }
     }
 }

--- a/src/Cake.Tests/Fixtures/DescriptionScriptHostFixture.cs
+++ b/src/Cake.Tests/Fixtures/DescriptionScriptHostFixture.cs
@@ -1,0 +1,40 @@
+﻿using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using Cake.Scripting;
+using NSubstitute;
+
+namespace Cake.Tests.Fixtures
+{
+    public sealed class DescriptionScriptHostFixture
+    {
+        public ICakeEngine Engine { get; set; }
+        public IFileSystem FileSystem { get; set; }
+        public ICakeEnvironment Environment { get; set; }
+        public ICakeLog Log { get; set; }
+        public IGlobber Globber { get; set; }
+        public ICakeArguments Arguments { get; set; }
+
+        public DescriptionScriptHostFixture()
+        {
+            FileSystem = Substitute.For<IFileSystem>();
+            Environment = Substitute.For<ICakeEnvironment>();
+            Log = Substitute.For<ICakeLog>();
+            Globber = Substitute.For<IGlobber>();
+            Arguments = Substitute.For<ICakeArguments>();
+
+            Engine = Substitute.For<ICakeEngine>();
+            Engine.FileSystem.Returns(FileSystem);
+            Engine.Environment.Returns(Environment);
+            Engine.Log.Returns(Log);
+            Engine.Globber.Returns(Globber);
+            Engine.Arguments.Returns(Arguments);
+            Engine.RunTarget(Arg.Any<string>()).Returns(new CakeReport());
+        }
+
+        public DescriptionScriptHost CreateHost()
+        {
+            return new DescriptionScriptHost(Engine);
+        }
+    }
+}

--- a/src/Cake.Tests/Unit/Arguments/ArgumentParserTests.cs
+++ b/src/Cake.Tests/Unit/Arguments/ArgumentParserTests.cs
@@ -140,6 +140,22 @@ namespace Cake.Tests.Unit.Arguments
                 Assert.NotNull(result.Script);
                 Assert.Equal("/home/test/build.csx", result.Script.FullPath);
             }
+
+            [Theory]
+            [InlineData("-showdescription")]
+            [InlineData("-s")]
+            public void Can_Parse_ShowDescription(string input)
+            {
+                // Given
+                var log = Substitute.For<ICakeLog>();
+                var parser = new ArgumentParser(log);
+
+                // When
+                var result = parser.Parse(new[] { "build.csx", input });
+
+                // Then
+                Assert.Equal(true, result.ShowDescription);
+            }
         }
     }
 }

--- a/src/Cake.Tests/Unit/CakeApplicationTests.cs
+++ b/src/Cake.Tests/Unit/CakeApplicationTests.cs
@@ -271,6 +271,40 @@ namespace Cake.Tests.Unit
                     Arg.Is<IEnumerable<string>>(c => c.Any(x => x == @namespace)),
                     Arg.Any<string>());
             }
+
+            [Fact]
+            public void Should_Use_Script_Host_When_ShowDescription_Is_False_In_Options()
+            {
+                // Given
+                var fixture = new CakeApplicationFixture(showDescription: false);
+
+                // When
+                fixture.Run();
+
+                // Then
+                fixture.ScriptRunner.Received(1).Run(
+                    Arg.Any<ScriptHost>(),
+                    Arg.Any<IEnumerable<Assembly>>(),
+                    Arg.Any<IEnumerable<string>>(),
+                    Arg.Any<string>());
+            }
+
+            [Fact]
+            public void Should_Use_Description_Script_Host_When_ShowDescription_Is_True_In_Options()
+            {
+                // Given
+                var fixture = new CakeApplicationFixture(showDescription: true);
+
+                // When
+                fixture.Run();
+
+                // Then
+                fixture.ScriptRunner.Received(1).Run(
+                    Arg.Any<DescriptionScriptHost>(),
+                    Arg.Any<IEnumerable<Assembly>>(),
+                    Arg.Any<IEnumerable<string>>(),
+                    Arg.Any<string>());
+            }
         }
     }
 }

--- a/src/Cake.Tests/Unit/Scripting/DescriptionScriptHostTests.cs
+++ b/src/Cake.Tests/Unit/Scripting/DescriptionScriptHostTests.cs
@@ -1,0 +1,26 @@
+using Cake.Tests.Fixtures;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Tests.Unit.Scripting
+{
+    public sealed class DescriptionScriptHostTests
+    {
+        public sealed class TheRunTargetMethod
+        {
+            [Fact]
+            public void Should_Not_Call_To_Engine()
+            {
+                // Given
+                var fixture = new DescriptionScriptHostFixture();
+                var host = fixture.CreateHost();
+
+                // When
+                host.RunTarget("Target");
+
+                // Then
+                fixture.Engine.Received(0).RunTarget("Target");
+            }
+        }
+    }
+}

--- a/src/Cake/Arguments/ArgumentParser.cs
+++ b/src/Cake/Arguments/ArgumentParser.cs
@@ -114,6 +114,12 @@ namespace Cake.Arguments
                 }                    
             }
 
+            if (name.Equals("showdescription", StringComparison.OrdinalIgnoreCase) ||
+                name.Equals("s", StringComparison.OrdinalIgnoreCase))
+            {
+                options.ShowDescription = true;
+            }
+
             if (options.Arguments.ContainsKey(name))
             {
                 _log.Error("Multiple arguments with the same name ({0}).", name);

--- a/src/Cake/Cake.csproj
+++ b/src/Cake/Cake.csproj
@@ -76,6 +76,7 @@
     <Compile Include="..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="Scripting\DescriptionScriptHost.cs" />
     <Compile Include="Scripting\RoslynScriptSession.cs" />
     <Compile Include="Scripting\RoslynScriptSessionFactory.cs" />
     <Compile Include="Scripting\ScriptCodeGenerator.cs" />

--- a/src/Cake/CakeOptions.cs
+++ b/src/Cake/CakeOptions.cs
@@ -17,12 +17,15 @@ namespace Cake
             get { return _arguments; }
         }
 
+        public bool ShowDescription { get; set; }
+
         public CakeOptions()
         {
             _arguments = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
             // Default to normal verbosity.
             Verbosity = Verbosity.Normal;
+            ShowDescription = false;
         }
     }
 }

--- a/src/Cake/Scripting/DescriptionScriptHost.cs
+++ b/src/Cake/Scripting/DescriptionScriptHost.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using Cake.Core;
+
+namespace Cake.Scripting
+{
+    public sealed class DescriptionScriptHost : ScriptHost
+    {
+        public Dictionary<string, string> TasksWithDescription { get; set; } 
+
+        public DescriptionScriptHost(ICakeEngine engine) : base(engine)
+        {
+            TasksWithDescription = new Dictionary<string, string>();
+        }
+
+        public override CakeReport RunTarget(string target)
+        {
+            foreach (var t in Tasks)
+            {
+                TasksWithDescription.Add(t.Name, t.Description);
+            }
+
+            return new CakeReport();
+        }
+    }
+}

--- a/src/Cake/Scripting/ScriptHost.cs
+++ b/src/Cake/Scripting/ScriptHost.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
@@ -6,9 +7,9 @@ using Cake.Core.Scripting;
 
 namespace Cake.Scripting
 {
-    public sealed class ScriptHost : IScriptHost
+    public class ScriptHost : IScriptHost
     {
-        private readonly ICakeEngine _engine;
+        protected readonly ICakeEngine _engine;
 
         public IFileSystem FileSystem
         {
@@ -49,12 +50,17 @@ namespace Cake.Scripting
             _engine = engine;
         }
 
+        public IReadOnlyList<CakeTask> Tasks
+        {
+            get { return _engine.Tasks; }
+        }
+
         public CakeTaskBuilder<ActionTask> Task(string name)
         {
             return _engine.Task(name);
         }
 
-        public CakeReport RunTarget(string target)
+        public virtual CakeReport RunTarget(string target)
         {
             var report = _engine.RunTarget(target);
             if (!report.IsEmpty)


### PR DESCRIPTION
Fixes #28

A Task can have a .Description extension in build script.
When running cake with -s or -showdescription Tasks a listed with their description (or a blank string) instead of invoked.
