### PR TITLE
[WIP] Added support for InternalsVisibleTo attribute as per issue #24…

### DIFF
--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>Cake.Common.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>178fe826</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>c5a81469</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>Cake.Common.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>c5a81469</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>6d299839</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoCreatorTests.cs
+++ b/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoCreatorTests.cs
@@ -1,4 +1,6 @@
-﻿using Cake.Common.Solution.Project.Properties;
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Cake.Common.Solution.Project.Properties;
 using Cake.Common.Tests.Fixtures;
 using Cake.Core;
 using Cake.Core.Diagnostics;
@@ -278,6 +280,37 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 Assert.True(result.Contains("using System;"));
                 Assert.True(result.Contains("[assembly: CLSCompliant(true)]"));
             }
+
+            [Fact]
+            public void Should_Add_InternalsVisibleTo_Attribute_If_Set()
+            {
+                // Given
+                var fixture = new AssemblyInfoFixture();
+                fixture.Settings.InternalsVisibleTo = new List<string> { "Assembly1.Tests" };
+
+                // When
+                var result = fixture.CreateAndReturnContent();
+
+                // Then
+                Assert.True(result.Contains("using System.Runtime.CompilerServices;"));
+                Assert.True(result.Contains("[assembly: InternalsVisibleTo(\"Assembly1.Tests\")]"));
+            }
+
+            [Fact]
+            public void Should_Add_Multiple_InternalsVisibleTo_Attribute_If_Set()
+            {
+                // Given
+                var fixture = new AssemblyInfoFixture();
+                fixture.Settings.InternalsVisibleTo = new Collection<string> { "Assembly1.Tests", "Assembly2.Tests", "Assembly3.Tests" };
+
+                // When
+                var result = fixture.CreateAndReturnContent();
+
+                // Then
+                Assert.True(result.Contains("using System.Runtime.CompilerServices;"));
+                Assert.True(result.Contains("[assembly: InternalsVisibleTo(\"Assembly1.Tests\"), InternalsVisibleTo(\"Assembly2.Tests\"), InternalsVisibleTo(\"Assembly3.Tests\")]"));
+            }
+
         }
     }
 }

--- a/src/Cake.Common/Build/TeamCity/ITeamCityProvider.cs
+++ b/src/Cake.Common/Build/TeamCity/ITeamCityProvider.cs
@@ -3,7 +3,7 @@
 namespace Cake.Common.Build.TeamCity
 {
     /// <summary>
-    /// Inteface for TeamCity BuildSystem provider.
+    /// Interface for TeamCity BuildSystem provider.
     /// </summary>
     public interface ITeamCityProvider
     {

--- a/src/Cake.Common/Build/TeamCity/TeamCityDisposableExtensions.cs
+++ b/src/Cake.Common/Build/TeamCity/TeamCityDisposableExtensions.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 namespace Cake.Common.Build.TeamCity
 {
     /// <summary>
-    /// A set of extensions for allowing "using" with teamcity "blocks".
+    /// A set of extensions for allowing "using" with TeamCity "blocks".
     /// </summary>
     public static class TeamCityDisposableExtensions
     {

--- a/src/Cake.Common/Build/TeamCity/TeamCityProvider.cs
+++ b/src/Cake.Common/Build/TeamCity/TeamCityProvider.cs
@@ -31,7 +31,7 @@ namespace Cake.Common.Build.TeamCity
         /// <summary>
         /// Initializes a new instance of the <see cref="TeamCityProvider"/> class.
         /// </summary>
-        /// <param name="environment">The cake enviroment.</param>
+        /// <param name="environment">The cake environment.</param>
         public TeamCityProvider(ICakeEnvironment environment)
         {
             if (environment == null)

--- a/src/Cake.Common/Solution/Project/Properties/AssemblyInfoCreator.cs
+++ b/src/Cake.Common/Solution/Project/Properties/AssemblyInfoCreator.cs
@@ -136,12 +136,19 @@ namespace Cake.Common.Solution.Project.Properties
             AssemblyInfoRegistration registration)
         {
             if (!SettingsIncludeInternalsVisibleTo(settings))
+            {
                 return;
+            }
 
-            if(registration == null)
+            if (registration == null)
+            {
                 return;
+            }
 
-            if(registration.Namespaces.Contains("System.Runtime.CompilerServices")) return;
+            if (registration.Namespaces.Contains("System.Runtime.CompilerServices"))
+            {
+                return;
+            }
 
             registration.Namespaces.Add("System.Runtime.CompilerServices");
         }
@@ -149,7 +156,9 @@ namespace Cake.Common.Solution.Project.Properties
         private static IEnumerable<string> GetInternalsVisibleTo(AssemblyInfoSettings settings)
         {
             if (!SettingsIncludeInternalsVisibleTo(settings))
+            {
                 return null;
+            }
 
             var nonEmptyInternalsVisibleTo = settings.InternalsVisibleTo.Where(x => x != null).ToList();
 
@@ -161,10 +170,14 @@ namespace Cake.Common.Solution.Project.Properties
         private static bool SettingsIncludeInternalsVisibleTo(AssemblyInfoSettings settings)
         {
             if (settings == null)
+            {
                 return false;
+            }
 
             if (settings.InternalsVisibleTo == null || !settings.InternalsVisibleTo.Any())
+            {
                 return false;
+            }
 
             return true;
         }

--- a/src/Cake.Common/Solution/Project/Properties/AssemblyInfoSettings.cs
+++ b/src/Cake.Common/Solution/Project/Properties/AssemblyInfoSettings.cs
@@ -1,4 +1,6 @@
-﻿namespace Cake.Common.Solution.Project.Properties
+﻿using System.Collections.Generic;
+
+namespace Cake.Common.Solution.Project.Properties
 {
     /// <summary>
     /// Contains settings used by <see cref="AssemblyInfoCreator"/>.
@@ -76,5 +78,12 @@
         /// </summary>
         /// <value>The company.</value>
         public string Company { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name(s) of the assembly(s) that internals should be visible to.
+        /// </summary>
+        /// <value>The name(s) of the assembly(s).</value>
+        public IEnumerable<string> InternalsVisibleTo { get; set; }
+
     }
 }

--- a/src/Cake.Common/Solution/Project/Properties/AssemblyInfoSettings.cs
+++ b/src/Cake.Common/Solution/Project/Properties/AssemblyInfoSettings.cs
@@ -84,6 +84,5 @@ namespace Cake.Common.Solution.Project.Properties
         /// </summary>
         /// <value>The name(s) of the assembly(s).</value>
         public IEnumerable<string> InternalsVisibleTo { get; set; }
-
     }
 }

--- a/src/Cake.Core.Tests/Cake.Core.Tests.csproj
+++ b/src/Cake.Core.Tests/Cake.Core.Tests.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>Cake.Core.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>3c415372</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>0440a91b</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Cake.Core.Tests/Cake.Core.Tests.csproj
+++ b/src/Cake.Core.Tests/Cake.Core.Tests.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>Cake.Core.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>0440a91b</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>31e0750e</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Cake.Tests/Cake.Tests.csproj
+++ b/src/Cake.Tests/Cake.Tests.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>Cake.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>4e4d6786</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>a8bf588e</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Cake.Tests/Cake.Tests.csproj
+++ b/src/Cake.Tests/Cake.Tests.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>Cake.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>bd255d2b</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>4e4d6786</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
…0 #243

If any InternalsVisibleTo are passed in the AssemblyInfoSettings, the
inclusion of proper namespace is ensured, and the they will be generated
with separate InternalsVisibleToAttribute tags but a single assembly
keyword.

Looking forward for your feedback. :)

Many thanks,
Mirela