### PR TITLE
 Added Sign extension for assembly certificate signing 

### DIFF
--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -98,6 +98,10 @@
     <Compile Include="Tools\NUnit\NUnitExtensions.cs" />
     <Compile Include="Tools\NUnit\NUnitRunner.cs" />
     <Compile Include="Tools\NUnit\NUnitSettings.cs" />
+    <Compile Include="Tools\SignTool\SignToolResolver.cs" />
+    <Compile Include="Tools\SignTool\Sign\SignToolSignExtensions.cs" />
+    <Compile Include="Tools\SignTool\Sign\SignToolSignRunner.cs" />
+    <Compile Include="Tools\SignTool\Sign\SignToolSignSettings.cs" />
     <Compile Include="Tools\WiX\Architecture.cs" />
     <Compile Include="Tools\WiX\CandleRunner.cs" />
     <Compile Include="Tools\WiX\CandleSettings.cs" />
@@ -118,6 +122,7 @@
       <Name>Cake.Core</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Cake.Common/Tools/SignTool/Sign/SignToolSignExtensions.cs
+++ b/src/Cake.Common/Tools/SignTool/Sign/SignToolSignExtensions.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.SignTool.Sign
+{
+    /// <summary>
+    /// Contains functionality related to signing assemblies with PFX certificate
+    /// </summary>
+    [CakeAliasCategoryAttribute("Signing")]
+    public static class SignToolSignExtensions
+    {
+        /// <summary>
+        /// Signs the specified assembly
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="assembly">The target assembly.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        public static void Sign(this ICakeContext context, string assembly, SignToolSignSettings settings)
+        {
+            if (assembly == null)
+            {
+                throw new ArgumentNullException("assembly");
+            }
+            Sign(context, new FilePath(assembly), settings);
+        }
+
+        /// <summary>
+        /// Signs the specified assembly
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="assembly">The target assembly.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        public static void Sign(this ICakeContext context, FilePath assembly, SignToolSignSettings settings)
+        {
+            if (assembly == null)
+            {
+                throw new ArgumentNullException("assembly");
+            }
+            var paths = new[] {assembly};
+            Sign(context, paths, settings);
+        }
+
+        /// <summary>
+        /// Signs the specified assemblies
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="assemblies">The target assembly.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        public static void Sign(this ICakeContext context, IEnumerable<string> assemblies, SignToolSignSettings settings)
+        {
+            if (assemblies == null)
+            {
+                throw new ArgumentNullException("assemblies");
+            }
+            var paths = assemblies.Select(p => new FilePath(p));
+            Sign(context, paths, settings);
+        }
+
+        /// <summary>
+        /// Signs the specified assemblies
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="assemblies">The target assembly.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        public static void Sign(this ICakeContext context, IEnumerable<FilePath> assemblies, SignToolSignSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            if (assemblies == null)
+            {
+                throw new ArgumentNullException("assemblies");
+            }
+
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            var runner = new SignToolSignRunner(context.FileSystem, context.Environment, context.ProcessRunner);            
+            Array.ForEach(
+                assemblies.ToArray(),
+                assembly=>runner.Run(assembly, settings)
+                );
+        }
+    }
+}

--- a/src/Cake.Common/Tools/SignTool/Sign/SignToolSignRunner.cs
+++ b/src/Cake.Common/Tools/SignTool/Sign/SignToolSignRunner.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Globalization;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Utilities;
+using File=System.IO.File;
+
+namespace Cake.Common.Tools.SignTool.Sign
+{
+    /// <summary>
+    /// The SignTool SIGN assembly runner
+    /// </summary>
+    public sealed class SignToolSignRunner : Tool<SignToolSignSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SignToolSignRunner"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        public SignToolSignRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner) : base(fileSystem, environment, processRunner)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Runs the tests in the specified assembly.
+        /// </summary>
+        /// <param name="assemblyPath">The assembly path.</param>
+        /// <param name="settings">The settings.</param>
+        public void Run(FilePath assemblyPath, SignToolSignSettings settings)
+        {
+            if (assemblyPath == null)
+            {
+                throw new ArgumentNullException("assemblyPath");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            Run(settings, GetArguments(assemblyPath, settings), settings.ToolPath);
+        }
+
+        private ToolArgumentBuilder GetArguments(FilePath assemblyPath, SignToolSignSettings settings)
+        {
+            if (assemblyPath==null || !File.Exists(assemblyPath.FullPath))
+               throw new ArgumentException(
+                    string.Format(CultureInfo.InvariantCulture, "{0}: AssemblyPath not specified or missing ({1})", GetToolName(), assemblyPath));
+
+
+            if (settings.TimeStampUri==null)
+               throw new ArgumentException(
+                    string.Format(CultureInfo.InvariantCulture, "{0}: TimeStampUri Required but not specified.", GetToolName()));
+
+            
+            if (settings.CertPath==null || !File.Exists(settings.CertPath.FullPath))
+               throw new ArgumentException(
+                    string.Format(CultureInfo.InvariantCulture, "{0}: CertPath not specified or missing ({1})", GetToolName(), settings.CertPath));
+
+            
+            if (string.IsNullOrEmpty(settings.Password))
+               throw new ArgumentException(
+                    string.Format(CultureInfo.InvariantCulture, "{0}: Password Required but not specified.", GetToolName()));
+
+            var builder = new ToolArgumentBuilder();
+
+            //SIGN Command
+            builder.AppendText("SIGN");
+
+
+            //TimeStamp server
+            builder.AppendText("/t");
+            builder.AppendQuotedText(settings.TimeStampUri.AbsoluteUri);
+
+            
+            //Path to PFX Certificate
+            builder.AppendText("/f");
+            builder.AppendQuotedText(settings.CertPath.MakeAbsolute(_environment).FullPath);
+
+            
+            //PFX Password
+            builder.AppendText("/p");
+            builder.AppendQuotedText(settings.Password);
+
+            //Target Assembly to sign
+            builder.AppendQuotedText(assemblyPath.MakeAbsolute(_environment).FullPath);
+
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Get name of tool
+        /// </summary>
+        /// <returns></returns>
+        protected override string GetToolName()
+        {
+            return "SignTool SIGN";
+        }
+
+        /// <summary>
+        /// Get the default path to tool
+        /// </summary>
+        /// <param name="settings"></param>
+        /// <returns></returns>
+        protected override FilePath GetDefaultToolPath(SignToolSignSettings settings)
+        {
+            return (settings==null ? null :  settings.ToolPath)
+                ?? SignToolResolver.GetSignToolPath(_environment);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/SignTool/Sign/SignToolSignSettings.cs
+++ b/src/Cake.Common/Tools/SignTool/Sign/SignToolSignSettings.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.SignTool.Sign
+{
+    /// <summary>
+    /// Contains settings used by  <see cref="SignToolSignRunner"/>.
+    /// </summary>
+    public sealed class SignToolSignSettings
+    {
+        /// <summary>
+        /// Gets or sets the tool path.
+        /// </summary>
+        /// <value>
+        /// The tool path.
+        /// Defaults to path given by <see cref="SignToolResolver.GetSignToolPath(ICakeEnvironment)"/>
+        /// </value>
+        public FilePath ToolPath { get; set; }
+
+        /// <summary>
+        /// Specify the timestamp server's URL.
+        /// </summary>
+        public Uri TimeStampUri { get; set; }
+
+        /// <summary>
+        /// Path to PFX cerificate
+        /// </summary>
+        public FilePath CertPath { get; set; }
+
+        /// <summary>
+        /// PFX certificate password
+        /// </summary>
+        public string Password { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/SignTool/SignToolResolver.cs
+++ b/src/Cake.Common/Tools/SignTool/SignToolResolver.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Linq;
+using Cake.Core;
+using Cake.Core.IO;
+using Microsoft.Win32;
+
+namespace Cake.Common.Tools.SignTool
+{
+    internal static class SignToolResolver
+    {
+        private static string _programFiles;
+        private static string _signToolPath;
+        public static FilePath GetSignToolPath(ICakeEnvironment environment)
+        {
+             //try SDK first
+            if (_programFiles == null)
+                _programFiles = environment.Is64BitOperativeSystem()
+                    ? Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)
+                    : Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+
+
+            if (_signToolPath == null)
+                _signToolPath = (
+                    from path in (environment.Is64BitOperativeSystem())
+                        ? new[]
+                        {
+                            System.IO.Path.Combine(_programFiles, @"Windows Kits\8.1\bin\x64\signtool.exe"),
+                            System.IO.Path.Combine(_programFiles, @"Windows Kits\8.0\bin\x64\signtool.exe"),
+                            System.IO.Path.Combine(_programFiles, @"Microsoft SDKs\Windows\v7.1A\Bin\signtool.exe")
+                        }
+                        : new[]
+                        {
+                            System.IO.Path.Combine(_programFiles, @"Windows Kits\8.1\bin\x86\signtool.exe"),
+                            System.IO.Path.Combine(_programFiles, @"Windows Kits\8.0\bin\x86\signtool.exe"),
+                            System.IO.Path.Combine(_programFiles, @"Microsoft SDKs\Windows\v7.1A\Bin\signtool.exe")
+                        }
+                    where System.IO.File.Exists(path)
+                    orderby path descending
+                    select path
+                    ).FirstOrDefault();
+
+            if (!string.IsNullOrEmpty(_signToolPath))
+            {
+                return _signToolPath;
+            }
+
+            //try fallback to registry for older SDK's
+            using (var windows = Registry.LocalMachine.OpenSubKey("Software\\Microsoft\\Microsoft SDKs\\Windows")
+                )
+            {
+                if (windows == null)
+                    throw new CakeException("No Microsoft Windows SDKs key found");
+
+                _signToolPath = (
+                    from key in windows.GetSubKeyNames()
+                    let sdk = windows.OpenSubKey(key)
+                    where sdk != null
+                    let installationFolder = sdk.GetValue("InstallationFolder") as string
+                    where !string.IsNullOrEmpty(installationFolder) && System.IO.Directory.Exists(installationFolder)
+                    let signToolPath = System.IO.Path.Combine(installationFolder, "bin\\signtool.exe")
+                    where System.IO.File.Exists(signToolPath)
+                    orderby key descending
+                    select signToolPath
+                    ).FirstOrDefault();
+            }
+
+            if (string.IsNullOrEmpty(_signToolPath) || !System.IO.File.Exists(_signToolPath))
+                throw new CakeException("Failed to find signtool");
+
+            return _signToolPath;
+        }
+    }
+}


### PR DESCRIPTION
This adds support for PFX certificate signing
(a.k.a Authenticode not to be confused with strong naming)
using the standard Windows SDK SignTool
Example usage:

```
Task("Sign")
    .IsDependentOn("Clean")
    .IsDependentOn("Restore")
    .IsDependentOn("Build")
    .Does(() =>
{
    var files = GetFiles(solutionDir + "/**/bin/" + configuration + "/**/*.exe");
    Sign(files, new SignToolSignSettings {
            TimeStampUri = new Uri("http://timestamp.digicert.com"),
            CertPath = "digicert.pfx",
            Password = "TopSecret"
    });
});
```
