### PR TITLE
Made UpdateBuildVersion() visible via IAppVeyorProvider

### DIFF
--- a/src/Cake.Common/Build/AppVeyor/IAppVeyorProvider.cs
+++ b/src/Cake.Common/Build/AppVeyor/IAppVeyorProvider.cs
@@ -29,5 +29,11 @@ namespace Cake.Common.Build.AppVeyor
         /// </summary>
         /// <param name="path">The file path of the artifact to upload.</param>
         void UploadArtifact(FilePath path);
+
+        /// <summary>
+        /// Updates the build version.
+        /// </summary>
+        /// <param name="version">The new build version.</param>
+        void UpdateBuildVersion(string version);
     }
 }


### PR DESCRIPTION
UpdateBuildVersion is missing from IAppVeyorProvider interface so can't be used from AppVeyor property alias.