### PR TITLE
Added support for MSBuild 14.0.

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -171,6 +171,33 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 fixture.AssertReceivedFilePath(expected);
             }
 
+            [Theory]
+            [InlineData(MSBuildToolVersion.NET46, PlatformTarget.MSIL, false, "/Program86/MSBuild/14.0/Bin/MSBuild.exe")]
+            [InlineData(MSBuildToolVersion.NET46, PlatformTarget.MSIL, true, "/Program86/MSBuild/14.0/Bin/amd64/MSBuild.exe")]
+            [InlineData(MSBuildToolVersion.VS2015, PlatformTarget.MSIL, false, "/Program86/MSBuild/14.0/Bin/MSBuild.exe")]
+            [InlineData(MSBuildToolVersion.VS2015, PlatformTarget.MSIL, true, "/Program86/MSBuild/14.0/Bin/amd64/MSBuild.exe")]
+            [InlineData(MSBuildToolVersion.NET46, PlatformTarget.x86, false, "/Program86/MSBuild/14.0/Bin/MSBuild.exe")]
+            [InlineData(MSBuildToolVersion.NET46, PlatformTarget.x86, true, "/Program86/MSBuild/14.0/Bin/MSBuild.exe")]
+            [InlineData(MSBuildToolVersion.VS2015, PlatformTarget.x86, false, "/Program86/MSBuild/14.0/Bin/MSBuild.exe")]
+            [InlineData(MSBuildToolVersion.VS2015, PlatformTarget.x86, true, "/Program86/MSBuild/14.0/Bin/MSBuild.exe")]
+            [InlineData(MSBuildToolVersion.NET46, PlatformTarget.x64, false, "/Program86/MSBuild/14.0/Bin/amd64/MSBuild.exe")]
+            [InlineData(MSBuildToolVersion.NET46, PlatformTarget.x64, true, "/Program86/MSBuild/14.0/Bin/amd64/MSBuild.exe")]
+            [InlineData(MSBuildToolVersion.VS2015, PlatformTarget.x64, false, "/Program86/MSBuild/14.0/Bin/amd64/MSBuild.exe")]
+            [InlineData(MSBuildToolVersion.VS2015, PlatformTarget.x64, true, "/Program86/MSBuild/14.0/Bin/amd64/MSBuild.exe")]
+            public void Should_Get_Correct_Path_To_MSBuild_Version_14(MSBuildToolVersion version, PlatformTarget target, bool is64BitOperativeSystem, string expected)
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(is64BitOperativeSystem, true);
+                fixture.Settings.ToolVersion = version;
+                fixture.Settings.PlatformTarget = target;
+
+                // When
+                fixture.Run();
+
+                // Then
+                fixture.AssertReceivedFilePath(expected);
+            }
+
             [Fact]
             public void Should_Throw_If_MSBuild_Executable_Did_Not_Exist()
             {

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsExtensionsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsExtensionsTests.cs
@@ -31,7 +31,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 var settings = new MSBuildSettings(solution);
 
                 // When
-                var result = settings.WithTarget("Target");          
+                var result = settings.WithTarget("Target");
 
                 // Then
                 Assert.Equal(settings, result);

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsTests.cs
@@ -55,7 +55,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 var settings = new MSBuildSettings(path);
 
                 // Then
-                Assert.Equal(Verbosity.Normal, settings.Verbosity);                
+                Assert.Equal(Verbosity.Normal, settings.Verbosity);
             }
         }
 
@@ -113,7 +113,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             public void Should_Be_Empty_By_Default()
             {
                 // Given
-                var solution = new FilePath("/src/Solution.sln");                
+                var solution = new FilePath("/src/Solution.sln");
 
                 // When
                 var configuration = new MSBuildSettings(solution);

--- a/src/Cake.Common/Tools/MSBuild/MSBuildResolver.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildResolver.cs
@@ -9,7 +9,7 @@ namespace Cake.Common.Tools.MSBuild
         public static FilePath GetMSBuildPath(IFileSystem fileSystem, ICakeEnvironment environment, MSBuildToolVersion version, PlatformTarget target)
         {
             var binPath = (version == MSBuildToolVersion.Default)
-                ? GetHighestAvailableMSBuildVersion(fileSystem, environment, target) 
+                ? GetHighestAvailableMSBuildVersion(fileSystem, environment, target)
                 : GetMSBuildPath(environment, (MSBuildVersion)version, target);
 
             if (binPath == null)
@@ -25,6 +25,7 @@ namespace Cake.Common.Tools.MSBuild
         {
             var versions = new[] 
             {
+                MSBuildVersion.MSBuild14,
                 MSBuildVersion.MSBuild12, 
                 MSBuildVersion.MSBuild4,
                 MSBuildVersion.MSBuild35,
@@ -46,8 +47,10 @@ namespace Cake.Common.Tools.MSBuild
         {
             switch (version)
             {
+                case MSBuildVersion.MSBuild14:
+                    return GetVisualStudioPath(environment, target, "14.0");
                 case MSBuildVersion.MSBuild12:
-                    return GetVisualStudioPath(environment, target);
+                    return GetVisualStudioPath(environment, target, "12.0");
                 case MSBuildVersion.MSBuild4:
                     return GetFrameworkPath(environment, target, "v4.0.30319");
                 case MSBuildVersion.MSBuild35:
@@ -59,11 +62,11 @@ namespace Cake.Common.Tools.MSBuild
             }
         }
 
-        private static DirectoryPath GetVisualStudioPath(ICakeEnvironment environment, PlatformTarget target)
+        private static DirectoryPath GetVisualStudioPath(ICakeEnvironment environment, PlatformTarget target, string version)
         {
             // Get the bin path.
             var programFilesPath = environment.GetSpecialPath(SpecialPath.ProgramFilesX86);
-            var binPath = programFilesPath.Combine("MSBuild/12.0/Bin");
+            var binPath = programFilesPath.Combine(string.Concat("MSBuild/", version, "/Bin"));
             if (target == PlatformTarget.MSIL)
             {
                 if (environment.Is64BitOperativeSystem())

--- a/src/Cake.Common/Tools/MSBuild/MSBuildToolVersion.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildToolVersion.cs
@@ -74,5 +74,15 @@
         /// MSBuild tool version: <c>Visual Studio 2013</c>
         /// </summary>
         VS2013 = 4,
+
+        /// <summary>
+        /// MSBuild tool version: <c>Visual Studio 2015</c>
+        /// </summary>
+        VS2015 = 5,
+
+        /// <summary>
+        /// MSBuild tool version: <c>.NET 4.6</c>
+        /// </summary>
+        NET46 = 5,
     }
 }

--- a/src/Cake.Common/Tools/MSBuild/MSBuildVersion.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildVersion.cs
@@ -5,6 +5,7 @@
         MSBuild20 = 1,
         MSBuild35 = 2,
         MSBuild4 = 3,
-        MSBuild12 = 4
+        MSBuild12 = 4,
+        MSBuild14 = 5
     }
 }


### PR DESCRIPTION
Projects created with Visual Studio 2015 RC using new compiler features (i.e. C# 6.0) and/or .NET 4.6, can now be compiled using MSBuild 14.0.

**Added enum values:**

* `MSBuildToolVersion.NET46`
* `MSBuildToolVersion.VS2015`

**Example:**

```csharp
MSBuild("./src/Cake.sln", settings =>
    settings.SetConfiguration(configuration)
        .UseToolVersion(MSBuildToolVersion.NET46)
        .SetNodeReuse(false));
```
