### PR TITLE
Added filter support to CleanDirectory

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/FileSystemFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/FileSystemFixture.cs
@@ -24,6 +24,7 @@ namespace Cake.Common.Tests.Fixtures
             fileSystem.GetCreatedDirectory("/Temp/Hello/More/Empty");
             fileSystem.GetCreatedDirectory("/Temp/Hello/World");
             fileSystem.GetCreatedDirectory("/Temp/Goodbye");
+            fileSystem.GetCreatedDirectory("/Temp/Hello/Hidden", true);
             fileSystem.GetCreatedFile("/Presentation.ppt");
             fileSystem.GetCreatedFile("/Budget.xlsx");
             fileSystem.GetCreatedFile("/Text.txt");
@@ -31,6 +32,7 @@ namespace Cake.Common.Tests.Fixtures
             fileSystem.GetCreatedFile("/Temp/Hello/Document.txt");
             fileSystem.GetCreatedFile("/Temp/Hello/World/Text.txt");
             fileSystem.GetCreatedFile("/Temp/Hello/World/Picture.png");
+            fileSystem.GetCreatedFile("/Temp/Hello/Hidden.txt", true);
             fileSystem.GetCreatedFile("/Temp/Goodbye/OtherText.txt");
             fileSystem.GetCreatedFile("/Temp/Goodbye/OtherPicture.png");
             fileSystem.GetCreatedFile("/Temp/HasFiles/A.txt");

--- a/src/Cake.Common/IO/DirectoryAliases.cs
+++ b/src/Cake.Common/IO/DirectoryAliases.cs
@@ -137,6 +137,19 @@ namespace Cake.Common.IO
         }
 
         /// <summary>
+        /// Cleans the specified directory.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="path">The directory path.</param>
+        /// <param name="wherePredicate">Filters which filesfiles/directories get deleted based on predicate</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Clean")]
+        public static void CleanDirectory(this ICakeContext context, DirectoryPath path, Func<IFileSystemInfo, bool> wherePredicate)
+        {
+            DirectoryCleaner.Clean(context, path, wherePredicate, null);
+        }
+
+        /// <summary>
         /// Creates the specified directory.
         /// </summary>
         /// <param name="context">The context.</param>

--- a/src/Cake.Common/IO/DirectoryCleaner.cs
+++ b/src/Cake.Common/IO/DirectoryCleaner.cs
@@ -5,47 +5,68 @@ using Cake.Core.IO;
 
 namespace Cake.Common.IO
 {
-    internal static class DirectoryCleaner
-    {
-        public static void Clean(ICakeContext context, DirectoryPath path)
-        {
-            if (context == null)
-            {
-                throw new ArgumentNullException("context");
-            }
-            if (path == null)
-            {
-                throw new ArgumentNullException("path");
-            }
-           
-            if (path.IsRelative)
-            {
-                path = path.MakeAbsolute(context.Environment);
-            }
+	internal static class DirectoryCleaner
+	{
+		public static void Clean(ICakeContext context, DirectoryPath path)
+		{
+			Clean(context, path, null, null);
+		}
 
-            // Get the root directory.
-            var root = context.FileSystem.GetDirectory(path);
-            if (!root.Exists)
-            {
-                context.Log.Verbose("Creating directory {0}", path);
-                root.Create();
-                return;
-            }
+		public static void Clean(ICakeContext context, DirectoryPath path, Func<IFileSystemInfo, bool> wherePredicate, Action<IFileSystemInfo> predicateFiltered)
+		{
+			if (context == null)
+			{
+				throw new ArgumentNullException("context");
+			}
+			if (path == null)
+			{
+				throw new ArgumentNullException("path");
+			}
+		   
+			if (path.IsRelative)
+			{
+				path = path.MakeAbsolute(context.Environment);
+			}
 
-            context.Log.Verbose("Deleting contents of {0}", path);
+			// Get the root directory.
+			var root = context.FileSystem.GetDirectory(path);
+			if (!root.Exists)
+			{
+				context.Log.Verbose("Creating directory {0}", path);
+				root.Create();
+				return;
+			}
 
-            // Delete all directories.
-            foreach (var directory in root.GetDirectories("*", SearchScope.Current))
-            {
-                Clean(context, directory.Path.FullPath);
-                directory.Delete(false);
-            }
+			context.Log.Verbose("Deleting contents of {0}", path);
 
-            // Delete all files.
-            foreach (var file in root.GetFiles("*", SearchScope.Current))
-            {
-                file.Delete();
-            }
-        }
-    }
+			var hasFilteredDirs = false;
+			// Delete all directories.
+			Action<IFileSystemInfo> directoryFiltered = filteredEntry =>
+			{
+				hasFilteredDirs = true;
+			    if (predicateFiltered != null)
+			    {
+			        predicateFiltered(filteredEntry);
+			    }
+			    else
+			    {
+			        context.Log.Verbose("Skipping {0} because specified predicate", filteredEntry.Path.FullPath);
+			    }
+			};
+			foreach (var directory in root.GetDirectories("*", SearchScope.Current, wherePredicate, directoryFiltered))
+			{
+				Clean(context, directory.Path.FullPath, wherePredicate, directoryFiltered);
+				if (!hasFilteredDirs)
+				{
+					directory.Delete(false);
+				}
+			}
+
+			// Delete all files.
+			foreach (var file in root.GetFiles("*", SearchScope.Current, wherePredicate, predicateFiltered))
+			{
+				file.Delete();
+			}
+		}
+	}
 }

--- a/src/Cake.Core/Cake.Core.csproj
+++ b/src/Cake.Core/Cake.Core.csproj
@@ -104,6 +104,7 @@
     <Compile Include="IO\IDirectory.cs" />
     <Compile Include="IO\IFile.cs" />
     <Compile Include="IO\IFileSystem.cs" />
+    <Compile Include="IO\IFileSystemInfo.cs" />
     <Compile Include="IO\IGlobber.cs" />
     <Compile Include="IO\IProcess.cs" />
     <Compile Include="IO\IProcessRunner.cs" />

--- a/src/Cake.Core/IO/Directory.cs
+++ b/src/Cake.Core/IO/Directory.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -13,10 +14,19 @@ namespace Cake.Core.IO
         {
             get { return _path; }
         }
+        Path IFileSystemInfo.Path
+        {
+            get { return _path; }
+        }
 
         public bool Exists
         {
             get { return _directory.Exists; }
+        }
+
+        public bool Hidden
+        {
+            get { return (_directory.Attributes & FileAttributes.Hidden) == FileAttributes.Hidden; }
         }
 
         public Directory(DirectoryPath path)
@@ -37,14 +47,50 @@ namespace Cake.Core.IO
 
         public IEnumerable<IDirectory> GetDirectories(string filter, SearchScope scope)
         {
+            return GetDirectories(filter, scope, null);
+        }
+
+        public IEnumerable<IDirectory> GetDirectories(string filter, SearchScope scope, Func<IFileSystemInfo, bool> wherePredicate)
+        {
+            return GetDirectories(filter, scope, wherePredicate, null);
+        }
+
+        public IEnumerable<IDirectory> GetDirectories(string filter, SearchScope scope, Func<IFileSystemInfo, bool> wherePredicate, Action<IFileSystemInfo> predicateFiltered)
+        {
             var option = scope == SearchScope.Current ? SearchOption.TopDirectoryOnly : SearchOption.AllDirectories;
-            return _directory.GetDirectories(filter, option).Select(directory => new Directory(directory.FullName));
+            return _directory
+                .GetDirectories(filter, option)
+                .Select(directory => new Directory(directory.FullName))
+                .Where(entry=>WherePredicate(entry, wherePredicate, predicateFiltered));
         }
 
         public IEnumerable<IFile> GetFiles(string filter, SearchScope scope)
         {
+            return GetFiles(filter, scope, null);
+        }
+
+        public IEnumerable<IFile> GetFiles(string filter, SearchScope scope, Func<IFileSystemInfo, bool> wherePredicate)
+        {
+            return GetFiles(filter, scope, wherePredicate, null);
+        }
+
+        public IEnumerable<IFile> GetFiles(string filter, SearchScope scope, Func<IFileSystemInfo, bool> wherePredicate, Action<IFileSystemInfo> predicateFiltered)
+        {
             var option = scope == SearchScope.Current ? SearchOption.TopDirectoryOnly : SearchOption.AllDirectories;
-            return _directory.GetFiles(filter, option).Select(file => new File(file.FullName));
+            return _directory
+                .GetFiles(filter, option)
+                .Select(file => new File(file.FullName))
+                .Where(entry=>WherePredicate(entry, wherePredicate, predicateFiltered));
+        }
+
+        private static bool WherePredicate(IFileSystemInfo entry, Func<IFileSystemInfo, bool> wherePredicate, Action<IFileSystemInfo> predicateFiltered)
+        {
+            var include = wherePredicate==null || wherePredicate(entry);
+            if (!include && predicateFiltered != null)
+            {
+                predicateFiltered(entry);
+            }
+            return include;
         }
     }
 }

--- a/src/Cake.Core/IO/File.cs
+++ b/src/Cake.Core/IO/File.cs
@@ -13,9 +13,19 @@ namespace Cake.Core.IO
             get { return _path; }
         }
 
+        Path IFileSystemInfo.Path
+        {
+            get { return _path; }
+        }
+
         public bool Exists
         {
             get { return _file.Exists; }
+        }
+
+        public bool Hidden
+        {
+            get { return (_file.Attributes & FileAttributes.Hidden) == FileAttributes.Hidden; }
         }
 
         public long Length

--- a/src/Cake.Core/IO/IDirectory.cs
+++ b/src/Cake.Core/IO/IDirectory.cs
@@ -1,25 +1,18 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Cake.Core.IO
 {
     /// <summary>
     /// Represents a directory.
     /// </summary>
-    public interface IDirectory
+    public interface IDirectory : IFileSystemInfo
     {
         /// <summary>
         /// Gets the path to the directory.
         /// </summary>
         /// <value>The path.</value>
-        DirectoryPath Path { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether this <see cref="IDirectory"/> exists.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if the directory exists; otherwise, <c>false</c>.
-        /// </value>
-        bool Exists { get; }
+        new DirectoryPath Path { get; }
 
         /// <summary>
         /// Creates the directory.
@@ -41,11 +34,49 @@ namespace Cake.Core.IO
         IEnumerable<IDirectory> GetDirectories(string filter, SearchScope scope);
 
         /// <summary>
+        /// Gets directories matching the specified filter and scope, with option to exclude hidden directories
+        /// </summary>
+        /// <param name="filter">The filter.</param>
+        /// <param name="scope">The scope.</param>
+        /// <param name="wherePredicate">Filters returned directories based on predicate</param>
+        /// <returns>Directories matching the filter and scope.</returns>
+        IEnumerable<IDirectory> GetDirectories(string filter, SearchScope scope, Func<IFileSystemInfo, bool> wherePredicate);
+
+        /// <summary>
+        /// Gets directories matching the specified filter and scope, with option to exclude hidden directories
+        /// </summary>
+        /// <param name="filter">The filter.</param>
+        /// <param name="scope">The scope.</param>
+        /// <param name="wherePredicate">Filters returned directories based on predicate</param>
+        /// <param name="predicateFiltered">Callback if directory gets filtered by wherePredicate</param>
+        /// <returns>Directories matching the filter and scope.</returns>
+        IEnumerable<IDirectory> GetDirectories(string filter, SearchScope scope, Func<IFileSystemInfo, bool> wherePredicate, Action<IFileSystemInfo> predicateFiltered);
+
+        /// <summary>
         /// Gets files matching the specified filter and scope.
         /// </summary>
         /// <param name="filter">The filter.</param>
         /// <param name="scope">The scope.</param>
         /// <returns>Files matching the specified filter and scope.</returns>
         IEnumerable<IFile> GetFiles(string filter, SearchScope scope);
+
+        /// <summary>
+        /// Gets files matching the specified filter and scope.
+        /// </summary>
+        /// <param name="filter">The filter.</param>
+        /// <param name="scope">The scope.</param>
+        /// <param name="wherePredicate">Filters returned files based on predicate</param>
+        /// <returns>Files matching the specified filter and scope.</returns>
+        IEnumerable<IFile> GetFiles(string filter, SearchScope scope, Func<IFileSystemInfo, bool> wherePredicate);
+
+        /// <summary>
+        /// Gets files matching the specified filter and scope.
+        /// </summary>
+        /// <param name="filter">The filter.</param>
+        /// <param name="scope">The scope.</param>
+        /// <param name="wherePredicate">Filters returned files based on predicate</param>
+        /// <param name="predicateFiltered">Callback if file gets filtered by wherePredicate</param>
+        /// <returns>Files matching the specified filter and scope.</returns>
+        IEnumerable<IFile> GetFiles(string filter, SearchScope scope, Func<IFileSystemInfo, bool> wherePredicate, Action<IFileSystemInfo> predicateFiltered);
     }
 }

--- a/src/Cake.Core/IO/IFile.cs
+++ b/src/Cake.Core/IO/IFile.cs
@@ -5,21 +5,14 @@ namespace Cake.Core.IO
     /// <summary>
     /// Represents a file.
     /// </summary>
-    public interface IFile
+    public interface IFile : IFileSystemInfo
     {
         /// <summary>
         /// Gets the path to the file.
         /// </summary>
         /// <value>The path.</value>
-        FilePath Path { get; }
+        new FilePath Path { get; }
 
-        /// <summary>
-        /// Gets a value indicating whether this <see cref="IFile"/> exists.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if the file exists; otherwise, <c>false</c>.
-        /// </value>
-        bool Exists { get; }
 
         /// <summary>
         /// Gets the length of the file.

--- a/src/Cake.Core/IO/IFileSystemInfo.cs
+++ b/src/Cake.Core/IO/IFileSystemInfo.cs
@@ -1,0 +1,30 @@
+namespace Cake.Core.IO
+{
+    /// <summary>
+    /// Represents an entry in the file system
+    /// </summary>
+    public interface IFileSystemInfo
+    {
+        /// <summary>
+        /// Gets the path to the entry.
+        /// </summary>
+        /// <value>The path.</value>
+        Path Path { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this <see cref="IFileSystemInfo"/> exists.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if the entry exists; otherwise, <c>false</c>.
+        /// </value>
+        bool Exists { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this <see cref="IFileSystemInfo"/> is hidden.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if the entry is hidden; otherwise, <c>false</c>.
+        /// </value>
+        bool Hidden { get; }
+    }
+}

--- a/src/Cake.Testing/Fakes/FakeFile.cs
+++ b/src/Cake.Testing/Fakes/FakeFile.cs
@@ -13,8 +13,14 @@ namespace Cake.Testing.Fakes
         private long _contentLength;
         private readonly object _contentLock = new object();
         private bool _deleted;
+        private bool _hidden;
 
         public FilePath Path
+        {
+            get { return _path; }
+        }
+
+        Core.IO.Path IFileSystemInfo.Path
         {
             get { return _path; }
         }
@@ -23,6 +29,12 @@ namespace Cake.Testing.Fakes
         {
             get { return _exists; }
             set { _exists = value; } 
+        }
+
+         public bool Hidden
+        {
+            get { return _hidden; }
+            set { _hidden = value; } 
         }
 
         public bool Deleted
@@ -57,6 +69,7 @@ namespace Cake.Testing.Fakes
             _fileSystem = fileSystem;
             _path = path;
             _exists = false;
+            _hidden = false;
         }
 
         public void Copy(FilePath destination, bool overwrite)

--- a/src/Cake.Testing/Fakes/FakeFileSystem.cs
+++ b/src/Cake.Testing/Fakes/FakeFileSystem.cs
@@ -28,16 +28,26 @@ namespace Cake.Testing.Fakes
 
         public IFile GetFile(FilePath path)
         {
+            return GetFile(path, false);
+        }
+
+        public IFile GetFile(FilePath path, bool hidden)
+        {
             if (!Files.ContainsKey(path))
             {
-                Files.Add(path, new FakeFile(this, path));
+                Files.Add(path, new FakeFile(this, path){Hidden = hidden});
             }
             return Files[path];
         }
 
         public IFile GetCreatedFile(FilePath path)
         {
-            var file = GetFile(path);
+            return GetCreatedFile(path, false);
+        }
+
+        public IFile GetCreatedFile(FilePath path, bool hidden)
+        {
+            var file = GetFile(path,hidden);
             file.Open(FileMode.Create, FileAccess.Write, FileShare.None).Close();
             return file;
         }
@@ -55,21 +65,26 @@ namespace Cake.Testing.Fakes
 
         public IDirectory GetDirectory(DirectoryPath path)
         {
-            return GetDirectory(path, creatable: true);
+            return GetDirectory(path, creatable: true, hidden:false);
         }
 
         public IDirectory GetCreatedDirectory(DirectoryPath path)
         {
-            var directory = GetDirectory(path, creatable: true);
+            return GetCreatedDirectory(path, false);
+        }
+
+        public IDirectory GetCreatedDirectory(DirectoryPath path, bool hidden)
+        {
+            var directory = GetDirectory(path, creatable: true, hidden:hidden);
             directory.Create();
             return directory;
         }
 
-        private IDirectory GetDirectory(DirectoryPath path, bool creatable)
+        private IDirectory GetDirectory(DirectoryPath path, bool creatable, bool hidden)
         {
             if (!Directories.ContainsKey(path))
             {
-                Directories.Add(path, new FakeDirectory(this, path, creatable));
+                Directories.Add(path, new FakeDirectory(this, path, creatable, hidden));
             }
             return Directories[path];
         }


### PR DESCRIPTION
This commit adds possibility to filter which files / directories get deleted by the `CleanDirectory` alias.
```csharp
    CleanDirectory("C:/temp/deploy/TestDeployRepo", entry=>!entry.Hidden);
```
Will result in something like
```
Deleting contents of C:/temp/deploy/TestDeployRepo
Skipping C:/temp/deploy/TestDeployRepo/.git because specified predicate
Deleting contents of C:/temp/deploy/TestDeployRepo/bin
```

This is done with adding a where predicate to `Cake.Core.IO.IDirectory` `GetDirectories` & `GetFiles`

Also added `Hidden` property to `Directory` & `File` to expose if file/directory is hidden and a common `IFileSystemInfo` do enable a common predicate for `CleanDirectory`

Added new overloads & tests for this, also added option to specify action to get "callback" when files are excluded, use this in the `Cake.Common.IO.DirectoryCleaner::Clean` method to not delete directories when child directories/files still remain after clean and verbose output which files are skipped.
