### PR TITLE
Only output handled process if diagnostic

### DIFF
--- a/src/Cake.Core/IO/ProcessWrapper.cs
+++ b/src/Cake.Core/IO/ProcessWrapper.cs
@@ -47,7 +47,7 @@ namespace Cake.Core.IO
             string line;
             while ((line = _process.StandardOutput.ReadLine()) != null)
             {
-                _log.Verbose("{0}", _filterOutput(line));
+                _log.Debug("{0}", _filterOutput(line));
                 yield return line;
             }
         }


### PR DESCRIPTION
When process output is redirected and handled, I propose it should only log this output on diagnostic loglevel.