### PR TITLE
Added process output&timeout, fixed codegen issue

### DIFF
--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/MethodAliasGeneratorTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/MethodAliasGeneratorTests.cs
@@ -85,7 +85,7 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
             {
                 const string expected = "public void NonGeneric_ExtensionMethodWithParameter(System.Int32 value){" +
                                         "Cake.Core.Tests.Fixtures.MethodAliasGeneratorFixture.NonGeneric_ExtensionMethodWithParameter" +
-                                        "(GetContext(),value);}";
+                                        "(GetContext(), value);}";
 
                 var method = typeof(MethodAliasGeneratorFixture).GetMethod("NonGeneric_ExtensionMethodWithParameter");
 
@@ -101,7 +101,7 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
             {
                 const string expected = "public void NonGeneric_ExtensionMethodWithGenericParameter(System.Action<System.Int32> value){" +
                                         "Cake.Core.Tests.Fixtures.MethodAliasGeneratorFixture.NonGeneric_ExtensionMethodWithGenericParameter" +
-                                        "(GetContext(),value);}";
+                                        "(GetContext(), value);}";
 
                 var method = typeof(MethodAliasGeneratorFixture).GetMethod("NonGeneric_ExtensionMethodWithGenericParameter");
 
@@ -149,7 +149,7 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
             {
                 const string expected = "public void Generic_ExtensionMethodWithParameter<TTest>(TTest value){" +
                                         "Cake.Core.Tests.Fixtures.MethodAliasGeneratorFixture.Generic_ExtensionMethodWithParameter<TTest>" +
-                                        "(GetContext(),value);}";
+                                        "(GetContext(), value);}";
 
                 var method = typeof(MethodAliasGeneratorFixture).GetMethods().SingleOrDefault(x => x.Name == "Generic_ExtensionMethodWithParameter");
 
@@ -165,7 +165,7 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
             {
                 const string expected = "public TTest Generic_ExtensionMethodWithGenericReturnValue<TTest>(TTest value){" +
                                         "return Cake.Core.Tests.Fixtures.MethodAliasGeneratorFixture.Generic_ExtensionMethodWithGenericReturnValue<TTest>" +
-                                        "(GetContext(),value);}";
+                                        "(GetContext(), value);}";
 
                 var method = typeof(MethodAliasGeneratorFixture).GetMethods().SingleOrDefault(x => x.Name == "Generic_ExtensionMethodWithGenericReturnValue");
 
@@ -181,7 +181,7 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
             {
                 const string expected = "public void NonGeneric_ExtensionMethodWithParameterArray(params System.Int32[] values){" +
                                         "Cake.Core.Tests.Fixtures.MethodAliasGeneratorFixture.NonGeneric_ExtensionMethodWithParameterArray" +
-                                        "(GetContext(),values);}";
+                                        "(GetContext(), values);}";
 
                 var method = typeof(MethodAliasGeneratorFixture).GetMethod("NonGeneric_ExtensionMethodWithParameterArray");
 

--- a/src/Cake.Core/Extensions/TypeExtensions.cs
+++ b/src/Cake.Core/Extensions/TypeExtensions.cs
@@ -40,8 +40,9 @@ namespace Cake.Core
             {
                 return type.Name;
             }
-            return type.IsGenericType
-                ? GetGenericTypeName(type, includeNamespace)
+            Type genericType;
+            return type.IsGenericType(out genericType)
+                ? GetGenericTypeName(genericType, includeNamespace)
                 : includeNamespace ? type.FullName : type.Name;
         }
 
@@ -58,6 +59,14 @@ namespace Cake.Core
             builder.Append(GetGenericTypeArguments(type, includeNamespace));
             builder.Append(">");
             return builder.ToString();
+        }
+
+        private static bool IsGenericType(this Type type, out Type genericType)
+        {
+            genericType = type.IsByRef
+                ? (type.GetElementType() ?? type)
+                : type;
+            return genericType.IsGenericType;
         }
 
         private static string GetGenericTypeArguments(this Type type, bool includeNamespace)

--- a/src/Cake.Core/IO/IProcess.cs
+++ b/src/Cake.Core/IO/IProcess.cs
@@ -13,6 +13,13 @@ namespace Cake.Core.IO
         void WaitForExit();
 
         /// <summary>
+        /// Waits for the process to exit with possible timeout for command.
+        /// </summary>
+        /// <param name="milliseconds">The amount of time, in milliseconds, to wait for the associated process to exit. The maximum is the largest possible value of a 32-bit integer, which represents infinity to the operating system.</param>
+        /// <returns>true if the associated process has exited; otherwise, false.</returns>
+        bool WaitForExit(int milliseconds);
+
+        /// <summary>
         /// Gets the exit code of the process.
         /// </summary>
         /// <returns>The exit code of the process.</returns>

--- a/src/Cake.Core/IO/ProcessSettings.cs
+++ b/src/Cake.Core/IO/ProcessSettings.cs
@@ -22,5 +22,10 @@
         /// </summary>
         /// <value>true if output should be written to <see cref="P:System.Diagnostics.Process.StandardOutput"/>; otherwise, false. The default is false.</value>
         public bool RedirectStandardOutput { get; set; }
+
+        /// <summary>
+        /// Gets or sets optional timeout for process execution
+        /// </summary>
+        public int? Timeout { get; set; }
     }
 }

--- a/src/Cake.Core/IO/ProcessWrapper.cs
+++ b/src/Cake.Core/IO/ProcessWrapper.cs
@@ -20,6 +20,20 @@ namespace Cake.Core.IO
             _process.WaitForExit();
         }
 
+        public bool WaitForExit(int milliseconds)
+        {
+            if (_process.WaitForExit(milliseconds))
+            {
+                return true;
+            }
+            _process.Refresh();
+            if (!_process.HasExited)
+            {
+                _process.Kill();
+            }
+            return false;
+        }
+
         public int GetExitCode()
         {
             return _process.ExitCode;


### PR DESCRIPTION
* Added option for getting the console output of an process
* Added option for setting an timeout when executing an process
* Fixed codegen issue with alias proxies and generic out parameters

Example usage of console output
```csharp
IEnumerable<string> redirectedOutput;
var exitCodeWithArgument = StartProcess("ping", new ProcessSettings{
Arguments = "localhost",
RedirectStandardOutput = true
},
out redirectedOutput
);
//Output last line of process output
Information("Last line of output: {0}", redirectedOutput.LastOrDefault());

// This should output 0 as valid arguments supplied
Information("Exit code: {0}", exitCodeWithArgument);
```
This will output something similar to:
```
Last line of output:     Minimum = 0ms, Maximum = 0ms, Average = 0ms
Exit code: 0
```

Example usage of process timeout
```csharp
var exitCodeWithArgument = StartProcess("ping", new ProcessSettings{
Arguments = "localhost",
Timeout = 1000
});
```
If operation takes longer than 1000ms it will output
```
Error: Process TimeOut (1000): ping
```