### PR TITLE
Made text transformation placeholders configurable.

### DIFF
--- a/src/Cake.Common.Tests/Unit/Text/TextTransformationAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/Text/TextTransformationAliasesTests.cs
@@ -11,94 +11,330 @@ namespace Cake.Common.Tests.Unit.Text
     {
         public sealed class TheTransformTextMethod
         {
-            [Fact]
-            public void Should_Throw_If_Context_Is_Null()
+            public sealed class WithDefaultPlaceholder
             {
-                // Given, When
-                var result = Record.Exception(() => 
-                    TextTransformationAliases.TransformText(null, "Hello World"));
+                [Fact]
+                public void Should_Throw_If_Context_Is_Null()
+                {
+                    // Given, When
+                    var result = Record.Exception(() =>
+                        TextTransformationAliases.TransformText(null, "Hello World"));
 
-                // Then
-                Assert.IsArgumentNullException(result, "context");
+                    // Then
+                    Assert.IsArgumentNullException(result, "context");
+                }
+
+                [Fact]
+                public void Should_Throw_If_Template_Is_Null()
+                {
+                    // Given
+                    var context = Substitute.For<ICakeContext>();
+
+                    // When
+                    var result = Record.Exception(() =>
+                        TextTransformationAliases.TransformText(context, null));
+
+                    // Then
+                    Assert.IsArgumentNullException(result, "template");
+                }
+
+                [Fact]
+                public void Should_Create_Text_Transformation()
+                {
+                    // Given
+                    var context = Substitute.For<ICakeContext>();
+
+                    // When
+                    var result = TextTransformationAliases.TransformText(context, "Hello World");
+
+                    // Then
+                    Assert.Equal("Hello World", result.ToString());
+                }
+
+                [Fact]
+                public void Should_Transform_Text_Using_Specified_Placeholders()
+                {
+                    // Given
+                    var context = Substitute.For<ICakeContext>();
+                    var transform = TextTransformationAliases.TransformText(context, "Hello <%subject%>");
+                    transform.WithToken("subject", "World");
+
+                    // When
+                    var result = transform.ToString();
+
+                    // Then
+                    Assert.Equal("Hello World", result);
+                }
             }
 
-            [Fact]
-            public void Should_Throw_If_Template_Is_Null()
+            public sealed class WithCustomPlaceholder
             {
-                // Given
-                var context = Substitute.For<ICakeContext>();
+                [Fact]
+                public void Should_Throw_If_Context_Is_Null()
+                {
+                    // Given, When
+                    var result = Record.Exception(() =>
+                        TextTransformationAliases.TransformText(null, "Hello World", "{", "}"));
 
-                // When
-                var result = Record.Exception(() =>
-                    TextTransformationAliases.TransformText(context, null));
+                    // Then
+                    Assert.IsArgumentNullException(result, "context");
+                }
 
-                // Then
-                Assert.IsArgumentNullException(result, "template");
+                [Fact]
+                public void Should_Throw_If_Template_Is_Null()
+                {
+                    // Given
+                    var context = Substitute.For<ICakeContext>();
+
+                    // When
+                    var result = Record.Exception(() =>
+                        TextTransformationAliases.TransformText(context, null, "{", "}"));
+
+                    // Then
+                    Assert.IsArgumentNullException(result, "template");
+                }
+
+                [Fact]
+                public void Should_Throw_If_Left_Placeholder_Is_Null()
+                {
+                    // Given
+                    var context = Substitute.For<ICakeContext>();
+
+                    // When
+                    var result = Record.Exception(() =>
+                        TextTransformationAliases.TransformText(context, null, null, "}"));
+
+                    // Then
+                    Assert.IsArgumentNullException(result, "leftPlaceholder");
+                }
+
+                [Fact]
+                public void Should_Throw_If_Right_Placeholder_Is_Null()
+                {
+                    // Given
+                    var context = Substitute.For<ICakeContext>();
+
+                    // When
+                    var result = Record.Exception(() =>
+                        TextTransformationAliases.TransformText(context, null, "{", null));
+
+                    // Then
+                    Assert.IsArgumentNullException(result, "rightPlaceholder");
+                }
+
+                [Fact]
+                public void Should_Create_Text_Transformation()
+                {
+                    // Given
+                    var context = Substitute.For<ICakeContext>();
+
+                    // When
+                    var result = TextTransformationAliases.TransformText(context, "Hello World", "{", "}");
+
+                    // Then
+                    Assert.Equal("Hello World", result.ToString());
+                }
+
+                [Fact]
+                public void Should_Transform_Text_Using_Specified_Placeholders()
+                {
+                    // Given
+                    var context = Substitute.For<ICakeContext>();
+                    var transform = TextTransformationAliases.TransformText(context, "Hello {subject}", "{", "}");
+                    transform.WithToken("subject", "World");
+
+                    // When
+                    var result = transform.ToString();
+
+                    // Then
+                    Assert.Equal("Hello World", result);
+                }
             }
-
-            [Fact]
-            public void Should_Create_Text_Transformation()
-            {
-                // Given
-                var context = Substitute.For<ICakeContext>();
-               
-                // When
-                var result = TextTransformationAliases.TransformText(context, "Hello World");
-
-                // Then
-                Assert.Equal("Hello World", result.ToString());
-           }
         }
 
         public sealed class TheTransformTextFileMethod
         {
-            [Fact]
-            public void Should_Throw_If_Context_Is_Null()
+            public sealed class WithDefaultPlaceholder
             {
-                // Given, When
-                var result = Record.Exception(() =>
-                    TextTransformationAliases.TransformTextFile(
-                        null, new FilePath("./template.txt")));
+                [Fact]
+                public void Should_Throw_If_Context_Is_Null()
+                {
+                    // Given, When
+                    var result = Record.Exception(() =>
+                        TextTransformationAliases.TransformTextFile(
+                            null, new FilePath("./template.txt")));
 
-                // Then
-                Assert.IsArgumentNullException(result, "context");
+                    // Then
+                    Assert.IsArgumentNullException(result, "context");
+                }
+
+                [Fact]
+                public void Should_Throw_If_Template_Is_Null()
+                {
+                    // Given
+                    var context = Substitute.For<ICakeContext>();
+
+                    // When
+                    var result = Record.Exception(() =>
+                        TextTransformationAliases.TransformTextFile(
+                            context, null));
+
+                    // Then
+                    Assert.IsArgumentNullException(result, "path");
+                }
+
+                [Fact]
+                public void Should_Create_Text_Transformation_From_Disc_Template()
+                {
+                    // Given
+                    var fileSystem = new FakeFileSystem(false);
+                    fileSystem.GetCreatedFile("/Working/template.txt", "Hello World");
+
+                    var environment = Substitute.For<ICakeEnvironment>();
+                    environment.WorkingDirectory.Returns("/Working");
+
+                    var context = Substitute.For<ICakeContext>();
+                    context.FileSystem.Returns(fileSystem);
+                    context.Environment.Returns(environment);
+
+                    // When
+                    var result = TextTransformationAliases.TransformTextFile(
+                        context, "./template.txt");
+
+                    // Then
+                    Assert.Equal("Hello World", result.ToString());
+                }
+
+                [Fact]
+                public void Should_Transform_Text_From_Disc_Template_Using_Default_Placeholders()
+                {
+                    // Given
+                    var fileSystem = new FakeFileSystem(false);
+                    fileSystem.GetCreatedFile("/Working/template.txt", "Hello <%subject%>");
+
+                    var environment = Substitute.For<ICakeEnvironment>();
+                    environment.WorkingDirectory.Returns("/Working");
+
+                    var context = Substitute.For<ICakeContext>();
+                    context.FileSystem.Returns(fileSystem);
+                    context.Environment.Returns(environment);
+
+                    var transform = TextTransformationAliases.TransformTextFile(context, "./template.txt");
+                    transform.WithToken("subject", "World");
+
+                    // When
+                    var result = transform.ToString();
+
+                    // Then
+                    Assert.Equal("Hello World", result);
+                }
             }
 
-            [Fact]
-            public void Should_Throw_If_Template_Is_Null()
+            public sealed class WithCustomPlaceholder
             {
-                // Given
-                var context = Substitute.For<ICakeContext>();
+                [Fact]
+                public void Should_Throw_If_Context_Is_Null()
+                {
+                    // Given, When
+                    var result = Record.Exception(() =>
+                        TextTransformationAliases.TransformTextFile(
+                            null, new FilePath("./template.txt"), "{", "}"));
 
-                // When
-                var result = Record.Exception(() =>
-                    TextTransformationAliases.TransformTextFile(
-                        context, null));
+                    // Then
+                    Assert.IsArgumentNullException(result, "context");
+                }
 
-                // Then
-                Assert.IsArgumentNullException(result, "path");
-            }
+                [Fact]
+                public void Should_Throw_If_Template_Is_Null()
+                {
+                    // Given
+                    var context = Substitute.For<ICakeContext>();
 
-            [Fact]
-            public void Should_Create_Text_Transformation_From_Disc_Template()
-            {
-                // Given
-                var fileSystem = new FakeFileSystem(false);
-                fileSystem.GetCreatedFile("/Working/template.txt", "Hello World");
-                
-                var environment = Substitute.For<ICakeEnvironment>();
-                environment.WorkingDirectory.Returns("/Working");
+                    // When
+                    var result = Record.Exception(() =>
+                        TextTransformationAliases.TransformTextFile(
+                            context, null, "{", "}"));
 
-                var context = Substitute.For<ICakeContext>();
-                context.FileSystem.Returns(fileSystem);
-                context.Environment.Returns(environment);
+                    // Then
+                    Assert.IsArgumentNullException(result, "path");
+                }
 
-                // When
-                var result = TextTransformationAliases.TransformTextFile(
-                    context, "./template.txt");
+                [Fact]
+                public void Should_Throw_If_Left_Placeholder_Is_Null()
+                {
+                    // Given
+                    var context = Substitute.For<ICakeContext>();
 
-                // Then
-                Assert.Equal("Hello World", result.ToString());
+                    // When
+                    var result = Record.Exception(() =>
+                        TextTransformationAliases.TransformTextFile(
+                            context, new FilePath("./template.txt"), null, "}"));
+
+                    // Then
+                    Assert.IsArgumentNullException(result, "leftPlaceholder");
+                }
+
+                [Fact]
+                public void Should_Throw_If_Right_Placeholder_Is_Null()
+                {
+                    // Given
+                    var context = Substitute.For<ICakeContext>();
+
+                    // When
+                    var result = Record.Exception(() =>
+                        TextTransformationAliases.TransformTextFile(
+                            context, new FilePath("./template.txt"), "{", null));
+
+                    // Then
+                    Assert.IsArgumentNullException(result, "rightPlaceholder");
+                }
+
+                [Fact]
+                public void Should_Create_Text_Transformation_From_Disc_Template()
+                {
+                    // Given
+                    var fileSystem = new FakeFileSystem(false);
+                    fileSystem.GetCreatedFile("/Working/template.txt", "Hello World");
+
+                    var environment = Substitute.For<ICakeEnvironment>();
+                    environment.WorkingDirectory.Returns("/Working");
+
+                    var context = Substitute.For<ICakeContext>();
+                    context.FileSystem.Returns(fileSystem);
+                    context.Environment.Returns(environment);
+
+                    // When
+                    var result = TextTransformationAliases.TransformTextFile(
+                        context, "./template.txt", "{", "}");
+
+                    // Then
+                    Assert.Equal("Hello World", result.ToString());
+                }
+
+                [Fact]
+                public void Should_Transform_Text_From_Disc_Template_Using_Specified_Placeholders()
+                {
+                    // Given
+                    var fileSystem = new FakeFileSystem(false);
+                    fileSystem.GetCreatedFile("/Working/template.txt", "Hello {subject}");
+
+                    var environment = Substitute.For<ICakeEnvironment>();
+                    environment.WorkingDirectory.Returns("/Working");
+
+                    var context = Substitute.For<ICakeContext>();
+                    context.FileSystem.Returns(fileSystem);
+                    context.Environment.Returns(environment);
+
+                    var transform = TextTransformationAliases.TransformTextFile(context, "./template.txt", "{", "}");
+                    transform.WithToken("subject", "World");
+
+                    // When
+                    var result = transform.ToString();
+
+
+                    // Then
+                    Assert.Equal("Hello World", result);
+                }
             }
         }
     }

--- a/src/Cake.Common/Text/TextTransformationAliases.cs
+++ b/src/Cake.Common/Text/TextTransformationAliases.cs
@@ -20,17 +20,65 @@ namespace Cake.Common.Text
         /// <param name="context">The context.</param>
         /// <param name="template">The template.</param>
         /// <returns>A <see cref="TextTransformation{TTemplate}"/> representing the provided template.</returns>
+        /// <example>  
+        /// This sample shows how to create a <see cref="TextTransformation{TTemplate}"/> using
+        /// the specified template.
+        /// <code> 
+        /// string text = TransformText("Hello &lt;%subject%&gt;!")
+        ///    .WithToken("subject", "world")
+        ///    .ToString();
+        /// </code> 
+        /// </example> 
         [CakeMethodAlias]
         public static TextTransformation<TextTransformationTemplate> TransformText(this ICakeContext context, string template)
+        {
+            return TransformText(context, template, "<%", "%>");
+        }
+
+        /// <summary>
+        /// Creates a text transformation from the provided template, using the specified placeholder.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="template">The template.</param>
+        /// <param name="leftPlaceholder">The left placeholder.</param>
+        /// <param name="rightPlaceholder">The right placeholder.</param>
+        /// <returns>A <see cref="TextTransformation{TTemplate}"/> representing the provided template.</returns>
+        /// <example>  
+        /// This sample shows how to create a <see cref="TextTransformation{TTemplate}"/> using
+        /// the specified template and placeholder.
+        /// <code> 
+        /// string text = TransformText("Hello {subject}!", "{", "}")
+        ///    .WithToken("subject", "world")
+        ///    .ToString();
+        /// </code> 
+        /// </example> 
+        [CakeMethodAlias]
+        public static TextTransformation<TextTransformationTemplate> TransformText(
+            this ICakeContext context,
+            string template,
+            string leftPlaceholder,
+            string rightPlaceholder)
         {
             if (context == null)
             {
                 throw new ArgumentNullException("context");
             }
+            if (leftPlaceholder == null)
+            {
+                throw new ArgumentNullException("leftPlaceholder");
+            }
+            if (rightPlaceholder == null)
+            {
+                throw new ArgumentNullException("rightPlaceholder");
+            }
 
+            // Create the placeholder.
+            var placeholder = new Tuple<string, string>(leftPlaceholder, rightPlaceholder);
+
+            // Create and return the text transformation.
             return new TextTransformation<TextTransformationTemplate>(
                 context.FileSystem, context.Environment,
-                new TextTransformationTemplate(template));
+                new TextTransformationTemplate(template, placeholder));
         }
 
         /// <summary>
@@ -39,9 +87,46 @@ namespace Cake.Common.Text
         /// <param name="context">The context.</param>
         /// <param name="path">The template file path.</param>
         /// <returns>A <see cref="TextTransformation{TTemplate}"/> representing the provided template.</returns>
+        /// <example>  
+        /// This sample shows how to create a <see cref="TextTransformation{TTemplate}"/> using
+        /// the specified template file with the placeholder format <c>&lt;%key%&gt;</c>.
+        /// <code> 
+        /// string text = TransformTextFile("./template.txt")
+        ///    .WithToken("subject", "world")
+        ///    .ToString();
+        /// </code> 
+        /// </example> 
+        [CakeMethodAlias]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage","CA2202:Do not dispose objects multiple times", Justification = "Stream reader leaves stream open.")]
+        public static TextTransformation<TextTransformationTemplate> TransformTextFile(this ICakeContext context, FilePath path)
+        {
+            return TransformTextFile(context, path, "<%", "%>");
+        }
+
+        /// <summary>
+        /// Creates a text transformation from the provided template on disc, using the specified placeholder.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="path">The template file path.</param>
+        /// <param name="leftPlaceholder">The left placeholder.</param>
+        /// <param name="rightPlaceholder">The right placeholder.</param>
+        /// <returns>A <see cref="TextTransformation{TTemplate}"/> representing the provided template.</returns>
+        /// <example>  
+        /// This sample shows how to create a <see cref="TextTransformation{TTemplate}"/> using
+        /// the specified template file and placeholder.
+        /// <code> 
+        /// string text = TransformTextFile("./template.txt", "{", "}")
+        ///    .WithToken("subject", "world")
+        ///    .ToString();
+        /// </code> 
+        /// </example> 
         [CakeMethodAlias]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times", Justification = "Stream reader leaves stream open.")]
-        public static TextTransformation<TextTransformationTemplate> TransformTextFile(this ICakeContext context, FilePath path)
+        public static TextTransformation<TextTransformationTemplate> TransformTextFile(
+            this ICakeContext context, 
+            FilePath path,
+            string leftPlaceholder,
+            string rightPlaceholder)
         {
             if (context == null)
             {
@@ -51,18 +136,30 @@ namespace Cake.Common.Text
             {
                 throw new ArgumentNullException("path");
             }
+            if (leftPlaceholder == null)
+            {
+                throw new ArgumentNullException("leftPlaceholder");
+            }
+            if (rightPlaceholder == null)
+            {
+                throw new ArgumentNullException("rightPlaceholder");
+            }
 
             // Make the path absolute if necessary.
             path = path.IsRelative ? path.MakeAbsolute(context.Environment) : path;
+
+            // Create the placeholder.
+            var placeholder = new Tuple<string, string>(leftPlaceholder, rightPlaceholder);
 
             // Read the content of the file.
             var file = context.FileSystem.GetFile(path);
             using (var stream = file.OpenRead())
             using (var reader = new StreamReader(stream, Encoding.UTF8, true, 1024, true))
             {
+                // Create and return the text transformation.
                 return new TextTransformation<TextTransformationTemplate>(
                     context.FileSystem, context.Environment,
-                    new TextTransformationTemplate(reader.ReadToEnd()));
+                    new TextTransformationTemplate(reader.ReadToEnd(), placeholder));
             }
         }
     }

--- a/src/Cake.Common/Text/TextTransformationAliases.cs
+++ b/src/Cake.Common/Text/TextTransformationAliases.cs
@@ -97,7 +97,7 @@ namespace Cake.Common.Text
         /// </code> 
         /// </example> 
         [CakeMethodAlias]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage","CA2202:Do not dispose objects multiple times", Justification = "Stream reader leaves stream open.")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times", Justification = "Stream reader leaves stream open.")]
         public static TextTransformation<TextTransformationTemplate> TransformTextFile(this ICakeContext context, FilePath path)
         {
             return TransformTextFile(context, path, "<%", "%>");
@@ -123,7 +123,7 @@ namespace Cake.Common.Text
         [CakeMethodAlias]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times", Justification = "Stream reader leaves stream open.")]
         public static TextTransformation<TextTransformationTemplate> TransformTextFile(
-            this ICakeContext context, 
+            this ICakeContext context,
             FilePath path,
             string leftPlaceholder,
             string rightPlaceholder)

--- a/src/Cake.Core.Tests/Unit/Text/TextTransformationTemplateTests.cs
+++ b/src/Cake.Core.Tests/Unit/Text/TextTransformationTemplateTests.cs
@@ -86,6 +86,21 @@ namespace Cake.Core.Tests.Unit.Text
             }
 
             [Fact]
+            public void Should_Replace_Tokens_With_Different_Placeholder()
+            {
+                // Given
+                var placeholder = new Tuple<string, string>("{{", "}}");
+                var transformation = new TextTransformationTemplate("{{greeting}} world!", placeholder);
+                transformation.Register("greeting", "Hello");
+
+                // When
+                var result = transformation.Render();
+
+                // Then
+                Assert.Equal("Hello world!", result);
+            }
+
+            [Fact]
             public void Should_Keep_Unmatched_Tokens()
             {
                 // Given
@@ -97,6 +112,21 @@ namespace Cake.Core.Tests.Unit.Text
 
                 // Then
                 Assert.Equal("Hello <%subject%>!", result);
+            }
+
+            [Fact]
+            public void Should_Keep_Unmatched_Tokens_With_Different_Placeholder()
+            {
+                // Given
+                var placeholder = new Tuple<string, string>("{{", "}}");
+                var transformation = new TextTransformationTemplate("{{greeting}} {{subject}}!", placeholder);
+                transformation.Register("greeting", "Hello");
+
+                // When
+                var result = transformation.Render();
+
+                // Then
+                Assert.Equal("Hello {{subject}}!", result);
             }
 
             [Theory]
@@ -147,6 +177,21 @@ namespace Cake.Core.Tests.Unit.Text
 
                 // Then
                 Assert.Equal("Hello <%pointer:foo%>", result);
+            }
+
+            [Fact]
+            public void Should_Return_Key_If_The_Value_Was_Not_Formattable_With_Different_Placeholder()
+            {
+                // Given
+                var placeholder = new Tuple<string, string>("{{", "}}");
+                var transformation = new TextTransformationTemplate("Hello {{pointer:foo}}", placeholder);
+                transformation.Register("pointer", IntPtr.Zero);
+
+                // When
+                var result = transformation.Render();
+
+                // Then
+                Assert.Equal("Hello {{pointer:foo}}", result);
             }
 
             [Fact]

--- a/src/Cake.Core/Text/TextTransformationTemplate.cs
+++ b/src/Cake.Core/Text/TextTransformationTemplate.cs
@@ -97,11 +97,13 @@ namespace Cake.Core.Text
                     {
                         return formattable.ToString(format, CultureInfo.InvariantCulture);
                     }
+
                     // Return what we received.
                     return match.Value;
                 }
                 return value.ToString();
             }
+
             // Return what we received.
             return match.Value;
         }

--- a/src/Cake.Core/Text/TextTransformationTemplate.cs
+++ b/src/Cake.Core/Text/TextTransformationTemplate.cs
@@ -13,19 +13,33 @@ namespace Cake.Core.Text
     {
         private readonly Dictionary<string, object> _tokens;
         private readonly string _template;
+        private readonly Tuple<string, string> _placeholder;
+        private readonly string _keyExpression;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TextTransformationTemplate"/> class.
         /// </summary>
         /// <param name="template">The template.</param>
         public TextTransformationTemplate(string template)
+            : this(template, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TextTransformationTemplate"/> class.
+        /// </summary>
+        /// <param name="template">The template.</param>
+        /// <param name="placeholder">The key placeholder.</param>
+        public TextTransformationTemplate(string template, Tuple<string, string> placeholder)
         {
             if (template == null)
             {
                 throw new ArgumentNullException("template");
             }
             _template = template;
+            _placeholder = placeholder ?? new Tuple<string, string>("<%", "%>");
             _tokens = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            _keyExpression = string.Concat(_placeholder.Item1, @"(?<key>[^", _placeholder.Item2[0], "]+)", _placeholder.Item2);
         }
 
         /// <summary>
@@ -58,8 +72,7 @@ namespace Cake.Core.Text
         /// <returns>The rendered template.</returns>
         public string Render()
         {
-            const string keyExpression = @"<%(?<key>[^%]+)%>";
-            return Regex.Replace(_template, keyExpression, Replace);
+            return Regex.Replace(_template, _keyExpression, Replace);
         }
 
         private string Replace(Match match)
@@ -81,16 +94,16 @@ namespace Cake.Core.Text
                     var format = string.Join(":", parts.Skip(1).Take(parts.Length - 1)).Trim();
                     var formattable = _tokens[key] as IFormattable;
                     if (formattable != null)
-                    {                        
+                    {
                         return formattable.ToString(format, CultureInfo.InvariantCulture);
                     }
-                    return string.Concat("<%", key, ":", format, "%>");   
+                    // Return what we received.
+                    return match.Value;
                 }
                 return value.ToString();
             }
-
             // Return what we received.
-            return string.Concat("<%", key, "%>");
+            return match.Value;
         }
     }
 }


### PR DESCRIPTION
Fix for suggestion/issue #186.
Also added documentation for aliases related to text transformation.

```csharp
string text = TransformText("Hello {subject}!", "{", "}")
    .WithToken("subject", "world")
    .ToString();
```