### PR TITLE
Implemented a file hash calculator.

### DIFF
--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Unit\Build\AppVeyor\Data\AppVeyorRepositoryInfoTests.cs" />
     <Compile Include="Unit\Build\BuildSystemAliasesTests.cs" />
     <Compile Include="Unit\Build\BuildSystemTests.cs" />
+    <Compile Include="Unit\Security\FileHashCalculatorTests.cs" />
     <Compile Include="Unit\Solution\Project\Properties\AssemblyInfoCreatorTests.cs" />
     <Compile Include="Unit\Solution\Project\Properties\AssemblyInfoParserTests.cs" />
     <Compile Include="Unit\Diagnostics\LoggingAliasesTests.cs" />

--- a/src/Cake.Common.Tests/Unit/Security/FileHashCalculatorTests.cs
+++ b/src/Cake.Common.Tests/Unit/Security/FileHashCalculatorTests.cs
@@ -1,0 +1,46 @@
+﻿using Cake.Common.Security;
+using Cake.Core;
+using Cake.Core.IO;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Security
+{
+    public sealed class FileHashCalculatorTests
+    {
+        public sealed class TheCalculateMethod 
+        {
+            [Fact]
+            public void Should_Throw_If_File_Path_Is_Null()
+            {
+                // Given
+                var fileSystem = Substitute.For<IFileSystem>();
+                var calculator = new FileHashCalculator(fileSystem);
+
+                // When
+                var result = Record.Exception(() => calculator.Calculate(null, HashAlgorithm.MD5));
+
+                // Then
+                Assert.IsArgumentNullException(result, "filePath");
+            }
+
+            [Fact]
+            public void Should_Throw_If_File_Does_Not_Exist()
+            {
+                // Given
+                var fileSystem = Substitute.For<IFileSystem>();
+                var file = Substitute.For<IFile>();
+                file.Exists.Returns(false);
+                fileSystem.GetFile(Arg.Any<FilePath>()).Returns(file);
+
+                var calculator = new FileHashCalculator(fileSystem);
+
+                // When
+                var result = Record.Exception(() => calculator.Calculate("./non-existent-path", HashAlgorithm.MD5));
+
+                // Then
+                Assert.IsExceptionWithMessage<CakeException>(result, "File 'non-existent-path' does not exist.");
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -62,6 +62,10 @@
     <Compile Include="Properties\Namespaces.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="Security\HashAlgorithm.cs" />
+    <Compile Include="Security\FileHash.cs" />
+    <Compile Include="Security\FileHashCalculator.cs" />
+    <Compile Include="Security\SecurityAliases.cs" />
     <Compile Include="Solution\Project\ProjectAliases.cs" />
     <Compile Include="Solution\Project\ProjectFile.cs" />
     <Compile Include="Solution\Project\ProjectParser.cs" />

--- a/src/Cake.Common/Security/FileHash.cs
+++ b/src/Cake.Common/Security/FileHash.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Text;
+using Cake.Core.IO;
+
+namespace Cake.Common.Security
+{
+    /// <summary>
+    /// Represents a calculated file hash.
+    /// </summary>
+    public sealed class FileHash
+    {
+        private readonly FilePath _filePath;
+        private readonly byte[] _hash;
+        private readonly HashAlgorithm _hashAlgorithm;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileHash"/> class.
+        /// </summary>
+        /// <param name="filePath">The file path.</param>
+        /// <param name="hash">The computed hash.</param>
+        /// <param name="hashAlgorithm">The algorithm used.</param>
+        public FileHash(FilePath filePath, byte[] hash, HashAlgorithm hashAlgorithm)
+        {
+            if (filePath == null)
+            {
+                throw new ArgumentNullException("filePath");
+            }
+
+            if (hash == null)
+            {
+                throw new ArgumentNullException("hash");
+            }
+
+            _filePath = filePath;
+            _hash = (byte[])hash.Clone();
+            _hashAlgorithm = hashAlgorithm;
+        }
+
+        /// <summary>
+        /// Gets the algorithm used for the hash computation.
+        /// </summary>
+        public HashAlgorithm Algorithm
+        {
+            get { return _hashAlgorithm; }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="FilePath"/> for the file.
+        /// </summary>
+        public FilePath Path
+        {
+            get { return _filePath; }
+        }
+
+        /// <summary>
+        /// Gets the raw computed hash.
+        /// </summary>
+        public byte[] ComputedHash
+        {
+            get { return (byte[])_hash.Clone(); }
+        }
+
+        /// <summary>
+        /// Convert the file hash to a hexadecimal string.
+        /// </summary>
+        /// <returns>A hexadecimal string representing the computed hash.</returns>
+        public string ToHex()
+        {
+            // Each byte becomes two characters. Prepare the StringBuilder accordingly.
+            var builder = new StringBuilder(_hash.Length * 2);
+
+            foreach (var b in _hash)
+            {
+                builder.AppendFormat("{0:x2}", b);
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/src/Cake.Common/Security/FileHashCalculator.cs
+++ b/src/Cake.Common/Security/FileHashCalculator.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Globalization;
+using System.Security.Cryptography;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Security
+{
+    /// <summary>
+    /// Represents a file hash operation.
+    /// </summary>
+    public sealed class FileHashCalculator
+    {
+        private readonly IFileSystem _fileSystem;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileHashCalculator"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        public FileHashCalculator(IFileSystem fileSystem)
+        {
+            if (fileSystem == null)
+            {
+                throw new ArgumentNullException("fileSystem");
+            }
+
+            _fileSystem = fileSystem;
+        }
+
+        /// <summary>
+        /// Calculates the hash for a file using the given algorithm.
+        /// </summary>
+        /// <param name="filePath">The file path.</param>
+        /// <param name="hashAlgorithm">The algorithm to use.</param>
+        /// <returns>A <see cref="FileHash"/> instance representing the calculated hash.</returns>
+        public FileHash Calculate(FilePath filePath, HashAlgorithm hashAlgorithm)
+        {
+            if (filePath == null)
+            {
+                throw new ArgumentNullException("filePath");
+            }
+
+            var file = _fileSystem.GetFile(filePath);
+
+            if (!file.Exists)
+            {
+                const string format = "File '{0}' does not exist.";
+                var message = string.Format(CultureInfo.InvariantCulture, format, filePath.FullPath);
+                throw new CakeException(message);
+            }
+
+            using (var hashAlgo = GetHashAlgorithm(hashAlgorithm))
+            using (var readStream = file.OpenRead())
+            {
+                var hash = hashAlgo.ComputeHash(readStream);
+                return new FileHash(filePath, hash, hashAlgorithm);
+            }
+        }
+
+        private System.Security.Cryptography.HashAlgorithm GetHashAlgorithm(HashAlgorithm hashAlgorithm)
+        {
+            switch (hashAlgorithm)
+            {
+                case HashAlgorithm.MD5:
+                    return new MD5CryptoServiceProvider();
+                    
+                case HashAlgorithm.SHA256:
+                    return new SHA256Managed();
+
+                case HashAlgorithm.SHA512:
+                    return new SHA512Managed();
+            }
+
+            throw new NotSupportedException(hashAlgorithm.ToString());
+        }
+    }
+}

--- a/src/Cake.Common/Security/HashAlgorithm.cs
+++ b/src/Cake.Common/Security/HashAlgorithm.cs
@@ -1,0 +1,26 @@
+﻿namespace Cake.Common.Security
+{
+    /// <summary>
+    /// The hash algorithm to use for a specific operation.
+    /// </summary>
+    public enum HashAlgorithm
+    {
+        /// <summary>
+        /// The MD5 hash algorithm.
+        /// </summary>
+        // ReSharper disable once InconsistentNaming
+        MD5,
+
+        /// <summary>
+        /// The SHA256 hash algorithm.
+        /// </summary>
+        // ReSharper disable once InconsistentNaming
+        SHA256,
+
+        /// <summary>
+        /// The SHA512 hash algorithm.
+        /// </summary>
+        // ReSharper disable once InconsistentNaming
+        SHA512
+    }
+}

--- a/src/Cake.Common/Security/SecurityAliases.cs
+++ b/src/Cake.Common/Security/SecurityAliases.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+
+namespace Cake.Common.Security
+{
+    /// <summary>
+    /// Contains security related functionality, such as calculating file
+    /// hashes.
+    /// </summary>
+    [CakeAliasCategory("Security")]
+    public static class SecurityAliases
+    {
+        /// <summary>
+        /// Calculates the hash for a given file using the default (SHA256) algorithm.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="filePath">The file path.</param>
+        /// <returns>A <see cref="FileHash"/> instance representing the calculated hash.</returns>
+        [CakeMethodAlias]
+        public static FileHash CalculateFileHash(this ICakeContext context, FilePath filePath)
+        {
+            return CalculateFileHash(context, filePath, HashAlgorithm.SHA256);
+        }
+
+        /// <summary>
+        /// Calculates the hash for a given file.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="filePath">The file path.</param>
+        /// <param name="hashAlgorithm">The hash algorithm to use.</param>
+        /// <returns>A <see cref="FileHash"/> instance representing the calculated hash.</returns>
+        [CakeMethodAlias]
+        public static FileHash CalculateFileHash(this ICakeContext context, FilePath filePath, HashAlgorithm hashAlgorithm)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var fileHashCalulator = new FileHashCalculator(context.FileSystem);
+            return fileHashCalulator.Calculate(filePath, hashAlgorithm);
+        }
+    }
+}


### PR DESCRIPTION
A small but useful alias for calculating file hashes. This can be used when (for example) publishing packages online and one wants to publish the file hash alongside it.

The default hash is SHA256 which is the same as Powershell uses as default hash in the `Get-FileHash` cmdlet.

## Usage example

```csharp
// Calculate the default SHA256 hash.
FileHash sha256Hash = CalculateFileHash("./some-file.txt");
Information("Hash: " + sha256Hash.ToHex());

// Calculate the MD5 hash.
FileHash md5Hash = CalculateFileHash("./some-file.txt", HashAlgorithm.MD5);
Information("Hash: " + md5Hash.ToHex());
```