### PR TITLE
Added AssemblyCompany to AssemblyInfoCreator

### DIFF
--- a/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoCreatorTests.cs
+++ b/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoCreatorTests.cs
@@ -145,6 +145,21 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
             }
 
             [Fact]
+            public void Should_Add_Company_Attribute_If_Set()
+            {
+                // Given
+                var fixture = new AssemblyInfoFixture();
+                fixture.Settings.Company = "TheCompany";
+
+                // When
+                var result = fixture.CreateAndReturnContent();
+
+                // Then
+                Assert.True(result.Contains("using System.Reflection;"));
+                Assert.True(result.Contains("[assembly: AssemblyCompany(\"TheCompany\")]"));
+            }
+
+            [Fact]
             public void Should_Add_Product_Attribute_If_Set()
             {
                 // Given

--- a/src/Cake.Common/Solution/Project/Properties/AssemblyInfoCreator.cs
+++ b/src/Cake.Common/Solution/Project/Properties/AssemblyInfoCreator.cs
@@ -108,6 +108,10 @@ namespace Cake.Common.Solution.Project.Properties
             {
                 registration.AddString("AssemblyDescription", "System.Reflection", settings.Description);
             }
+            if (settings.Company != null)
+            {
+                registration.AddString("AssemblyCompany", "System.Reflection", settings.Company);
+            }
             if (settings.Product != null)
             {
                 registration.AddString("AssemblyProduct", "System.Reflection", settings.Product);

--- a/src/Cake.Common/Solution/Project/Properties/AssemblyInfoSettings.cs
+++ b/src/Cake.Common/Solution/Project/Properties/AssemblyInfoSettings.cs
@@ -70,5 +70,11 @@
         /// </summary>
         /// <value>Whether or not the assembly is CLS compliant.</value>
         public bool? CLSCompliant { get; set; }
+
+        /// <summary>
+        /// Gets or sets the company.
+        /// </summary>
+        /// <value>The company.</value>
+        public string Company { get; set; }
     }
 }


### PR DESCRIPTION
Added support for assembly info company setting
```csharp
	var file = "./src/SolutionInfo.cs";
	CreateAssemblyInfo(file, new AssemblyInfoSettings {
		Company= "WCOM AB"
	});
``` 
will add
`[assembly: AssemblyCompany("WCOM AB")]`