### PR TITLE
Changed argument precedence in favor of help/version

### DIFF
--- a/src/Cake.Tests/Unit/CakeApplicationTests.cs
+++ b/src/Cake.Tests/Unit/CakeApplicationTests.cs
@@ -197,7 +197,7 @@ namespace Cake.Tests.Unit
             }
 
             [Fact]
-            public void Should_Not_Create_Help_Command_If_Script_Is_Specified()
+            public void Should_Create_Help_Command_Even_If_Script_Is_Specified()
             {
                 // Given
                 var fixture = new CakeApplicationFixture();
@@ -208,11 +208,12 @@ namespace Cake.Tests.Unit
                 fixture.RunApplication();
 
                 // Then
-                fixture.CommandFactory.Received(1).CreateBuildCommand();
+                fixture.CommandFactory.Received(0).CreateBuildCommand();
+                fixture.CommandFactory.Received(1).CreateHelpCommand();
             }
 
             [Fact]
-            public void Should_Not_Create_Version_Command_If_Script_Is_Specified()
+            public void Should_Create_Version_Command_Even_If_Script_Is_Specified()
             {
                 // Given
                 var fixture = new CakeApplicationFixture();
@@ -223,7 +224,8 @@ namespace Cake.Tests.Unit
                 fixture.RunApplication();
 
                 // Then
-                fixture.CommandFactory.Received(1).CreateBuildCommand();
+                fixture.CommandFactory.Received(0).CreateBuildCommand();
+                fixture.CommandFactory.Received(1).CreateVersionCommand();
             }
         }
     }

--- a/src/Cake/CakeApplication.cs
+++ b/src/Cake/CakeApplication.cs
@@ -84,6 +84,14 @@ namespace Cake
         {
             if (options != null)
             {
+                if (options.ShowHelp)
+                {
+                    return _commandFactory.CreateHelpCommand();
+                }
+                if (options.ShowVersion)
+                {
+                    return _commandFactory.CreateVersionCommand();
+                }
                 if (options.Script != null)
                 {
                     if (options.ShowDescription)
@@ -92,14 +100,6 @@ namespace Cake
                         return _commandFactory.CreateDescriptionCommand();
                     }
                     return _commandFactory.CreateBuildCommand();
-                }
-                if (options.ShowHelp)
-                {
-                    return _commandFactory.CreateHelpCommand();
-                }
-                if (options.ShowVersion)
-                {
-                    return _commandFactory.CreateVersionCommand();
                 }
             }
             return _commandFactory.CreateHelpCommand();


### PR DESCRIPTION
Since default script functionality was added it's kinda hard to reach the help / version functionality.

In this PR I propose a raised priority of help / version command to be invoked regardless of other parameters.

Also modified tests to work accordingly