### PR TITLE
Should write line break after resetting console colors.

### DIFF
--- a/src/Cake/Diagnostics/CakeBuildLog.cs
+++ b/src/Cake/Diagnostics/CakeBuildLog.cs
@@ -37,12 +37,12 @@ namespace Cake.Diagnostics
                     {
                         SetPalette(token, palette);
                         _console.Write("{0}", token.Render(args));
-                    }
-                    _console.WriteLine();
+                    }                    
                 }
                 finally
                 {
                     _console.ResetColor();
+                    _console.WriteLine();
                 }
             }
         }


### PR DESCRIPTION
This fixes an issue with background colors in the console.