### PR TITLE
Added MSBuild verbosity setting.

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -22,19 +22,14 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 };
 
                 var fixture = new MSBuildRunnerFixture(existingToolPaths);
-                var runner = fixture.CreateRunner();
+                fixture.Settings.PlatformTarget = PlatformTarget.x64;
+                fixture.Settings.ToolVersion = MSBuildToolVersion.Default;
 
                 // When
-                runner.Run(new MSBuildSettings("./src/Solution.sln")
-                {
-                    PlatformTarget = PlatformTarget.x64,
-                    ToolVersion = MSBuildToolVersion.Default
-                });
+                fixture.Run();
 
                 // Then
-                fixture.ProcessRunner.Received(1).Start(
-                    Arg.Is<FilePath>(p => p.FullPath == "/Windows/Microsoft.NET/Framework64/v4.0.30319/MSBuild.exe"),
-                    Arg.Any<ProcessSettings>());
+                fixture.AssertReceivedFilePath("/Windows/Microsoft.NET/Framework64/v4.0.30319/MSBuild.exe");
             }
 
             [Theory]
@@ -60,19 +55,14 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             {
                 // Given
                 var fixture = new MSBuildRunnerFixture(is64BitOperativeSystem, true);
-                var runner = fixture.CreateRunner();
+                fixture.Settings.ToolVersion = version;
+                fixture.Settings.PlatformTarget = target;
 
                 // When
-                runner.Run(new MSBuildSettings("./src/Solution.sln")
-                {
-                    PlatformTarget = target,
-                    ToolVersion = version
-                });
+                fixture.Run();
 
                 // Then
-                fixture.ProcessRunner.Received(1).Start(
-                    Arg.Is<FilePath>(p => p.FullPath == expected),
-                    Arg.Any<ProcessSettings>());
+                fixture.AssertReceivedFilePath(expected);
             }
 
             [Theory]
@@ -92,19 +82,14 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             {
                 // Given
                 var fixture = new MSBuildRunnerFixture(is64BitOperativeSystem, true);
-                var runner = fixture.CreateRunner();
+                fixture.Settings.ToolVersion = version;
+                fixture.Settings.PlatformTarget = target;
 
                 // When
-                runner.Run(new MSBuildSettings("./src/Solution.sln")
-                {
-                    ToolVersion = version,
-                    PlatformTarget = target
-                });
+                fixture.Run();
 
                 // Then
-                fixture.ProcessRunner.Received(1).Start(
-                    Arg.Is<FilePath>(p => p.FullPath == expected),
-                    Arg.Any<ProcessSettings>());
+                fixture.AssertReceivedFilePath(expected);
             }
 
             [Theory]
@@ -142,19 +127,14 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             {
                 // Given
                 var fixture = new MSBuildRunnerFixture(is64BitOperativeSystem, true);
-                var runner = fixture.CreateRunner();
+                fixture.Settings.ToolVersion = version;
+                fixture.Settings.PlatformTarget = target;
 
                 // When
-                runner.Run(new MSBuildSettings("./src/Solution.sln")
-                {
-                    ToolVersion = version,
-                    PlatformTarget = target
-                });
+                fixture.Run();
 
                 // Then
-                fixture.ProcessRunner.Received(1).Start(
-                    Arg.Is<FilePath>(p => p.FullPath == expected),
-                    Arg.Any<ProcessSettings>());
+                fixture.AssertReceivedFilePath(expected);
             }
 
             [Theory]
@@ -180,19 +160,14 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             {
                 // Given
                 var fixture = new MSBuildRunnerFixture(is64BitOperativeSystem, true);
-                var runner = fixture.CreateRunner();
+                fixture.Settings.ToolVersion = version;
+                fixture.Settings.PlatformTarget = target;
 
                 // When
-                runner.Run(new MSBuildSettings("./src/Solution.sln")
-                {
-                    ToolVersion = version,
-                    PlatformTarget = target
-                });
+                fixture.Run();
 
                 // Then
-                fixture.ProcessRunner.Received(1).Start(
-                    Arg.Is<FilePath>(p => p.FullPath == expected),
-                    Arg.Any<ProcessSettings>());
+                fixture.AssertReceivedFilePath(expected);
             }
 
             [Fact]
@@ -200,18 +175,14 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             {
                 // Given
                 var fixture = new MSBuildRunnerFixture(false, false);
-                var runner = fixture.CreateRunner();
+                fixture.Settings.PlatformTarget = PlatformTarget.x86;
+                fixture.Settings.ToolVersion = MSBuildToolVersion.NET20;
 
                 // When
-                var result = Record.Exception(() => runner.Run( 
-                    new MSBuildSettings("./src/Solution.sln") {
-                        PlatformTarget = PlatformTarget.x86,
-                        ToolVersion = MSBuildToolVersion.NET20
-                    }));
+                var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                Assert.IsType<CakeException>(result);
-                Assert.Equal("MSBuild: Could not locate executable.", result.Message);
+                Assert.IsCakeException(result, "MSBuild: Could not locate executable.");
             }
 
             [Fact]
@@ -219,21 +190,14 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             {
                 // Given
                 var fixture = new MSBuildRunnerFixture(false, true);
-                var runner = fixture.CreateRunner();
-
-                var settings = new MSBuildSettings("./src/Solution.sln");
-                settings.ToolVersion = MSBuildToolVersion.VS2013;
-                settings.MaxCpuCount = 0;
+                fixture.Settings.MaxCpuCount = 0;
 
                 // When
-                runner.Run(settings);
+                fixture.Run();
 
                 // Then
-                var args = "/m /v:normal /target:Build \"/Working/src/Solution.sln\"";
-                fixture.ProcessRunner.Received(1).Start(
-                    Arg.Any<FilePath>(), 
-                    Arg.Is<ProcessSettings>(p =>
-                        p.Arguments.Render() == args));
+                fixture.AssertReceivedArguments(
+                    "/m /v:normal /target:Build \"/Working/src/Solution.sln\"");
             }
 
             [Fact]
@@ -241,21 +205,14 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             {
                 // Given
                 var fixture = new MSBuildRunnerFixture(false, true);
-                var runner = fixture.CreateRunner();
-
-                var settings = new MSBuildSettings("./src/Solution.sln");
-                settings.ToolVersion = MSBuildToolVersion.VS2013;
-                settings.MaxCpuCount = 4;
+                fixture.Settings.MaxCpuCount = 4;
 
                 // When
-                runner.Run(settings);
+                fixture.Run();
 
                 // Then
-                var args = "/m:4 /v:normal /target:Build \"/Working/src/Solution.sln\"";
-                fixture.ProcessRunner.Received(1).Start(
-                    Arg.Any<FilePath>(), 
-                    Arg.Is<ProcessSettings>(p =>
-                        p.Arguments.Render() == args));
+                fixture.AssertReceivedArguments(
+                    "/m:4 /v:normal /target:Build \"/Working/src/Solution.sln\"");
             }
 
             [Fact]
@@ -263,20 +220,13 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             {
                 // Given
                 var fixture = new MSBuildRunnerFixture(false, true);
-                var runner = fixture.CreateRunner();
-
-                var settings = new MSBuildSettings("./src/Solution.sln");
-                settings.ToolVersion = MSBuildToolVersion.VS2013;
 
                 // When
-                runner.Run(settings);
+                fixture.Run();
 
                 // Then
-                var args = "/m /v:normal /target:Build \"/Working/src/Solution.sln\"";
-                fixture.ProcessRunner.Received(1).Start(
-                    Arg.Any<FilePath>(), 
-                    Arg.Is<ProcessSettings>(p =>
-                        p.Arguments.Render() == args));
+                fixture.AssertReceivedArguments(
+                    "/m /v:normal /target:Build \"/Working/src/Solution.sln\"");
             }
 
             [Fact]
@@ -284,21 +234,14 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             {
                 // Given
                 var fixture = new MSBuildRunnerFixture(false, true);
-                var runner = fixture.CreateRunner();
-
-                var settings = new MSBuildSettings("./src/Solution.sln");
-                settings.ToolVersion = MSBuildToolVersion.VS2013;
-                settings.NodeReuse = true;
+                fixture.Settings.NodeReuse = true;
 
                 // When
-                runner.Run(settings);
+                fixture.Run();
 
                 // Then
-                var args = "/m /v:normal /nr:true /target:Build \"/Working/src/Solution.sln\"";
-                fixture.ProcessRunner.Received(1).Start(
-                    Arg.Any<FilePath>(),
-                    Arg.Is<ProcessSettings>(p =>
-                        p.Arguments.Render() == args));
+                fixture.AssertReceivedArguments(
+                    "/m /v:normal /nr:true /target:Build \"/Working/src/Solution.sln\"");
             }
 
             [Fact]
@@ -306,22 +249,15 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             {
                 // Given
                 var fixture = new MSBuildRunnerFixture(false, true);
-                var runner = fixture.CreateRunner();
-
-                var settings = new MSBuildSettings("./src/Solution.sln");
-                settings.ToolVersion = MSBuildToolVersion.VS2013;
-                settings.WithTarget("A");
-                settings.WithTarget("B");
+                fixture.Settings.WithTarget("A");
+                fixture.Settings.WithTarget("B");
 
                 // When
-                runner.Run(settings);
+                fixture.Run();
 
                 // Then
-                var args = "/m /v:normal /target:A;B \"/Working/src/Solution.sln\"";
-                fixture.ProcessRunner.Received(1).Start(
-                    Arg.Any<FilePath>(),
-                    Arg.Is<ProcessSettings>(p =>
-                        p.Arguments.Render() == args));
+                fixture.AssertReceivedArguments(
+                    "/m /v:normal /target:A;B \"/Working/src/Solution.sln\"");
             }
 
             [Fact]
@@ -329,22 +265,15 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             {
                 // Given
                 var fixture = new MSBuildRunnerFixture(false, true);
-                var runner = fixture.CreateRunner();
-
-                var settings = new MSBuildSettings("./src/Solution.sln");
-                settings.ToolVersion = MSBuildToolVersion.VS2013;
-                settings.WithProperty("A", "B");
-                settings.WithProperty("C", "D");
+                fixture.Settings.WithProperty("A", "B");
+                fixture.Settings.WithProperty("C", "D");
 
                 // When
-                runner.Run(settings);
+                fixture.Run();
 
                 // Then
-                var args = "/m /v:normal /p:\"A\"=\"B\" /p:\"C\"=\"D\" /target:Build \"/Working/src/Solution.sln\"";
-                fixture.ProcessRunner.Received(1).Start(
-                    Arg.Any<FilePath>(),
-                    Arg.Is<ProcessSettings>(p =>
-                        p.Arguments.Render() == args));
+                fixture.AssertReceivedArguments(
+                    "/m /v:normal /p:\"A\"=\"B\" /p:\"C\"=\"D\" /target:Build \"/Working/src/Solution.sln\"");
             }
 
             [Fact]
@@ -352,22 +281,15 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             {
                 // Given
                 var fixture = new MSBuildRunnerFixture(false, true);
-                var runner = fixture.CreateRunner();
-
-                var settings = new MSBuildSettings("./src/Solution.sln");
-                settings.ToolVersion = MSBuildToolVersion.VS2013;
-                settings.WithProperty("A", "B", "E");
-                settings.WithProperty("C", "D");
+                fixture.Settings.WithProperty("A", "B", "E");
+                fixture.Settings.WithProperty("C", "D");
 
                 // When
-                runner.Run(settings);
+                fixture.Run();
 
                 // Then
-                var args = "/m /v:normal /p:\"A\"=\"B\" /p:\"A\"=\"E\" /p:\"C\"=\"D\" /target:Build \"/Working/src/Solution.sln\"";
-                fixture.ProcessRunner.Received(1).Start(
-                    Arg.Any<FilePath>(),
-                    Arg.Is<ProcessSettings>(p =>
-                        p.Arguments.Render() == args));
+                fixture.AssertReceivedArguments(
+                    "/m /v:normal /p:\"A\"=\"B\" /p:\"A\"=\"E\" /p:\"C\"=\"D\" /target:Build \"/Working/src/Solution.sln\"");
             }
 
             [Fact]
@@ -375,21 +297,14 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             {
                 // Given
                 var fixture = new MSBuildRunnerFixture(false, true);
-                var runner = fixture.CreateRunner();
-
-                var settings = new MSBuildSettings("./src/Solution.sln");
-                settings.ToolVersion = MSBuildToolVersion.VS2013;
-                settings.SetConfiguration("Release");                
+                fixture.Settings.SetConfiguration("Release");
 
                 // When
-                runner.Run(settings);
+                fixture.Run();
 
                 // Then
-                var args = "/m /v:normal /p:\"Configuration\"=\"Release\" /target:Build \"/Working/src/Solution.sln\"";
-                fixture.ProcessRunner.Received(1).Start(
-                    Arg.Any<FilePath>(),
-                    Arg.Is<ProcessSettings>(p => 
-                        p.Arguments.Render() == args));
+                fixture.AssertReceivedArguments(
+                    "/m /v:normal /p:\"Configuration\"=\"Release\" /target:Build \"/Working/src/Solution.sln\"");
             }
 
             [Fact]
@@ -397,17 +312,14 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             {
                 // Given
                 var fixture = new MSBuildRunnerFixture(false, true);
-                var runner = fixture.CreateRunner();
-                var settings = new MSBuildSettings("./src/Solution.sln");
-                settings.ToolVersion = MSBuildToolVersion.VS2013;
 
                 // When
-                runner.Run(settings);
+                fixture.Run();
 
                 // Then
                 fixture.ProcessRunner.Received(1).Start(
                     Arg.Any<FilePath>(),
-                    Arg.Is<ProcessSettings>(p => 
+                    Arg.Is<ProcessSettings>(p =>
                         p.WorkingDirectory.FullPath == "/Working"));
             }
 
@@ -416,18 +328,15 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             {
                 // Given
                 var fixture = new MSBuildRunnerFixture(false, true);
-                fixture.ProcessRunner.Start(Arg.Any<FilePath>(), Arg.Any<ProcessSettings>()).Returns((IProcess)null);
-                var runner = fixture.CreateRunner();
-
-                var settings = new MSBuildSettings("./src/Solution.sln");
-                settings.ToolVersion = MSBuildToolVersion.VS2013;
+                fixture.ProcessRunner
+                    .Start(Arg.Any<FilePath>(), Arg.Any<ProcessSettings>())
+                    .Returns((IProcess)null);
 
                 // When
-                var result = Record.Exception(() => runner.Run(settings));
+                var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                Assert.IsType<CakeException>(result);
-                Assert.Equal("MSBuild: Process was not started.", result.Message);
+                Assert.IsCakeException(result, "MSBuild: Process was not started.");
             }
 
             [Fact]
@@ -436,44 +345,46 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 // Given
                 var fixture = new MSBuildRunnerFixture(false, true);
                 fixture.Process.GetExitCode().Returns(1);
-                var runner = fixture.CreateRunner();
-
-                var settings = new MSBuildSettings("./src/Solution.sln");
-                settings.ToolVersion = MSBuildToolVersion.VS2013;
 
                 // When
-                var result = Record.Exception(() => runner.Run(settings));
+                var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                Assert.IsType<CakeException>(result);
-                Assert.Equal("MSBuild: Process returned an error.", result.Message);
+                Assert.IsCakeException(result, "MSBuild: Process returned an error.");
             }
 
             [Theory]
-            [InlineData(Verbosity.Quiet, "/v:quiet")]
-            [InlineData(Verbosity.Minimal, "/v:minimal")]
-            [InlineData(Verbosity.Normal, "/v:normal")]
-            [InlineData(Verbosity.Verbose, "/v:verbose")]
-            [InlineData(Verbosity.Diagnostic, "/v:diagnostic")]
+            [InlineData(Verbosity.Quiet, "quiet")]
+            [InlineData(Verbosity.Minimal, "minimal")]
+            [InlineData(Verbosity.Normal, "normal")]
+            [InlineData(Verbosity.Verbose, "verbose")]
+            [InlineData(Verbosity.Diagnostic, "diagnostic")]
             public void Should_Append_Correct_Verbosity(Verbosity verbosity, string expected)
             {
                 // Given
                 var fixture = new MSBuildRunnerFixture(false, true);
-                var runner = fixture.CreateRunner();
-
-                var settings = new MSBuildSettings("./src/Solution.sln");
-                settings.ToolVersion = MSBuildToolVersion.VS2013;
-                settings.Verbosity = verbosity;
+                fixture.Settings.Verbosity = verbosity;
 
                 // When
-                runner.Run(settings);
+                fixture.Run();
 
                 // Then
-                var args = string.Concat("/m ", expected, " /target:Build \"/Working/src/Solution.sln\"");
-                fixture.ProcessRunner.Received(1).Start(
-                    Arg.Any<FilePath>(),
-                    Arg.Is<ProcessSettings>(p =>
-                        p.Arguments.Render() == args));                
+                fixture.AssertReceivedArguments(
+                    "/m /v:{0} /target:Build \"/Working/src/Solution.sln\"", expected);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Verbosity_Is_Unknown()
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, true);
+                fixture.Settings.Verbosity = (Verbosity)int.MaxValue;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsCakeException(result, "Encountered unknown MSBuild build log verbosity.");
             }
         }
     }

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -1,6 +1,7 @@
 ﻿using Cake.Common.Tests.Fixtures;
 using Cake.Common.Tools.MSBuild;
 using Cake.Core;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using NSubstitute;
 using Xunit;
@@ -228,10 +229,11 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 runner.Run(settings);
 
                 // Then
+                var args = "/m /v:normal /target:Build \"/Working/src/Solution.sln\"";
                 fixture.ProcessRunner.Received(1).Start(
                     Arg.Any<FilePath>(), 
                     Arg.Is<ProcessSettings>(p =>
-                        p.Arguments.Render() == "/m /target:Build \"/Working/src/Solution.sln\""));
+                        p.Arguments.Render() == args));
             }
 
             [Fact]
@@ -249,10 +251,11 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 runner.Run(settings);
 
                 // Then
+                var args = "/m:4 /v:normal /target:Build \"/Working/src/Solution.sln\"";
                 fixture.ProcessRunner.Received(1).Start(
                     Arg.Any<FilePath>(), 
                     Arg.Is<ProcessSettings>(p =>
-                        p.Arguments.Render() == "/m:4 /target:Build \"/Working/src/Solution.sln\""));
+                        p.Arguments.Render() == args));
             }
 
             [Fact]
@@ -269,10 +272,11 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 runner.Run(settings);
 
                 // Then
+                var args = "/m /v:normal /target:Build \"/Working/src/Solution.sln\"";
                 fixture.ProcessRunner.Received(1).Start(
                     Arg.Any<FilePath>(), 
                     Arg.Is<ProcessSettings>(p =>
-                        p.Arguments.Render() == "/m /target:Build \"/Working/src/Solution.sln\""));
+                        p.Arguments.Render() == args));
             }
 
             [Fact]
@@ -290,10 +294,11 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 runner.Run(settings);
 
                 // Then
+                var args = "/m /v:normal /nr:true /target:Build \"/Working/src/Solution.sln\"";
                 fixture.ProcessRunner.Received(1).Start(
                     Arg.Any<FilePath>(),
                     Arg.Is<ProcessSettings>(p =>
-                        p.Arguments.Render() == "/m /nr:true /target:Build \"/Working/src/Solution.sln\""));
+                        p.Arguments.Render() == args));
             }
 
             [Fact]
@@ -312,10 +317,11 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 runner.Run(settings);
 
                 // Then
+                var args = "/m /v:normal /target:A;B \"/Working/src/Solution.sln\"";
                 fixture.ProcessRunner.Received(1).Start(
                     Arg.Any<FilePath>(),
                     Arg.Is<ProcessSettings>(p =>
-                        p.Arguments.Render() == "/m /target:A;B \"/Working/src/Solution.sln\""));
+                        p.Arguments.Render() == args));
             }
 
             [Fact]
@@ -334,10 +340,11 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 runner.Run(settings);
 
                 // Then
+                var args = "/m /v:normal /p:\"A\"=\"B\" /p:\"C\"=\"D\" /target:Build \"/Working/src/Solution.sln\"";
                 fixture.ProcessRunner.Received(1).Start(
                     Arg.Any<FilePath>(),
                     Arg.Is<ProcessSettings>(p =>
-                        p.Arguments.Render() == "/m /p:\"A\"=\"B\" /p:\"C\"=\"D\" /target:Build \"/Working/src/Solution.sln\""));
+                        p.Arguments.Render() == args));
             }
 
             [Fact]
@@ -356,10 +363,11 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 runner.Run(settings);
 
                 // Then
+                var args = "/m /v:normal /p:\"A\"=\"B\" /p:\"A\"=\"E\" /p:\"C\"=\"D\" /target:Build \"/Working/src/Solution.sln\"";
                 fixture.ProcessRunner.Received(1).Start(
                     Arg.Any<FilePath>(),
                     Arg.Is<ProcessSettings>(p =>
-                        p.Arguments.Render() == "/m /p:\"A\"=\"B\" /p:\"A\"=\"E\" /p:\"C\"=\"D\" /target:Build \"/Working/src/Solution.sln\""));
+                        p.Arguments.Render() == args));
             }
 
             [Fact]
@@ -377,10 +385,11 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 runner.Run(settings);
 
                 // Then
+                var args = "/m /v:normal /p:\"Configuration\"=\"Release\" /target:Build \"/Working/src/Solution.sln\"";
                 fixture.ProcessRunner.Received(1).Start(
                     Arg.Any<FilePath>(),
                     Arg.Is<ProcessSettings>(p => 
-                        p.Arguments.Render() == "/m /p:\"Configuration\"=\"Release\" /target:Build \"/Working/src/Solution.sln\""));
+                        p.Arguments.Render() == args));
             }
 
             [Fact]
@@ -438,6 +447,33 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 // Then
                 Assert.IsType<CakeException>(result);
                 Assert.Equal("MSBuild: Process returned an error.", result.Message);
+            }
+
+            [Theory]
+            [InlineData(Verbosity.Quiet, "/v:quiet")]
+            [InlineData(Verbosity.Minimal, "/v:minimal")]
+            [InlineData(Verbosity.Normal, "/v:normal")]
+            [InlineData(Verbosity.Verbose, "/v:verbose")]
+            [InlineData(Verbosity.Diagnostic, "/v:diagnostic")]
+            public void Should_Append_Correct_Verbosity(Verbosity verbosity, string expected)
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, true);
+                var runner = fixture.CreateRunner();
+
+                var settings = new MSBuildSettings("./src/Solution.sln");
+                settings.ToolVersion = MSBuildToolVersion.VS2013;
+                settings.Verbosity = verbosity;
+
+                // When
+                runner.Run(settings);
+
+                // Then
+                var args = string.Concat("/m ", expected, " /target:Build \"/Working/src/Solution.sln\"");
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(),
+                    Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == args));                
             }
         }
     }

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsExtensionsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsExtensionsTests.cs
@@ -255,7 +255,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 var settings = new MSBuildSettings(solution);
 
                 // When
-                var result = settings.SetVerbosity(verbosity);
+                settings.SetVerbosity(verbosity);
 
                 // Then
                 Assert.Equal(verbosity, settings.Verbosity);

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsExtensionsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using Cake.Common.Tools.MSBuild;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Xunit;
 
@@ -224,21 +225,55 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 Assert.Equal(reuse, settings.NodeReuse);
             }
 
-            [Theory]
-            [InlineData(true)]
-            [InlineData(false)]
-            public void Should_Return_The_Same_Configuration(bool reuse)
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
             {
                 // Given
                 var solution = new FilePath("/src/Solution.sln");
                 var settings = new MSBuildSettings(solution);
 
                 // When
-                var result = settings.SetNodeReuse(reuse);
+                var result = settings.SetNodeReuse(true);
 
                 // Then
                 Assert.Equal(settings, result);
             }        
+        }
+
+        public sealed class TheSetVerbosityMethod
+        {
+            [Theory]
+            [InlineData(Verbosity.Quiet)]
+            [InlineData(Verbosity.Minimal)]
+            [InlineData(Verbosity.Normal)]
+            [InlineData(Verbosity.Verbose)]
+            [InlineData(Verbosity.Diagnostic)]
+            public void Should_Set_Verbosity(Verbosity verbosity)
+            {
+                // Given
+                var solution = new FilePath("/src/Solution.sln");
+                var settings = new MSBuildSettings(solution);
+
+                // When
+                var result = settings.SetVerbosity(verbosity);
+
+                // Then
+                Assert.Equal(verbosity, settings.Verbosity);
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var solution = new FilePath("/src/Solution.sln");
+                var settings = new MSBuildSettings(solution);
+
+                // When
+                var result = settings.SetVerbosity(Verbosity.Normal);
+
+                // Then
+                Assert.Equal(settings, result);
+            } 
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsTests.cs
@@ -1,4 +1,5 @@
 ﻿using Cake.Common.Tools.MSBuild;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Xunit;
 
@@ -42,6 +43,19 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
 
                 // Then
                 Assert.Equal(PlatformTarget.MSIL, settings.PlatformTarget);
+            }
+
+            [Fact]
+            public void Should_Set_Default_Verbosity_To_Normal()
+            {
+                // Given
+                var path = new FilePath("./Project.sln");
+
+                // When
+                var settings = new MSBuildSettings(path);
+
+                // Then
+                Assert.Equal(Verbosity.Normal, settings.Verbosity);                
             }
         }
 

--- a/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Cake.Core;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.Core.Utilities;
 
@@ -43,10 +45,13 @@ namespace Cake.Common.Tools.MSBuild
             // Set the maximum number of processors.
             builder.Append(settings.MaxCpuCount > 0 ? string.Concat("/m:", settings.MaxCpuCount) : "/m");
 
-if (settings.NodeReuse != null)
-{
-    builder.Append(string.Concat("/nr:", settings.NodeReuse.Value ? "true" : "false"));
-}
+            // Set the verbosity.
+            builder.Append(string.Format(CultureInfo.InvariantCulture, "/v:{0}", GetVerbosityName(settings.Verbosity)));
+
+            if (settings.NodeReuse != null)
+            {
+                builder.Append(string.Concat("/nr:", settings.NodeReuse.Value ? "true" : "false"));
+            }
 
             // Got a specific configuration in mind?
             if (!string.IsNullOrWhiteSpace(settings.Configuration))
@@ -83,6 +88,24 @@ if (settings.NodeReuse != null)
             return builder;
         }
 
+        private static string GetVerbosityName(Verbosity verbosity)
+        {
+            switch (verbosity)
+            {
+                case Verbosity.Quiet:
+                    return "quiet";
+                case Verbosity.Minimal:
+                    return "minimal";
+                case Verbosity.Normal:
+                    return "normal";
+                case Verbosity.Verbose:
+                    return "verbose";
+                case Verbosity.Diagnostic: 
+                    return "diagnostic";
+            }
+            throw new CakeException("Unknown MSBuild verbosity.");
+        }
+
         private static IEnumerable<string> GetPropertyArguments(IDictionary<string, IList<string>> properties)
         {
             foreach (var propertyKey in properties.Keys)
@@ -91,7 +114,7 @@ if (settings.NodeReuse != null)
                 {
                     yield return string.Concat("/p:", propertyKey.Quote(), "=", propertyValue.Quote());
                 }
-            }            
+            }
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
@@ -103,7 +103,7 @@ namespace Cake.Common.Tools.MSBuild
                 case Verbosity.Diagnostic: 
                     return "diagnostic";
             }
-            throw new CakeException("Unknown MSBuild verbosity.");
+            throw new CakeException("Encountered unknown MSBuild build log verbosity.");
         }
 
         private static IEnumerable<string> GetPropertyArguments(IDictionary<string, IList<string>> properties)

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 
 namespace Cake.Common.Tools.MSBuild
@@ -72,6 +73,13 @@ namespace Cake.Common.Tools.MSBuild
         public bool? NodeReuse { get; set; }
 
         /// <summary>
+        /// Gets or sets the amount of information to display in the build log. 
+        /// Each logger displays events based on the verbosity level that you set for that logger.
+        /// </summary>
+        /// <value>The build log verbosity.</value>
+        public Verbosity Verbosity { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="MSBuildSettings"/> class.
         /// </summary>
         /// <param name="solution">The solution.</param>
@@ -89,6 +97,7 @@ namespace Cake.Common.Tools.MSBuild
             PlatformTarget = PlatformTarget.MSIL;
             ToolVersion = MSBuildToolVersion.Default;
             Configuration = string.Empty;
-        } 
+            Verbosity = Verbosity.Normal;
+        }
     }
 }

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Cake.Core.Diagnostics;
 
 namespace Cake.Common.Tools.MSBuild
 {
@@ -127,6 +128,22 @@ namespace Cake.Common.Tools.MSBuild
                 throw new ArgumentNullException("settings");
             }
             settings.NodeReuse = reuse;
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the build log verbosity.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="verbosity">The build log verbosity.</param>
+        /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static MSBuildSettings SetVerbosity(this MSBuildSettings settings, Verbosity verbosity)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+            settings.Verbosity = verbosity;
             return settings;
         }
     }

--- a/src/Cake.Testing/ExceptionAsserts.cs
+++ b/src/Cake.Testing/ExceptionAsserts.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Cake.Core;
 
 // ReSharper disable once CheckNamespace
 namespace Xunit
@@ -9,6 +10,11 @@ namespace Xunit
         {
             IsType<ArgumentNullException>(exception);
             Equal(parameterName, ((ArgumentNullException)exception).ParamName);
+        }
+
+        public static void IsCakeException(Exception exception, string message)
+        {
+            IsExceptionWithMessage<CakeException>(exception, message);
         }
 
         public static void IsExceptionWithMessage<T>(Exception exception, string message)


### PR DESCRIPTION
Using `Cake.Core.Diagnostics.Verbosity` as argument type, since the MSBuild verbosity parameters (`quiet`, `minimal`, `normal`, `verbose`, `diagnostic`) map 1:1 to this.

```csharp
MSBuild("./src/Cake.sln", settings =>
    settings.SetConfiguration(configuration)
        .SetVerbosity(Verbosity.Minimal)
        .WithProperty("TreatWarningsAsErrors", "true")
        .UseToolVersion(MSBuildToolVersion.NET45));
```

The default verbosity is `Normal`.