### PR TITLE
Fixed script path bug.

### DIFF
--- a/src/Cake.Core.Tests/Unit/Scripting/ScriptRunnerTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/ScriptRunnerTests.cs
@@ -267,6 +267,26 @@ namespace Cake.Core.Tests.Unit.Scripting
                 // Then
                 fixture.Session.Received(1).Execute(fixture.GetExpectedSource());
             }
+
+            [Theory]
+            [InlineData("test/build.cake")]
+            [InlineData("./test/build.cake")]
+            [InlineData("/test/build.cake")]
+            public void Should_Remove_Directory_From_Script_Path(string path)
+            {
+                // Given
+                var fixture = new ScriptRunnerFixture(path);
+                fixture.ScriptProcessor = Substitute.For<IScriptProcessor>();
+                var runner = fixture.CreateScriptRunner();
+
+                // When
+                runner.Run(fixture.Host, fixture.Script, fixture.ArgumentDictionary);
+
+                // Then
+                fixture.ScriptProcessor.Received(1).Process(
+                    Arg.Is<FilePath>(p => p.FullPath == "build.cake"), 
+                    Arg.Any<ScriptProcessorContext>());
+            }
         }
     }
 }

--- a/src/Cake.Core/Scripting/ScriptRunner.cs
+++ b/src/Cake.Core/Scripting/ScriptRunner.cs
@@ -69,6 +69,9 @@ namespace Cake.Core.Scripting
             // Set the working directory.
             host.Environment.WorkingDirectory = script.MakeAbsolute(host.Environment).GetDirectory();
 
+            // Make sure that any directories are stripped from the script path.
+            script = script.GetFilename();
+
             // Create and prepare the session.
             var session = _sessionFactory.CreateSession(host);
 


### PR DESCRIPTION
Fixes a bug that might have to do with issue #172.

If a script with the path `test/build.cake` is passed to `Cake.exe`, The script runner would set the `test` directory as the working directory (as expected) but would forget to strip the directory part of the script path which would result in a working directory `./test` and the script path `test/build.cake`, which would evaluate to the absolute script path `./test/test/build.cake`.

Since the convention so far has been to put the build scripts in the root directory, we simply haven't noticed this...