### PR TITLE
Added dry run support.

### DIFF
--- a/src/Cake.Core.Tests/Fixtures/CakeEngineFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/CakeEngineFixture.cs
@@ -15,6 +15,7 @@ namespace Cake.Core.Tests.Fixtures
         public IProcessRunner ProcessRunner { get; set; }
         public IEnumerable<IToolResolver> ToolResolvers { get; set; }
         public ICakeContext Context { get; set; }
+        public IExecutionStrategy ExecutionStrategy { get; set; }
 
         public CakeEngineFixture()
         {
@@ -25,6 +26,7 @@ namespace Cake.Core.Tests.Fixtures
             Arguments = Substitute.For<ICakeArguments>();
             ProcessRunner = Substitute.For<IProcessRunner>();
             ToolResolvers = Substitute.For<IEnumerable<IToolResolver>>();
+            ExecutionStrategy = new DefaultExecutionStrategy(Log);
 
             Context = Substitute.For<ICakeContext>();
             Context.Arguments.Returns(Arguments);

--- a/src/Cake.Core.Tests/Fixtures/ScriptHostFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/ScriptHostFixture.cs
@@ -44,7 +44,8 @@ namespace Cake.Core.Tests.Fixtures
             Context.Log.Returns(Log);
 
             Engine = Substitute.For<ICakeEngine>();
-            Engine.RunTarget(Context, Arg.Any<string>()).Returns(new CakeReport());
+            Engine.RunTarget(Context, Arg.Any<IExecutionStrategy>(), Arg.Any<string>())
+                .Returns(new CakeReport());
         }
 
         public ScriptHost CreateHost()

--- a/src/Cake.Core.Tests/Unit/CakeEngineTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeEngineTests.cs
@@ -96,7 +96,8 @@ namespace Cake.Core.Tests.Unit
                     var engine = fixture.CreateEngine();
 
                     // When
-                    var result = Record.Exception(() => engine.RunTarget(fixture.Context, null));
+                    var result = Record.Exception(() =>
+                        engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, null));
 
                     // Then
                     Assert.IsArgumentNullException(result, "target");
@@ -113,7 +114,8 @@ namespace Cake.Core.Tests.Unit
                     var engine = fixture.CreateEngine();
 
                     // When
-                    var result = Record.Exception(() => engine.RunTarget(fixture.Context, new DefaultExecutionStrategy(), null));
+                    var result = Record.Exception(() =>
+                        engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, null));
 
                     // Then
                     Assert.IsArgumentNullException(result, "target");
@@ -146,7 +148,7 @@ namespace Cake.Core.Tests.Unit
                 engine.RegisterTask("C").IsDependentOn("B").Does(() => result.Add("C"));
 
                 // When
-                engine.RunTarget(fixture.Context, "C");
+                engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "C");
 
                 // Then
                 Assert.Equal(3, result.Count);
@@ -167,7 +169,7 @@ namespace Cake.Core.Tests.Unit
                 engine.RegisterTask("C").IsDependentOn("B").Does(() => result.Add("C"));
 
                 // When
-                engine.RunTarget(fixture.Context, "C");
+                engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "C");
 
                 // Then
                 Assert.Equal(2, result.Count);
@@ -187,7 +189,7 @@ namespace Cake.Core.Tests.Unit
                 engine.RegisterTask("C").IsDependentOn("B").Does(() => result.Add("C"));
 
                 // When
-                engine.RunTarget(fixture.Context, "C");
+                engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "C");
 
                 // Then
                 Assert.Equal(3, result.Count);
@@ -205,7 +207,7 @@ namespace Cake.Core.Tests.Unit
 
                 // When
                 var result = Record.Exception(() =>
-                    engine.RunTarget(fixture.Context, "Run-Some-Tests"));
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "Run-Some-Tests"));
 
                 // Then
                 Assert.IsType<CakeException>(result);
@@ -222,7 +224,7 @@ namespace Cake.Core.Tests.Unit
 
                 // When
                 var result = Record.Exception(() =>
-                    engine.RunTarget(fixture.Context, "A"));
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
 
                 // Then
                 Assert.IsType<InvalidOperationException>(result);
@@ -238,7 +240,7 @@ namespace Cake.Core.Tests.Unit
                 engine.RegisterTask("A").ContinueOnError().Does(() => { throw new InvalidOperationException(); });
 
                 // When, Then
-                engine.RunTarget(fixture.Context, "A");
+                engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A");
             }
 
             [Fact]
@@ -254,7 +256,7 @@ namespace Cake.Core.Tests.Unit
 
                 // When
                 Record.Exception(() =>
-                    engine.RunTarget(fixture.Context, "A"));
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
 
                 // Then
                 Assert.True(invoked);
@@ -272,7 +274,7 @@ namespace Cake.Core.Tests.Unit
 
                 // When
                 var result = Record.Exception(() =>
-                    engine.RunTarget(fixture.Context, "A"));
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
 
                 // Then
                 Assert.IsType<InvalidOperationException>(result);
@@ -291,7 +293,7 @@ namespace Cake.Core.Tests.Unit
 
                 // When
                 Record.Exception(() =>
-                    engine.RunTarget(fixture.Context, "A"));
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
 
                 // Then
                 Assert.True(fixture.Log.Messages.Contains("Error: Whoopsie"));
@@ -307,8 +309,8 @@ namespace Cake.Core.Tests.Unit
                 engine.RegisterTask("B").IsDependentOn("A").WithCriteria(false);
 
                 // When
-                var result = Record.Exception(() => 
-                    engine.RunTarget(fixture.Context, "B"));
+                var result = Record.Exception(() =>
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "B"));
 
                 // Then
                 Assert.IsType<CakeException>(result);
@@ -326,7 +328,7 @@ namespace Cake.Core.Tests.Unit
                 engine.RegisterTask("A").Does(() => result.Add("A"));
 
                 // When
-                engine.RunTarget(fixture.Context, "A");
+                engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A");
 
                 // Then
                 Assert.Equal(2, result.Count);
@@ -345,7 +347,8 @@ namespace Cake.Core.Tests.Unit
                 engine.RegisterTask("A").Does(() => runTask = true);
 
                 // When
-                Record.Exception(() => engine.RunTarget(fixture.Context, "A"));
+                Record.Exception(() =>
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
 
                 // Then
                 Assert.False(runTask, "Task A was executed although it shouldn't have been.");
@@ -365,7 +368,7 @@ namespace Cake.Core.Tests.Unit
                 engine.RegisterTask("A").Does(() => result.Add("A"));
 
                 // When
-                engine.RunTarget(fixture.Context, "A");
+                engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A");
 
                 // Then
                 Assert.Equal(3, result.Count);
@@ -385,7 +388,7 @@ namespace Cake.Core.Tests.Unit
 
                 // When
                 var result = Record.Exception(() =>
-                    engine.RunTarget(fixture.Context, "A"));
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
 
                 // Then
                 Assert.NotNull(result);
@@ -407,7 +410,7 @@ namespace Cake.Core.Tests.Unit
 
                 // When
                 var result = Record.Exception(() =>
-                    engine.RunTarget(fixture.Context, "A"));
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
 
                 // Then
                 Assert.NotNull(result);
@@ -429,7 +432,7 @@ namespace Cake.Core.Tests.Unit
 
                 // When
                 var result = Record.Exception(() =>
-                    engine.RunTarget(fixture.Context, "A"));
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
 
                 // Then
                 Assert.NotNull(result);
@@ -450,7 +453,7 @@ namespace Cake.Core.Tests.Unit
 
                 // When
                 var result = Record.Exception(() =>
-                    engine.RunTarget(fixture.Context, "A"));
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
 
                 // Then
                 Assert.Equal(expected, result);
@@ -469,7 +472,7 @@ namespace Cake.Core.Tests.Unit
 
                 // When
                 Record.Exception(() =>
-                    engine.RunTarget(fixture.Context, "A"));
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
 
                 // Then
                 Assert.True(fixture.Log.Messages.Any(x => x.StartsWith("Teardown error:")));
@@ -487,7 +490,7 @@ namespace Cake.Core.Tests.Unit
 
                 // When
                 var result = Record.Exception(() =>
-                    engine.RunTarget(fixture.Context, "A"));
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
 
                 // Then
                 Assert.NotNull(result);
@@ -506,8 +509,8 @@ namespace Cake.Core.Tests.Unit
                 engine.RegisterTask("A").Does(() => { throw new InvalidOperationException("Task"); });
 
                 // When
-                Record.Exception(() => 
-                    engine.RunTarget(fixture.Context, "A"));
+                Record.Exception(() =>
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
 
                 // Then
                 Assert.True(fixture.Log.Messages.Any(x => x.StartsWith("Teardown error:")));
@@ -524,7 +527,7 @@ namespace Cake.Core.Tests.Unit
                     .Finally(() => invoked = true);
 
                 // When
-                engine.RunTarget(fixture.Context, "A");
+                engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A");
 
                 // Then
                 Assert.True(invoked);
@@ -544,7 +547,7 @@ namespace Cake.Core.Tests.Unit
                     .Finally(() => invoked = true);
 
                 // When
-                engine.RunTarget(fixture.Context, "A");
+                engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A");
 
                 // Then
                 Assert.True(invoked);
@@ -563,7 +566,7 @@ namespace Cake.Core.Tests.Unit
                     .Finally(() => result.Add("Finally"));
 
                 // When
-                engine.RunTarget(fixture.Context, "A");
+                engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A");
 
                 // Then
                 Assert.Equal(2, result.Count);
@@ -583,7 +586,7 @@ namespace Cake.Core.Tests.Unit
                     .ReportError(ex => result.Add("Report"));
 
                 // When
-                engine.RunTarget(fixture.Context, "A");
+                engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A");
 
                 // Then
                 Assert.Equal(2, result.Count);
@@ -602,7 +605,7 @@ namespace Cake.Core.Tests.Unit
 
                 // When
                 var result = Record.Exception(() =>
-                    engine.RunTarget(fixture.Context, "A"));
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
 
                 // Then
                 Assert.Equal("Task", result.Message);
@@ -621,7 +624,7 @@ namespace Cake.Core.Tests.Unit
 
                 // When
                 var result = Record.Exception(() =>
-                    engine.RunTarget(fixture.Context, "A"));
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
 
                 // Then
                 Assert.Equal("Error", result.Message);

--- a/src/Cake.Core/CakeEngine.cs
+++ b/src/Cake.Core/CakeEngine.cs
@@ -84,17 +84,6 @@ namespace Cake.Core
         /// Runs the specified target.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="target">The target to run.</param>
-        /// <returns>The resulting report.</returns>
-        public CakeReport RunTarget(ICakeContext context, string target)
-        {
-            return RunTarget(context, new DefaultExecutionStrategy(), target);
-        }
-
-        /// <summary>
-        /// Runs the specified target.
-        /// </summary>
-        /// <param name="context">The context.</param>
         /// <param name="strategy">The execution strategy.</param>
         /// <param name="target">The target to run.</param>
         /// <returns>The resulting report.</returns>
@@ -142,20 +131,11 @@ namespace Cake.Core
                     // Should we execute the task?
                     if (ShouldTaskExecute(task, isTarget))
                     {
-                        _log.Information(string.Empty);
-                        _log.Information("========================================");
-                        _log.Information(task.Name);
-                        _log.Information("========================================");
-                        _log.Verbose("Executing task: {0}", task.Name);
-
-                        // Execute the task.
                         ExecuteTask(context, strategy, stopWatch, task, report);
-
-                        _log.Verbose("Finished executing task: {0}", task.Name);
                     }
                     else
                     {
-                        _log.Verbose("Skipping task: {0}", task.Name);
+                        SkipTask(strategy, task);
                     }
                 }
 
@@ -176,12 +156,6 @@ namespace Cake.Core
         {
             if (_setupAction != null)
             {
-                _log.Information(string.Empty);
-                _log.Information("----------------------------------------");
-                _log.Information("Setup");
-                _log.Information("----------------------------------------");
-                _log.Verbose("Executing custom setup action...");
-
                 strategy.PerformSetup(_setupAction);
             }
         }
@@ -251,6 +225,11 @@ namespace Cake.Core
             report.Add(task.Name, stopWatch.Elapsed);
         }
 
+        private static void SkipTask(IExecutionStrategy strategy, CakeTask task)
+        {
+            strategy.Skip(task);
+        }
+
         private static void ReportErrors(IExecutionStrategy strategy, Action<Exception> errorReporter, Exception taskException)
         {
             try
@@ -286,12 +265,6 @@ namespace Cake.Core
             {
                 try
                 {
-                    _log.Information(string.Empty);
-                    _log.Information("----------------------------------------");
-                    _log.Information("Teardown");
-                    _log.Information("----------------------------------------");
-                    _log.Verbose("Executing custom teardown action...");
-
                     strategy.PerformTeardown(_teardownAction);
                 }
                 catch (Exception ex)

--- a/src/Cake.Core/DefaultExecutionStrategy.cs
+++ b/src/Cake.Core/DefaultExecutionStrategy.cs
@@ -1,12 +1,24 @@
 ﻿using System;
+using Cake.Core.Diagnostics;
 
 namespace Cake.Core
 {
     /// <summary>
     /// The default execution strategy.
     /// </summary>
-    internal sealed class DefaultExecutionStrategy : IExecutionStrategy
+    public sealed class DefaultExecutionStrategy : IExecutionStrategy
     {
+        private readonly ICakeLog _log;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultExecutionStrategy"/> class.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        public DefaultExecutionStrategy(ICakeLog log)
+        {
+            _log = log;
+        }
+
         /// <summary>
         /// Performs the setup.
         /// </summary>
@@ -15,6 +27,12 @@ namespace Cake.Core
         {
             if (action != null)
             {
+                _log.Information(string.Empty);
+                _log.Information("----------------------------------------");
+                _log.Information("Setup");
+                _log.Information("----------------------------------------");
+                _log.Verbose("Executing custom setup action...");
+
                 action();
             }
         }
@@ -27,6 +45,12 @@ namespace Cake.Core
         {
             if (action != null)
             {
+                _log.Information(string.Empty);
+                _log.Information("----------------------------------------");
+                _log.Information("Teardown");
+                _log.Information("----------------------------------------");
+                _log.Verbose("Executing custom teardown action...");
+
                 action();
             }
         }
@@ -40,7 +64,27 @@ namespace Cake.Core
         {
             if (task != null)
             {
+                _log.Information(string.Empty);
+                _log.Information("========================================");
+                _log.Information(task.Name);
+                _log.Information("========================================");
+                _log.Verbose("Executing task: {0}", task.Name);
+
                 task.Execute(context);
+
+                _log.Verbose("Finished executing task: {0}", task.Name);
+            }
+        }
+
+        /// <summary>
+        /// Skips the specified task.
+        /// </summary>
+        /// <param name="task">The task to skip.</param>
+        public void Skip(CakeTask task)
+        {
+            if (task != null)
+            {
+                _log.Verbose("Skipping task: {0}", task.Name);
             }
         }
 

--- a/src/Cake.Core/ICakeEngine.cs
+++ b/src/Cake.Core/ICakeEngine.cs
@@ -36,14 +36,6 @@ namespace Cake.Core
         void RegisterTeardownAction(Action action);
 
         /// <summary>
-        /// Runs the specified target.
-        /// </summary>
-        /// <param name="context">The context.</param>
-        /// <param name="target">The target to run.</param>
-        /// <returns>The resulting report.</returns>
-        CakeReport RunTarget(ICakeContext context, string target);
-
-        /// <summary>
         /// Runs the specified target using the specified <see cref="IExecutionStrategy"/>.
         /// </summary>
         /// <param name="context">The context.</param>

--- a/src/Cake.Core/IExecutionStrategy.cs
+++ b/src/Cake.Core/IExecutionStrategy.cs
@@ -27,6 +27,12 @@ namespace Cake.Core
         void Execute(CakeTask task, ICakeContext context);
 
         /// <summary>
+        /// Skips the specified task.
+        /// </summary>
+        /// <param name="task">The task to skip.</param>
+        void Skip(CakeTask task);
+
+        /// <summary>
         /// Executes the error reporter.
         /// </summary>
         /// <param name="action">The action.</param>

--- a/src/Cake.Core/Scripting/ScriptHost.cs
+++ b/src/Cake.Core/Scripting/ScriptHost.cs
@@ -40,6 +40,10 @@ namespace Cake.Core.Scripting
             {
                 throw new ArgumentNullException("engine");
             }
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
             _engine = engine;
             _context = context;
         }

--- a/src/Cake.Tests/Cake.Tests.csproj
+++ b/src/Cake.Tests/Cake.Tests.csproj
@@ -81,6 +81,8 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Unit\Scripting\DescriptionScriptHostTests.cs" />
+    <Compile Include="Unit\Scripting\DryRunExecutionStrategyTests.cs" />
+    <Compile Include="Unit\Scripting\DryRunScriptHostTests.cs" />
     <Compile Include="Unit\Scripting\Roslyn\RoslynScriptSessionFactoryTests.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/Cake.Tests/Unit/Arguments/ArgumentParserTests.cs
+++ b/src/Cake.Tests/Unit/Arguments/ArgumentParserTests.cs
@@ -192,6 +192,23 @@ namespace Cake.Tests.Unit.Arguments
             }
 
             [Theory]
+            [InlineData("-dryrun")]
+            [InlineData("-noop")]
+            [InlineData("-whatif")]
+            public void Can_Parse_DryRun(string input)
+            {
+                // Given
+                var fixture = new ArgumentParserFixture();
+                var parser = new ArgumentParser(fixture.Log, fixture.FileSystem);
+
+                // When
+                var result = parser.Parse(new[] { "build.csx", input });
+
+                // Then
+                Assert.Equal(true, result.PerformDryRun);
+            }
+
+            [Theory]
             [InlineData("-help")]
             [InlineData("-?")]
             public void Can_Parse_Help(string input)

--- a/src/Cake.Tests/Unit/CakeApplicationTests.cs
+++ b/src/Cake.Tests/Unit/CakeApplicationTests.cs
@@ -260,6 +260,35 @@ namespace Cake.Tests.Unit
                 // Then
                 Assert.Equal(1, result);
             }
+
+            [Fact]
+            public void Should_Create_Dry_Run_Command_If_Specified_In_Options()
+            {
+                // Given
+                var fixture = new CakeApplicationFixture();
+                fixture.Options.PerformDryRun = true;
+                fixture.Options.Script = "./build.cake";
+
+                // When
+                fixture.RunApplication();
+
+                // Then
+                fixture.CommandFactory.Received(1).CreateDryRunCommand();
+            }
+
+            [Fact]
+            public void Should_Not_Create_Dry_Run_Command_If_Options_Do_Not_Contain_Script()
+            {
+                // Given
+                var fixture = new CakeApplicationFixture();
+                fixture.Options.PerformDryRun = true;
+
+                // When
+                fixture.RunApplication();
+
+                // Then
+                fixture.CommandFactory.Received(1).CreateHelpCommand();
+            }
         }
     }
 }

--- a/src/Cake.Tests/Unit/Scripting/BuildScriptHostTests.cs
+++ b/src/Cake.Tests/Unit/Scripting/BuildScriptHostTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Cake.Core;
+using Cake.Core.Diagnostics;
 using Cake.Scripting;
 using NSubstitute;
 using Xunit;
@@ -17,13 +18,14 @@ namespace Cake.Tests.Unit.Scripting
                 var engine = Substitute.For<ICakeEngine>();
                 var context = Substitute.For<ICakeContext>();
                 var printer = Substitute.For<ICakeReportPrinter>();
-                var host = new BuildScriptHost(engine, context, printer);
+                var log = Substitute.For<ICakeLog>();
+                var host = new BuildScriptHost(engine, context, printer, log);
 
                 // When
                 host.RunTarget("Target");
 
                 // Then
-                engine.Received(1).RunTarget(context, "Target");
+                engine.Received(1).RunTarget(context, Arg.Any<DefaultExecutionStrategy>(), "Target");
             }
 
             [Fact]
@@ -34,9 +36,10 @@ namespace Cake.Tests.Unit.Scripting
                 report.Add("Target", TimeSpan.FromSeconds(1));
                 var engine = Substitute.For<ICakeEngine>();
                 var context = Substitute.For<ICakeContext>();
-                engine.RunTarget(context, "Target").Returns(report);
+                engine.RunTarget(context, Arg.Any<DefaultExecutionStrategy>(), "Target").Returns(report);
                 var printer = Substitute.For<ICakeReportPrinter>();
-                var host = new BuildScriptHost(engine, context, printer);
+                var log = Substitute.For<ICakeLog>();
+                var host = new BuildScriptHost(engine, context, printer, log);
 
                 // When
                 host.RunTarget("Target");
@@ -51,9 +54,10 @@ namespace Cake.Tests.Unit.Scripting
                 // Given
                 var engine = Substitute.For<ICakeEngine>();
                 var context = Substitute.For<ICakeContext>();
-                engine.RunTarget(context, Arg.Any<string>()).Returns((CakeReport)null);
+                engine.RunTarget(context, Arg.Any<DefaultExecutionStrategy>(), Arg.Any<string>()).Returns((CakeReport)null);
                 var printer = Substitute.For<ICakeReportPrinter>();
-                var host = new BuildScriptHost(engine, context, printer);
+                var log = Substitute.For<ICakeLog>();
+                var host = new BuildScriptHost(engine, context, printer, log);
 
                 // When
                 host.RunTarget("Target");
@@ -68,9 +72,10 @@ namespace Cake.Tests.Unit.Scripting
                 // Given
                 var engine = Substitute.For<ICakeEngine>();
                 var context = Substitute.For<ICakeContext>();
-                engine.RunTarget(context, Arg.Any<string>()).Returns(new CakeReport());
+                engine.RunTarget(context, Arg.Any<DefaultExecutionStrategy>(), Arg.Any<string>()).Returns(new CakeReport());
                 var printer = Substitute.For<ICakeReportPrinter>();
-                var host = new BuildScriptHost(engine, context, printer);
+                var log = Substitute.For<ICakeLog>();
+                var host = new BuildScriptHost(engine, context, printer, log);
 
                 // When
                 host.RunTarget("Target");

--- a/src/Cake.Tests/Unit/Scripting/DryRunExecutionStrategyTests.cs
+++ b/src/Cake.Tests/Unit/Scripting/DryRunExecutionStrategyTests.cs
@@ -1,0 +1,45 @@
+﻿using Cake.Core;
+using Cake.Scripting;
+using Cake.Testing.Fakes;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Tests.Unit.Scripting
+{
+    public sealed class DryRunExecutionStrategyTests
+    {
+        public sealed class TheConstructor
+        {
+            [Fact]
+            public void Should_Throw_If_Log_Is_Null()
+            {
+                // Given, When
+                var result = Record.Exception(() => new DryRunExecutionStrategy(null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "log");
+            }
+        }
+
+        public sealed class TheExecuteMethod
+        {
+            [Fact]
+            public void Should_Write_Correct_Output_To_The_Log()
+            {
+                // Given
+                var log = new FakeLog();
+                var context = Substitute.For<ICakeContext>();
+                var strategy = new DryRunExecutionStrategy(log);
+
+                // When
+                strategy.Execute(new ActionTask("First"), context);
+                strategy.Execute(new ActionTask("Second"), context);
+
+                // Then
+                Assert.Equal(2, log.Messages.Count);
+                Assert.Equal("1. First", log.Messages[0]);
+                Assert.Equal("2. Second", log.Messages[1]);
+            }
+        }
+    }
+}

--- a/src/Cake.Tests/Unit/Scripting/DryRunScriptHostTests.cs
+++ b/src/Cake.Tests/Unit/Scripting/DryRunScriptHostTests.cs
@@ -1,11 +1,12 @@
 ﻿using Cake.Core;
+using Cake.Core.Diagnostics;
 using Cake.Scripting;
 using NSubstitute;
 using Xunit;
 
 namespace Cake.Tests.Unit.Scripting
 {
-    public sealed class DescriptionScriptHostTests
+    public sealed class DryRunScriptHostTests
     {
         public sealed class TheConstructor
         {
@@ -14,10 +15,10 @@ namespace Cake.Tests.Unit.Scripting
             {
                 // Given
                 var context = Substitute.For<ICakeContext>();
-                var console = Substitute.For<IConsole>();
+                var log = Substitute.For<ICakeLog>();
 
                 // When
-                var result = Record.Exception(() => new DescriptionScriptHost(null, context, console));
+                var result = Record.Exception(() => new DryRunScriptHost(null, context, log));
 
                 // Then
                 Assert.IsArgumentNullException(result, "engine");
@@ -28,49 +29,46 @@ namespace Cake.Tests.Unit.Scripting
             {
                 // Given
                 var engine = Substitute.For<ICakeEngine>();
-                var console = Substitute.For<IConsole>();
+                var log = Substitute.For<ICakeLog>();
 
                 // When
-                var result = Record.Exception(() => new DescriptionScriptHost(engine, null, console));
+                var result = Record.Exception(() => new DryRunScriptHost(engine, null, log));
 
                 // Then
                 Assert.IsArgumentNullException(result, "context");
             }
 
             [Fact]
-            public void Should_Throw_If_Console_Is_Null()
+            public void Should_Throw_If_Log_Is_Null()
             {
                 // Given
                 var engine = Substitute.For<ICakeEngine>();
                 var context = Substitute.For<ICakeContext>();
 
                 // When
-                var result = Record.Exception(() => new DescriptionScriptHost(engine, context, null));
+                var result = Record.Exception(() => new DryRunScriptHost(engine, context, null));
 
                 // Then
-                Assert.IsArgumentNullException(result, "console");
+                Assert.IsArgumentNullException(result, "log");
             }
         }
 
         public sealed class TheRunTargetMethod
         {
             [Fact]
-            public void Should_Not_Call_To_Engine()
+            public void Should_Invoke_The_Engine_With_Correct_Execution_Strategy()
             {
                 // Given
                 var engine = Substitute.For<ICakeEngine>();
                 var context = Substitute.For<ICakeContext>();
-                var console = Substitute.For<IConsole>();
-                var host = new DescriptionScriptHost(engine, context, console);
+                var log = Substitute.For<ICakeLog>();
+                var host = new DryRunScriptHost(engine, context, log);
 
                 // When
-                host.RunTarget("Target");
+                host.RunTarget("TheTarget");
 
                 // Then
-                engine.Received(0).RunTarget(
-                    context,
-                    Arg.Any<DefaultExecutionStrategy>(),
-                    "Target");
+                engine.Received(1).RunTarget(context, Arg.Any<DryRunExecutionStrategy>(), "TheTarget");
             }
         }
     }

--- a/src/Cake/Arguments/ArgumentParser.cs
+++ b/src/Cake/Arguments/ArgumentParser.cs
@@ -143,6 +143,13 @@ namespace Cake.Arguments
                 options.ShowDescription = true;
             }
 
+            if (name.Equals("dryrun", StringComparison.OrdinalIgnoreCase) ||
+                name.Equals("noop", StringComparison.OrdinalIgnoreCase) ||
+                name.Equals("whatif", StringComparison.OrdinalIgnoreCase))
+            {
+                options.PerformDryRun = true;
+            }
+
             if (name.Equals("help", StringComparison.OrdinalIgnoreCase) ||
                 name.Equals("?", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/Cake/Cake.csproj
+++ b/src/Cake/Cake.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Commands\BuildCommand.cs" />
     <Compile Include="Commands\CommandFactory.cs" />
     <Compile Include="Commands\DescriptionCommand.cs" />
+    <Compile Include="Commands\DryRunCommand.cs" />
     <Compile Include="Commands\ErrorCommandDecorator.cs" />
     <Compile Include="Commands\HelpCommand.cs" />
     <Compile Include="Commands\ICommand.cs">
@@ -118,6 +119,8 @@
     </Compile>
     <Compile Include="Scripting\BuildScriptHost.cs" />
     <Compile Include="Scripting\DescriptionScriptHost.cs" />
+    <Compile Include="Scripting\DryRunExecutionStrategy.cs" />
+    <Compile Include="Scripting\DryRunScriptHost.cs" />
     <Compile Include="Scripting\Roslyn\IRoslynInstaller.cs" />
     <Compile Include="Scripting\Roslyn\RoslynInstaller.cs" />
     <Compile Include="Scripting\Roslyn\RoslynScriptSession.cs" />

--- a/src/Cake/CakeApplication.cs
+++ b/src/Cake/CakeApplication.cs
@@ -108,6 +108,11 @@ namespace Cake
 
                 if (options.Script != null)
                 {
+                    if (options.PerformDryRun)
+                    {
+                        return _commandFactory.CreateDryRunCommand();
+                    }
+
                     if (options.ShowDescription)
                     {
                         _log.Verbosity = Verbosity.Quiet;

--- a/src/Cake/CakeOptions.cs
+++ b/src/Cake/CakeOptions.cs
@@ -42,6 +42,14 @@ namespace Cake
         public bool ShowDescription { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to perform a dry run.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if a dry run should be performed; otherwise, <c>false</c>.
+        /// </value>
+        public bool PerformDryRun { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to show help.
         /// </summary>
         /// <value>

--- a/src/Cake/Commands/CommandFactory.cs
+++ b/src/Cake/Commands/CommandFactory.cs
@@ -4,16 +4,20 @@
     {
         private readonly BuildCommand.Factory _buildCommandFactory;
         private readonly DescriptionCommand.Factory _descriptionCommandFactory;
+        private readonly DryRunCommand.Factory _dryRunCommandFactory;
         private readonly HelpCommand.Factory _helpCommandFactory;
         private readonly VersionCommand.Factory _versionCommandFactory;
 
-        public CommandFactory(BuildCommand.Factory buildCommandFactory, 
-            DescriptionCommand.Factory descriptionCommandFactory, 
+        public CommandFactory(
+            BuildCommand.Factory buildCommandFactory,
+            DescriptionCommand.Factory descriptionCommandFactory,
+            DryRunCommand.Factory dryRunCommandFactory,
             HelpCommand.Factory helpCommandFactory,
             VersionCommand.Factory versionCommandFactory)
         {
             _buildCommandFactory = buildCommandFactory;
             _descriptionCommandFactory = descriptionCommandFactory;
+            _dryRunCommandFactory = dryRunCommandFactory;
             _helpCommandFactory = helpCommandFactory;
             _versionCommandFactory = versionCommandFactory;
         }
@@ -26,6 +30,11 @@
         public ICommand CreateDescriptionCommand()
         {
             return _descriptionCommandFactory();
+        }
+
+        public ICommand CreateDryRunCommand()
+        {
+            return _dryRunCommandFactory();
         }
 
         public ICommand CreateHelpCommand()

--- a/src/Cake/Commands/DryRunCommand.cs
+++ b/src/Cake/Commands/DryRunCommand.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Cake.Core.Scripting;
+using Cake.Scripting;
+
+namespace Cake.Commands
+{
+    /// <summary>
+    /// A command that dry runs a build script.
+    /// </summary>
+    internal sealed class DryRunCommand : ICommand
+    {
+        private readonly IScriptRunner _scriptRunner;
+        private readonly DryRunScriptHost _host;
+
+        // Delegate factory used by Autofac.
+        public delegate DryRunCommand Factory();
+
+        public DryRunCommand(IScriptRunner scriptRunner, DryRunScriptHost host)
+        {
+            _scriptRunner = scriptRunner;
+            _host = host;
+        }
+
+        public bool Execute(CakeOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException("options");
+            }
+            _scriptRunner.Run(_host, options.Script, options.Arguments);
+            return true;
+        }
+    }
+}

--- a/src/Cake/Commands/HelpCommand.cs
+++ b/src/Cake/Commands/HelpCommand.cs
@@ -20,7 +20,8 @@ namespace Cake.Commands
         public bool Execute(CakeOptions options)
         {
             _console.WriteLine();
-            _console.WriteLine("Usage: Cake.exe [build-script] [-verbosity=value] [-showdescription] [..]");
+            _console.WriteLine("Usage: Cake.exe [build-script] [-verbosity=value]");
+            _console.WriteLine("                [-showdescription] [-dryrun] [..]");
             _console.WriteLine();
             _console.WriteLine("Example: Cake.exe");
             _console.WriteLine("Example: Cake.exe build.cake -verbosity=quiet");
@@ -29,6 +30,7 @@ namespace Cake.Commands
             _console.WriteLine("Options:");
             _console.WriteLine("    -verbosity=value    Specifies the amount of information to be displayed.");
             _console.WriteLine("    -showdescription    Shows description about tasks.");
+            _console.WriteLine("    -dryrun             Performs a dry run.");
             _console.WriteLine("    -version            Displays version information.");
             _console.WriteLine("    -help               Displays usage information.");
             _console.WriteLine();

--- a/src/Cake/Commands/ICommandFactory.cs
+++ b/src/Cake/Commands/ICommandFactory.cs
@@ -18,6 +18,12 @@
         ICommand CreateDescriptionCommand();
 
         /// <summary>
+        /// Creates the dry run command.
+        /// </summary>
+        /// <returns>The dry run command.</returns>
+        ICommand CreateDryRunCommand();
+
+        /// <summary>
         /// Creates the help command.
         /// </summary>
         /// <returns>The help command.</returns>

--- a/src/Cake/Program.cs
+++ b/src/Cake/Program.cs
@@ -66,10 +66,12 @@ namespace Cake
             // Register script hosts.            
             builder.RegisterType<BuildScriptHost>().SingleInstance();
             builder.RegisterType<DescriptionScriptHost>().SingleInstance();
+            builder.RegisterType<DryRunScriptHost>().SingleInstance();
 
             // Register commands.
             builder.RegisterType<BuildCommand>().AsSelf().InstancePerDependency();
             builder.RegisterType<DescriptionCommand>().AsSelf().InstancePerDependency();
+            builder.RegisterType<DryRunCommand>().AsSelf().InstancePerDependency();
             builder.RegisterType<HelpCommand>().AsSelf().InstancePerDependency();
             builder.RegisterType<VersionCommand>().AsSelf().InstancePerDependency();
 

--- a/src/Cake/Scripting/BuildScriptHost.cs
+++ b/src/Cake/Scripting/BuildScriptHost.cs
@@ -1,4 +1,5 @@
 ﻿using Cake.Core;
+using Cake.Core.Diagnostics;
 using Cake.Core.Scripting;
 
 namespace Cake.Scripting
@@ -9,6 +10,7 @@ namespace Cake.Scripting
     public sealed class BuildScriptHost : ScriptHost
     {
         private readonly ICakeReportPrinter _reportPrinter;
+        private readonly ICakeLog _log;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BuildScriptHost"/> class.
@@ -16,10 +18,15 @@ namespace Cake.Scripting
         /// <param name="engine">The engine.</param>
         /// <param name="context">The context.</param>
         /// <param name="reportPrinter">The report printer.</param>
-        public BuildScriptHost(ICakeEngine engine, ICakeContext context, ICakeReportPrinter reportPrinter)
-            : base(engine, context)
+        /// <param name="log">The log.</param>
+        public BuildScriptHost(
+            ICakeEngine engine,
+            ICakeContext context,
+            ICakeReportPrinter reportPrinter,
+            ICakeLog log) : base(engine, context)
         {
             _reportPrinter = reportPrinter;
+            _log = log;
         }
 
         /// <summary>
@@ -29,7 +36,8 @@ namespace Cake.Scripting
         /// <returns>The resulting report.</returns>
         public override CakeReport RunTarget(string target)
         {
-            var report = Engine.RunTarget(Context, target);
+            var strategy = new DefaultExecutionStrategy(_log);
+            var report = Engine.RunTarget(Context, strategy, target);
             if (report != null && !report.IsEmpty)
             {
                 _reportPrinter.Write(report);

--- a/src/Cake/Scripting/DescriptionScriptHost.cs
+++ b/src/Cake/Scripting/DescriptionScriptHost.cs
@@ -23,6 +23,10 @@ namespace Cake.Scripting
         public DescriptionScriptHost(ICakeEngine engine, ICakeContext context, IConsole console)
             : base(engine, context)
         {
+            if (console == null)
+            {
+                throw new ArgumentNullException("console");
+            }
             _console = console;
             _descriptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }

--- a/src/Cake/Scripting/DryRunExecutionStrategy.cs
+++ b/src/Cake/Scripting/DryRunExecutionStrategy.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+
+namespace Cake.Scripting
+{
+    internal sealed class DryRunExecutionStrategy : IExecutionStrategy
+    {
+        private readonly ICakeLog _log;
+        private int _counter;
+
+        public DryRunExecutionStrategy(ICakeLog log)
+        {
+            if (log == null)
+            {
+                throw new ArgumentNullException("log");
+            }
+            _log = log;
+            _counter = 1;
+        }
+
+        public void PerformSetup(Action action)
+        {
+        }
+
+        public void PerformTeardown(Action action)
+        {
+        }
+
+        public void Execute(CakeTask task, ICakeContext context)
+        {
+            if (task != null)
+            {
+                _log.Information("{0}. {1}", _counter, task.Name);
+                _counter++;
+            }
+        }
+
+        public void Skip(CakeTask task)
+        {
+        }
+
+        public void ReportErrors(Action<Exception> action, Exception exception)
+        {
+        }
+
+        public void HandleErrors(Action<Exception> action, Exception exception)
+        {
+        }
+
+        public void InvokeFinally(Action action)
+        {
+        }
+    }
+}

--- a/src/Cake/Scripting/DryRunScriptHost.cs
+++ b/src/Cake/Scripting/DryRunScriptHost.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Core.Scripting;
+
+namespace Cake.Scripting
+{
+    /// <summary>
+    /// The script host used to dry run Cake scripts.
+    /// </summary>
+    public sealed class DryRunScriptHost : ScriptHost
+    {
+        private readonly ICakeLog _log;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DryRunScriptHost"/> class.
+        /// </summary>
+        /// <param name="engine">The engine.</param>
+        /// <param name="context">The context.</param>
+        /// <param name="log">The log.</param>
+        public DryRunScriptHost(ICakeEngine engine, ICakeContext context, ICakeLog log)
+            : base(engine, context)
+        {
+            if (log == null)
+            {
+                throw new ArgumentNullException("log");
+            }
+            _log = log;
+        }
+
+        /// <summary>
+        /// Runs the specified target.
+        /// </summary>
+        /// <param name="target">The target to run.</param>
+        /// <returns>The resulting report.</returns>
+        public override CakeReport RunTarget(string target)
+        {
+            _log.Information("Performing dry run...");
+            _log.Information("Target is: {0}", target);
+            _log.Information(string.Empty);
+
+            var strategy = new DryRunExecutionStrategy(_log);
+            var result = Engine.RunTarget(Context, strategy, target);
+
+            _log.Information(string.Empty);
+            _log.Information("This was a dry run.");
+            _log.Information("No tasks were actually executed.");
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
By providing the parameter `dryrun`, `noop` or `whatif`, a [dry run](http://en.wikipedia.org/wiki/Dry_run_%28testing%29) will be performed. This is useful to see what tasks will be executed given the current context (environment variables, arguments etc). 

No tasks will actually be executed.

```
PS> .\Cake.exe build.cake -dryrun

Performing dry run...
Target is: Build

1. Clean
2. Build
3. Copy-Files
4. Package-Files

This was a dry run.
No tasks were actually executed.
```

Related to issue #155.