### PR TITLE
Added support for lazy by verbosity logging

### DIFF
--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Fixtures\FileDeleteFixture.cs" />
     <Compile Include="Fixtures\FileSystemFixture.cs" />
     <Compile Include="Fixtures\ILMergeRunnerFixture.cs" />
+    <Compile Include="Fixtures\LogActionFixture.cs" />
     <Compile Include="Fixtures\MSBuildRunnerFixture.cs" />
     <Compile Include="Fixtures\NSISFixture.cs" />
     <Compile Include="Fixtures\NuGetFixture.cs" />

--- a/src/Cake.Common.Tests/Fixtures/LogActionFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/LogActionFixture.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using NSubstitute;
+
+namespace Cake.Common.Tests.Fixtures
+{
+    public sealed class LogActionFixture
+    {
+        public string Format { get; private set; }
+        public object[] Args { get; private set; }
+        public ICakeContext Context { get; set; }
+        public bool Evaluated { get; private set; }
+
+        public void Log(LogActionEntry actionEntry)
+        {
+            if (Evaluated)
+            {
+                throw new Exception("Message allready evaluated");
+            }
+            Evaluated = true;
+            actionEntry(Format, Args);
+        }
+
+        public LogActionFixture(string format = "Hello {0}!", object[] args = null, Verbosity verbosity = Verbosity.Quiet)
+        {
+            Format = format;
+            Args = args ?? new object[] { "World" };
+            var context = Substitute.For<ICakeContext>();
+            var log = Substitute.For<ICakeLog>();
+            log.Verbosity.Returns(verbosity);
+            context.Log.Returns(log);
+            Context = context;
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Diagnostics/LoggingAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/Diagnostics/LoggingAliasesTests.cs
@@ -1,4 +1,5 @@
 ﻿using Cake.Common.Diagnostics;
+using Cake.Common.Tests.Fixtures;
 using Cake.Core;
 using Cake.Core.Diagnostics;
 using NSubstitute;
@@ -25,6 +26,20 @@ namespace Cake.Common.Tests.Unit.Diagnostics
                 // Then
                 context.Log.Received(1).Write(Verbosity.Quiet, LogLevel.Error, format, args);
             }
+
+            [Fact]
+            public void Should_Evaluate_And_Write_Error_Message_To_Log()
+            {
+                // Given
+                var fixture = new LogActionFixture();
+
+                // When
+                fixture.Context.Error(fixture.Log);
+
+                // Then
+                fixture.Context.Log.Received(1).Write(Verbosity.Quiet, LogLevel.Error, fixture.Format, fixture.Args);
+                Assert.True(fixture.Evaluated);
+            }
         }
 
         public sealed class TheWarningMethod
@@ -43,6 +58,34 @@ namespace Cake.Common.Tests.Unit.Diagnostics
 
                 // Then
                 context.Log.Received(1).Write(Verbosity.Minimal, LogLevel.Warning, format, args);
+            }
+
+            [Fact]
+            public void Should_Evaluate_And_Write_Warning_Message_To_Log()
+            {
+                // Given
+                var fixture = new LogActionFixture(verbosity:Verbosity.Minimal);
+
+                // When
+                fixture.Context.Warning(fixture.Log);
+
+                // Then
+                fixture.Context.Log.Received(1).Write(Verbosity.Minimal, LogLevel.Warning, fixture.Format, fixture.Args);
+                Assert.True(fixture.Evaluated);
+            }
+
+            [Fact]
+            public void Should_Not_Evaluate_And_Write_Warning_Message_To_Log()
+            {
+                // Given
+                var fixture = new LogActionFixture();
+
+                // When
+                fixture.Context.Warning(fixture.Log);
+
+                // Then
+                fixture.Context.Log.DidNotReceive().Write(Verbosity.Minimal, LogLevel.Warning, fixture.Format, fixture.Args);
+                Assert.False(fixture.Evaluated);
             }
         }
 
@@ -63,6 +106,34 @@ namespace Cake.Common.Tests.Unit.Diagnostics
                 // Then
                 context.Log.Received(1).Write(Verbosity.Normal, LogLevel.Information, format, args);
             }
+
+            [Fact]
+            public void Should_Evaluate_And_Write_Information_Message_To_Log()
+            {
+                // Given
+                var fixture = new LogActionFixture(verbosity:Verbosity.Normal);
+
+                // When
+                fixture.Context.Information(fixture.Log);
+
+                // Then
+                fixture.Context.Log.Received(1).Write(Verbosity.Normal, LogLevel.Information, fixture.Format, fixture.Args);
+                Assert.True(fixture.Evaluated);
+            }
+
+            [Fact]
+            public void Should_Not_Evaluate_And_Write_Information_Message_To_Log()
+            {
+                // Given
+                var fixture = new LogActionFixture(verbosity:Verbosity.Minimal);
+
+                // When
+                fixture.Context.Information(fixture.Log);
+
+                // Then
+                fixture.Context.Log.DidNotReceive().Write(Verbosity.Normal, LogLevel.Information, fixture.Format, fixture.Args);
+                Assert.False(fixture.Evaluated);
+            }
         }
 
         public sealed class TheVerboseMethod
@@ -82,6 +153,34 @@ namespace Cake.Common.Tests.Unit.Diagnostics
                 // Then
                 context.Log.Received(1).Write(Verbosity.Verbose, LogLevel.Verbose, format, args);
             }
+
+            [Fact]
+            public void Should_Evaluate_And_Write_Verbose_Message_To_Log()
+            {
+                // Given
+                var fixture = new LogActionFixture(verbosity:Verbosity.Verbose);
+
+                // When
+                fixture.Context.Verbose(fixture.Log);
+
+                // Then
+                fixture.Context.Log.Received(1).Write(Verbosity.Verbose, LogLevel.Verbose, fixture.Format, fixture.Args);
+                Assert.True(fixture.Evaluated);
+            }
+
+            [Fact]
+            public void Should_Not_Evaluate_And_Write_Verbose_Message_To_Log()
+            {
+                // Given
+                var fixture = new LogActionFixture(verbosity:Verbosity.Normal);
+
+                // When
+                fixture.Context.Verbose(fixture.Log);
+
+                // Then
+                fixture.Context.Log.DidNotReceive().Write(Verbosity.Verbose, LogLevel.Verbose, fixture.Format, fixture.Args);
+                Assert.False(fixture.Evaluated);
+            }
         }
 
         public sealed class TheDebugMethod
@@ -100,6 +199,34 @@ namespace Cake.Common.Tests.Unit.Diagnostics
 
                 // Then
                 context.Log.Received(1).Write(Verbosity.Diagnostic, LogLevel.Debug, format, args);
+            }
+
+            [Fact]
+            public void Should_Evaluate_And_Write_Debug_Message_To_Log()
+            {
+                // Given
+                var fixture = new LogActionFixture(verbosity:Verbosity.Diagnostic);
+
+                // When
+                fixture.Context.Debug(fixture.Log);
+
+                // Then
+                fixture.Context.Log.Received(1).Write(Verbosity.Diagnostic, LogLevel.Debug, fixture.Format, fixture.Args);
+                Assert.True(fixture.Evaluated);
+            }
+
+            [Fact]
+            public void Should_Not_Evaluate_And_Write_Debug_Message_To_Log()
+            {
+                // Given
+                var fixture = new LogActionFixture(verbosity:Verbosity.Normal);
+
+                // When
+                fixture.Context.Debug(fixture.Log);
+
+                // Then
+                fixture.Context.Log.DidNotReceive().Write(Verbosity.Diagnostic, LogLevel.Debug, fixture.Format, fixture.Args);
+                Assert.False(fixture.Evaluated);
             }
         }
     }

--- a/src/Cake.Common/Diagnostics/LoggingAliases.cs
+++ b/src/Cake.Common/Diagnostics/LoggingAliases.cs
@@ -26,6 +26,22 @@ namespace Cake.Common.Diagnostics
             }
             context.Log.Error(format, args);
         }
+        
+        /// <summary>
+        /// Writes an error message to the log using the specified log message action.
+        /// Evaluation message only if verbosity same or more verbose.
+        /// </summary>
+        /// <param name="context">the context.</param>
+        /// <param name="logAction">The function called for message when logging.</param>
+        [CakeMethodAlias]
+        public static void Error(this ICakeContext context, LogAction logAction)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            context.Log.Error(logAction);
+        }
 
         /// <summary>
         /// Writes a warning message to the log using the specified format information.
@@ -41,6 +57,22 @@ namespace Cake.Common.Diagnostics
                 throw new ArgumentNullException("context");
             }
             context.Log.Warning(format, args);
+        }
+
+        /// <summary>
+        /// Writes a warning message to the log using the specified log message action.
+        /// Evaluation message only if verbosity same or more verbose.
+        /// </summary>
+        /// <param name="context">the context.</param>
+        /// <param name="logAction">The function called for message when logging.</param>
+        [CakeMethodAlias]
+        public static void Warning(this ICakeContext context, LogAction logAction)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            context.Log.Warning(logAction);
         }
 
         /// <summary>
@@ -60,6 +92,22 @@ namespace Cake.Common.Diagnostics
         }
 
         /// <summary>
+        /// Writes an informational message to the log using the specified log message action.
+        /// Evaluation message only if verbosity same or more verbose.
+        /// </summary>
+        /// <param name="context">the context.</param>
+        /// <param name="logAction">The function called for message when logging.</param>
+        [CakeMethodAlias]
+        public static void Information(this ICakeContext context, LogAction logAction)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            context.Log.Information(logAction);
+        }
+
+        /// <summary>
         /// Writes a verbose message to the log using the specified format information.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -76,6 +124,22 @@ namespace Cake.Common.Diagnostics
         }
 
         /// <summary>
+        /// Writes a verbose message to the log using the specified log message action.
+        /// Evaluation message only if verbosity same or more verbose.
+        /// </summary>
+        /// <param name="context">the context.</param>
+        /// <param name="logAction">The function called for message when logging.</param>
+        [CakeMethodAlias]
+        public static void Verbose(this ICakeContext context, LogAction logAction)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            context.Log.Verbose(logAction);
+        }
+
+        /// <summary>
         /// Writes a debug message to the log using the specified format information.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -89,6 +153,22 @@ namespace Cake.Common.Diagnostics
                 throw new ArgumentNullException("context");
             }
             context.Log.Debug(format, args);
+        }
+
+        /// <summary>
+        /// Writes a debug message to the log using the specified log message action.
+        /// Evaluation message only if verbosity same or more verbose.
+        /// </summary>
+        /// <param name="context">the context.</param>
+        /// <param name="logAction">The function called for message when logging.</param>
+        [CakeMethodAlias]
+        public static void Debug(this ICakeContext context, LogAction logAction)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            context.Log.Debug(logAction);
         }
     }
 }

--- a/src/Cake.Core/Cake.Core.csproj
+++ b/src/Cake.Core/Cake.Core.csproj
@@ -65,6 +65,7 @@
     <Compile Include="CakeTaskBuilderExtensions.cs" />
     <Compile Include="DefaultExecutionStrategy.cs" />
     <Compile Include="Diagnostics\ICakeLog.cs" />
+    <Compile Include="Diagnostics\LogAction.cs" />
     <Compile Include="Diagnostics\LogExtensions.cs" />
     <Compile Include="Diagnostics\LogLevel.cs" />
     <Compile Include="Diagnostics\NullLog.cs" />

--- a/src/Cake.Core/Diagnostics/ICakeLog.cs
+++ b/src/Cake.Core/Diagnostics/ICakeLog.cs
@@ -6,6 +6,12 @@
     public interface ICakeLog
     {
         /// <summary>
+        /// Gets the verbosity.
+        /// </summary>
+        /// <value>The verbosity.</value>
+        Verbosity Verbosity { get; }
+
+        /// <summary>
         /// Writes the text representation of the specified array of objects to the 
         /// log using the specified verbosity, log level and format information.
         /// </summary>

--- a/src/Cake.Core/Diagnostics/LogAction.cs
+++ b/src/Cake.Core/Diagnostics/LogAction.cs
@@ -1,0 +1,15 @@
+﻿namespace Cake.Core.Diagnostics
+{
+    /// <summary>
+    /// Delegate representing lazy log action.
+    /// </summary>
+    /// <param name="actionEntry">Proxy to log.</param>
+    public delegate void LogAction(LogActionEntry actionEntry);
+
+    /// <summary>
+    /// Delegate representing lazy log entry.
+    /// </summary>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write using format.</param>
+    public delegate void LogActionEntry(string format, params object[] args);
+}

--- a/src/Cake.Core/Diagnostics/LogExtensions.cs
+++ b/src/Cake.Core/Diagnostics/LogExtensions.cs
@@ -33,6 +33,30 @@
         }
 
         /// <summary>
+        /// Writes an error message to the log using the specified 
+        /// verbosity and log message action.
+        /// Evaluation message only if verbosity same or more verbose.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="verbosity">The verbosity.</param>
+        /// <param name="logAction">The function called for message when logging.</param>
+        public static void Error(this ICakeLog log, Verbosity verbosity, LogAction logAction)
+        {
+            Write(log, verbosity, LogLevel.Error, logAction);
+        }
+
+        /// <summary>
+        /// Writes an error message to the log using the specified log message action.
+        /// Evaluation message only if verbosity same or more verbose.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="logAction">The function called for message when logging.</param>
+        public static void Error(this ICakeLog log, LogAction logAction)
+        {
+            Error(log, Verbosity.Quiet, logAction);
+        }
+
+        /// <summary>
         /// Writes a warning message to the log using the specified format information.
         /// </summary>
         /// <param name="log">The log.</param>
@@ -57,6 +81,30 @@
             {
                 log.Write(verbosity, LogLevel.Warning, format, args);
             }
+        }
+
+        /// <summary>
+        /// Writes a warning message to the log using the specified log message action.
+        /// Evaluation message only if verbosity same or more verbose.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="logAction">The function called for message when logging.</param>
+        public static void Warning(this ICakeLog log, LogAction logAction)
+        {
+            Warning(log, Verbosity.Minimal, logAction);
+        }
+
+        /// <summary>
+        /// Writes a warning message to the log using the specified 
+        /// verbosity and log message action.
+        /// Evaluation message only if verbosity same or more verbose.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="verbosity">The verbosity.</param>
+        /// <param name="logAction">The function called for message when logging.</param>
+        public static void Warning(this ICakeLog log, Verbosity verbosity, LogAction logAction)
+        {
+            Write(log, verbosity, LogLevel.Warning, logAction);
         }
 
         /// <summary>
@@ -87,6 +135,30 @@
         }
 
         /// <summary>
+        /// Writes an informational message to the log using the specified 
+        /// verbosity and log message action.
+        /// Evaluation message only if verbosity same or more verbose.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="verbosity">The verbosity.</param>
+        /// <param name="logAction">The function called for message when logging.</param>
+        public static void Information(this ICakeLog log, Verbosity verbosity, LogAction logAction)
+        {
+            Write(log, verbosity, LogLevel.Information, logAction);
+        }
+
+        /// <summary>
+        /// Writes an informational message to the log using the specified log message action.
+        /// Evaluation message only if verbosity same or more verbose.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="logAction">The function called for message when logging.</param>
+        public static void Information(this ICakeLog log, LogAction logAction)
+        {
+            Information(log, Verbosity.Normal, logAction);
+        }
+
+        /// <summary>
         /// Writes a verbose message to the log using the specified format information.
         /// </summary>
         /// <param name="log">The log.</param>
@@ -114,6 +186,30 @@
         }
 
         /// <summary>
+        /// Writes a verbose message to the log using the specified log message action.
+        /// Evaluation message only if verbosity same or more verbose.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="logAction">The function called for message when logging.</param>
+        public static void Verbose(this ICakeLog log, LogAction logAction)
+        {
+            Verbose(log, Verbosity.Verbose, logAction);
+        }
+
+        /// <summary>
+        /// Writes a verbose message to the log using the specified 
+        /// verbosity and log message action.
+        /// Evaluation message only if verbosity same or more verbose.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="verbosity">The verbosity.</param>
+        /// <param name="logAction">The function called for message when logging.</param>
+        public static void Verbose(this ICakeLog log, Verbosity verbosity, LogAction logAction)
+        {
+            Write(log, verbosity, LogLevel.Verbose, logAction);
+        }
+
+        /// <summary>
         /// Writes a debug message to the log using the specified format information.
         /// </summary>
         /// <param name="log">The log.</param>
@@ -138,6 +234,54 @@
             {
                 log.Write(verbosity, LogLevel.Debug, format, args);
             }
+        }
+
+        /// <summary>
+        /// Writes a debug message to the log using the specified log message action.
+        /// Evaluation message only if verbosity same or more verbose.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="logAction">The function called for message when logging.</param>
+        public static void Debug(this ICakeLog log, LogAction logAction)
+        {
+            Debug(log, Verbosity.Diagnostic, logAction);
+        }
+
+        /// <summary>
+        /// Writes a debug message to the log using the specified 
+        /// verbosity and log message action.
+        /// Evaluation message only if verbosity same or more verbose.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="verbosity">The verbosity.</param>
+        /// <param name="logAction">The function called for message when logging.</param>
+        public static void Debug(this ICakeLog log, Verbosity verbosity, LogAction logAction)
+        {
+            Write(log, verbosity, LogLevel.Debug, logAction);
+        }
+
+        /// <summary>
+        /// Writes a message to the log using the specified verbosity, loglevel and logAction delegate
+        /// Evaluation message only if verbosity same or more verbose.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="verbosity">The verbosity.</param>
+        /// <param name="level">The log level.</param>
+        /// <param name="logAction">The function called for message when logging.</param>
+        public static void Write(this ICakeLog log, Verbosity verbosity, LogLevel level, LogAction logAction)
+        {
+            if (log == null || logAction == null)
+            {
+                return;
+            }
+
+            if (verbosity > log.Verbosity)
+            {
+                return;
+            }
+
+            LogActionEntry actionEntry = (format, args) => log.Write(verbosity, level, format, args);
+            logAction(actionEntry);
         }
     }
 }

--- a/src/Cake.Core/Diagnostics/NullLog.cs
+++ b/src/Cake.Core/Diagnostics/NullLog.cs
@@ -6,6 +6,15 @@
     public sealed class NullLog : ICakeLog
     {
         /// <summary>
+        /// Gets the verbosity.
+        /// </summary>
+        /// <value>The verbosity.</value>
+        public Verbosity Verbosity
+        {
+            get { return Verbosity.Quiet; }
+        }
+
+        /// <summary>
         /// Writes the text representation of the specified array of objects to the 
         /// log using the specified verbosity, log level and format information.
         /// </summary>

--- a/src/Cake.Testing/Fakes/FakeLog.cs
+++ b/src/Cake.Testing/Fakes/FakeLog.cs
@@ -28,6 +28,15 @@ namespace Cake.Testing.Fakes
         }
 
         /// <summary>
+        /// Gets the verbosity.
+        /// </summary>
+        /// <value>The verbosity.</value>
+        public Verbosity Verbosity
+        {
+            get { return Verbosity.Quiet; }
+        }
+
+        /// <summary>
         /// Writes the text representation of the specified array of objects to the
         /// log using the specified verbosity, log level and format information.
         /// </summary>

--- a/src/Cake.Tests/Unit/CakeApplicationTests.cs
+++ b/src/Cake.Tests/Unit/CakeApplicationTests.cs
@@ -80,7 +80,7 @@ namespace Cake.Tests.Unit
                 fixture.RunApplication();
 
                 // Then
-                fixture.Log.Received(1).Verbosity = Verbosity.Diagnostic;
+                fixture.Log.Received(1).SetVerbosity(Verbosity.Diagnostic);
             }
 
             [Fact]

--- a/src/Cake.Tests/Unit/Diagnostics/CakeBuildLogTests.cs
+++ b/src/Cake.Tests/Unit/Diagnostics/CakeBuildLogTests.cs
@@ -18,10 +18,7 @@ namespace Cake.Tests.Unit.Diagnostics
             {
                 // Given
                 var console = new FakeConsole();
-                var log = new CakeBuildLog(console)
-                {
-                    Verbosity = logVerbosity
-                };
+                var log = new CakeBuildLog(console, logVerbosity);
 
                 // When
                 log.Write(messageVerbosity, LogLevel.Information, "Hello World");
@@ -39,10 +36,7 @@ namespace Cake.Tests.Unit.Diagnostics
             {
                 // Given
                 var console = new FakeConsole();
-                var log = new CakeBuildLog(console)
-                {
-                    Verbosity = logVerbosity
-                };
+                var log = new CakeBuildLog(console, logVerbosity);
 
                 // When
                 log.Write(messageVerbosity, LogLevel.Information, "Hello World");

--- a/src/Cake/CakeApplication.cs
+++ b/src/Cake/CakeApplication.cs
@@ -67,7 +67,7 @@ namespace Cake
                 var options = _argumentParser.Parse(args);
                 if (options != null)
                 {
-                    _log.Verbosity = options.Verbosity;
+                    _log.SetVerbosity(options.Verbosity);
                 }
 
                 // Create the correct command and execute it.
@@ -110,7 +110,7 @@ namespace Cake
                 {
                     if (options.ShowDescription)
                     {
-                        _log.Verbosity = Verbosity.Quiet;
+                        _log.SetVerbosity(options.Verbosity);
                         return _commandFactory.CreateDescriptionCommand();
                     }
 

--- a/src/Cake/Diagnostics/CakeBuildLog.cs
+++ b/src/Cake/Diagnostics/CakeBuildLog.cs
@@ -12,13 +12,14 @@ namespace Cake.Diagnostics
         private readonly object _lock;
         private readonly IDictionary<LogLevel, ConsolePalette> _palettes;
 
-        public Verbosity Verbosity { get; set; }
+        public Verbosity Verbosity { get; private set; }
 
-        public CakeBuildLog(IConsole console)
+        public CakeBuildLog(IConsole console, Verbosity verbosity = Verbosity.Normal)
         {
             _console = console;
             _lock = new object();
             _palettes = CreatePalette();
+            Verbosity = verbosity;
         }
 
         public void Write(Verbosity verbosity, LogLevel level, string format, params object[] args)
@@ -45,6 +46,11 @@ namespace Cake.Diagnostics
                     _console.WriteLine();
                 }
             }
+        }
+
+        public void SetVerbosity(Verbosity verbosity)
+        {
+            Verbosity = verbosity;
         }
 
         private void SetPalette(FormatToken token, ConsolePalette palette)

--- a/src/Cake/Diagnostics/IVerbosityAware.cs
+++ b/src/Cake/Diagnostics/IVerbosityAware.cs
@@ -8,9 +8,9 @@ namespace Cake.Diagnostics
     public interface IVerbosityAwareLog : ICakeLog
     {
         /// <summary>
-        /// Gets or sets the verbosity.
+        /// Sets the verbosity.
         /// </summary>
-        /// <value>The verbosity.</value>
-        Verbosity Verbosity { get; set; }
+        /// <param name="verbosity">The desired verbosity.</param>
+        void SetVerbosity(Verbosity verbosity);
     }
 }


### PR DESCRIPTION
Some logging takes time / resources and because of that we might only want to run them if i.e. `verbosity` is set to `Diagnostic`

Currently it will just omit the data when logging higher verbosity then `Cake` is launched with, but the work to evaluate the log message is till done.

That's why a propose that add an option where an function could be passed instead of `format` & `args` to the logging aliases.

A simple example of these new alias would be:
```csharp
Information(
    write => {
        //do some hard word
        write("This will only be called Verbosity>={0}", "Normal");
    });
``` 
The above message would only be evaluated and displayes if cake is launched withe the verbosities Normal, Verbose or Verbose

An more advanced example would be
```csharp
var tests = new KeyValuePair<string, Action<LazyLog>> [] {
                new KeyValuePair<string, Action<LazyLog>>("Error",         Error),
                new KeyValuePair<string, Action<LazyLog>>("Warning",       Warning),
                new KeyValuePair<string, Action<LazyLog>>("Information",   Information),
                new KeyValuePair<string, Action<LazyLog>>("Verbose",       Verbose),
                new KeyValuePair<string, Action<LazyLog>>("Debug",         Debug)
            };

Array.ForEach(
    tests,
    test=>{
        Context.Log.Write(Verbosity.Quiet, LogLevel.Information, "Testing {0}.", test.Key);
        bool funcEvaluated = false;
        LazyLog logFunc = write=> {
            funcEvaluated = true;
            write("Message from logging function ({0:yyyy-MM-dd})", DateTime.Now);
        };
        test.Value(logFunc);
        Context.Log.Write(
            Verbosity.Quiet,
            LogLevel.Information,
            "{0} {1} evaluated.\r\n",
            test.Key, (funcEvaluated) ? "was" : "wasn't");
    });
```

In this case if verbosity=Quiet the output would be
```
Testing Error.
Message from logging function (2015-03-14)
Error was evaluated.

Testing Warning.
Warning wasn't evaluated.

Testing Information.
Information wasn't evaluated.

Testing Verbose.
Verbose wasn't evaluated.

Testing Debug.
Debug wasn't evaluated.
```

And in case of diagnostic
```
Testing Error.
Message from logging function (2015-03-14)
Error was evaluated.

Testing Warning.
Message from logging function (2015-03-14)
Warning was evaluated.

Testing Information.
Message from logging function (2015-03-14)
Information was evaluated.

Testing Verbose.
Message from logging function (2015-03-14)
Verbose was evaluated.

Testing Debug.
Message from logging function (2015-03-14)
Debug was evaluated.
```