### PR TITLE
Build Cake with Cake version 0.3.2

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,6 @@
+### New in 0.3.2 (Released 2015/04/16)
+* NuGet package issue fix.
+
 ### New in 0.3.1 (Released 2015/04/16)
 * Fixed an issue where Roslyn assemblies weren't loaded properly after install.
 

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -6,7 +6,7 @@
 using System.Reflection;
 
 [assembly: AssemblyProduct("Cake")]
-[assembly: AssemblyVersion("0.3.1")]
-[assembly: AssemblyFileVersion("0.3.1")]
-[assembly: AssemblyInformationalVersion("0.3.1")]
+[assembly: AssemblyVersion("0.3.2")]
+[assembly: AssemblyFileVersion("0.3.2")]
+[assembly: AssemblyInformationalVersion("0.3.2")]
 [assembly: AssemblyCopyright("Copyright (c) Patrik Svensson 2014")]

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.2.2" />
+    <package id="Cake" version="0.3.2" />
     <package id="xunit.runner.console" version="2.0.0" />
 </packages>


### PR DESCRIPTION
Do enable building Cake on Windows 10 we should bump the version being used.