### PR TITLE
Added NuGet set api key aliases

### DIFF
--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -123,6 +123,7 @@
     <Compile Include="Unit\Tools\NuGet\Push\NuGetPusherTests.cs" />
     <Compile Include="Unit\Tools\NuGet\Restore\NuGetRestorerTests.cs" />
     <Compile Include="Unit\Tools\NuGet\Restore\NuGetRestoreSettingsTests.cs" />
+    <Compile Include="Unit\Tools\NuGet\SetApiKey\NuGetSetApiKeyTests.cs" />
     <Compile Include="Unit\Tools\NuGet\Sources\NuGetSourcesSettingsTests.cs" />
     <Compile Include="Unit\Tools\NuGet\Sources\NuGetSourcesTests.cs" />
     <Compile Include="Unit\Tools\NUnit\NUnitRunnerTests.cs" />

--- a/src/Cake.Common.Tests/Fixtures/NuGetFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/NuGetFixture.cs
@@ -4,6 +4,7 @@ using Cake.Common.Tools.NuGet.Install;
 using Cake.Common.Tools.NuGet.Pack;
 using Cake.Common.Tools.NuGet.Push;
 using Cake.Common.Tools.NuGet.Restore;
+using Cake.Common.Tools.NuGet.SetApiKey;
 using Cake.Common.Tools.NuGet.Sources;
 using Cake.Core;
 using Cake.Core.Diagnostics;
@@ -23,7 +24,8 @@ namespace Cake.Common.Tests.Fixtures
         public IToolResolver NuGetToolResolver { get; set; }
 
         public NuGetFixture(FilePath toolPath = null, bool defaultToolExist = true, 
-            string xml = null, KeyValuePair<string, string>? sourceExists = null)
+            string xml = null, KeyValuePair<string, string>? sourceExists = null,
+            KeyValuePair<string, string>? setApiKey = null)
         {
             Environment = Substitute.For<ICakeEnvironment>();
             Environment.WorkingDirectory.Returns("/Working");
@@ -66,6 +68,14 @@ namespace Cake.Common.Tests.Fixtures
                         string.Format("      {0}", sourceExists.Value.Value)
                     });
             }
+            else if (setApiKey.HasValue)
+            {
+                Process.GetStandardOutput()
+                    .Returns(new[]
+                    {
+                        string.Concat("The API Key '", setApiKey.Value.Key, "' was saved for '", setApiKey.Value.Value, "'.")
+                    });
+            }
             else
             {
                 Process.GetStandardOutput()
@@ -96,6 +106,11 @@ namespace Cake.Common.Tests.Fixtures
         public NuGetInstaller CreateInstaller()
         {
             return new NuGetInstaller(FileSystem, Environment, ProcessRunner, NuGetToolResolver);
+        }
+
+        public NuGetSetApiKey CreateSetApiKey()
+        {
+            return new NuGetSetApiKey(Log, FileSystem, Environment, ProcessRunner, NuGetToolResolver);
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/NuGet/SetApiKey/NuGetSetApiKeyTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NuGet/SetApiKey/NuGetSetApiKeyTests.cs
@@ -1,0 +1,228 @@
+﻿using System.Collections.Generic;
+using Cake.Common.Tests.Fixtures;
+using Cake.Common.Tools.NuGet;
+using Cake.Common.Tools.NuGet.SetApiKey;
+using Cake.Core;
+using Cake.Core.IO;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.NuGet.SetApiKey
+{
+    public sealed class NuGetSetApiKeyTests
+    {
+        
+        public sealed class TheSetApiKeyMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Target_Api_Key_Is_Null()
+            {
+                // Given
+                var fixture = new NuGetFixture(defaultToolExist: false);
+                var installer = fixture.CreateSetApiKey();
+
+
+                // When
+                var result = Record.Exception(() => installer.SetApiKey(null, "http://nugetfeed.com", new NuGetSetApiKeySettings()));
+
+                // Then
+                Assert.IsArgumentNullException(result, "apiKey");
+            }
+            [Fact]
+            public void Should_Throw_If_Target_Source_Is_Null()
+            {
+                // Given
+                var fixture = new NuGetFixture(defaultToolExist: false);
+                var installer = fixture.CreateSetApiKey();
+
+
+                // When
+                var result = Record.Exception(() => installer.SetApiKey("*secret key*", null, new NuGetSetApiKeySettings()));
+
+                // Then
+                Assert.IsArgumentNullException(result, "source");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new NuGetFixture(defaultToolExist: false);
+                var installer = fixture.CreateSetApiKey();
+
+                // When
+                var result = Record.Exception(() => installer.SetApiKey("*secret key*", "http://nugetfeed.com", null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+
+            [Fact]
+            public void Should_Throw_If_UnexpectedOutput()
+            {
+                // Given
+                var fixture = new NuGetFixture();
+                var installer = fixture.CreateSetApiKey();
+
+                // When
+                var result = Record.Exception(() => installer.SetApiKey("*secret key*", "http://nugetfeed.com", new NuGetSetApiKeySettings()));
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("SetApiKey returned unexpected response.", result.Message);
+            }
+
+
+            [Fact]
+            public void Should_Throw_If_NuGet_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new NuGetFixture(defaultToolExist: false);
+                var installer = fixture.CreateSetApiKey();
+
+                // When
+                var result = Record.Exception(() => installer.SetApiKey("*secret key*", "http://nugetfeed.com", new NuGetSetApiKeySettings()));
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("NuGet: Could not locate executable.", result.Message);
+            }
+
+            [Theory]
+            [InlineData("C:/nuget/nuget.exe", "C:/nuget/nuget.exe")]
+            [InlineData("./tools/nuget/nuget.exe", "/Working/tools/nuget/nuget.exe")]
+            public void Should_Use_NuGet_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var apiKeySource = new KeyValuePair<string, string>("*secret key*", "http://nugetfeed.com");
+                var fixture = new NuGetFixture(setApiKey:apiKeySource, toolPath:expected);
+                var installer = fixture.CreateSetApiKey();
+                
+                // When
+                installer.SetApiKey(apiKeySource.Key, apiKeySource.Value, new NuGetSetApiKeySettings
+                {
+                    ToolPath = toolPath
+                });
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == expected),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new NuGetFixture();
+                fixture.ProcessRunner.Start(Arg.Any<FilePath>(), Arg.Any<ProcessSettings>()).Returns((IProcess)null);
+                var installer = fixture.CreateSetApiKey();
+
+                // When
+                var result = Record.Exception(() => installer.SetApiKey("*secret key*", "http://nugetfeed.com", new NuGetSetApiKeySettings()));
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("NuGet: Process was not started.", result.Message);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new NuGetFixture();
+                fixture.Process.GetExitCode().Returns(1);
+                var installer = fixture.CreateSetApiKey();
+
+                // When
+                var result = Record.Exception(() => installer.SetApiKey("*secret key*", "http://nugetfeed.com", new NuGetSetApiKeySettings()));
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("NuGet: Process returned an error.", result.Message);
+            }
+
+            [Fact]
+            public void Should_Find_NuGet_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var apiKeySource = new KeyValuePair<string, string>("*secret key*", "http://nugetfeed.com");
+                var fixture = new NuGetFixture(setApiKey:apiKeySource);
+                var installer = fixture.CreateSetApiKey();
+                
+                // When
+                installer.SetApiKey("*secret key*", "http://nugetfeed.com", new NuGetSetApiKeySettings());
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == "/Working/tools/NuGet.exe"),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var apiKeySource = new KeyValuePair<string, string>("*secret key*", "http://nugetfeed.com");
+                var fixture = new NuGetFixture(setApiKey:apiKeySource);
+                var installer = fixture.CreateSetApiKey();
+                var expected = string.Format("setapikey \"{0}\" -Source \"{1}\" -NonInteractive", apiKeySource.Key, apiKeySource.Value);
+
+                // When
+                installer.SetApiKey(apiKeySource.Key, apiKeySource.Value, new NuGetSetApiKeySettings());
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p => 
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(NuGetVerbosity.Detailed, "detailed")]
+            [InlineData(NuGetVerbosity.Normal, "normal")]
+            [InlineData(NuGetVerbosity.Quiet, "quiet")]
+            public void Should_Add_Verbosity_To_Arguments_If_Set(NuGetVerbosity verbosity, string name)
+            {
+                // Given
+                var apiKeySource = new KeyValuePair<string, string>("*secret key*", "http://nugetfeed.com");
+                var fixture = new NuGetFixture(setApiKey:apiKeySource);
+                var installer = fixture.CreateSetApiKey();
+                var expected = string.Format("setapikey \"{0}\" -Source \"{1}\" -Verbosity {2} -NonInteractive", apiKeySource.Key, apiKeySource.Value, name);
+
+                // When
+                installer.SetApiKey(apiKeySource.Key, apiKeySource.Value, new NuGetSetApiKeySettings
+                {
+                    Verbosity = verbosity
+                });
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Fact]
+            public void Should_Add_ConfigFile_To_Arguments_If_Set()
+            {
+                // Given
+                var apiKeySource = new KeyValuePair<string, string>("*secret key*", "http://nugetfeed.com");
+                var fixture = new NuGetFixture(setApiKey:apiKeySource);
+                var installer = fixture.CreateSetApiKey();
+                var expected = string.Format("setapikey \"{0}\" -Source \"{1}\" -ConfigFile \"/Working/nuget.config\" -NonInteractive", apiKeySource.Key, apiKeySource.Value);
+                
+                // When
+                installer.SetApiKey(apiKeySource.Key, apiKeySource.Value, new NuGetSetApiKeySettings
+                {
+                    ConfigFile = "./nuget.config"
+                });
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -129,6 +129,8 @@
     <Compile Include="Tools\NuGet\Install\NuGetInstaller.cs" />
     <Compile Include="Tools\NuGet\Install\NugetInstallSettings.cs" />
     <Compile Include="Tools\NuGet\Pack\NuSpecContent.cs" />
+    <Compile Include="Tools\NuGet\SetApiKey\NuGetSetApiKey.cs" />
+    <Compile Include="Tools\NuGet\SetApiKey\NuGetSetApiKeySettings.cs" />
     <Compile Include="Tools\NuGet\Sources\NuGetSources.cs" />
     <Compile Include="Tools\NuGet\Sources\NuGetSourcesSettings.cs" />
     <Compile Include="Tools\NuGet\NuGetAliases.cs" />

--- a/src/Cake.Common/Tools/NuGet/NuGetAliases.cs
+++ b/src/Cake.Common/Tools/NuGet/NuGetAliases.cs
@@ -3,6 +3,7 @@ using Cake.Common.Tools.NuGet.Install;
 using Cake.Common.Tools.NuGet.Pack;
 using Cake.Common.Tools.NuGet.Push;
 using Cake.Common.Tools.NuGet.Restore;
+using Cake.Common.Tools.NuGet.SetApiKey;
 using Cake.Common.Tools.NuGet.Sources;
 using Cake.Core;
 using Cake.Core.Annotations;
@@ -471,6 +472,41 @@ namespace Cake.Common.Tools.NuGet
 
             var runner = new NuGetInstaller(context.FileSystem, context.Environment, context.ProcessRunner, context.GetToolResolver("NuGet"));
             runner.InstallFromConfig(packageConfigPath, settings);
+        }
+
+        /// <summary>
+        /// Installs NuGet packages using the specified API key, source and settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="apiKey">The API key.</param>
+        /// <param name="source">Server URL where the API key is valid.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("SetApiKey")]
+        [CakeNamespaceImport("Cake.Common.Tools.NuGet.SetApiKey")]
+        public static void NuGetSetApiKey(this ICakeContext context, string apiKey, string source, NuGetSetApiKeySettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var runner = new NuGetSetApiKey(context.Log, context.FileSystem, context.Environment, context.ProcessRunner, context.GetToolResolver("NuGet"));
+            runner.SetApiKey(apiKey, source, settings);
+        }
+
+        /// <summary>
+        /// Installs NuGet packages using the specified API key and source.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="apiKey">The API key.</param>
+        /// <param name="source">Server URL where the API key is valid.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("SetApiKey")]
+        [CakeNamespaceImport("Cake.Common.Tools.NuGet.SetApiKey")]
+        public static void NuGetSetApiKey(this ICakeContext context, string apiKey, string source)
+        {
+            context.NuGetSetApiKey(apiKey, source, new NuGetSetApiKeySettings());
         }
     }
 }

--- a/src/Cake.Common/Tools/NuGet/SetApiKey/NuGetSetApiKey.cs
+++ b/src/Cake.Common/Tools/NuGet/SetApiKey/NuGetSetApiKey.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using Cake.Core.Utilities;
+
+namespace Cake.Common.Tools.NuGet.SetApiKey
+{
+    /// <summary>
+    /// The NuGet set API key used to set API key used for API/feed authentication.
+    /// </summary>
+    public sealed class NuGetSetApiKey : Tool<NuGetSetApiKeySettings>
+    {
+        private readonly ICakeLog _log;
+        private readonly ICakeEnvironment _environment;
+        private readonly IToolResolver _nugetToolResolver;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NuGetSetApiKey"/> class.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="nugetToolResolver">The NuGet tool resolver.</param>
+        public NuGetSetApiKey(ICakeLog log, IFileSystem fileSystem, ICakeEnvironment environment, 
+            IProcessRunner processRunner, IToolResolver nugetToolResolver)
+            : base(fileSystem, environment, processRunner)
+        {
+            _log = log;
+            _environment = environment;
+            _nugetToolResolver = nugetToolResolver;
+        }
+
+        /// <summary>
+        /// Installs NuGet packages using the specified package id and settings.
+        /// </summary>
+        /// <param name="apiKey">The API key.</param>
+        /// <param name="source">The Server URL where the API key is valid.</param>
+        /// <param name="settings">The settings.</param>
+        public void SetApiKey(string apiKey, string source, NuGetSetApiKeySettings settings)
+        {
+            if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                throw new ArgumentNullException("apiKey");
+            }
+            
+            if (string.IsNullOrWhiteSpace(source))
+            {
+                throw new ArgumentNullException("source");
+            }
+
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+            string output = null;
+            var processSettings = new ProcessSettings
+            {
+                Arguments = GetArguments(apiKey, source, settings),
+                RedirectStandardOutput = true
+            };
+            Run(settings, null, settings.ToolPath, processSettings, process => output = string.Join("\r\n", process.GetStandardOutput()));
+
+            if (string.IsNullOrWhiteSpace(output) ||
+                !output.Contains(string.Concat("The API Key '", apiKey, "' was saved for '", source, "'.")))
+            {
+                throw new CakeException("SetApiKey returned unexpected response.");
+            }
+        }
+
+        private ProcessArgumentBuilder GetArguments(string apiKey, string source, NuGetSetApiKeySettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("setapikey");
+            builder.AppendQuotedSecret(apiKey);
+
+            // Source
+            builder.Append("-Source");
+            builder.AppendQuoted(source);
+
+            // Verbosity?
+            if (settings.Verbosity.HasValue)
+            {
+                builder.Append("-Verbosity");
+                builder.Append(settings.Verbosity.Value.ToString().ToLowerInvariant());
+            }
+
+            // Configuration file
+            if (settings.ConfigFile != null)
+            {
+                builder.Append("-ConfigFile");
+                builder.AppendQuoted(settings.ConfigFile.MakeAbsolute(_environment).FullPath);
+            }
+
+            builder.Append("-NonInteractive");
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Gets the name of the tool.
+        /// </summary>
+        /// <returns>The name of the tool.</returns>
+        protected override string GetToolName()
+        {
+            return _nugetToolResolver.Name;
+        }
+
+        /// <summary>
+        /// Gets the default tool path.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The default tool path.</returns>
+        protected override FilePath GetDefaultToolPath(NuGetSetApiKeySettings settings)
+        {
+            return _nugetToolResolver.ResolveToolPath();
+        }
+    }
+}

--- a/src/Cake.Common/Tools/NuGet/SetApiKey/NuGetSetApiKeySettings.cs
+++ b/src/Cake.Common/Tools/NuGet/SetApiKey/NuGetSetApiKeySettings.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.NuGet.SetApiKey
+{
+    /// <summary>
+    /// Contains settings used by <see cref="NuGetSetApiKey"/>.
+    /// </summary>
+    public sealed class NuGetSetApiKeySettings
+    {
+        /// <summary>
+        /// Gets or sets the path to <c>nuget.exe</c>.
+        /// </summary>
+        public FilePath ToolPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the output verbosity.
+        /// </summary>
+        /// <value>The output verbosity.</value>
+        public NuGetVerbosity? Verbosity { get; set; }
+
+        /// <summary>
+        /// Gets or sets the NuGet configuration file.
+        /// If not specified, the file <c>%AppData%\NuGet\NuGet.config</c> is used as the configuration file.
+        /// </summary>
+        /// <value>The NuGet configuration file.</value>
+        public FilePath ConfigFile { get; set; }
+    }
+}

--- a/src/Cake.Core/IO/ProcessArgumentBuilder.cs
+++ b/src/Cake.Core/IO/ProcessArgumentBuilder.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
 using Cake.Core.IO.Arguments;
 
 namespace Cake.Core.IO
@@ -46,6 +48,31 @@ namespace Cake.Core.IO
         public string RenderSafe()
         {
             return string.Join(" ", _tokens.Select(t => t.RenderSafe()));
+        }
+
+        /// <summary>
+        /// Tries to filer any unsafe arguments from string
+        /// </summary>
+        /// <param name="source">unsafe source string.</param>
+        /// <returns>Filtered string.</returns>
+        public string FilterUnsafe(string source)
+        {
+            if (string.IsNullOrWhiteSpace(source))
+            {
+                return source;
+            }
+
+            return _tokens
+                .Select(token => new
+                {
+                    Safe = token.RenderSafe().Trim('"').Trim(),
+                    Unsafe = token.Render().Trim('"').Trim()
+                })
+                .Where(token => token.Safe != token.Unsafe)
+                .Aggregate(
+                    new StringBuilder(source),
+                    (sb, token) => sb.Replace(token.Unsafe, token.Safe),
+                    sb => sb.ToString());
         }
 
         /// <summary>

--- a/src/Cake.Core/IO/ProcessRunner.cs
+++ b/src/Cake.Core/IO/ProcessRunner.cs
@@ -70,7 +70,7 @@ namespace Cake.Core.IO
 
             // Start and return the process.
             var process = Process.Start(info);
-            return process == null ? null : new ProcessWrapper(process, _log);
+            return process == null ? null : new ProcessWrapper(process, _log, arguments.FilterUnsafe);
         }
     }
 }

--- a/src/Cake.Core/IO/ProcessWrapper.cs
+++ b/src/Cake.Core/IO/ProcessWrapper.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Cake.Core.Diagnostics;
 
@@ -8,11 +9,13 @@ namespace Cake.Core.IO
     {
         private readonly Process _process;
         private readonly ICakeLog _log;
+        private readonly Func<string, string> _filterOutput;
 
-        public ProcessWrapper(Process process, ICakeLog log)
+        public ProcessWrapper(Process process, ICakeLog log, Func<string, string> filterOutput)
         {
             _process = process;
             _log = log;
+            _filterOutput = filterOutput ?? (source => "[REDACTED]");
         }
 
         public void WaitForExit()
@@ -44,7 +47,7 @@ namespace Cake.Core.IO
             string line;
             while ((line = _process.StandardOutput.ReadLine()) != null)
             {
-                _log.Verbose("{0}", line);
+                _log.Verbose("{0}", _filterOutput(line));
                 yield return line;
             }
         }


### PR DESCRIPTION
Added aliases for setting api key for a given source. This allows you to authenticate to private feeds using an API key. 

Example usage:
```csharp
NuGetSetApiKey("3f81e328-3ba1-47eb-a92b-363d804bd132", "http://www.privatenugetfeed.com");
```