### PR TITLE
DownloadFile alias

### DIFF
--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -48,6 +48,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Net" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Build\AppVeyor\Data\AppVeyorEnvironmentInfo.cs" />
@@ -187,6 +188,7 @@
     <Compile Include="Xml\XmlTransformation.cs" />
     <Compile Include="Xml\XmlTransformationAlias.cs" />
     <Compile Include="Xml\XmlTransformationSettings.cs" />
+    <Compile Include="IO\Net\HttpAliases.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cake.Core\Cake.Core.csproj">
@@ -213,4 +215,7 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <ItemGroup>
+    <Folder Include="IO\Net\" />
+  </ItemGroup>
 </Project>

--- a/src/Cake.Common/IO/Net/HttpAliases.cs
+++ b/src/Cake.Common/IO/Net/HttpAliases.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+
+namespace Cake.Common
+{
+    /// <summary>
+    /// Contains functionality related to HTTP operations
+    /// </summary>
+    [CakeAliasCategory("HTTP Operations")]
+    public static class HttpAliases
+    {
+        /// <summary>
+        /// Downloads the specified File over HTTP to the specified local output path
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="url">URL of file to download.</param>
+        /// <param name="outputPath">Where to download the file to.</param>
+        [CakeMethodAlias]
+        public static void DownloadFile(this ICakeContext context, string url, FilePath outputPath)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            if (url == null)
+            {
+                throw new ArgumentNullException("url");
+            }
+            if (outputPath == null)
+            {
+                throw new ArgumentNullException("outputPath");
+            }
+
+            context.Log.Write(Verbosity.Verbose, LogLevel.Information, "Downloading File: {0}", url);
+
+            // We track the last posted value since the event seems to fire many times for the same value
+            var percentComplete = 0;
+
+            var http = new System.Net.WebClient();
+            http.DownloadProgressChanged += (sender, e) => 
+            {
+                // Only write to log if the value changed and only ever 5%
+                if (percentComplete != e.ProgressPercentage && e.ProgressPercentage % 5 == 0)
+                {
+                    percentComplete = e.ProgressPercentage;
+                    context.Log.Write(Verbosity.Verbose, LogLevel.Information, "Downloading File: {0}%", e.ProgressPercentage);
+                }
+            };
+
+            // Download file async so we get the progress events, but block for it to complete anyway
+            http.DownloadFileTaskAsync(url, outputPath.FullPath).Wait();
+
+            context.Log.Write(Verbosity.Verbose, LogLevel.Information, "Download Complete, saved to: {0}", outputPath.FullPath);
+        }
+    }
+}

--- a/src/Cake.Common/Xml/XmlTransformationSettings.cs
+++ b/src/Cake.Common/Xml/XmlTransformationSettings.cs
@@ -33,6 +33,7 @@ namespace Cake.Common.Xml
             set { XmlWriterSettings.ConformanceLevel = value; }
         }
 
+        #if !__MonoCS__
         /// <summary>
         /// Gets or sets a value indicating whether the XmlWriter does not escape URI attributes.
         /// </summary>
@@ -41,6 +42,7 @@ namespace Cake.Common.Xml
             get { return XmlWriterSettings.DoNotEscapeUriAttributes; }
             set { XmlWriterSettings.DoNotEscapeUriAttributes = value; }
         }
+        #endif
 
         /// <summary>
         /// Gets or sets the type of text encoding to use.

--- a/src/Cake/Cake.csproj
+++ b/src/Cake/Cake.csproj
@@ -85,6 +85,9 @@
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
+    <Reference Include="Mono.CSharp">
+      <HintPath>..\packages\Mono.CSharp.4.0.0.143\lib\4.5\Mono.CSharp.dll</HintPath>
+    </Reference>
     <Reference Include="NuGet.Core, Version=2.8.50926.602, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NuGet.Core.2.8.3\lib\net40-Client\NuGet.Core.dll</HintPath>
@@ -159,6 +162,12 @@
     <Compile Include="Scripting\Roslyn\Stable\RoslynScriptSession.cs" />
     <Compile Include="Scripting\Roslyn\ScriptEngine.cs" />
     <Compile Include="Scripting\Roslyn\Stable\RoslynScriptSessionFactory.cs" />
+    <Compile Include="Scripting\Mono\MonoScriptSession.cs" />
+    <Compile Include="Scripting\Mono\MonoScriptEngine.cs" />
+    <Compile Include="Scripting\Mono\MonoCodeGenerator.cs" />
+    <Compile Include="Scripting\Mono\MonoPropertyAliasGenerator.cs" />
+    <Compile Include="Scripting\Mono\MonoMethodAliasGenerator.cs" />
+    <Compile Include="Scripting\Mono\MonoScriptHostProxy.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
@@ -208,4 +217,7 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <ItemGroup>
+    <Folder Include="Scripting\Mono\" />
+  </ItemGroup>
 </Project>

--- a/src/Cake/Program.cs
+++ b/src/Cake/Program.cs
@@ -24,7 +24,7 @@ namespace Cake
     /// </summary>
     public static class Program
     {
-        static bool IsRunningOnMono = false;
+        private static bool isRunningOnMono = false;
 
         /// <summary>
         /// The application entry point.
@@ -32,7 +32,7 @@ namespace Cake
         /// <returns>The application exit code.</returns>
         public static int Main()
         {
-            IsRunningOnMono = (Type.GetType ("Mono.Runtime") != null);
+            isRunningOnMono = Type.GetType("Mono.Runtime") != null;
            
             using (var container = CreateContainer())
             {
@@ -68,10 +68,13 @@ namespace Cake
             builder.RegisterType<WindowsRegistry>().As<IRegistry>().SingleInstance();
             builder.RegisterType<CakeContext>().As<ICakeContext>().SingleInstance();
 
-            if (IsRunningOnMono) {
+            if (isRunningOnMono) 
+            {
                 // Mono scripting
                 builder.RegisterType<Cake.Scripting.Mono.MonoScriptEngine>().As<IScriptEngine>().SingleInstance();
-            } else {
+            } 
+            else 
+            {
                 // Roslyn related services.
                 builder.RegisterType<RoslynScriptEngine>().As<IScriptEngine>().SingleInstance();
                 builder.RegisterType<RoslynScriptSessionFactory>().SingleInstance();

--- a/src/Cake/Program.cs
+++ b/src/Cake/Program.cs
@@ -24,12 +24,16 @@ namespace Cake
     /// </summary>
     public static class Program
     {
+        static bool IsRunningOnMono = false;
+
         /// <summary>
         /// The application entry point.
         /// </summary>
         /// <returns>The application exit code.</returns>
         public static int Main()
         {
+            IsRunningOnMono = (Type.GetType ("Mono.Runtime") != null);
+           
             using (var container = CreateContainer())
             {
                 // Parse arguments.
@@ -64,10 +68,15 @@ namespace Cake
             builder.RegisterType<WindowsRegistry>().As<IRegistry>().SingleInstance();
             builder.RegisterType<CakeContext>().As<ICakeContext>().SingleInstance();
 
-            // Roslyn related services.
-            builder.RegisterType<RoslynScriptEngine>().As<IScriptEngine>().SingleInstance();
-            builder.RegisterType<RoslynScriptSessionFactory>().SingleInstance();
-            builder.RegisterType<RoslynNightlyScriptSessionFactory>().SingleInstance();
+            if (IsRunningOnMono) {
+                // Mono scripting
+                builder.RegisterType<Cake.Scripting.Mono.MonoScriptEngine>().As<IScriptEngine>().SingleInstance();
+            } else {
+                // Roslyn related services.
+                builder.RegisterType<RoslynScriptEngine>().As<IScriptEngine>().SingleInstance();
+                builder.RegisterType<RoslynScriptSessionFactory>().SingleInstance();
+                builder.RegisterType<RoslynNightlyScriptSessionFactory>().SingleInstance();
+            }
 
             // Cake services.
             builder.RegisterType<ArgumentParser>().As<IArgumentParser>().SingleInstance();

--- a/src/Cake/Scripting/Mono/MonoCodeGenerator.cs
+++ b/src/Cake/Scripting/Mono/MonoCodeGenerator.cs
@@ -55,13 +55,13 @@ namespace Cake.Scripting.Mono
         static string GetScriptHostProxy ()
         {
             return "    " + string.Join ("\r\n    ", new string[] {
-            "public static IScriptHost ScriptHost { get; set; }",
-            "public ICakeContext Context { get { return ScriptHost.Context; } }",
-            "public IReadOnlyList<CakeTask> Tasks { get { return ScriptHost.Tasks; } }",
-            "public CakeTaskBuilder<ActionTask> Task(string name) { return ScriptHost.Task (name); }",
-            "public void Setup (Action action) { ScriptHost.Setup (action); }",
-            "public void Teardown(Action action) { ScriptHost.Teardown (action); }",
-            "public CakeReport RunTarget(string target) { return ScriptHost.RunTarget (target); }" });
+            "IScriptHost ScriptHost { get; set; }",
+            "ICakeContext Context { get { return ScriptHost.Context; } }",
+            "IReadOnlyList<CakeTask> Tasks { get { return ScriptHost.Tasks; } }",
+            "CakeTaskBuilder<ActionTask> Task(string name) { return ScriptHost.Task (name); }",
+            "void Setup (Action action) { ScriptHost.Setup (action); }",
+            "void Teardown(Action action) { ScriptHost.Teardown (action); }",
+            "CakeReport RunTarget(string target) { return ScriptHost.RunTarget (target); }" });
         }
     }
 }

--- a/src/Cake/Scripting/Mono/MonoCodeGenerator.cs
+++ b/src/Cake/Scripting/Mono/MonoCodeGenerator.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using Cake.Core.Scripting;
+
+namespace Cake.Scripting.Mono
+{
+    internal sealed class MonoCodeGenerator
+    {
+        public string Generate(Script script)
+        {
+            var alteredLines = new List<string> ();
+
+            foreach (var l in script.Lines) {
+                if (l.StartsWith ("#line 1"))
+                    alteredLines.Add ("// " + l);
+                else
+                    alteredLines.Add (l);               
+            }
+
+            var aliases = GetAliasCode(script);
+            var code = string.Join("\r\n", alteredLines);
+            return string.Join("\r\n", aliases, code);
+        }
+
+        private static string GetAliasCode(Script context)
+        {
+            var result = new List<string>();
+            foreach (var alias in context.Aliases)
+            {
+                result.Add(alias.Type == ScriptAliasType.Method
+                    ? MethodAliasGenerator.Generate(alias.Method)
+                    : PropertyAliasGenerator.Generate(alias.Method));
+            }
+            return string.Join("\r\n", result);
+        }
+    }
+}

--- a/src/Cake/Scripting/Mono/MonoMethodAliasGenerator.cs
+++ b/src/Cake/Scripting/Mono/MonoMethodAliasGenerator.cs
@@ -46,10 +46,10 @@ namespace Cake.Scripting.Mono
             builder.Append("(");
             builder.Append(string.Concat(GetProxyParameters(parameters, true)));
             builder.Append(")");
-            builder.AppendLine ();
+            builder.AppendLine();
             builder.Append("{");
-            builder.AppendLine ();
-            builder.Append ("    ");
+            builder.AppendLine();
+            builder.Append("    ");
 
             if (isFunction)
             {
@@ -69,12 +69,12 @@ namespace Cake.Scripting.Mono
             builder.Append("(");
             builder.Append(string.Concat(GetProxyParameters(parameters, false)));
             builder.Append(");");
-            builder.AppendLine ();
+            builder.AppendLine();
 
             // End method.
             builder.Append("}");
-            builder.AppendLine ();
-            builder.AppendLine ();
+            builder.AppendLine();
+            builder.AppendLine();
 
             return builder.ToString();
         }

--- a/src/Cake/Scripting/Mono/MonoMethodAliasGenerator.cs
+++ b/src/Cake/Scripting/Mono/MonoMethodAliasGenerator.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Cake.Core;
+using Cake.Core.Annotations;
+
+namespace Cake.Scripting.Mono
+{
+    /// <summary>
+    /// Responsible for generating script method aliases.
+    /// </summary>
+    public static class MethodAliasGenerator
+    {
+        /// <summary>
+        /// Generates a script method alias from the specified method.
+        /// The provided method must be an extension method for <see cref="ICakeContext"/>
+        /// and it must be decorated with the <see cref="CakeMethodAliasAttribute"/>.
+        /// </summary>
+        /// <param name="method">The method to generate the code for.</param>
+        /// <returns>The generated code.</returns>
+        public static string Generate(MethodInfo method)
+        {
+            if (method == null)
+            {
+                throw new ArgumentNullException("method");
+            }
+
+            var isFunction = method.ReturnType != typeof(void);
+            var builder = new StringBuilder();
+            var parameters = method.GetParameters().Skip(1).ToArray();
+
+            // Generate method signature.
+            builder.Append("public ");
+            builder.Append(GetReturnType(method));
+            builder.Append(" ");
+            builder.Append(method.Name);
+
+            if (method.IsGenericMethod)
+            {
+                // Add generic arguments to proxy signature.
+                BuildGenericArguments(method, builder);
+            }
+
+            builder.Append("(");
+            builder.Append(string.Concat(GetProxyParameters(parameters, true)));
+            builder.Append(")");
+            builder.AppendLine ();
+            builder.Append("{");
+            builder.AppendLine ();
+            builder.Append ("    ");
+
+            if (isFunction)
+            {
+                // Add return keyword.
+                builder.Append("return ");
+            }
+
+            // Call extension method.
+            builder.Append(method.GetFullName());
+
+            if (method.IsGenericMethod)
+            {
+                // Add generic arguments to method call.
+                BuildGenericArguments(method, builder);
+            }
+
+            builder.Append("(");
+            builder.Append(string.Concat(GetProxyParameters(parameters, false)));
+            builder.Append(");");
+            builder.AppendLine ();
+
+            // End method.
+            builder.Append("}");
+            builder.AppendLine ();
+            builder.AppendLine ();
+
+            return builder.ToString();
+        }
+
+        private static string GetReturnType(MethodInfo method)
+        {
+            return method.ReturnType == typeof(void)
+                ? "void"
+                    : method.ReturnType.GetFullName();
+        }
+
+        private static IEnumerable<string> GetProxyParameters(IEnumerable<ParameterInfo> parameters, bool includeType)
+        {
+            var first = includeType;
+            if (!includeType)
+            {
+                yield return "Context";
+            }
+            foreach (var parameter in parameters)
+            {
+                if (first)
+                {
+                    first = false;
+                }
+                else
+                {
+                    yield return ", ";
+                }
+                if (parameter.IsOut)
+                {
+                    yield return "out ";
+                }
+                else if (parameter.ParameterType.IsByRef)
+                {
+                    yield return "ref ";
+                }
+                if (includeType)
+                {
+                    if (parameter.IsDefined(typeof(ParamArrayAttribute)))
+                    {
+                        yield return "params ";
+                    }
+                    yield return parameter.ParameterType.GetFullName();
+                    yield return " ";
+                }
+                yield return parameter.Name;
+            }
+        }
+
+        private static void BuildGenericArguments(MethodInfo method, StringBuilder builder)
+        {
+            builder.Append("<");
+            var genericArguments = new List<string>();
+            foreach (var argument in method.GetGenericArguments())
+            {
+                genericArguments.Add(argument.Name);
+            }
+            builder.Append(string.Join(", ", genericArguments));
+            builder.Append(">");
+        }
+    }
+}

--- a/src/Cake/Scripting/Mono/MonoPropertyAliasGenerator.cs
+++ b/src/Cake/Scripting/Mono/MonoPropertyAliasGenerator.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Cake.Core;
+using Cake.Core.Annotations;
+
+namespace Cake.Scripting.Mono
+{
+    /// <summary>
+    /// Responsible for generating script property aliases.
+    /// </summary>
+    public static class PropertyAliasGenerator
+    {
+        /// <summary>
+        /// Generates a script property alias from the specified method.
+        /// The provided method must be an extension method for <see cref="ICakeContext"/>
+        /// and it must be decorated with the <see cref="CakePropertyAliasAttribute"/>.
+        /// </summary>
+        /// <param name="method">The method to generate the code for.</param>
+        /// <returns>The generated code.</returns>
+        public static string Generate(MethodInfo method)
+        {
+            if (method == null)
+            {
+                throw new ArgumentNullException("method");
+            }
+
+            // Perform validation.
+            ValidateMethod(method);
+            ValidateMethodParameters(method);
+
+            // Get the property alias attribute.
+            var attribute = method.GetCustomAttribute<CakePropertyAliasAttribute>();
+
+            // Generate code.
+            return attribute.Cache
+                ? GenerateCachedCode(method)
+                    : GenerateCode(method);
+        }
+
+        private static void ValidateMethod(MethodInfo method)
+        {
+            Debug.Assert(method.DeclaringType != null, "method.DeclaringType != null"); // Resharper
+
+            if (!method.DeclaringType.IsStatic())
+            {
+                const string format = "The type '{0}' is not static.";
+                throw new CakeException(string.Format(CultureInfo.InvariantCulture, format, method.DeclaringType.FullName));
+            }
+
+            if (!method.IsDefined(typeof(ExtensionAttribute)))
+            {
+                const string format = "The method '{0}' is not an extension method.";
+                throw new CakeException(string.Format(CultureInfo.InvariantCulture, format, method.Name));
+            }
+
+            if (!method.IsDefined(typeof(CakePropertyAliasAttribute)))
+            {
+                const string format = "The method '{0}' is not a property alias.";
+                throw new CakeException(string.Format(CultureInfo.InvariantCulture, format, method.Name));
+            }
+        }
+
+        private static void ValidateMethodParameters(MethodInfo method)
+        {
+            var parameters = method.GetParameters();
+            var parameterCorrect = false;
+            if (parameters.Length == 1)
+            {
+                if (parameters[0].ParameterType == typeof(ICakeContext))
+                {
+                    parameterCorrect = true;
+                }
+            }
+
+            if (!parameterCorrect)
+            {
+                const string format = "The property alias '{0}' has an invalid signature.";
+                throw new CakeException(string.Format(CultureInfo.InvariantCulture, format, method.Name));
+            }
+
+            if (method.IsGenericMethod)
+            {
+                const string format = "The property alias '{0}' cannot be generic.";
+                throw new CakeException(string.Format(CultureInfo.InvariantCulture, format, method.Name));
+            }
+
+            if (method.ReturnType == typeof(void))
+            {
+                const string format = "The property alias '{0}' cannot return void.";
+                throw new CakeException(string.Format(CultureInfo.InvariantCulture, format, method.Name));
+            }
+        }
+
+        private static string GenerateCode(MethodInfo method)
+        {
+            var builder = new StringBuilder();
+
+            builder.Append("public ");
+            builder.Append(GetReturnType(method));
+            builder.Append(" ");
+            builder.Append(method.Name);
+            builder.AppendLine ();
+            builder.Append("{");
+            builder.AppendLine ();
+            builder.Append ("    get {");
+            builder.AppendLine ();
+            builder.Append ("        return ");
+            builder.Append(method.GetFullName());
+            builder.Append("(Context);");
+            builder.Append ("    }");
+            builder.AppendLine ();
+            builder.Append ("}");
+            builder.AppendLine ();
+            builder.AppendLine ();
+
+            return builder.ToString();
+        }
+
+        private static string GenerateCachedCode(MethodInfo method)
+        {
+            var builder = new StringBuilder();
+
+            // Backing field.
+            builder.Append("private ");
+            builder.Append(GetReturnType(method));
+            if (method.ReturnType.IsValueType)
+            {
+                builder.Append("?");
+            }
+            builder.Append(" _");
+            builder.Append(method.Name);
+            builder.Append(";");
+            builder.AppendLine();
+
+            // Property
+            builder.Append("public ");
+            builder.Append(GetReturnType(method));
+            builder.Append(" ");
+            builder.Append(method.Name);
+            builder.AppendLine ();
+            builder.Append("{");
+            builder.AppendLine ();
+            builder.Append("    get { ");
+            builder.AppendLine ();
+            builder.AppendFormat("        if (_{0}==null)", method.Name);
+            builder.Append(" {");
+            builder.AppendLine ();
+            builder.AppendFormat("            _{0} = ", method.Name);
+            builder.Append(method.GetFullName());
+            builder.Append("(Context);");
+            builder.AppendLine ();
+            builder.Append("        }");
+            builder.AppendLine ();
+            builder.AppendFormat("        return _{0}", method.Name);
+            if (method.ReturnType.IsValueType)
+            {
+                builder.Append(".Value");
+            }
+            builder.Append(";");
+            builder.AppendLine ();
+            builder.Append("    }");
+            builder.AppendLine ();
+            builder.Append("}");
+            builder.AppendLine ();
+            builder.AppendLine ();
+
+            return builder.ToString();
+        }
+
+        private static string GetReturnType(MethodInfo method)
+        {
+            return method.ReturnType.GetFullName();
+        }
+    }
+}

--- a/src/Cake/Scripting/Mono/MonoPropertyAliasGenerator.cs
+++ b/src/Cake/Scripting/Mono/MonoPropertyAliasGenerator.cs
@@ -103,19 +103,19 @@ namespace Cake.Scripting.Mono
             builder.Append(GetReturnType(method));
             builder.Append(" ");
             builder.Append(method.Name);
-            builder.AppendLine ();
+            builder.AppendLine();
             builder.Append("{");
-            builder.AppendLine ();
-            builder.Append ("    get {");
-            builder.AppendLine ();
-            builder.Append ("        return ");
+            builder.AppendLine();
+            builder.Append("    get {");
+            builder.AppendLine();
+            builder.Append("        return ");
             builder.Append(method.GetFullName());
             builder.Append("(Context);");
-            builder.Append ("    }");
-            builder.AppendLine ();
-            builder.Append ("}");
-            builder.AppendLine ();
-            builder.AppendLine ();
+            builder.Append("    }");
+            builder.AppendLine();
+            builder.Append("}");
+            builder.AppendLine();
+            builder.AppendLine();
 
             return builder.ToString();
         }
@@ -141,32 +141,32 @@ namespace Cake.Scripting.Mono
             builder.Append(GetReturnType(method));
             builder.Append(" ");
             builder.Append(method.Name);
-            builder.AppendLine ();
+            builder.AppendLine();
             builder.Append("{");
-            builder.AppendLine ();
+            builder.AppendLine();
             builder.Append("    get { ");
-            builder.AppendLine ();
+            builder.AppendLine();
             builder.AppendFormat("        if (_{0}==null)", method.Name);
             builder.Append(" {");
-            builder.AppendLine ();
+            builder.AppendLine();
             builder.AppendFormat("            _{0} = ", method.Name);
             builder.Append(method.GetFullName());
             builder.Append("(Context);");
-            builder.AppendLine ();
+            builder.AppendLine();
             builder.Append("        }");
-            builder.AppendLine ();
+            builder.AppendLine();
             builder.AppendFormat("        return _{0}", method.Name);
             if (method.ReturnType.IsValueType)
             {
                 builder.Append(".Value");
             }
             builder.Append(";");
-            builder.AppendLine ();
+            builder.AppendLine();
             builder.Append("    }");
-            builder.AppendLine ();
+            builder.AppendLine();
             builder.Append("}");
-            builder.AppendLine ();
-            builder.AppendLine ();
+            builder.AppendLine();
+            builder.AppendLine();
 
             return builder.ToString();
         }

--- a/src/Cake/Scripting/Mono/MonoScriptEngine.cs
+++ b/src/Cake/Scripting/Mono/MonoScriptEngine.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using Cake.Core.Scripting;
-using Cake.Core.Diagnostics;
 using System.Collections.Generic;
+using Cake.Core.Diagnostics;
+using Cake.Core.Scripting;
 
 namespace Cake.Scripting.Mono
 {
@@ -24,8 +24,7 @@ namespace Cake.Scripting.Mono
             // Create the script session.
             _log.Debug("Creating script session...");
 
-            return new MonoScriptSession (host, _log);
+            return new MonoScriptSession(host, _log);
         }
     }
 }
-

--- a/src/Cake/Scripting/Mono/MonoScriptEngine.cs
+++ b/src/Cake/Scripting/Mono/MonoScriptEngine.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Cake.Core.Scripting;
+using Cake.Core.Diagnostics;
+using System.Collections.Generic;
+
+namespace Cake.Scripting.Mono
+{
+    internal sealed class MonoScriptEngine : IScriptEngine
+    {
+        private readonly ICakeLog _log;
+
+        public MonoScriptEngine(ICakeLog log)
+        {
+            _log = log;
+        }
+
+        public IScriptSession CreateSession(IScriptHost host, IDictionary<string, string> arguments)
+        {
+            if (arguments == null)
+            {
+                throw new ArgumentNullException("arguments");
+            }
+
+            // Create the script session.
+            _log.Debug("Creating script session...");
+
+            return new MonoScriptSession (host, _log);
+        }
+    }
+}
+

--- a/src/Cake/Scripting/Mono/MonoScriptHostProxy.cs
+++ b/src/Cake/Scripting/Mono/MonoScriptHostProxy.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Cake.Core.Scripting;
+using Cake.Core;
+using System.Collections.Generic;
+
+namespace Cake
+{
+    public static class MonoScriptHostProxy
+    {
+        public static IScriptHost ScriptHost { get; set; }
+
+        /// <summary>
+        /// Gets the context.
+        /// </summary>
+        /// <value>The context.</value>
+        public static ICakeContext Context { get { return ScriptHost.Context; } }
+
+        /// <summary>
+        /// Gets all registered tasks.
+        /// </summary>
+        /// <value>The registered tasks.</value>
+        public static IReadOnlyList<CakeTask> Tasks { get { return ScriptHost.Tasks; } }
+
+        /// <summary>
+        /// Registers a new task.
+        /// </summary>
+        /// <param name="name">The name of the task.</param>
+        /// <returns>A <see cref="CakeTaskBuilder{ActionTask}"/>.</returns>
+        public static CakeTaskBuilder<ActionTask> Task(string name)
+        {
+            return ScriptHost.Task (name);
+        }
+
+        /// <summary>
+        /// Allows registration of an action that's executed before any tasks are run.
+        /// If setup fails, no tasks will be executed but teardown will be performed.
+        /// </summary>
+        /// <param name="action">The action to be executed.</param>
+        public static void Setup (Action action)
+        {
+            ScriptHost.Setup (action);
+        }
+
+        /// <summary>
+        /// Allows registration of an action that's executed after all other tasks have been run.
+        /// If a setup action or a task fails with or without recovery, the specified teardown action will still be executed.
+        /// </summary>
+        /// <param name="action">The action to be executed.</param>
+        public static void Teardown(Action action)
+        {
+            ScriptHost.Teardown (action);
+        }
+
+        /// <summary>
+        /// Runs the specified target.
+        /// </summary>
+        /// <param name="target">The target to run.</param>
+        /// <returns>The resulting report.</returns>
+        public static CakeReport RunTarget(string target)
+        {
+            return ScriptHost.RunTarget (target);
+        }
+    }
+}
+

--- a/src/Cake/Scripting/Mono/MonoScriptHostProxy.cs
+++ b/src/Cake/Scripting/Mono/MonoScriptHostProxy.cs
@@ -10,6 +10,10 @@ namespace Cake.Scripting.Mono
     /// </summary>
     public class MonoScriptHostProxy
     {
+        /// <summary>
+        /// Gets or sets the script host.
+        /// </summary>
+        /// <value>The script host.</value>
         public static IScriptHost ScriptHost { get; set; }
     }
 }

--- a/src/Cake/Scripting/Mono/MonoScriptHostProxy.cs
+++ b/src/Cake/Scripting/Mono/MonoScriptHostProxy.cs
@@ -1,13 +1,15 @@
 ﻿using System;
-using Cake.Core.Scripting;
-using Cake.Core;
 using System.Collections.Generic;
+using Cake.Core;
+using Cake.Core.Scripting;
 
 namespace Cake.Scripting.Mono
 {
+    /// <summary>
+    /// Mono script host proxy.
+    /// </summary>
     public class MonoScriptHostProxy
     {
         public static IScriptHost ScriptHost { get; set; }
     }
 }
-

--- a/src/Cake/Scripting/Mono/MonoScriptHostProxy.cs
+++ b/src/Cake/Scripting/Mono/MonoScriptHostProxy.cs
@@ -3,63 +3,11 @@ using Cake.Core.Scripting;
 using Cake.Core;
 using System.Collections.Generic;
 
-namespace Cake
+namespace Cake.Scripting.Mono
 {
-    public static class MonoScriptHostProxy
+    public class MonoScriptHostProxy
     {
         public static IScriptHost ScriptHost { get; set; }
-
-        /// <summary>
-        /// Gets the context.
-        /// </summary>
-        /// <value>The context.</value>
-        public static ICakeContext Context { get { return ScriptHost.Context; } }
-
-        /// <summary>
-        /// Gets all registered tasks.
-        /// </summary>
-        /// <value>The registered tasks.</value>
-        public static IReadOnlyList<CakeTask> Tasks { get { return ScriptHost.Tasks; } }
-
-        /// <summary>
-        /// Registers a new task.
-        /// </summary>
-        /// <param name="name">The name of the task.</param>
-        /// <returns>A <see cref="CakeTaskBuilder{ActionTask}"/>.</returns>
-        public static CakeTaskBuilder<ActionTask> Task(string name)
-        {
-            return ScriptHost.Task (name);
-        }
-
-        /// <summary>
-        /// Allows registration of an action that's executed before any tasks are run.
-        /// If setup fails, no tasks will be executed but teardown will be performed.
-        /// </summary>
-        /// <param name="action">The action to be executed.</param>
-        public static void Setup (Action action)
-        {
-            ScriptHost.Setup (action);
-        }
-
-        /// <summary>
-        /// Allows registration of an action that's executed after all other tasks have been run.
-        /// If a setup action or a task fails with or without recovery, the specified teardown action will still be executed.
-        /// </summary>
-        /// <param name="action">The action to be executed.</param>
-        public static void Teardown(Action action)
-        {
-            ScriptHost.Teardown (action);
-        }
-
-        /// <summary>
-        /// Runs the specified target.
-        /// </summary>
-        /// <param name="target">The target to run.</param>
-        /// <returns>The resulting report.</returns>
-        public static CakeReport RunTarget(string target)
-        {
-            return ScriptHost.RunTarget (target);
-        }
     }
 }
 

--- a/src/Cake/Scripting/Mono/MonoScriptSession.cs
+++ b/src/Cake/Scripting/Mono/MonoScriptSession.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using Mono.CSharp;
+using Cake.Core.Scripting;
+using System.Text;
+using System.Collections.Generic;
+using Cake.Scripting.Roslyn;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+
+namespace Cake.Scripting.Mono
+{
+    public class MonoScriptSession : IScriptSession
+    {
+        Evaluator evaluator;
+        CompilerSettings compilerSettings;
+        ConsoleReportPrinter reportPrinter;
+        CompilerContext compilerContext;
+
+        readonly ICakeLog _log;
+
+        public MonoScriptSession (IScriptHost host, ICakeLog log)
+        {
+            if (host == null)
+            {
+                throw new ArgumentNullException("host");
+            }
+            if (log == null)
+            {
+                throw new ArgumentNullException("log");
+            }
+
+            _log = log;
+
+            compilerSettings = new CompilerSettings ();
+
+            reportPrinter = new ConsoleReportPrinter ();// CakeReportPrinter (new CakeConsole ());
+            compilerContext = new CompilerContext (compilerSettings, reportPrinter);
+            evaluator = new Evaluator (compilerContext);
+
+            // Set our instance of the script host to this static member
+            MonoScriptHostProxy.ScriptHost = host;
+
+            // This will be our 'base' type from which the evaluator grants access
+            // to static members to the script being run 
+            evaluator.ReferenceAssembly(typeof(MonoScriptHostProxy).Assembly);
+            evaluator.InteractiveBaseClass = typeof(MonoScriptHostProxy);
+        }
+
+        public void AddReference (Cake.Core.IO.FilePath path)
+        {
+            _log.Debug("Adding reference to {0}...", path.FullPath);
+            evaluator.ReferenceAssembly (System.Reflection.Assembly.LoadFile (path.FullPath));
+        }
+
+        public void AddReference (System.Reflection.Assembly assembly)
+        {
+            _log.Debug("Adding reference to {0}...", new FilePath(assembly.Location).GetFilename().FullPath);
+            evaluator.ReferenceAssembly (assembly);
+        }
+
+        public void ImportNamespace (string @namespace)
+        {
+            _log.Debug("Importing namespace {0}...", @namespace);
+            var result = evaluator.Run ("using " + @namespace + ";");
+            _log.Debug ("Ran Import {0}...", result);
+        }
+
+        public void Execute (Script script)
+        {
+            var generator = new MonoCodeGenerator();
+            var code = generator.Generate(script);
+
+            var result = evaluator.Evaluate (code);
+
+            _log.Debug ("Execution complete");
+        }            
+    }
+}
+

--- a/src/Cake/packages.config
+++ b/src/Cake/packages.config
@@ -12,4 +12,5 @@
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
+  <package id="Mono.CSharp" version="4.0.0.143" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I do a lot of downloading of external files in my build scripts. 

This adds a new `HttpAliases` class with (so far) a single `DownloadFile(string url, DirectoryPath outputPath)` alias which does exactly what it looks like.

Eventually there could be more HTTP related aliases here such as `DownloadString`