### PR TITLE
Add support for transforming nuspec files

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/NuGet/Pack/NuGetPackerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NuGet/Pack/NuGetPackerTests.cs
@@ -369,5 +369,83 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Pack
                     fixture.FileSystem.GetTextContent("/Working/existing.temp.nuspec").NormalizeLineEndings());
             }
         }
+
+            [Fact]
+            public void Should_Replace_Template_Tokens_In_Nuspec_With_Files()
+            {
+                // Given
+                var fixture = new NuGetFixture();
+                var packer = fixture.CreatePacker();
+
+                // When
+                packer.Pack("./existing.nuspec", new NuGetPackSettings
+                {
+                    Id = "The ID",
+                    Version = "The version",
+                    Title = "The title",
+                    Authors = new[] { "Author #1", "Author #2" },
+                    Owners = new[] { "Owner #1", "Owner #2" },
+                    Description = "The description",
+                    Summary = "The summary",
+                    LicenseUrl = new Uri("https://license.com"),
+                    ProjectUrl = new Uri("https://project.com"),
+                    IconUrl = new Uri("https://icon.com"),
+                    RequireLicenseAcceptance = true,
+                    Copyright = "The copyright",
+                    ReleaseNotes = new[] { "Line #1", "Line #2", "Line #3" },
+                    Tags = new[] { "Tag1", "Tag2", "Tag3" },
+                    Files = new[]
+                    {
+                        new NuSpecContent {Source = "Cake.Core.dll", Target = "lib/net45"},
+                        new NuSpecContent {Source = "Cake.Core.xml", Target = "lib/net45"},
+                        new NuSpecContent {Source = "Cake.Core.pdb", Target = "lib/net45"},
+                        new NuSpecContent {Source = "LICENSE"}
+                    }
+                });
+
+                // Then
+                Assert.Equal(
+                    Resources.Nuspec_Metadata.NormalizeLineEndings(),
+                    fixture.FileSystem.GetTextContent("/Working/existing.temp.nuspec").NormalizeLineEndings());
+            }
+
+            [Fact]
+            public void Should_Replace_Template_Tokens_In_Nuspec_With_Files_Without_Namespaces()
+            {
+                // Given
+                var fixture = new NuGetFixture(xml: Resources.Nuspec_NoMetadataValues_WithoutNamespaces);
+                var packer = fixture.CreatePacker();
+
+                // When
+                packer.Pack("./existing.nuspec", new NuGetPackSettings
+                {
+                    Id = "The ID",
+                    Version = "The version",
+                    Title = "The title",
+                    Authors = new[] { "Author #1", "Author #2" },
+                    Owners = new[] { "Owner #1", "Owner #2" },
+                    Description = "The description",
+                    Summary = "The summary",
+                    LicenseUrl = new Uri("https://license.com"),
+                    ProjectUrl = new Uri("https://project.com"),
+                    IconUrl = new Uri("https://icon.com"),
+                    RequireLicenseAcceptance = true,
+                    Copyright = "The copyright",
+                    ReleaseNotes = new[] { "Line #1", "Line #2", "Line #3" },
+                    Tags = new[] { "Tag1", "Tag2", "Tag3" },
+                    Files = new[]
+                    {
+                        new NuSpecContent {Source = "Cake.Core.dll", Target = "lib/net45"},
+                        new NuSpecContent {Source = "Cake.Core.xml", Target = "lib/net45"},
+                        new NuSpecContent {Source = "Cake.Core.pdb", Target = "lib/net45"},
+                        new NuSpecContent {Source = "LICENSE"}
+                    }
+                });
+
+                // Then
+                Assert.Equal(
+                    Resources.Nuspec_Metadata_WithoutNamespaces.NormalizeLineEndings(),
+                    fixture.FileSystem.GetTextContent("/Working/existing.temp.nuspec").NormalizeLineEndings());
+            }
     }
 }

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Tools\MSTest\MSTestAliases.cs" />
     <Compile Include="Tools\MSTest\MSTestRunner.cs" />
     <Compile Include="Tools\MSTest\MSTestSettings.cs" />
+    <Compile Include="Tools\NuGet\Pack\NuSpecContent.cs" />
     <Compile Include="Tools\NuGet\Sources\NuGetSources.cs" />
     <Compile Include="Tools\NuGet\Sources\NuGetSourcesSettings.cs" />
     <Compile Include="Tools\NuGet\NuGetAliases.cs" />

--- a/src/Cake.Common/Tools/NuGet/Pack/NuGetPackSettings.cs
+++ b/src/Cake.Common/Tools/NuGet/Pack/NuGetPackSettings.cs
@@ -130,5 +130,11 @@ namespace Cake.Common.Tools.NuGet.Pack
         /// </summary>
         /// <value>The tool path.</value>
         public FilePath ToolPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the package files.
+        /// </summary>
+        /// <value>The package files.</value>
+        public ICollection<NuSpecContent> Files { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/NuGet/Pack/NuSpecContent.cs
+++ b/src/Cake.Common/Tools/NuGet/Pack/NuSpecContent.cs
@@ -1,0 +1,23 @@
+﻿namespace Cake.Common.Tools.NuGet.Pack
+{
+    /// <summary>
+    /// Represents a NuGet nuspec file
+    /// </summary>
+    public class NuSpecContent
+    {
+        /// <summary>
+        /// The location of the file or files to include. The path is relative to the NuSpec file unless an absolute path is specified. The wildcard character, *, is allowed. Using a double wildcard, **, implies a recursive directory search.
+        /// </summary>
+        public string Source { get; set; }
+
+        /// <summary>
+        /// This is a relative path to the directory within the package where the source files will be placed.
+        /// </summary>
+        public string Target { get; set; }
+
+        /// <summary>
+        /// The file or files to exclude. This is usually combined with a wildcard value in the `src` attribute. The `exclude` attribute can contain a semi-colon delimited list of files or a file pattern. Using a double wildcard, **, implies a recursive exclude pattern.
+        /// </summary>
+        public string Exclude { get; set; }
+    }
+}


### PR DESCRIPTION
Added support for specifying the nuspec files from cake via NuGetPackSettings like below
```csharp
NuGetPack("App.nuspec", new NuGetPackSettings
{
    Files = new[]
    {
        new NuSpecContent {Src = "App.Core.dll", Target = "lib/net45"},
        new NuSpecContent {Src = "App.Core.xml", Target = "lib/net45"},
        new NuSpecContent {Src = "App.Core.pdb", Target = "lib/net45"},
        new NuSpecContent {Src = "LICENSE"}
        new NuSpecContent {Src = "App.Common.*", Target = "lib/net45", Exclude = "*.pdb"},
    }
});
```