### PR TITLE
Added #addin directive for NuGet addins

### DIFF
--- a/src/Cake.Core.Tests/Fixtures/ScriptProcessorFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/ScriptProcessorFixture.cs
@@ -1,5 +1,6 @@
 ﻿using Cake.Core.Diagnostics;
 using Cake.Core.IO;
+using Cake.Core.IO.NuGet;
 using Cake.Core.Scripting;
 using Cake.Testing.Fakes;
 using NSubstitute;
@@ -13,6 +14,8 @@ namespace Cake.Core.Tests.Fixtures
         public ICakeLog Log { get; set; }
         public FilePath ScriptPath { get; set; }
         public string Source { get; private set; }
+        public IGlobber Globber{ get; set; }
+        public INuGetToolResolver NuGetToolResolver{ get; private set; }
         
         public ScriptProcessorFixture(string scriptPath = "./build.cake", bool scriptExist = true,
             string scriptSource = "Console.WriteLine();")
@@ -25,16 +28,20 @@ namespace Cake.Core.Tests.Fixtures
 
             Log = Substitute.For<ICakeLog>();
 
+            Globber = Substitute.For<IGlobber>();
+
             FileSystem = new FakeFileSystem(true);
             if (scriptExist)
             {
                 FileSystem.GetCreatedFile(ScriptPath.MakeAbsolute(Environment), Source);
             }
+
+            NuGetToolResolver = new NuGetToolResolver(FileSystem, Globber, Environment);
         }
 
         public ScriptProcessor CreateProcessor()
         {
-            return new ScriptProcessor(FileSystem, Environment, Log);
+            return new ScriptProcessor(FileSystem, Environment, Log, NuGetToolResolver);
         }
 
         public ScriptProcessorContext Process()

--- a/src/Cake.Core.Tests/Fixtures/ScriptRunnerFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/ScriptRunnerFixture.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
+using Cake.Core.IO.NuGet;
 using Cake.Core.Scripting;
 using Cake.Testing.Fakes;
 using NSubstitute;
@@ -23,6 +24,8 @@ namespace Cake.Core.Tests.Fixtures
         public FilePath Script { get; set; }
         public IDictionary<string, string> ArgumentDictionary { get; set; }
         public string Source { get; private set; }
+        public IGlobber Globber{ get; set; }
+        public INuGetToolResolver NuGetToolResolver{ get; private set; }
 
         public ScriptRunnerFixture(string fileName = "./build.cake")
         {
@@ -37,6 +40,8 @@ namespace Cake.Core.Tests.Fixtures
             FileSystem = new FakeFileSystem(true);
             FileSystem.GetCreatedFile(Script.MakeAbsolute(Environment), Source);
 
+            Globber = Substitute.For<IGlobber>();
+
             Session = Substitute.For<IScriptSession>();
             SessionFactory = Substitute.For<IScriptSessionFactory>();
             SessionFactory.CreateSession(Arg.Any<IScriptHost>()).Returns(Session);
@@ -44,7 +49,8 @@ namespace Cake.Core.Tests.Fixtures
             Arguments = Substitute.For<ICakeArguments>();
             AliasGenerator = Substitute.For<IScriptAliasGenerator>();            
             Log = Substitute.For<ICakeLog>();
-            ScriptProcessor = new ScriptProcessor(FileSystem, Environment, Log);
+            NuGetToolResolver = new NuGetToolResolver(FileSystem, Globber, Environment);
+            ScriptProcessor = new ScriptProcessor(FileSystem, Environment, Log, NuGetToolResolver);
 
             Host = Substitute.For<IScriptHost>();
             Host.FileSystem.Returns(c => FileSystem);

--- a/src/Cake.Core/Cake.Core.csproj
+++ b/src/Cake.Core/Cake.Core.csproj
@@ -109,6 +109,7 @@
     <Compile Include="IO\IProcessRunner.cs" />
     <Compile Include="IO\Machine.cs" />
     <Compile Include="IO\IToolResolver.cs" />
+    <Compile Include="IO\NuGet\INuGetToolResolver.cs" />
     <Compile Include="IO\NuGet\NuGetToolResolver.cs" />
     <Compile Include="IO\Path.cs" />
     <Compile Include="IO\DirectoryPath.cs" />
@@ -136,6 +137,7 @@
     <Compile Include="Scripting\IScriptSession.cs" />
     <Compile Include="Scripting\IScriptSessionFactory.cs" />
     <Compile Include="Scripting\LineProcessor.cs" />
+    <Compile Include="Scripting\Processors\AddInDirectiveProcessor.cs" />
     <Compile Include="Scripting\Processors\LoadDirectiveProcessor.cs" />
     <Compile Include="Scripting\Processors\ReferenceDirectiveProcessor.cs" />
     <Compile Include="Scripting\ScriptProcessor.cs" />

--- a/src/Cake.Core/IO/NuGet/INuGetToolResolver.cs
+++ b/src/Cake.Core/IO/NuGet/INuGetToolResolver.cs
@@ -1,0 +1,9 @@
+namespace Cake.Core.IO.NuGet
+{
+    /// <summary>
+    /// NuGet Tool Resolver Interface
+    /// </summary>
+    public interface INuGetToolResolver : IToolResolver
+    {
+    }
+}

--- a/src/Cake.Core/IO/NuGet/NuGetToolResolver.cs
+++ b/src/Cake.Core/IO/NuGet/NuGetToolResolver.cs
@@ -6,7 +6,7 @@ namespace Cake.Core.IO.NuGet
     /// <summary>
     /// Contains NuGet path resolver functionality
     /// </summary>
-    public sealed class NuGetToolResolver : IToolResolver
+    public sealed class NuGetToolResolver : INuGetToolResolver
     {
         private IFile _nugetExeFile;
         private readonly IFileSystem _fileSystem;

--- a/src/Cake.Core/Scripting/Processors/AddInDirectiveProcessor.cs
+++ b/src/Cake.Core/Scripting/Processors/AddInDirectiveProcessor.cs
@@ -1,0 +1,201 @@
+﻿using System;
+using System.Linq;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using Cake.Core.IO.NuGet;
+
+namespace Cake.Core.Scripting.Processors
+{
+    /// <summary>
+    /// Processor for #r directives.
+    /// </summary>
+    public sealed class AddInDirectiveProcessor : LineProcessor
+    {
+        private static FilePath _nuGetPath;
+        private readonly IFileSystem _fileSystem;
+        private readonly ICakeEnvironment _environment;
+        private readonly ICakeLog _log;
+        private readonly IToolResolver _nugetToolResolver;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReferenceDirectiveProcessor"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="log">The log.</param>
+        /// <param name="nugetToolResolver">Nuget tool resolver</param>
+        public AddInDirectiveProcessor(IFileSystem fileSystem, ICakeEnvironment environment, ICakeLog log, INuGetToolResolver nugetToolResolver) 
+            : base(environment)
+        {
+            
+            if (fileSystem == null)
+            {
+                throw new ArgumentNullException("fileSystem");
+            }
+            if (environment == null)
+            {
+                throw new ArgumentNullException("environment");
+            }
+            if (log == null)
+            {
+                throw new ArgumentNullException("log");
+            }
+            if (nugetToolResolver == null)
+            {
+                throw new ArgumentNullException("nugetToolResolver");
+            }
+
+            _fileSystem = fileSystem;
+            _environment = environment;
+            _log = log;
+            _nugetToolResolver = nugetToolResolver;
+        }
+
+        /// <summary>
+        /// Processes the specified line.
+        /// </summary>
+        /// <param name="processor">The script processor.</param>
+        /// <param name="context">The script processor context.</param>
+        /// <param name="currentScriptPath">The current script path.</param>
+        /// <param name="line">The line to process.</param>
+        /// <returns>
+        ///   <c>true</c> if the processor handled the line; otherwise <c>false</c>.
+        /// </returns>
+        public override bool Process(IScriptProcessor processor, ScriptProcessorContext context, FilePath currentScriptPath, string line)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var tokens = Split(line);
+            var directive = tokens.FirstOrDefault();
+            if (string.IsNullOrWhiteSpace(directive))
+            {
+                return false;
+            }
+
+            if (!directive.Equals("#addin", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            //Fetch addin NuGet Id
+            var addInId = tokens
+                .Select(value=>value.UnQuote())
+                .Skip(1).FirstOrDefault();
+
+
+            if (string.IsNullOrWhiteSpace(addInId))
+            {
+                return false;
+            }
+
+            //Fetch optional NuGet source
+            var source = tokens
+                .Skip(2)
+                .Select(value=>value.UnQuote())
+                .FirstOrDefault();
+
+            //Get Cake path
+            var applicationRoot = _environment
+                .GetApplicationRoot();
+
+            //Get Addin directory
+            var addInRootDirectoryPath = applicationRoot
+                .Combine("..\\Addins")
+                .Collapse()
+                .MakeAbsolute(_environment);
+
+
+            var addInDirectoryPath = addInRootDirectoryPath.Combine(addInId);
+
+            var addInRootDirectory = _fileSystem.GetDirectory(addInRootDirectoryPath);
+
+            // Create AddIn directory if it doesn't exist
+            if (!addInRootDirectory.Exists)
+            {
+                _log.Verbose("Creating addin directory {0}", addInRootDirectoryPath.FullPath);
+                addInRootDirectory.Create();
+            }
+
+            // Fetch AddIn available assemblies
+            var addInAssemblies = GetAddInAssemblies(addInDirectoryPath);
+ 
+            // If no assemblies found try install add in from NuGet
+            if (addInAssemblies.Length==0)
+            {
+                InstallAddin(addInId, addInRootDirectory, source);
+                addInAssemblies = GetAddInAssemblies(addInDirectoryPath);
+            }
+
+            // Validate assemblies found
+            if (addInAssemblies.Length == 0)
+            {
+                throw new CakeException("Failed to find AddIn assemblies");
+            }
+
+            // Reference found assemblies
+            foreach (var assemblyPath in addInAssemblies.Select(assembly=>assembly.Path.FullPath))
+            {
+                _log.Verbose("Addin: {0}, adding Reference {1}", addInId, assemblyPath);
+                context.AddReference(assemblyPath);
+            }
+            return true;
+        }
+
+        private void InstallAddin(string addInId, IDirectory addInRootDirectory, string source)
+        {
+            var nuGetPath = GetNuGetPath();
+
+            var runner = new ProcessRunner(_environment, _log);
+            var process = runner.Start(
+                nuGetPath,
+                new ProcessSettings
+                {
+                    Arguments = GetNuGetAddinInstallArguments(addInId, addInRootDirectory, source)
+                }
+                );
+            process.WaitForExit();
+        }
+
+        private FilePath GetNuGetPath()
+        {
+            var nuGetPath = _nuGetPath
+                            ?? (_nuGetPath = _nugetToolResolver.ResolveToolPath());
+
+            if (nuGetPath == null)
+            {
+                throw new CakeException("Failed to find NuGet");
+            }
+            return nuGetPath;
+        }
+
+        private static ProcessArgumentBuilder GetNuGetAddinInstallArguments(string addInId, IDirectory addInRootDirectory,
+            string source)
+        {
+            var arguments = new ProcessArgumentBuilder();
+            arguments.Append("install");
+            arguments.AppendQuoted(addInId);
+            arguments.Append("-OutputDirectory");
+            arguments.AppendQuoted(addInRootDirectory.Path.FullPath);
+            if (!string.IsNullOrWhiteSpace(source))
+            {
+                arguments.Append("-Source");
+                arguments.AppendQuoted(source);
+            }
+            arguments.Append("-ExcludeVersion -NonInteractive -NoCache");
+            return arguments;
+        }
+
+        private IFile[] GetAddInAssemblies(DirectoryPath addInDirectoryPath)
+        {
+            var addInDirectory = _fileSystem.GetDirectory(addInDirectoryPath);
+            return (addInDirectory.Exists)
+                ? addInDirectory.GetFiles("*.dll", SearchScope.Recursive)
+                    .Where(file => !file.Path.FullPath.EndsWith("Cake.Core.dll", StringComparison.OrdinalIgnoreCase))
+                    .ToArray()
+                : new IFile[0];
+        }
+    }
+}

--- a/src/Cake.Core/Scripting/ScriptProcessor.cs
+++ b/src/Cake.Core/Scripting/ScriptProcessor.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
+using Cake.Core.IO.NuGet;
 using Cake.Core.Scripting.Processors;
 
 namespace Cake.Core.Scripting
@@ -25,7 +26,8 @@ namespace Cake.Core.Scripting
         /// <param name="fileSystem">The file system.</param>
         /// <param name="environment">The environment.</param>
         /// <param name="log">The log.</param>
-        public ScriptProcessor(IFileSystem fileSystem, ICakeEnvironment environment, ICakeLog log)
+        /// <param name="nugetToolResolver">Nuget tool resolver</param>
+        public ScriptProcessor(IFileSystem fileSystem, ICakeEnvironment environment, ICakeLog log, INuGetToolResolver nugetToolResolver)
         {
             if (fileSystem == null)
             {
@@ -35,14 +37,29 @@ namespace Cake.Core.Scripting
             {
                 throw new ArgumentNullException("environment");
             }
+            if (log == null)
+            {
+                throw new ArgumentNullException("log");
+            }
+            if (nugetToolResolver == null)
+            {
+                throw new ArgumentNullException("nugetToolResolver");
+            }
             _fileSystem = fileSystem;
             _environment = environment;
             _log = log;
 
-            _lineProcessors = new LineProcessor[] {
+            _lineProcessors = new LineProcessor[]
+            {
                 new LoadDirectiveProcessor(_environment),
                 new ReferenceDirectiveProcessor(_fileSystem, _environment),
-                new UsingStatementProcessor(_environment) 
+                new UsingStatementProcessor(_environment),
+                new AddInDirectiveProcessor(
+                    _fileSystem,
+                    _environment,
+                    _log,
+                    nugetToolResolver
+                    )
             };
         }
 

--- a/src/Cake/Program.cs
+++ b/src/Cake/Program.cs
@@ -41,7 +41,7 @@ namespace Cake
             builder.RegisterType<CakeConsole>().As<IConsole>().SingleInstance();
             builder.RegisterType<ScriptProcessor>().As<IScriptProcessor>().SingleInstance();
             builder.RegisterCollection<IToolResolver>("toolResolvers").As<IEnumerable<IToolResolver>>();
-            builder.RegisterType<NuGetToolResolver>().As<IToolResolver>().SingleInstance().MemberOf("toolResolvers");
+            builder.RegisterType<NuGetToolResolver>().As<IToolResolver>().As<INuGetToolResolver>().SingleInstance().MemberOf("toolResolvers");
 
             // Roslyn related services.
             builder.RegisterType<RoslynScriptSessionFactory>().As<IScriptSessionFactory>();


### PR DESCRIPTION
Makes it possible to load and reference addins via NuGet

Sample script
```csharp
#addin "Cake.AliaSql"

AliaSql("Rebuild", new AliaSqlSettings{ToolPath=""});
```

This will give an output  similar to (It outputs an error as I'm sending in bogus settings, but it's from the AddIn code)
```
Installing 'Cake.AliaSql 0.4.1'.
Successfully installed 'Cake.AliaSql 0.4.1'.
Addin: Cake.AliaSql, adding Reference C:/temp/dev/github/cake/tools/Addins/Cake.AliaSql/Cake.AliaSql.dll
Error: Path cannot be empty.
Parameter name: path
```

What it does is basically
  1. Check if AddIns folder exists if not it creates it
  2. Then if checks if the choosen Addin exists and if it contains any assemblies, if not it will try to find nuget.exe and install the package
  3. It will reference any found assemblies 
 