### PR TITLE
Added predictable encoding to AssemblyInfoCreator

### DIFF
--- a/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoCreatorTests.cs
+++ b/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoCreatorTests.cs
@@ -275,7 +275,7 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("using System.Runtime.InteropServices;"));
+                Assert.True(result.Contains("using System;"));
                 Assert.True(result.Contains("[assembly: CLSCompliant(true)]"));
             }
         }

--- a/src/Cake.Common/Solution/Project/Properties/AssemblyInfoCreator.cs
+++ b/src/Cake.Common/Solution/Project/Properties/AssemblyInfoCreator.cs
@@ -67,7 +67,7 @@ namespace Cake.Common.Solution.Project.Properties
             _log.Verbose("Creating assembly info file: {0}", absoluteOutputPath);
 
             using (var stream = _fileSystem.GetFile(absoluteOutputPath).OpenWrite())
-            using (var writer = new StreamWriter(stream))
+            using (var writer = new StreamWriter(stream, System.Text.Encoding.UTF8))
             {
                 // Write header.
                 writer.WriteLine("//------------------------------------------------------------------------------");

--- a/src/Cake.Common/Solution/Project/Properties/AssemblyInfoCreator.cs
+++ b/src/Cake.Common/Solution/Project/Properties/AssemblyInfoCreator.cs
@@ -146,7 +146,7 @@ namespace Cake.Common.Solution.Project.Properties
             }
             if (settings.CLSCompliant != null)
             {
-                registration.AddBoolean("CLSCompliant", "System.Runtime.InteropServices", settings.CLSCompliant.Value);
+                registration.AddBoolean("CLSCompliant", "System", settings.CLSCompliant.Value);
             }
 
             return registration;


### PR DESCRIPTION
Currently uses `System.Text.Encoding.Default` which isn't predictable and often doesn't support non ascii characters.