### PR TITLE
Added DownloadFile alias

### DIFF
--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -48,6 +48,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Net" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Build\AppVeyor\Data\AppVeyorEnvironmentInfo.cs" />
@@ -187,6 +188,7 @@
     <Compile Include="Xml\XmlTransformation.cs" />
     <Compile Include="Xml\XmlTransformationAlias.cs" />
     <Compile Include="Xml\XmlTransformationSettings.cs" />
+    <Compile Include="IO\Net\HttpAliases.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cake.Core\Cake.Core.csproj">
@@ -213,4 +215,7 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <ItemGroup>
+    <Folder Include="IO\Net\" />
+  </ItemGroup>
 </Project>

--- a/src/Cake.Common/IO/Net/HttpAliases.cs
+++ b/src/Cake.Common/IO/Net/HttpAliases.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+
+namespace Cake.Common
+{
+    /// <summary>
+    /// Contains functionality related to HTTP operations
+    /// </summary>
+    [CakeAliasCategory("HTTP Operations")]
+    public static class HttpAliases
+    {
+        /// <summary>
+        /// Downloads the specified File over HTTP to the specified local output path
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="url">URL of file to download.</param>
+        /// <param name="outputPath">Where to download the file to.</param>
+        [CakeMethodAlias]
+        public static void DownloadFile(this ICakeContext context, string url, FilePath outputPath)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            if (url == null)
+            {
+                throw new ArgumentNullException("url");
+            }
+            if (outputPath == null)
+            {
+                throw new ArgumentNullException("outputPath");
+            }
+
+            context.Log.Write(Verbosity.Verbose, LogLevel.Information, "Downloading File: {0}", url);
+
+            // We track the last posted value since the event seems to fire many times for the same value
+            var percentComplete = 0;
+
+            var http = new System.Net.WebClient();
+            http.DownloadProgressChanged += (sender, e) => 
+            {
+                // Only write to log if the value changed and only ever 5%
+                if (percentComplete != e.ProgressPercentage && e.ProgressPercentage % 5 == 0)
+                {
+                    percentComplete = e.ProgressPercentage;
+                    context.Log.Write(Verbosity.Verbose, LogLevel.Information, "Downloading File: {0}%", e.ProgressPercentage);
+                }
+            };
+
+            // Download file async so we get the progress events, but block for it to complete anyway
+            http.DownloadFileTaskAsync(url, outputPath.FullPath).Wait();
+
+            context.Log.Write(Verbosity.Verbose, LogLevel.Information, "Download Complete, saved to: {0}", outputPath.FullPath);
+        }
+    }
+}

--- a/src/Cake.Common/IO/Net/HttpAliases.cs
+++ b/src/Cake.Common/IO/Net/HttpAliases.cs
@@ -39,19 +39,21 @@ namespace Cake.Common
             // We track the last posted value since the event seems to fire many times for the same value
             var percentComplete = 0;
 
-            var http = new System.Net.WebClient();
-            http.DownloadProgressChanged += (sender, e) => 
+            using (var http = new System.Net.WebClient()) 
             {
-                // Only write to log if the value changed and only ever 5%
-                if (percentComplete != e.ProgressPercentage && e.ProgressPercentage % 5 == 0)
+                http.DownloadProgressChanged += (sender, e) => 
                 {
-                    percentComplete = e.ProgressPercentage;
-                    context.Log.Write(Verbosity.Verbose, LogLevel.Information, "Downloading File: {0}%", e.ProgressPercentage);
-                }
-            };
+                    // Only write to log if the value changed and only ever 5%
+                    if (percentComplete != e.ProgressPercentage && e.ProgressPercentage % 5 == 0) 
+                    {
+                        percentComplete = e.ProgressPercentage;
+                        context.Log.Write(Verbosity.Verbose, LogLevel.Information, "Downloading File: {0}%", e.ProgressPercentage);
+                    }
+                };
 
-            // Download file async so we get the progress events, but block for it to complete anyway
-            http.DownloadFileTaskAsync(url, outputPath.FullPath).Wait();
+                // Download file async so we get the progress events, but block for it to complete anyway
+                http.DownloadFileTaskAsync(url, outputPath.FullPath).Wait();
+            }
 
             context.Log.Write(Verbosity.Verbose, LogLevel.Information, "Download Complete, saved to: {0}", outputPath.FullPath);
         }


### PR DESCRIPTION
I do a lot of downloading of external files in my build scripts. 

This adds a new `HttpAliases` class with (so far) a single `DownloadFile(string url, DirectoryPath outputPath)` alias which does exactly what it looks like.

Eventually there could be more HTTP related aliases here such as `DownloadString`