### PR TITLE
Added method to retrieve the filename without it's extension.

### DIFF
--- a/src/Cake.Core.Tests/Unit/IO/FilePathTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/FilePathTests.cs
@@ -129,6 +129,24 @@ namespace Cake.Core.Tests.Unit.IO
             }
         }
 
+        public sealed class TheGetFilenameWithoutExtensionMethod
+        {
+            [Theory]
+            [InlineData("/input/test.txt", "test")]
+            [InlineData("/input/test", "test")]
+            public void Should_Return_Filename_Without_Extension_From_Path(string fullPath, string expected)
+            {
+                // Given
+                var path = new FilePath(fullPath);
+
+                // When
+                var result = path.GetFilenameWithoutExtension();
+
+                // Then
+                Assert.Equal(expected, result.FullPath);
+            }
+        }
+
         public sealed class TheMakeAbsoluteMethod
         {
             public sealed class WithEnvironment

--- a/src/Cake.Core/IO/FilePath.cs
+++ b/src/Cake.Core/IO/FilePath.cs
@@ -52,6 +52,16 @@ namespace Cake.Core.IO
         }
 
         /// <summary>
+        /// Gets the filename without it's extension.
+        /// </summary>
+        /// <returns>The filename without it's extension.</returns>
+        public FilePath GetFilenameWithoutExtension()
+        {
+            var filename = System.IO.Path.GetFileNameWithoutExtension(FullPath);
+            return new FilePath(filename);
+        }
+
+        /// <summary>
         /// Gets the file extension.
         /// </summary>
         /// <returns>The file extension.</returns>


### PR DESCRIPTION
Added the method `FilePath.GetFilenameWithoutExtension` to retrieve a new `FilePath` containing the filename without it's extension.

```csharp
var path = new FilePath("./src/dummy.txt");
var filename = path.GetFilenameWithoutExtension();

Debug.Assert(filename.FullPath == "dummy");
```