### PR TITLE
Deduplicated NuGet GetDefaultToolPath

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/NuGetFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/NuGetFixture.cs
@@ -20,6 +20,7 @@ namespace Cake.Common.Tests.Fixtures
         public IProcessRunner ProcessRunner { get; set; }
         public IProcess Process { get; set; }
         public ICakeLog Log { get; set; }
+        public IToolResolver NuGetToolResolver { get; set; }
 
         public NuGetFixture(FilePath toolPath = null, bool defaultToolExist = true, string xml = null, KeyValuePair<string, string>? sourceExists = null)
         {
@@ -34,6 +35,14 @@ namespace Cake.Common.Tests.Fixtures
             ProcessRunner = Substitute.For<IProcessRunner>();
             ProcessRunner.Start(Arg.Any<FilePath>(), Arg.Any<ProcessSettings>()).Returns(Process);
 
+            
+
+            NuGetToolResolver = Substitute.For<IToolResolver>();
+            NuGetToolResolver.Name.Returns("NuGet");
+            NuGetToolResolver.ResolveToolPath().Returns(
+                defaultToolExist ? "/Working/tools/NuGet.exe" : "/NonWorking/tools/NuGet.exe"
+                );
+
             Log = Substitute.For<ICakeLog>();
 
             FileSystem = new FakeFileSystem(true);
@@ -43,6 +52,7 @@ namespace Cake.Common.Tests.Fixtures
             {
                 FileSystem.GetCreatedFile("/Working/tools/NuGet.exe");
             }
+
             if (toolPath != null)
             {
                 FileSystem.GetCreatedFile(toolPath);
@@ -75,22 +85,22 @@ namespace Cake.Common.Tests.Fixtures
 
         public NuGetPacker CreatePacker()
         {
-            return new NuGetPacker(FileSystem, Environment, Globber, ProcessRunner, Log);
+            return new NuGetPacker(FileSystem,Environment, ProcessRunner,Log, NuGetToolResolver);
         }
 
         public NuGetPusher CreatePusher()
         {
-            return new NuGetPusher(FileSystem, Environment, Globber, ProcessRunner);
+            return new NuGetPusher(FileSystem, Environment, Globber, ProcessRunner, NuGetToolResolver);
         }
 
         public NuGetRestorer CreateRestorer()
         {
-            return new NuGetRestorer(FileSystem, Environment, Globber, ProcessRunner);
+            return new NuGetRestorer(FileSystem, Environment, ProcessRunner, NuGetToolResolver);
         }
 
         public NuGetSources CreateSources()
         {
-            return new NuGetSources(FileSystem, Environment, Globber, ProcessRunner);
+            return new NuGetSources(FileSystem, Environment, ProcessRunner, NuGetToolResolver);
         }
     }
 }

--- a/src/Cake.Common/Tools/NuGet/NuGetAliases.cs
+++ b/src/Cake.Common/Tools/NuGet/NuGetAliases.cs
@@ -32,7 +32,7 @@ namespace Cake.Common.Tools.NuGet
             }
 
             var packer = new NuGetPacker(context.FileSystem, context.Environment, 
-                context.Globber, context.ProcessRunner, context.Log);
+                context.ProcessRunner, context.Log, context.GetToolResolver("NuGet"));
             packer.Pack(nuspecFilePath, settings);
         }
 
@@ -66,7 +66,7 @@ namespace Cake.Common.Tools.NuGet
                 throw new ArgumentNullException("context");
             }
 
-            var runner = new NuGetRestorer(context.FileSystem, context.Environment, context.Globber, context.ProcessRunner);
+            var runner = new NuGetRestorer(context.FileSystem, context.Environment, context.ProcessRunner, context.GetToolResolver("NuGet"));
             runner.Restore(targetFilePath, settings);
         }
 
@@ -86,7 +86,7 @@ namespace Cake.Common.Tools.NuGet
                 throw new ArgumentNullException("context");
             }
 
-            var packer = new NuGetPusher(context.FileSystem, context.Environment, context.Globber, context.ProcessRunner);
+            var packer = new NuGetPusher(context.FileSystem, context.Environment, context.Globber, context.ProcessRunner, context.GetToolResolver("NuGet"));
             packer.Push(packageFilePath, settings);
         }
 
@@ -121,7 +121,7 @@ namespace Cake.Common.Tools.NuGet
                 throw new ArgumentNullException("context");
             }
 
-            var runner = new NuGetSources(context.FileSystem, context.Environment, context.Globber, context.ProcessRunner);
+            var runner = new NuGetSources(context.FileSystem, context.Environment, context.ProcessRunner, context.GetToolResolver("NuGet"));
             runner.AddSource(name, source, settings);
         }
 
@@ -156,7 +156,7 @@ namespace Cake.Common.Tools.NuGet
                 throw new ArgumentNullException("context");
             }
 
-            var runner = new NuGetSources(context.FileSystem, context.Environment, context.Globber, context.ProcessRunner);
+            var runner = new NuGetSources(context.FileSystem, context.Environment, context.ProcessRunner, context.GetToolResolver("NuGet"));
             runner.RemoveSource(name, source, settings);
         }
 
@@ -189,7 +189,7 @@ namespace Cake.Common.Tools.NuGet
                 throw new ArgumentNullException("context");
             }
 
-            var runner = new NuGetSources(context.FileSystem, context.Environment, context.Globber, context.ProcessRunner);
+            var runner = new NuGetSources(context.FileSystem, context.Environment, context.ProcessRunner, context.GetToolResolver("NuGet"));
             return runner.HasSource(source, settings);
         }
     }

--- a/src/Cake.Common/Tools/NuGet/Pack/NuGetPacker.cs
+++ b/src/Cake.Common/Tools/NuGet/Pack/NuGetPacker.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using System.Linq;
 using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
+using Cake.Core.IO.NuGet;
 using Cake.Core.Utilities;
 
 namespace Cake.Common.Tools.NuGet.Pack
@@ -14,25 +14,26 @@ namespace Cake.Common.Tools.NuGet.Pack
     {
         private readonly IFileSystem _fileSystem;
         private readonly ICakeEnvironment _environment;
-        private readonly IGlobber _globber;
         private readonly NuspecProcessor _processor;
+        private readonly IToolResolver _nuGetToolResolver;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NuGetPacker"/> class.
         /// </summary>
         /// <param name="fileSystem">The file system.</param>
         /// <param name="environment">The environment.</param>
-        /// <param name="globber">The globber.</param>
         /// <param name="processRunner">The process runner.</param>
         /// <param name="log">The log.</param>
+        /// <param name="nuGetToolResolver">The NuGet tool resolver</param>
         public NuGetPacker(IFileSystem fileSystem, ICakeEnvironment environment,
-            IGlobber globber, IProcessRunner processRunner, ICakeLog log)
+            IProcessRunner processRunner, ICakeLog log,
+            IToolResolver nuGetToolResolver)
             : base(fileSystem, environment, processRunner)
         {
             _fileSystem = fileSystem;
             _environment = environment;
-            _globber = globber;
-            _processor = new NuspecProcessor(_fileSystem, _environment, log);    
+            _processor = new NuspecProcessor(_fileSystem, _environment, log);
+            _nuGetToolResolver = nuGetToolResolver;
         }
 
         /// <summary>
@@ -124,7 +125,7 @@ namespace Cake.Common.Tools.NuGet.Pack
         /// <returns>The name of the tool.</returns>
         protected override string GetToolName()
         {
-            return "NuGet";
+            return _nuGetToolResolver.Name;
         }
 
         /// <summary>
@@ -133,8 +134,7 @@ namespace Cake.Common.Tools.NuGet.Pack
         /// <returns>The default tool path.</returns>
         protected override FilePath GetDefaultToolPath(NuGetPackSettings settings)
         {
-            const string expression = "./tools/**/NuGet.exe";
-            return _globber.GetFiles(expression).FirstOrDefault();
+            return _nuGetToolResolver.ResolveToolPath();
         }
     }
 }

--- a/src/Cake.Common/Tools/NuGet/Push/NuGetPusher.cs
+++ b/src/Cake.Common/Tools/NuGet/Push/NuGetPusher.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Globalization;
-using System.Linq;
 using Cake.Core;
 using Cake.Core.IO;
+using Cake.Core.IO.NuGet;
 using Cake.Core.Utilities;
 
 namespace Cake.Common.Tools.NuGet.Push
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.NuGet.Push
     public sealed class NuGetPusher : Tool<NuGetPushSettings>
     {
         private readonly ICakeEnvironment _environment;
-        private readonly IGlobber _globber;
+        private readonly IToolResolver _nuGetToolResolver;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NuGetPusher"/> class.
@@ -22,11 +22,18 @@ namespace Cake.Common.Tools.NuGet.Push
         /// <param name="environment">The environment.</param>
         /// <param name="globber">The globber.</param>
         /// <param name="processRunner">The process runner.</param>
-        public NuGetPusher(IFileSystem fileSystem, ICakeEnvironment environment, IGlobber globber, IProcessRunner processRunner)
+        /// <param name="nuGetToolResolver">The NuGet tool resolver.</param>
+        public NuGetPusher(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IGlobber globber,
+            IProcessRunner processRunner,
+            IToolResolver nuGetToolResolver
+            )
             : base(fileSystem, environment, processRunner)
         {
             _environment = environment;
-            _globber = globber;
+            _nuGetToolResolver = nuGetToolResolver;
         }
 
         /// <summary>
@@ -95,7 +102,7 @@ namespace Cake.Common.Tools.NuGet.Push
         /// <returns>The name of the tool.</returns>
         protected override string GetToolName()
         {
-            return "NuGet";
+            return _nuGetToolResolver.Name;
         }
 
         /// <summary>
@@ -104,8 +111,7 @@ namespace Cake.Common.Tools.NuGet.Push
         /// <returns>The default tool path.</returns>
         protected override FilePath GetDefaultToolPath(NuGetPushSettings settings)
         {
-            const string expression = "./tools/**/NuGet.exe";
-            return _globber.GetFiles(expression).FirstOrDefault();
+            return _nuGetToolResolver.ResolveToolPath();
         }
     }
 }

--- a/src/Cake.Common/Tools/NuGet/Restore/NuGetRestorer.cs
+++ b/src/Cake.Common/Tools/NuGet/Restore/NuGetRestorer.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Cake.Core;
 using Cake.Core.IO;
+using Cake.Core.IO.NuGet;
 using Cake.Core.Utilities;
 
 namespace Cake.Common.Tools.NuGet.Restore
@@ -12,20 +13,20 @@ namespace Cake.Common.Tools.NuGet.Restore
     public sealed class NuGetRestorer : Tool<NuGetRestoreSettings>
     {
         private readonly ICakeEnvironment _environment;
-        private readonly IGlobber _globber;
+        private readonly IToolResolver _nuGetToolResolver;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NuGetRestorer"/> class.
         /// </summary>
         /// <param name="fileSystem">The file system.</param>
         /// <param name="environment">The environment.</param>
-        /// <param name="globber">The globber.</param>
         /// <param name="processRunner">The process runner.</param>
-        public NuGetRestorer(IFileSystem fileSystem, ICakeEnvironment environment, IGlobber globber, IProcessRunner processRunner)
+        /// <param name="nuGetToolResolver">The NuGet tool resolver</param>
+        public NuGetRestorer(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IToolResolver nuGetToolResolver)
             : base(fileSystem, environment, processRunner)
         {
             _environment = environment;
-            _globber = globber;
+            _nuGetToolResolver = nuGetToolResolver;
         }
 
         /// <summary>
@@ -111,7 +112,7 @@ namespace Cake.Common.Tools.NuGet.Restore
         /// <returns>The name of the tool.</returns>
         protected override string GetToolName()
         {
-            return "NuGet";
+            return _nuGetToolResolver.Name;
         }
 
         /// <summary>
@@ -121,8 +122,7 @@ namespace Cake.Common.Tools.NuGet.Restore
         /// <returns>The default tool path.</returns>
         protected override FilePath GetDefaultToolPath(NuGetRestoreSettings settings)
         {
-            const string expression = "./tools/**/NuGet.exe";
-            return _globber.GetFiles(expression).FirstOrDefault();
+            return _nuGetToolResolver.ResolveToolPath();
         }
     }
 }

--- a/src/Cake.Common/Tools/NuGet/Sources/NuGetSources.cs
+++ b/src/Cake.Common/Tools/NuGet/Sources/NuGetSources.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Linq;
 using Cake.Core;
 using Cake.Core.IO;
+using Cake.Core.IO.NuGet;
 using Cake.Core.Utilities;
 
 namespace Cake.Common.Tools.NuGet.Sources
@@ -12,19 +13,19 @@ namespace Cake.Common.Tools.NuGet.Sources
     /// </summary>
     public sealed class NuGetSources : Tool<NuGetSourcesSettings>
     {
-        private readonly IGlobber _globber;
+        private readonly IToolResolver _nuGetToolResolver;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NuGetSources"/> class.
         /// </summary>
         /// <param name="fileSystem">The file system.</param>
         /// <param name="environment">The environment.</param>
-        /// <param name="globber">The globber.</param>
         /// <param name="processRunner">The process runner.</param>
-        public NuGetSources(IFileSystem fileSystem, ICakeEnvironment environment, IGlobber globber, IProcessRunner processRunner)
+        /// <param name="nuGetToolResolver">The NuGet tool resolver.</param>
+        public NuGetSources(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IToolResolver nuGetToolResolver)
             : base(fileSystem, environment, processRunner)
         {
-            _globber = globber;
+            _nuGetToolResolver = nuGetToolResolver;
         }
 
         /// <summary>
@@ -206,7 +207,7 @@ namespace Cake.Common.Tools.NuGet.Sources
         /// <returns>The name of the tool.</returns>
         protected override string GetToolName()
         {
-            return "NuGet";
+            return _nuGetToolResolver.Name;
         }
 
         /// <summary>
@@ -216,8 +217,7 @@ namespace Cake.Common.Tools.NuGet.Sources
         /// <returns>The default tool path.</returns>
         protected override FilePath GetDefaultToolPath(NuGetSourcesSettings settings)
         {
-            const string expression = "./tools/**/NuGet.exe";
-            return _globber.GetFiles(expression).FirstOrDefault();
+            return _nuGetToolResolver.ResolveToolPath();
         }
     }
 }

--- a/src/Cake.Core.Tests/Fixtures/CakeEngineFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/CakeEngineFixture.cs
@@ -1,4 +1,7 @@
-﻿using Cake.Core.IO;
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Cake.Core.IO;
 using Cake.Core.Tests.Fakes;
 using NSubstitute;
 
@@ -12,6 +15,7 @@ namespace Cake.Core.Tests.Fixtures
         public IGlobber Globber { get; set; }
         public ICakeArguments Arguments { get; set; }
         public IProcessRunner ProcessRunner { get; set; }
+        public IEnumerable<IToolResolver> ToolResolvers { get; set; }
 
         public CakeEngineFixture()
         {
@@ -21,11 +25,12 @@ namespace Cake.Core.Tests.Fixtures
             Globber = Substitute.For<IGlobber>();
             Arguments = Substitute.For<ICakeArguments>();
             ProcessRunner = Substitute.For<IProcessRunner>();
+            ToolResolvers = Substitute.For<IEnumerable<IToolResolver>>();
         }
 
         public CakeEngine CreateEngine()
         {
-            return new CakeEngine(FileSystem, Environment, Log, Arguments, Globber, ProcessRunner);
+            return new CakeEngine(FileSystem, Environment, Log, Arguments, Globber, ProcessRunner, ToolResolvers);
         }
     }
 }

--- a/src/Cake.Core/Cake.Core.csproj
+++ b/src/Cake.Core/Cake.Core.csproj
@@ -108,6 +108,8 @@
     <Compile Include="IO\IProcess.cs" />
     <Compile Include="IO\IProcessRunner.cs" />
     <Compile Include="IO\Machine.cs" />
+    <Compile Include="IO\IToolResolver.cs" />
+    <Compile Include="IO\NuGet\NuGetToolResolver.cs" />
     <Compile Include="IO\Path.cs" />
     <Compile Include="IO\DirectoryPath.cs" />
     <Compile Include="IO\FilePath.cs" />

--- a/src/Cake.Core/CakeEngine.cs
+++ b/src/Cake.Core/CakeEngine.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Cake.Core.Diagnostics;
 using Cake.Core.Graph;
 using Cake.Core.IO;
+using Cake.Core.IO.NuGet;
 
 namespace Cake.Core
 {
@@ -21,6 +22,7 @@ namespace Cake.Core
         private readonly ICakeArguments _arguments;
         private readonly IProcessRunner _processRunner;
         private readonly List<CakeTask> _tasks;
+        private readonly ILookup<string, IToolResolver> _toolResolverLookup;
         private Action _setupAction;
         private Action _teardownAction;
 
@@ -88,6 +90,21 @@ namespace Cake.Core
         }
 
         /// <summary>
+        /// Gets resolver by tool name
+        /// </summary>
+        /// <param name="toolName">resolver tool name</param>
+        /// <returns>IToolResolver for tool</returns>
+        public IToolResolver GetToolResolver(string toolName)
+        {
+            var toolResolver = _toolResolverLookup[toolName].FirstOrDefault();
+            if (toolResolver == null)
+            {
+                throw new CakeException(string.Format(CultureInfo.InvariantCulture, "Failed to resolve tool: {0}", toolName));
+            }
+            return toolResolver;
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="CakeEngine"/> class.
         /// </summary>
         /// <param name="fileSystem">The file system.</param>
@@ -96,8 +113,10 @@ namespace Cake.Core
         /// <param name="arguments">The arguments.</param>
         /// <param name="globber">The globber.</param>
         /// <param name="processRunner">The process runner.</param>
+        /// <param name="toolResolvers">The tool resolvers.</param>
         public CakeEngine(IFileSystem fileSystem, ICakeEnvironment environment, ICakeLog log, 
-            ICakeArguments arguments, IGlobber globber, IProcessRunner processRunner)
+            ICakeArguments arguments, IGlobber globber, IProcessRunner processRunner,
+            IEnumerable<IToolResolver> toolResolvers)
         {
             if (fileSystem == null)
             {
@@ -123,6 +142,10 @@ namespace Cake.Core
             {
                 throw new ArgumentNullException("processRunner");
             }
+            if (processRunner == null)
+            {
+                throw new ArgumentNullException("toolResolvers");
+            }
             _fileSystem = fileSystem;
             _environment = environment;
             _log = log;            
@@ -130,6 +153,11 @@ namespace Cake.Core
             _globber = globber;
             _processRunner = processRunner;
             _tasks = new List<CakeTask>();
+            _toolResolverLookup =toolResolvers.ToLookup(
+                key=>key.Name,
+                value=>value,
+                StringComparer.OrdinalIgnoreCase
+                );
         }
 
         /// <summary>

--- a/src/Cake.Core/ICakeContext.cs
+++ b/src/Cake.Core/ICakeContext.cs
@@ -43,5 +43,12 @@ namespace Cake.Core
         /// </summary>
         /// <value>The process runner.</value>
         IProcessRunner ProcessRunner { get; }
+
+        /// <summary>
+        /// Gets resolver by tool name
+        /// </summary>
+        /// <param name="toolName">resolver tool name</param>
+        /// <returns>IToolResolver for tool</returns>
+        IToolResolver GetToolResolver(string toolName);
     }
 }

--- a/src/Cake.Core/IO/FileExtensions.cs
+++ b/src/Cake.Core/IO/FileExtensions.cs
@@ -77,6 +77,7 @@ namespace Cake.Core.IO
         /// <param name="file">The file to be read from.</param>
         /// <param name="encoding">The encoding that is applied to the content of the file.</param>
         /// <returns>A <see cref="IEnumerable{T}"/> of file line content</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
         public static IEnumerable<string> ReadLines(this IFile file, System.Text.Encoding encoding)
         {
             if (file == null)

--- a/src/Cake.Core/IO/IToolResolver.cs
+++ b/src/Cake.Core/IO/IToolResolver.cs
@@ -1,0 +1,19 @@
+﻿namespace Cake.Core.IO
+{
+    /// <summary>
+    /// Generic Tool Resolver Interface
+    /// </summary>
+    public interface IToolResolver
+    {
+        /// <summary>
+        /// Name of tool
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Generic resolve path to tool
+        /// </summary>
+        /// <returns>nuget.exe path</returns>
+        FilePath ResolveToolPath();
+    }
+}

--- a/src/Cake.Core/IO/NuGet/NuGetToolResolver.cs
+++ b/src/Cake.Core/IO/NuGet/NuGetToolResolver.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Linq;
+
+namespace Cake.Core.IO.NuGet
+{
+    /// <summary>
+    /// Contains NuGet path resolver functionality
+    /// </summary>
+    public sealed class NuGetToolResolver : IToolResolver
+    {
+        private IFile _nugetExeFile;
+        private readonly IFileSystem _fileSystem;
+        private readonly IGlobber _globber;
+        private readonly ICakeEnvironment _environment;
+
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NuGetToolResolver"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="globber">The globber.</param>
+        public NuGetToolResolver(IFileSystem fileSystem, IGlobber globber, ICakeEnvironment environment)
+        {
+            _fileSystem = fileSystem;
+            _globber = globber;
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Name of tool
+        /// </summary>
+        public string Name
+        {
+            get { return "NuGet"; }
+        }
+
+        /// <summary>
+        /// Resolve path to NuGet tool
+        /// </summary>
+        /// <returns>nuget.exe path</returns>
+        public FilePath ResolveToolPath()
+        {
+            // Check if path allready resolved
+            if (_nugetExeFile != null && _nugetExeFile.Exists)
+            {
+                return _nugetExeFile.Path;
+            }
+
+            // Check if path set to environment variable
+            var environmentExe = _environment.GetEnvironmentVariable("NUGET_EXE");
+            if (!string.IsNullOrWhiteSpace(environmentExe))
+            {
+                var envFile = _fileSystem.GetFile(environmentExe);
+                if (envFile.Exists)
+                {
+                    return (_nugetExeFile = envFile).Path;
+                }
+            }
+
+            // Check if tool exists in tool folder
+            const string expression = "./tools/**/NuGet.exe";
+            var toolsExe = _globber.GetFiles(expression).FirstOrDefault();
+            if (toolsExe != null)
+            {
+                var toolsFile = _fileSystem.GetFile(toolsExe);
+                if (toolsFile.Exists)
+                {
+                    return (_nugetExeFile = toolsFile).Path;
+                }
+            }
+
+            // Last resort try path
+            var envPath = _environment.GetEnvironmentVariable("path");
+            if (!string.IsNullOrWhiteSpace(envPath))
+            {
+                var pathFile = envPath
+                    .Split(new[] {';'}, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(path=>_fileSystem.GetDirectory(path))
+                    .Where(path => path.Exists)
+                    .Select(path => path.Path.CombineWithFilePath("nuget.exe"))
+                    .Select(_fileSystem.GetFile)
+                    .FirstOrDefault(file => file.Exists);
+
+                if (pathFile!=null)
+                {
+                    return (_nugetExeFile = pathFile).Path;
+                }
+            }
+
+            throw new CakeException("No NuGet.exe found by resolver");
+        }
+    }
+}

--- a/src/Cake.Core/Scripting/ScriptHost.cs
+++ b/src/Cake.Core/Scripting/ScriptHost.cs
@@ -66,6 +66,16 @@ namespace Cake.Core.Scripting
             get { return _engine.ProcessRunner; }
         }
 
+         /// <summary>
+        /// Gets resolver by tool name
+        /// </summary>
+        /// <param name="toolName">resolver tool name</param>
+        /// <returns>IToolResolver for tool</returns>
+        public IToolResolver GetToolResolver(string toolName)
+        {
+            return _engine.GetToolResolver(toolName);
+        }
+
         /// <summary>
         /// Gets the engine.
         /// </summary>

--- a/src/Cake/Program.cs
+++ b/src/Cake/Program.cs
@@ -1,9 +1,12 @@
-﻿using Autofac;
+﻿using System.Collections.Generic;
+using Autofac;
+using Autofac.Builder;
 using Cake.Arguments;
 using Cake.Commands;
 using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
+using Cake.Core.IO.NuGet;
 using Cake.Core.Scripting;
 using Cake.Diagnostics;
 using Cake.Scripting;
@@ -37,6 +40,8 @@ namespace Cake
             builder.RegisterType<CakeReportPrinter>().As<ICakeReportPrinter>().SingleInstance();            
             builder.RegisterType<CakeConsole>().As<IConsole>().SingleInstance();
             builder.RegisterType<ScriptProcessor>().As<IScriptProcessor>().SingleInstance();
+            builder.RegisterCollection<IToolResolver>("toolResolvers").As<IEnumerable<IToolResolver>>();
+            builder.RegisterType<NuGetToolResolver>().As<IToolResolver>().SingleInstance().MemberOf("toolResolvers");
 
             // Roslyn related services.
             builder.RegisterType<RoslynScriptSessionFactory>().As<IScriptSessionFactory>();


### PR DESCRIPTION
Added a common `NuGetToolResolver` for the NuGet `Tool<T>`:s
Extended it so it
1. Caches nuget.exe path if allready found
2. Not only checks via globber pattern but now
   1. `NUGET_EXE` environment variable
   2. Globber ? "./tools/**/NuGet.exe"`
   3. If exists in environment `path`

This would solve when nuget.exe is placed in a common location and shared between scripts. Also most build servers/services like i..e. AppVeyor already has nuget installed.

This also reduces code duplication as default tool path is resolved in 1 place.
