### PR TITLE
Made Cake work on .NET 4.6 without experimental flag.

### DIFF
--- a/src/Cake/Cake.csproj
+++ b/src/Cake/Cake.csproj
@@ -41,6 +41,7 @@
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <RunCodeAnalysis>false</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\Cake.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
Kind of embarassing, but I found the reason for Cake not working on .NET 4.6 with the old bits. Not sure why the prefer 32-bit flag was set at all in the first place to be honest...

Should probably be tested on a machine without .NET 4.6 as well.