### PR TITLE
Changed the way nuget.exe is resolved.

### DIFF
--- a/src/Cake.Core.Tests/Cake.Core.Tests.csproj
+++ b/src/Cake.Core.Tests/Cake.Core.Tests.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Unit\IO\FilePathCollectionTests.cs" />
     <Compile Include="Unit\IO\FileSystemExtensionsTest.cs" />
     <Compile Include="Unit\IO\GlobberTests.cs" />
+    <Compile Include="Unit\IO\NuGet\NuGetToolResolverTests.cs" />
     <Compile Include="Unit\IO\PathComparerTests.cs" />
     <Compile Include="Unit\IO\DirectoryPathTests.cs" />
     <Compile Include="Unit\IO\FilePathTests.cs" />

--- a/src/Cake.Core.Tests/Fixtures/ScriptProcessorFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/ScriptProcessorFixture.cs
@@ -36,7 +36,7 @@ namespace Cake.Core.Tests.Fixtures
                 FileSystem.GetCreatedFile(ScriptPath.MakeAbsolute(Environment), Source);
             }
 
-            NuGetToolResolver = new NuGetToolResolver(FileSystem, Globber, Environment);
+            NuGetToolResolver = new NuGetToolResolver(FileSystem, Environment, Globber);
         }
 
         public ScriptProcessor CreateProcessor()

--- a/src/Cake.Core.Tests/Fixtures/ScriptRunnerFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/ScriptRunnerFixture.cs
@@ -47,9 +47,9 @@ namespace Cake.Core.Tests.Fixtures
             SessionFactory.CreateSession(Arg.Any<IScriptHost>(), ArgumentDictionary).Returns(Session);
 
             Arguments = Substitute.For<ICakeArguments>();
-            AliasGenerator = Substitute.For<IScriptAliasGenerator>();            
+            AliasGenerator = Substitute.For<IScriptAliasGenerator>();
             Log = Substitute.For<ICakeLog>();
-            NuGetToolResolver = new NuGetToolResolver(FileSystem, Globber, Environment);
+            NuGetToolResolver = new NuGetToolResolver(FileSystem, Environment, Globber);
             ScriptProcessor = new ScriptProcessor(FileSystem, Environment, Log, NuGetToolResolver);
 
             var context = Substitute.For<ICakeContext>();

--- a/src/Cake.Core.Tests/Unit/IO/NuGet/NuGetToolResolverTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/NuGet/NuGetToolResolverTests.cs
@@ -1,0 +1,161 @@
+﻿using Cake.Core.IO;
+using Cake.Core.IO.NuGet;
+using Cake.Testing.Fakes;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Core.Tests.Unit.IO.NuGet
+{
+    public sealed class NuGetToolResolverTests
+    {
+        public sealed class TheConstructor
+        {
+            [Fact]
+            public void Should_Throw_If_File_System_Is_Null()
+            {
+                // Given
+                var globber = Substitute.For<IGlobber>();
+                var environment = Substitute.For<ICakeEnvironment>();
+
+                // When
+                var result = Record.Exception(() => new NuGetToolResolver(null, environment, globber));
+
+                // Then
+                Assert.IsArgumentNullException(result, "fileSystem");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Environment_Is_Null()
+            {
+                // Given
+                var fileSystem = new FakeFileSystem(false);
+                var globber = Substitute.For<IGlobber>();
+
+                // When
+                var result = Record.Exception(() => new NuGetToolResolver(fileSystem, null, globber));
+
+                // Then
+                Assert.IsArgumentNullException(result, "environment");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Globber_Is_Null()
+            {
+                // Given
+                var fileSystem = new FakeFileSystem(false);
+                var environment = Substitute.For<ICakeEnvironment>();
+
+                // When
+                var result = Record.Exception(() => new NuGetToolResolver(fileSystem, environment, null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "globber");
+            }
+        }
+
+        public sealed class TheResolveToolPathMethod
+        {
+            [Fact]
+            public void Should_Throw_If_NuGet_Exe_Could_Not_Be_Found()
+            {
+                // Given
+                var fileSystem = new FakeFileSystem(false);
+                var globber = Substitute.For<IGlobber>();
+                globber.GetFiles("./tools/**/NuGet.exe").Returns(new FilePath[] { });
+                var environment = Substitute.For<ICakeEnvironment>();
+                environment.GetEnvironmentVariable("NUGET_EXE").Returns(c => null);
+                environment.GetEnvironmentVariable("path").Returns(c => null);
+                var resolver = new NuGetToolResolver(fileSystem, environment, globber);
+
+                // When
+                var result = Record.Exception(() => resolver.ResolveToolPath());
+
+                // Assert
+                Assert.IsCakeException(result, "Could not locate nuget.exe.");
+            }
+
+            [Fact]
+            public void Should_Resolve_In_Correct_Order()
+            {
+                // Given
+                var fileSystem = new FakeFileSystem(false);
+                var globber = Substitute.For<IGlobber>();
+                globber.GetFiles("./tools/**/NuGet.exe").Returns(new FilePath[] { });
+                var environment = Substitute.For<ICakeEnvironment>();
+                environment.GetEnvironmentVariable("NUGET_EXE").Returns(c => null);
+                environment.GetEnvironmentVariable("path").Returns(c => null);
+                var resolver = new NuGetToolResolver(fileSystem, environment, globber);
+
+                // When
+                Record.Exception(() => resolver.ResolveToolPath());
+
+                // Then
+                Received.InOrder(() =>
+                {
+                    // 1. Look in the tools directory.
+                    globber.GetFiles("./tools/**/NuGet.exe");
+                    // 2. Look for the environment variable NUGET_EXE.
+                    environment.GetEnvironmentVariable("NUGET_EXE");
+                    // 3. Panic and look in the path variable.
+                    environment.GetEnvironmentVariable("path");
+                });
+            }
+
+            [Fact]
+            public void Should_Be_Able_To_Resolve_Path_From_The_Tools_Directory()
+            {
+                // Given
+                var globber = Substitute.For<IGlobber>();
+                globber.Match("./tools/**/NuGet.exe").Returns(p => new FilePath[] { "/root/tools/nuget.exe" });
+                var fileSystem = new FakeFileSystem(false);
+                fileSystem.GetCreatedFile("/root/tools/nuget.exe");
+
+                var environment = Substitute.For<ICakeEnvironment>();
+                var resolver = new NuGetToolResolver(fileSystem, environment, globber);
+
+                // When
+                var result = resolver.ResolveToolPath();
+
+                // Then
+                Assert.Equal("/root/tools/nuget.exe", result.FullPath);
+            }
+
+            [Fact]
+            public void Should_Be_Able_To_Resolve_Path_Via_NuGet_Environment_Variable()
+            {
+                // Given
+                var globber = Substitute.For<IGlobber>();
+                var environment = Substitute.For<ICakeEnvironment>();
+                environment.GetEnvironmentVariable("NUGET_EXE").Returns("/programs/nuget.exe");
+                var fileSystem = new FakeFileSystem(false);
+                fileSystem.GetCreatedFile("/programs/nuget.exe");
+                var resolver = new NuGetToolResolver(fileSystem, environment, globber);
+
+                // When
+                var result = resolver.ResolveToolPath();
+
+                // Then
+                Assert.Equal("/programs/nuget.exe", result.FullPath);
+            }
+
+            [Fact]
+            public void Should_Be_Able_To_Resolve_Path_Via_Environment_Path_Variable()
+            {
+                // Given
+                var globber = Substitute.For<IGlobber>();
+                var environment = Substitute.For<ICakeEnvironment>();
+                environment.GetEnvironmentVariable("path").Returns("/temp;stuff/programs;/programs");
+                var fileSystem = new FakeFileSystem(false);
+                fileSystem.GetCreatedDirectory("stuff/programs");
+                fileSystem.GetCreatedFile("stuff/programs/nuget.exe");
+                var resolver = new NuGetToolResolver(fileSystem, environment, globber);
+
+                // When
+                var result = resolver.ResolveToolPath();
+
+                // Then
+                Assert.Equal("stuff/programs/nuget.exe", result.FullPath);
+            }
+        }
+    }
+}


### PR DESCRIPTION
NuGet exe will now be resolved in the following order:

1. Check tools path (`./tools/**/nuget.exe`)
2. Use `NUGET_EXE` environment variable (if present).
3. Check all paths in the `path` environment variable.