### PR TITLE
Added convenience aliases for working with directory and file paths.

### DIFF
--- a/src/Cake.Common.Tests/Unit/IO/DirectoryAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/DirectoryAliasesTests.cs
@@ -14,6 +14,49 @@ namespace Cake.Common.Tests.Unit.IO
 {
     public sealed class DirectoryAliasesTests
     {
+        public sealed class TheDirectoryMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Context_Is_Null()
+            {
+                // Given
+                const string path = "./temp";
+
+                // When
+                var result = Record.Exception(() => DirectoryAliases.Directory(null, path));
+
+                // Then
+                Assert.IsArgumentNullException(result, "context");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Path_Is_Null()
+            {
+                // Given
+                var context = Substitute.For<ICakeContext>();
+
+                // When
+                var result = Record.Exception(() => DirectoryAliases.Directory(context, null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "path");
+            }
+
+            [Fact]
+            public void Should_Return_A_File_Path_Proxy()
+            {
+                // Given
+                var context = Substitute.For<ICakeContext>();
+
+                // When
+                var result = DirectoryAliases.Directory(context, "./temp");
+
+                // Then
+                Assert.Equal("temp", result.FullPath);
+            }
+        }
+
+
         public sealed class TheCleanMethod
         {
             [Fact]

--- a/src/Cake.Common.Tests/Unit/IO/FileAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/FileAliasesTests.cs
@@ -13,6 +13,48 @@ namespace Cake.Common.Tests.Unit.IO
 {
     public sealed class FileAliasesTests
     {
+        public sealed class TheFileMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Context_Is_Null()
+            {
+                // Given
+                const string path = "./file.txt";
+
+                // When
+                var result = Record.Exception(() => FileAliases.File(null, path));
+
+                // Then
+                Assert.IsArgumentNullException(result, "context");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Path_Is_Null()
+            {
+                // Given
+                var context = Substitute.For<ICakeContext>();
+
+                // When
+                var result = Record.Exception(() => FileAliases.File(context, null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "path");
+            }
+
+            [Fact]
+            public void Should_Return_A_File_Path_Proxy()
+            {
+                // Given
+                var context = Substitute.For<ICakeContext>();
+
+                // When
+                var result = FileAliases.File(context, "./file.txt");
+
+                // Then
+                Assert.Equal("file.txt", result.FullPath);
+            }
+        }
+
         public sealed class TheCopyToDirectoryMethod
         {
             [Fact]

--- a/src/Cake.Common/IO/DirectoryAliases.cs
+++ b/src/Cake.Common/IO/DirectoryAliases.cs
@@ -14,6 +14,36 @@ namespace Cake.Common.IO
     public static class DirectoryAliases
     {
         /// <summary>
+        /// Gets a directory path from string.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// // Get the temp directory.
+        /// var root = Directory("./");
+        /// var temp = root + Directory("temp");
+        /// 
+        /// // Clean the directory.
+        /// CleanDirectory(temp);
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="path">The path.</param>
+        /// <returns>A directory path.</returns>
+        [CakeMethodAlias]
+        public static DirectoryPath Directory(this ICakeContext context, string path)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            if (path == null)
+            {
+                throw new ArgumentNullException("path");
+            }
+            return new DirectoryPath(path);
+        }
+
+        /// <summary>
         /// Deletes the specified directories.
         /// </summary>
         /// <param name="context">The context.</param>

--- a/src/Cake.Common/IO/FileAliases.cs
+++ b/src/Cake.Common/IO/FileAliases.cs
@@ -14,6 +14,36 @@ namespace Cake.Common.IO
     public static class FileAliases
     {
         /// <summary>
+        /// Gets a file path from string.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// // Get the temp file.
+        /// var root = Directory("./");
+        /// var temp = root + File("temp");
+        /// 
+        /// // Delete the file.
+        /// CleanDirectory(temp);
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="path">The path.</param>
+        /// <returns>A file path.</returns>
+        [CakeMethodAlias]
+        public static FilePath File(this ICakeContext context, string path)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            if (path == null)
+            {
+                throw new ArgumentNullException("path");
+            }
+            return new FilePath(path);
+        }
+
+        /// <summary>
         /// Copies an existing file to a new location.
         /// </summary>
         /// <param name="context">The context.</param>

--- a/src/Cake.Core.Tests/Unit/IO/DirectoryPathTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/DirectoryPathTests.cs
@@ -277,5 +277,100 @@ namespace Cake.Core.Tests.Unit.IO
                 }
             }
         }
+
+        public sealed class TheAddOperator
+        {
+            public sealed class ForDirectoryPath
+            {
+                [Fact]
+                public void Should_Combine_Paths()
+                {
+                    // Given
+                    var left = new DirectoryPath("./temp");
+                    var right = new DirectoryPath("files");
+
+                    // When
+                    var result = left + right;
+
+                    // Then
+                    Assert.IsType<DirectoryPath>(result);
+                    Assert.Equal("temp/files", result.FullPath);
+                }
+
+                [Fact]
+                public void Should_Throw_If_Proxy_Is_Null()
+                {
+                    // Given
+                    var left = (DirectoryPath)null;
+                    var right = new DirectoryPath("files");
+
+                    // When
+                    var result = Record.Exception(() => left + right);
+
+                    // Then
+                    Assert.IsArgumentNullException(result, "left");
+                }
+
+                [Fact]
+                public void Should_Throw_If_Directory_Path_Is_Null()
+                {
+                    // Given
+                    var left = new DirectoryPath("./temp");
+                    var right = (DirectoryPath)null;
+
+                    // When
+                    var result = Record.Exception(() => left + right);
+
+                    // Then
+                    Assert.IsArgumentNullException(result, "right");
+                }
+            }
+
+            public sealed class ForFilePath
+            {
+                [Fact]
+                public void Should_Combine_Paths()
+                {
+                    // Given
+                    var left = new DirectoryPath("./temp");
+                    var right = new FilePath("file.txt");
+
+                    // When
+                    var result = left + right;
+
+                    // Then
+                    Assert.IsType<FilePath>(result);
+                    Assert.Equal("temp/file.txt", result.FullPath);
+                }
+
+                [Fact]
+                public void Should_Throw_If_Left_Is_Null()
+                {
+                    // Given
+                    var left = (DirectoryPath)null;
+                    var right = new FilePath("file.txt");
+
+                    // When
+                    var result = Record.Exception(() => left + right);
+
+                    // Then
+                    Assert.IsArgumentNullException(result, "directory");
+                }
+
+                [Fact]
+                public void Should_Return_Left_Path_If_Left_Is_Null()
+                {
+                    // Given
+                    var left = new DirectoryPath("./temp");
+                    var right = (FilePath)null;
+
+                    // When
+                    var result = Record.Exception(() => left + right);
+
+                    // Then
+                    Assert.IsArgumentNullException(result, "file");
+                }
+            }
+        }
     }
 }

--- a/src/Cake.Core/IO/DirectoryPath.cs
+++ b/src/Cake.Core/IO/DirectoryPath.cs
@@ -143,6 +143,50 @@ namespace Cake.Core.IO
         }
 
         /// <summary>
+        /// Operator that combines A <see cref="DirectoryPath"/> instance 
+        /// with a <see cref="DirectoryPath"/> instance.
+        /// </summary>
+        /// <param name="left">The left directory path operand.</param>
+        /// <param name="right">The right directory path operand.</param>
+        /// <returns>
+        /// A new directory path representing a combination of the two provided paths.
+        /// </returns>
+        public static DirectoryPath operator +(DirectoryPath left, DirectoryPath right)
+        {
+            if (left == null)
+            {
+                throw new ArgumentNullException("left");
+            }
+            if (right == null)
+            {
+                throw new ArgumentNullException("right");
+            }
+            return left.Combine(right);
+        }
+
+        /// <summary>
+        /// Operator that combines A <see cref="DirectoryPath"/> instance 
+        /// with a <see cref="FilePath"/> instance.
+        /// </summary>
+        /// <param name="directory">The directory.</param>
+        /// <param name="file">The file.</param>
+        /// <returns>
+        /// A new file path representing a combination of the two provided paths.
+        /// </returns>
+        public static FilePath operator +(DirectoryPath directory, FilePath file)
+        {
+            if (directory == null)
+            {
+                throw new ArgumentNullException("directory");
+            }
+            if (file == null)
+            {
+                throw new ArgumentNullException("file");
+            }
+            return directory.CombineWithFilePath(file);
+        }
+
+        /// <summary>
         /// Performs a conversion from <see cref="System.String"/> to <see cref="DirectoryPath"/>.
         /// </summary>
         /// <param name="path">The path.</param>


### PR DESCRIPTION
Added aliases to make working with paths easier and the script code more readable.
Also, no more strings concatenation to get a `DirectoryPath`/`FilePath`. :tada: :balloon: 

```csharp
// Get the path to the plugins directory.
var root = Directory("./");
var bin = root + Directory("app/bin");
var plugins = bin + Directory("plugins");

// Get the executable path.
var executable = bin + File("MyApp.exe");

// Do some work.
CleanDirectory(plugins);
DeleteFile(executable);
```

**Note/Question:**
Not sure if I should rename the aliases `Directory` and `File` to `GetDirectory` and `GetFile`.
This would probably be more consistent with [GetDirectories](http://cakebuild.net/api/cake.common.io/b6f866f7/0a89ebe2/) and [GetFiles](http://cakebuild.net/api/cake.common.io/b6f866f7/796bd28f/).