### PR TITLE
Added Windows  8.1 & 10 OS Support

### DIFF
--- a/src/Cake/Cake.csproj
+++ b/src/Cake/Cake.csproj
@@ -57,6 +57,9 @@
   <PropertyGroup>
     <StartupObject>Cake.Program</StartupObject>
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Autofac">
       <HintPath>..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
@@ -129,6 +132,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="app.manifest" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Cake/app.manifest
+++ b/src/Cake/app.manifest
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<asmv1:assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv1="urn:schemas-microsoft-com:asm.v1" xmlns:asmv2="urn:schemas-microsoft-com:asm.v2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows Vista and Windows Server 2008 -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"></supportedOS>
+
+      <!-- Windows 7 and Windows Server 2008 R2 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+
+      <!-- Windows 8 and Windows Server 2012 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"></supportedOS>
+
+      <!-- Windows 8.1 and Windows Server 2012 R2 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+
+    </application>
+  </compatibility>
+</asmv1:assembly>


### PR DESCRIPTION
Since Windows 8.1 Microsoft changed Win32 GetVersionEx that .Net uses for compatibility reasons report latest version app is compiled for.

This PR adds manifest aware of 8.1 & 10 to the Cake.exe, so `System.Environment.OSVersion` reports correct version up to Windows 10.

Example cake
```csharp
Information("OSVersion version: {0}", System.Environment.OSVersion);
```

Before fix it returns `6.2` on 8.1 & 10, after fix it returns `6.3` and `10.0`.

Example output on Windows 10 build 10049 before fix
```
OSVersion version: Microsoft Windows NT 6.2.9200.0
```
Example output Windows 10 build 10049 after fix
```
OSVersion version: Microsoft Windows NT 10.0.10049.0
``` 