### PR TITLE
Added ToString for convertable paths.

### DIFF
--- a/src/Cake.Common.Tests/Unit/IO/Paths/ConvertableDirectoryPathTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/Paths/ConvertableDirectoryPathTests.cs
@@ -302,5 +302,21 @@ namespace Cake.Common.Tests.Unit.IO.Paths
                 }
             }
         }
+
+        public sealed class TheToStringMethod
+        {
+            [Fact]
+            public void Should_Return_String_Representation_Of_Path()
+            {
+                // Given
+                var path = new ConvertableDirectoryPath("./foo/bar");
+
+                // When
+                var result = path.ToString();
+
+                // Then
+                Assert.Equal("foo/bar", result);
+            }
+        }
     }
 }

--- a/src/Cake.Common.Tests/Unit/IO/Paths/ConvertableFilePathTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/Paths/ConvertableFilePathTests.cs
@@ -1,4 +1,5 @@
-﻿using Cake.Common.IO.Paths;
+﻿using System;
+using Cake.Common.IO.Paths;
 using Cake.Core.IO;
 using Xunit;
 
@@ -93,6 +94,22 @@ namespace Cake.Common.Tests.Unit.IO.Paths
                     // Then
                     Assert.Null(result);
                 }
+            }
+        }
+
+        public sealed class TheToStringMethod
+        {
+            [Fact]
+            public void Should_Return_String_Representation_Of_Path()
+            {
+                // Given
+                var path = new ConvertableFilePath("./foo/bar.baz");
+                
+                // When
+                var result = path.ToString();
+
+                // Then
+                Assert.Equal("foo/bar.baz", result);
             }
         }
     }

--- a/src/Cake.Common/IO/Paths/ConvertableDirectoryPath.cs
+++ b/src/Cake.Common/IO/Paths/ConvertableDirectoryPath.cs
@@ -154,5 +154,16 @@ namespace Cake.Common.IO.Paths
             }
             return path.Path.FullPath;
         }
+
+        /// <summary>
+        /// Returns a <see cref="System.String" /> that represents this instance.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String" /> that represents this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            return _path.FullPath;
+        }
     }
 }

--- a/src/Cake.Common/IO/Paths/ConvertableFilePath.cs
+++ b/src/Cake.Common/IO/Paths/ConvertableFilePath.cs
@@ -59,5 +59,16 @@ namespace Cake.Common.IO.Paths
             }
             return path.Path.FullPath;
         }
+
+        /// <summary>
+        /// Returns a <see cref="System.String" /> that represents this instance.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String" /> that represents this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            return _path.FullPath;
+        }
     }
 }


### PR DESCRIPTION
So we get a sane representation of convertable paths.

```csharp
Information("Writing {0}...", File("./foo.bar"));
Warning("The directory {0} do not exist.", Directory("./foo/bar"));
```