### PR TITLE
Added aliases for making paths absolute.

### DIFF
--- a/src/Cake.Common.Tests/Unit/IO/DirectoryAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/DirectoryAliasesTests.cs
@@ -1036,13 +1036,13 @@ namespace Cake.Common.Tests.Unit.IO
             }
         }
 
-        public sealed class TheGetAbsoluteDirectoryPathMethod
+        public sealed class TheMakeAbsoluteMethod
         {
             [Fact]
             public void Should_Throw_If_Context_Is_Null()
             {
                 // Given, When
-                var result = Record.Exception(() => DirectoryAliases.GetAbsoluteDirectoryPath(null, "./build"));
+                var result = Record.Exception(() => DirectoryAliases.MakeAbsolute(null, "./build"));
 
                 // Then
                 Assert.IsArgumentNullException(result, "context");
@@ -1055,7 +1055,7 @@ namespace Cake.Common.Tests.Unit.IO
                 var context = Substitute.For<ICakeContext>();
 
                 // When
-                var result = Record.Exception(() => DirectoryAliases.GetAbsoluteDirectoryPath(context, null));
+                var result = Record.Exception(() => DirectoryAliases.MakeAbsolute(context, null));
 
                 // Then
                 Assert.IsArgumentNullException(result, "path");
@@ -1069,7 +1069,7 @@ namespace Cake.Common.Tests.Unit.IO
                 context.Environment.WorkingDirectory.Returns(d => "/Working");
 
                 // When
-                var result = DirectoryAliases.GetAbsoluteDirectoryPath(context, "./build");
+                var result = DirectoryAliases.MakeAbsolute(context, "./build");
 
                 // Then
                 Assert.Equal("/Working/build", result.FullPath);

--- a/src/Cake.Common.Tests/Unit/IO/DirectoryAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/DirectoryAliasesTests.cs
@@ -1035,5 +1035,45 @@ namespace Cake.Common.Tests.Unit.IO
                 Assert.True(result);
             }
         }
+
+        public sealed class TheGetAbsoluteDirectoryPathMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Context_Is_Null()
+            {
+                // Given, When
+                var result = Record.Exception(() => DirectoryAliases.GetAbsoluteDirectoryPath(null, "./build"));
+
+                // Then
+                Assert.IsArgumentNullException(result, "context");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Path_Is_Null()
+            {
+                // Given
+                var context = Substitute.For<ICakeContext>();
+
+                // When
+                var result = Record.Exception(() => DirectoryAliases.GetAbsoluteDirectoryPath(context, null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "path");
+            }
+
+            [Fact]
+            public void Should_Return_Absolute_Directory_Path()
+            {
+                // Given
+                var context = Substitute.For<ICakeContext>();
+                context.Environment.WorkingDirectory.Returns(d => "/Working");
+
+                // When
+                var result = DirectoryAliases.GetAbsoluteDirectoryPath(context, "./build");
+
+                // Then
+                Assert.Equal("/Working/build", result.FullPath);
+            }
+        }
     }
 }

--- a/src/Cake.Common.Tests/Unit/IO/FileAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/FileAliasesTests.cs
@@ -1047,5 +1047,45 @@ namespace Cake.Common.Tests.Unit.IO
                 Assert.True(result);
             }
         }
+
+        public sealed class TheGetAbsoluteFilePathMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Context_Is_Null()
+            {
+                // Given, When
+                var result = Record.Exception(() => FileAliases.GetAbsoluteFilePath(null, "./build.txt"));
+
+                // Then
+                Assert.IsArgumentNullException(result, "context");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Path_Is_Null()
+            {
+                // Given
+                var context = Substitute.For<ICakeContext>();
+
+                // When
+                var result = Record.Exception(() => FileAliases.GetAbsoluteFilePath(context, null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "path");
+            }
+
+            [Fact]
+            public void Should_Return_Absolute_Directory_Path()
+            {
+                // Given
+                var context = Substitute.For<ICakeContext>();
+                context.Environment.WorkingDirectory.Returns(d => "/Working");
+
+                // When
+                var result = FileAliases.GetAbsoluteFilePath(context, "./build.txt");
+
+                // Then
+                Assert.Equal("/Working/build.txt", result.FullPath);
+            }
+        }
     }
 }

--- a/src/Cake.Common.Tests/Unit/IO/FileAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/FileAliasesTests.cs
@@ -1048,13 +1048,13 @@ namespace Cake.Common.Tests.Unit.IO
             }
         }
 
-        public sealed class TheGetAbsoluteFilePathMethod
+        public sealed class TheMakeAbsoluteMethod
         {
             [Fact]
             public void Should_Throw_If_Context_Is_Null()
             {
                 // Given, When
-                var result = Record.Exception(() => FileAliases.GetAbsoluteFilePath(null, "./build.txt"));
+                var result = Record.Exception(() => FileAliases.MakeAbsolute(null, "./build.txt"));
 
                 // Then
                 Assert.IsArgumentNullException(result, "context");
@@ -1067,7 +1067,7 @@ namespace Cake.Common.Tests.Unit.IO
                 var context = Substitute.For<ICakeContext>();
 
                 // When
-                var result = Record.Exception(() => FileAliases.GetAbsoluteFilePath(context, null));
+                var result = Record.Exception(() => FileAliases.MakeAbsolute(context, null));
 
                 // Then
                 Assert.IsArgumentNullException(result, "path");
@@ -1081,7 +1081,7 @@ namespace Cake.Common.Tests.Unit.IO
                 context.Environment.WorkingDirectory.Returns(d => "/Working");
 
                 // When
-                var result = FileAliases.GetAbsoluteFilePath(context, "./build.txt");
+                var result = FileAliases.MakeAbsolute(context, "./build.txt");
 
                 // Then
                 Assert.Equal("/Working/build.txt", result.FullPath);

--- a/src/Cake.Common/IO/DirectoryAliases.cs
+++ b/src/Cake.Common/IO/DirectoryAliases.cs
@@ -358,7 +358,7 @@ namespace Cake.Common.IO
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="path">The path.</param>
-        /// <returns>An absolute path.</returns>
+        /// <returns>An absolute directory path.</returns>
         /// <example>
         /// <code>
         /// var path = MakeAbsolute(Directory("./resources"));
@@ -366,7 +366,7 @@ namespace Cake.Common.IO
         /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Path")]
-        public static DirectoryPath GetAbsoluteDirectoryPath(this ICakeContext context, DirectoryPath path)
+        public static DirectoryPath MakeAbsolute(this ICakeContext context, DirectoryPath path)
         {
             if (context == null)
             {

--- a/src/Cake.Common/IO/DirectoryAliases.cs
+++ b/src/Cake.Common/IO/DirectoryAliases.cs
@@ -352,5 +352,33 @@ namespace Cake.Common.IO
 
             return context.FileSystem.GetDirectory(path).Exists;
         }
+
+        /// <summary>
+        /// Makes the path absolute (if relative) using the current working directory.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="path">The path.</param>
+        /// <returns>An absolute path.</returns>
+        /// <example>
+        /// <code>
+        /// var path = MakeAbsolute(Directory("./resources"));
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Path")]
+        public static DirectoryPath GetAbsoluteDirectoryPath(this ICakeContext context, DirectoryPath path)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            if (path == null)
+            {
+                throw new ArgumentNullException("path");
+            }
+
+            return path.MakeAbsolute(context.Environment);
+        }
     }
 }

--- a/src/Cake.Common/IO/FileAliases.cs
+++ b/src/Cake.Common/IO/FileAliases.cs
@@ -303,5 +303,33 @@ namespace Cake.Common.IO
 
             return context.FileSystem.GetFile(filePath).Exists;
         }
+
+        /// <summary>
+        /// Makes the path absolute (if relative) using the current working directory.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="path">The path.</param>
+        /// <returns>An absolute path.</returns>
+        /// <example>
+        /// <code>
+        /// var path = MakeAbsolute(File("./resources"));
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Path")]
+        public static FilePath GetAbsoluteFilePath(ICakeContext context, FilePath path)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            if (path == null)
+            {
+                throw new ArgumentNullException("path");
+            }
+
+            return path.MakeAbsolute(context.Environment);
+        }
     }
 }

--- a/src/Cake.Common/IO/FileAliases.cs
+++ b/src/Cake.Common/IO/FileAliases.cs
@@ -309,7 +309,7 @@ namespace Cake.Common.IO
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="path">The path.</param>
-        /// <returns>An absolute path.</returns>
+        /// <returns>An absolute file path.</returns>
         /// <example>
         /// <code>
         /// var path = MakeAbsolute(File("./resources"));
@@ -317,7 +317,7 @@ namespace Cake.Common.IO
         /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Path")]
-        public static FilePath GetAbsoluteFilePath(ICakeContext context, FilePath path)
+        public static FilePath MakeAbsolute(ICakeContext context, FilePath path)
         {
             if (context == null)
             {


### PR DESCRIPTION
Added two aliases for making paths absolute.

```csharp
// Get absolute file path.
var file = GetAbsoluteFilePath(File("./foo.txt"));

// Get absoltue directory path.
var dir = GetAbsoluteDirectoryPath(Directory("./foo"));
```

Not sure of the name of the aliases are good or consistent.
Any thoughts about this? 