### PR TITLE
Diagnostic Log complete exception with StackTrace

### DIFF
--- a/src/Cake/CakeApplication.cs
+++ b/src/Cake/CakeApplication.cs
@@ -53,7 +53,11 @@ namespace Cake
             }
             catch (Exception ex)
             {
-                _log.Error("Error: {0}", ex.Message);
+                if (_log.Verbosity == Verbosity.Diagnostic)
+                    _log.Error("Error: {0}", ex);
+                else
+                    _log.Error("Error: {0}", ex.Message);
+                    
                 return 1;
             }
         }


### PR DESCRIPTION
When troubleshooting an error it can sometimes be very hard to find where the error is, especially if it turns out to be internal.
I propose when Verbosity is set to Diagnostic the full exception should be logged with stack trace and all, making it allot easier to locate any issues.
