### PR TITLE
Fixed logging null issue & sln version parsing

### DIFF
--- a/src/Cake.Common/Solution/SolutionParser.cs
+++ b/src/Cake.Common/Solution/SolutionParser.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -61,61 +63,88 @@ namespace Cake.Common.Solution
                 throw new CakeException(message);
             }
 
+            string
+                version = null,
+                visualStudioVersion = null,
+                minimumVisualStudioVersion = null;
+            var projects = new List<SolutionProject>();
+
+            foreach (var line in file.ReadLines(Encoding.UTF8))
+            {
+                if (line.StartsWith("Project(\"{"))
+                {
+                    var project = ParseSolutionProjectLine(file, line);
+                    if (!StringComparer.OrdinalIgnoreCase.Equals(project.Type, SolutionFolder))
+                        projects.Add(project);
+                }
+                else if (line.StartsWith("Microsoft Visual Studio Solution File, "))
+                {
+                    version = string.Concat(line.Skip(39));
+                }
+                else if (line.StartsWith("VisualStudioVersion = "))
+                {
+                    visualStudioVersion = string.Concat(line.Skip(22));
+                }
+                else if (line.StartsWith("MinimumVisualStudioVersion = "))
+                {
+                    minimumVisualStudioVersion = string.Concat(line.Skip(29));
+                }
+            }
+
             var solutionParserResult = new SolutionParserResult(
-                file
-                    .ReadLines(Encoding.UTF8)
-                    .Where(line => line.StartsWith("Project(\"{"))
-                    .Select(
-                        line =>
-                        {
-                            var withinQuotes = false;
-                            StringBuilder
-                                projectTypeBuilder = new StringBuilder(),
-                                nameBuilder = new StringBuilder(),
-                                pathBuilder = new StringBuilder(),
-                                idBuilder = new StringBuilder();
-                            var result = new[]
-                            {
-                                projectTypeBuilder,
-                                nameBuilder,
-                                pathBuilder,
-                                idBuilder
-                            };
-                            var position = 0;
-                            foreach (var c in line.Skip(8))
-                            {
-                                if (c == '"')
-                                {
-                                    withinQuotes = !withinQuotes;
-                                    if (!withinQuotes)
-                                    {
-                                        if (position++ >= result.Length)
-                                            break;
-                                    }
-                                    continue;
-                                }
-
-                                if (!withinQuotes) continue;
-
-                                result[position].Append(c);
-                            }
-
-                            return new SolutionProject(
-                                idBuilder.ToString(),
-                                nameBuilder.ToString(),
-                                file
-                                    .Path
-                                    .GetDirectory()
-                                    .CombineWithFilePath(pathBuilder.ToString()),
-                                projectTypeBuilder.ToString()
-                                );
-                        }
-                    )
-                    //Exclude solution folder
-                    .Where(project => !StringComparer.OrdinalIgnoreCase.Equals(project.Type, SolutionFolder))
+                version,
+                visualStudioVersion,
+                minimumVisualStudioVersion,
+                projects.AsReadOnly()
                 );
 
             return solutionParserResult;
+        }
+
+
+        private static SolutionProject ParseSolutionProjectLine(IFile file, string line)
+        {
+            var withinQuotes = false;
+            StringBuilder
+                projectTypeBuilder = new StringBuilder(),
+                nameBuilder = new StringBuilder(),
+                pathBuilder = new StringBuilder(),
+                idBuilder = new StringBuilder();
+            var result = new[]
+            {
+                projectTypeBuilder,
+                nameBuilder,
+                pathBuilder,
+                idBuilder
+            };
+            var position = 0;
+            foreach (var c in line.Skip(8))
+            {
+                if (c == '"')
+                {
+                    withinQuotes = !withinQuotes;
+                    if (!withinQuotes)
+                    {
+                        if (position++ >= result.Length)
+                            break;
+                    }
+                    continue;
+                }
+
+                if (!withinQuotes) continue;
+
+                result[position].Append(c);
+            }
+
+            return new SolutionProject(
+                idBuilder.ToString(),
+                nameBuilder.ToString(),
+                file
+                    .Path
+                    .GetDirectory()
+                    .CombineWithFilePath(pathBuilder.ToString()),
+                projectTypeBuilder.ToString()
+                );
         }
     }
 }

--- a/src/Cake.Common/Solution/SolutionParserResult.cs
+++ b/src/Cake.Common/Solution/SolutionParserResult.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Cake.Common.Solution
 {
@@ -8,12 +7,39 @@ namespace Cake.Common.Solution
     /// </summary>
     public sealed class SolutionParserResult
     {
-        private readonly ICollection<SolutionProject> _projects;
+        private readonly string _version;
+        private readonly string _visualStudioVersion;
+        private readonly string _minimumVisualStudioVersion;
+        private readonly IReadOnlyCollection<SolutionProject> _projects;
+
+        /// <summary>
+        /// Fileformat version
+        /// </summary>
+        public string Version
+        {
+            get { return _version; }
+        }
+
+        /// <summary>
+        /// Version of Visual Studio that created the file
+        /// </summary>
+        public string VisualStudioVersion
+        {
+            get { return _visualStudioVersion; }
+        }
+
+        /// <summary>
+        /// Minimum supported versions of Visual Studio
+        /// </summary>
+        public string MinimumVisualStudioVersion
+        {
+            get { return _minimumVisualStudioVersion; }
+        }
 
         /// <summary>
         /// Solution Projects
         /// </summary>
-        public ICollection<SolutionProject> Projects
+        public IReadOnlyCollection<SolutionProject> Projects
         {
             get { return _projects; }
         }
@@ -21,12 +47,20 @@ namespace Cake.Common.Solution
         /// <summary>
         /// Solution Projects
         /// </summary>
+        /// <param name="version">Fileformat version</param>
+        /// <param name="visualStudioVersion">Version of Visual Studio that created the file</param>
+        /// <param name="minimumVisualStudioVersion">Minimum supported versions of Visual Studio</param>
         /// <param name="projects">Solution Projects</param>
-        public SolutionParserResult(IEnumerable<SolutionProject> projects)
+        public SolutionParserResult(
+            string version,
+            string visualStudioVersion,
+            string minimumVisualStudioVersion,
+            IReadOnlyCollection<SolutionProject> projects)
         {
-            _projects = projects
-                .ToList()
-                .AsReadOnly();
+            _version = version;
+            _visualStudioVersion = visualStudioVersion;
+            _minimumVisualStudioVersion = minimumVisualStudioVersion;
+            _projects = projects;
         }
     }
 }

--- a/src/Cake/Diagnostics/Formatting/PropertyToken.cs
+++ b/src/Cake/Diagnostics/Formatting/PropertyToken.cs
@@ -35,7 +35,9 @@ namespace Cake.Diagnostics.Formatting
                     return formattable.ToString(_format, CultureInfo.InvariantCulture);
                 }
             }
-            return value.ToString();
+            return (value == null)
+                ? "[NULL]"
+                : value.ToString();
         }
     }
 }


### PR DESCRIPTION
1. Fixed so logging won't throw an exception if one of the args should be null but instead log [NULL]
2. Now parses solution version information if available

Example Cake script iterates all solutions in given path and outputs solution info:

``` csharp
var solutions       = GetFiles("/dev/github/**/*.sln");
foreach(var solutionPath in solutions)
{
    Information("Parsing {0}", solutionPath);
    var parsedSolution = ParseSolution(solutionPath);
    Information(
        @"Solution file
Version:                     {0}
VisualStudioVersion:         {1}
MinimumVisualStudioVersion:  {2}
Projects:                    {3}",
        parsedSolution.Version,
        parsedSolution.VisualStudioVersion,
        parsedSolution.MinimumVisualStudioVersion,
        string.Join(",", parsedSolution.Projects.Select(project=>project.Name))
    );
}
```
