### PR TITLE
Added aliases for executing cake scripts out of process

### DIFF
--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Fixtures\AppVeyorInfoFixture.cs" />
     <Compile Include="Fixtures\AssemblyInfoFixture.cs" />
     <Compile Include="Fixtures\AssemblyInfoParserFixture.cs" />
+    <Compile Include="Fixtures\CakeRunnerFixture.cs" />
     <Compile Include="Fixtures\FileCopyFixture.cs" />
     <Compile Include="Fixtures\FileDeleteFixture.cs" />
     <Compile Include="Fixtures\FileSystemFixture.cs" />
@@ -96,6 +97,7 @@
     <Compile Include="Unit\Text\TextTransformationAliasesTests.cs" />
     <Compile Include="Unit\Text\TextTransformationExtensionsTests.cs" />
     <Compile Include="Unit\Text\TextTransformationTests.cs" />
+    <Compile Include="Unit\Tools\Cake\CakeRunnerTests.cs" />
     <Compile Include="Unit\Tools\ILMerge\ILMergeRunnerTests.cs" />
     <Compile Include="Unit\Tools\ILMerge\ILMergeSettingsTests.cs" />
     <Compile Include="Unit\IO\ZipperTests.cs" />

--- a/src/Cake.Common.Tests/Fixtures/CakeRunnerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/CakeRunnerFixture.cs
@@ -1,0 +1,51 @@
+﻿using Cake.Common.Tools.Cake;
+using Cake.Core;
+using Cake.Core.IO;
+using NSubstitute;
+
+namespace Cake.Common.Tests.Fixtures
+{
+    internal sealed class CakeRunnerFixture
+    {
+        public IFileSystem FileSystem { get; set; }
+        public IProcess Process { get; set; }
+        public IProcessRunner ProcessRunner { get; set; }
+        public ICakeEnvironment Environment { get; set; }
+        public IGlobber Globber { get; set; }
+        public FilePath ScriptPath { get; set; }
+        public CakeSettings Settings { get; set; }
+        public CakeRunnerFixture(FilePath toolPath = null, bool defaultToolExist = true, bool scriptExist = true)
+        {
+            ScriptPath = "/Working/build.cake";
+
+            Process = Substitute.For<IProcess>();
+            Process.GetExitCode().Returns(0);
+
+            ProcessRunner = Substitute.For<IProcessRunner>();
+            ProcessRunner.Start(Arg.Any<FilePath>(), Arg.Any<ProcessSettings>()).Returns(Process);
+
+            Environment = Substitute.For<ICakeEnvironment>();
+            Environment.WorkingDirectory = "/Working";
+
+            Globber = Substitute.For<IGlobber>();
+            Globber.Match("./tools/**/Cake.exe").Returns(new[] { (FilePath)"/Working/tools/Cake.exe" });
+
+            FileSystem = Substitute.For<IFileSystem>();
+            FileSystem.Exist(Arg.Is<FilePath>(a => a.FullPath == "/Working/tools/Cake.exe")).Returns(defaultToolExist);
+            FileSystem.Exist(Arg.Is<FilePath>(a => a.FullPath == "/Working/build.cake")).Returns(scriptExist);
+
+            if (toolPath != null)
+            {
+                FileSystem.Exist(Arg.Is<FilePath>(a => a.FullPath == toolPath.FullPath)).Returns(true);
+            }
+
+            Settings = new CakeSettings();
+        }
+
+        public void Run()
+        {
+            var runner = new CakeRunner(FileSystem, Environment, Globber, ProcessRunner);
+            runner.ExecuteScript(ScriptPath, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/Cake/CakeRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Cake/CakeRunnerTests.cs
@@ -1,0 +1,139 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Cake.Common.Tests.Fixtures;
+using Cake.Common.Tools.Cake;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using NSubstitute;
+using Xunit;
+using Path = Cake.Core.IO.Path;
+
+namespace Cake.Common.Tests.Unit.Tools.Cake
+{
+    public sealed class CakeRunnerTests
+    {
+        public sealed class TheExecuteScriptMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Script_Path_Was_Null()
+            {
+                // Given
+                var fixture = new CakeRunnerFixture();
+                fixture.ScriptPath = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "scriptPath");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Script_Is_Missing()
+            {
+                // Given
+                var fixture = new CakeRunnerFixture();
+                fixture.ScriptPath = "/Working/missing.cake";
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsType<FileNotFoundException>(result);
+                Assert.Equal("Cake script file not found.", result.Message);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Cake_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new CakeRunnerFixture();
+                fixture.Globber.Match("./tools/**/Cake.exe").Returns(Enumerable.Empty<Path>());
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("Cake: Could not locate executable.", result.Message);
+            }
+
+            [Theory]
+            [InlineData("C:/Cake/Cake.exe", "C:/Cake/Cake.exe")]
+            [InlineData("./tools/Cake/Cake.exe", "/Working/tools/Cake/Cake.exe")]
+            public void Should_Use_Cake_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new CakeRunnerFixture(expected);
+                fixture.Settings.ToolPath = toolPath;               
+
+                // When
+                fixture.Run();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == expected),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Add_Provided_Script_To_Process_Arguments()
+            {
+                // Given
+                var fixture = new CakeRunnerFixture();
+
+                // When
+                fixture.Run();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(),
+                    Arg.Is<ProcessSettings>(p => 
+                        p.Arguments.Render() == "\"/Working/build.cake\""));
+            }
+
+            [Fact]
+            public void Should_Add_Provided_Verbosity_To_Process_Arguments()
+            {
+                // Given
+                var fixture = new CakeRunnerFixture();
+                fixture.Settings = new CakeSettings{ Verbosity = Verbosity.Diagnostic };
+
+                // When
+                fixture.Run();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(),
+                    Arg.Is<ProcessSettings>(p => 
+                        p.Arguments.Render() == "\"/Working/build.cake\" -verbosity=Diagnostic"));
+            }
+
+            [Fact]
+            public void Should_Add_Provided_Arguments_To_Process_Arguments()
+            {
+                // Given
+                var fixture = new CakeRunnerFixture();
+                fixture.Settings = new CakeSettings
+                {
+                    Arguments = new Dictionary<string, string>
+                    {
+                        { "target", "Build" },
+                        { "configuration", "Debug" }
+                    }
+                };
+
+                // When
+                fixture.Run();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(),
+                    Arg.Is<ProcessSettings>(p => 
+                        p.Arguments.Render() == "\"/Working/build.cake\" -target=\"Build\" -configuration=\"Debug\""));
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -85,6 +85,9 @@
     <Compile Include="Text\TextTransformationAliases.cs" />
     <Compile Include="Text\TextTransformation.cs" />
     <Compile Include="Text\TextTransformationExtensions.cs" />
+    <Compile Include="Tools\Cake\CakeAliases.cs" />
+    <Compile Include="Tools\Cake\CakeRunner.cs" />
+    <Compile Include="Tools\Cake\CakeSettings.cs" />
     <Compile Include="Tools\ILMerge\ILMergeAliases.cs" />
     <Compile Include="Tools\ILMerge\ILMergeRunner.cs" />
     <Compile Include="Tools\ILMerge\ILMergeSettings.cs" />

--- a/src/Cake.Common/Tools/Cake/CakeAliases.cs
+++ b/src/Cake.Common/Tools/Cake/CakeAliases.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Cake
+{
+    /// <summary>
+    /// Contains functionality related to running Cake scripts out of process.
+    /// </summary>
+    public static class CakeAliases
+    {
+        /// <summary>
+        /// Executes cake script out of process
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="cakeScriptPath">The script file.</param>
+        [CakeMethodAlias]
+        public static void CakeExecuteScript(this ICakeContext context, FilePath cakeScriptPath)
+        {
+            context.CakeExecuteScript(cakeScriptPath, null);
+        }
+
+        /// <summary>
+        /// Executes cake script out of process
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="cakeScriptPath">The script file.</param>
+        /// <param name="settings">The settings <see cref="CakeSettings"/>.</param>
+        [CakeMethodAlias]
+        public static void CakeExecuteScript(this ICakeContext context, FilePath cakeScriptPath, CakeSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var cakeRunner = new CakeRunner(context.FileSystem, context.Environment, context.Globber, context.ProcessRunner);
+            cakeRunner.ExecuteScript(cakeScriptPath, settings);
+        }
+
+        /// <summary>
+        /// Executes Cake expression out of process
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="cakeExpression">The cake expression</param>
+        [CakeMethodAlias]
+        public static void CakeExecuteExpression(this ICakeContext context, string cakeExpression)
+        {
+            context.CakeExecuteExpression(cakeExpression, null);
+        }
+
+        /// <summary>
+        /// Executes Cake expression out of process
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="cakeExpression">The cake expression</param>
+        /// <param name="settings">The settings <see cref="CakeSettings"/>.</param>
+        [CakeMethodAlias]
+        public static void CakeExecuteExpression(this ICakeContext context, string cakeExpression, CakeSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var cakeRunner = new CakeRunner(context.FileSystem, context.Environment, context.Globber, context.ProcessRunner);
+            cakeRunner.ExecuteExpression(cakeExpression, settings);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/Cake/CakeRunner.cs
+++ b/src/Cake.Common/Tools/Cake/CakeRunner.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Utilities;
+
+namespace Cake.Common.Tools.Cake
+{
+    /// <summary>
+    /// Cake out process runner
+    /// </summary>
+    public sealed class CakeRunner : Tool<CakeSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+        private readonly IGlobber _globber;
+        private readonly IFileSystem _fileSystem;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CakeRunner"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="globber">The globber.</param>
+        /// <param name="processRunner">The process runner.</param>
+        public CakeRunner(IFileSystem fileSystem, ICakeEnvironment environment, IGlobber globber,
+            IProcessRunner processRunner)
+            : base(fileSystem, environment, processRunner)
+        {
+            _environment = environment;
+            _globber = globber;
+            _fileSystem = fileSystem;
+        }
+
+        /// <summary>
+        /// Executes supplied cake script in own process and supplied settings
+        /// </summary>
+        /// <param name="scriptPath">Path to script to execute</param>
+        /// <param name="settings">optional cake settings</param>
+        public void ExecuteScript(FilePath scriptPath, CakeSettings settings = null)
+        {
+            if (scriptPath == null)
+            {
+                throw new ArgumentNullException("scriptPath");
+            }
+
+            if (!_fileSystem.GetFile(scriptPath).Exists)
+            {
+                throw new FileNotFoundException("Cake script file not found.", scriptPath.FullPath);
+            }
+
+            settings = settings ?? new CakeSettings();
+
+            Run(settings, GetArguments(scriptPath, settings), settings.ToolPath);
+        }
+
+        /// <summary>
+        /// Executes supplied cake code expression in own process and supplied settings
+        /// </summary>
+        /// <param name="cakeExpression">Code expression to execute</param>
+        /// <param name="settings">optional cake settings</param>
+       [SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
+       public void ExecuteExpression(string cakeExpression, CakeSettings settings = null)
+        {
+            if (string.IsNullOrWhiteSpace(cakeExpression))
+            {
+                throw new ArgumentNullException("cakeExpression");
+            }
+            DirectoryPath tempPath = _environment.GetEnvironmentVariable("TEMP") ?? "./";
+            var tempScriptFile = _fileSystem.GetFile(tempPath
+                .CombineWithFilePath(string.Format(CultureInfo.InvariantCulture, "{0}.cake", Guid.NewGuid()))
+                .MakeAbsolute(_environment));
+            try
+            {
+                using (var stream = tempScriptFile.OpenWrite())
+                {
+                    using (var streamWriter = new StreamWriter(stream, Encoding.UTF8))
+                    {
+                        streamWriter.WriteLine(cakeExpression);
+                    }
+                }
+                ExecuteScript(tempScriptFile.Path.FullPath, settings);
+            }
+            finally
+            {
+                if (tempScriptFile.Exists)
+                {
+                    tempScriptFile.Delete();
+                }
+            }
+        }
+
+        private ProcessArgumentBuilder GetArguments(FilePath scriptPath, CakeSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+            builder.AppendQuoted(scriptPath.MakeAbsolute(_environment).FullPath);
+
+            if (settings.Verbosity.HasValue)
+            {
+                builder.Append(string.Concat("-verbosity=", settings.Verbosity.Value.ToString()));
+            }
+
+            if (settings.Arguments != null)
+            {
+                foreach (var argument in settings.Arguments)
+                {
+                    builder.Append(string.Format(
+                        CultureInfo.InvariantCulture,
+                        "-{0}={1}",
+                        argument.Key,
+                        (argument.Value ?? string.Empty).Quote()));
+                }
+            }
+            return builder;
+        }
+
+        /// <summary>
+        /// Gets the name of the tool.
+        /// </summary>
+        /// <returns>The name of the tool.</returns>
+        protected override string GetToolName()
+        {
+            return "Cake";
+        }
+
+        /// <summary>
+        /// Gets the default tool path.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The default tool path.</returns>
+        protected override FilePath GetDefaultToolPath(CakeSettings settings)
+        {
+            const string expression = "./tools/**/Cake.exe";
+            return _globber.GetFiles(expression).FirstOrDefault();
+        }
+    }
+}

--- a/src/Cake.Common/Tools/Cake/CakeSettings.cs
+++ b/src/Cake.Common/Tools/Cake/CakeSettings.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Cake
+{
+    /// <summary>
+    /// Contains settings used by <see cref="CakeRunner"/>.
+    /// </summary>
+    public sealed class CakeSettings
+    {
+        /// <summary>
+        /// Gets or sets the tool path.
+        /// </summary>
+        /// <value>The tool path.</value>
+        public FilePath ToolPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the output verbosity.
+        /// </summary>
+        /// <value>The output verbosity.</value>
+        public Verbosity? Verbosity { get; set; }
+
+        /// <summary>
+        /// Gets or sets cake additional arguments.
+        /// </summary>
+        /// <value>The properties.</value>
+        public IDictionary<string, string> Arguments { get; set; }
+    }
+}


### PR DESCRIPTION
Proposed added functionality to the DSL to run cake scripts & expression out of process.

Example usage script:
```csharp
CakeExecuteScript("build.cake", new CakeSettings { ToolPath="./src/Cake/bin/debug/cake.exe" });
```
Example usage expression:
```csharp
CakeExecuteExpression("Information(\"Hello!\");", new CakeSettings { ToolPath="./src/Cake/bin/debug/cake.exe" });
```