### PR TITLE
Added support for Fixie test framework

### DIFF
--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Fixtures\IO\FileCopyFixture.cs" />
     <Compile Include="Fixtures\IO\FileDeleteFixture.cs" />
     <Compile Include="Fixtures\IO\FileSystemFixture.cs" />
+    <Compile Include="Fixtures\Tools\FixieRunnerFixture.cs" />
     <Compile Include="Fixtures\Tools\ILMergeRunnerFixture.cs" />
     <Compile Include="Fixtures\Diagnostics\LogActionFixture.cs" />
     <Compile Include="Fixtures\Tools\MSBuildRunnerFixture.cs" />
@@ -119,6 +120,7 @@
     <Compile Include="Unit\Text\TextTransformationExtensionsTests.cs" />
     <Compile Include="Unit\Text\TextTransformationTests.cs" />
     <Compile Include="Unit\Tools\Cake\CakeRunnerTests.cs" />
+    <Compile Include="Unit\Tools\Fixie\FixieRunnerTests.cs" />
     <Compile Include="Unit\Tools\ILMerge\ILMergeRunnerTests.cs" />
     <Compile Include="Unit\Tools\ILMerge\ILMergeSettingsTests.cs" />
     <Compile Include="Unit\IO\ZipperTests.cs" />

--- a/src/Cake.Common.Tests/Fixtures/Tools/FixieRunnerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/FixieRunnerFixture.cs
@@ -1,0 +1,44 @@
+﻿using Cake.Common.Tools.Fixie;
+using Cake.Core;
+using Cake.Core.IO;
+using NSubstitute;
+
+namespace Cake.Common.Tests.Fixtures.Tools
+{
+    internal sealed class FixieRunnerFixture
+    {
+        public IProcess Process { get; set; }
+        public IFileSystem FileSystem { get; set; }
+        public ICakeEnvironment Environment { get; set; }
+        public IProcessRunner ProcessRunner { get; set; }
+        public IGlobber Globber { get; set; }
+
+        public FixieRunnerFixture(FilePath toolPath = null, bool defaultToolExist = true)
+        {
+            Process = Substitute.For<IProcess>();
+            Process.GetExitCode().Returns(0);
+
+            ProcessRunner = Substitute.For<IProcessRunner>();
+            ProcessRunner.Start(Arg.Any<FilePath>(), Arg.Any<ProcessSettings>()).Returns(Process);
+
+            Environment = Substitute.For<ICakeEnvironment>();
+            Environment.WorkingDirectory = "/Working";
+
+            Globber = Substitute.For<IGlobber>();
+            Globber.Match("./tools/**/Fixie.Console.exe").Returns(new[] { (FilePath)"/Working/tools/Fixie.Console.exe" });
+
+            FileSystem = Substitute.For<IFileSystem>();
+            FileSystem.Exist(Arg.Is<FilePath>(a => a.FullPath == "/Working/tools/Fixie.Console.exe")).Returns(defaultToolExist);
+
+            if (toolPath != null)
+            {
+                FileSystem.Exist(Arg.Is<FilePath>(a => a.FullPath == toolPath.FullPath)).Returns(true);
+            }
+        }
+
+        public FixieRunner CreateRunner()
+        {
+            return new FixieRunner(FileSystem, Environment, ProcessRunner, Globber);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/Fixie/FixieRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Fixie/FixieRunnerTests.cs
@@ -154,6 +154,46 @@ namespace Cake.Common.Tests.Unit.Tools.Fixie
                 Assert.IsType<CakeException>(result);
                 Assert.Equal("Fixie: Process returned an error.", result.Message);
             }
+
+            [Fact]
+            public void Should_set_NUnitXml_Output_File()
+            {
+                // Given
+                var fixture = new FixieRunnerFixture();
+                var runner = fixture.CreateRunner();
+
+                // When
+                runner.Run("./blarg.dll", new FixieSettings
+                {
+                    NUnitXml = "nunit-style-results.xml",
+                });
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(),
+                    Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "\"/Working/blarg.dll\" --NUnitXml \"/Working/nunit-style-results.xml\""));
+            }
+
+            [Fact]
+            public void Should_set_xUnitXml_Output_File()
+            {
+                // Given
+                var fixture = new FixieRunnerFixture();
+                var runner = fixture.CreateRunner();
+
+                // When
+                runner.Run("./blarg.dll", new FixieSettings
+                {
+                    XUnitXml = "xunit-results.xml",
+                });
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(),
+                    Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "\"/Working/blarg.dll\" --xUnitXml \"/Working/xunit-results.xml\""));
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/Fixie/FixieRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Fixie/FixieRunnerTests.cs
@@ -1,0 +1,159 @@
+using System.Collections.Generic;
+using Cake.Common.Tests.Fixtures.Tools;
+using Cake.Common.Tools.Fixie;
+using Cake.Core;
+using Cake.Core.IO;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.Fixie
+{
+    public sealed class FixieRunnerTests
+    {
+        public sealed class TheRunMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Assembly_Path_Is_Null()
+            {
+                // Given
+                var fixture = new FixieRunnerFixture();
+                var runner = fixture.CreateRunner();
+
+                // When
+                var result = Record.Exception(() => runner.Run((FilePath) null, new FixieSettings()));
+
+                // Then
+                Assert.IsArgumentNullException(result, "assemblyPath");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Fixie_Runner_Was_Not_Found()
+            {
+                // Given
+                var fixture = new FixieRunnerFixture(defaultToolExist: false);
+                var runner = fixture.CreateRunner();
+
+                // When
+                var result = Record.Exception(() => runner.Run("./Test1.dll", new FixieSettings()));
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("Fixie: Could not locate executable.", result.Message);
+            }
+
+            [Theory]
+            [InlineData("C:/Fixie/Fixie.Console.exe", "C:/Fixie/Fixie.Console.exe")]
+            [InlineData("./tools/Fixie/Fixie.Console.exe", "/Working/tools/Fixie/Fixie.Console.exe")]
+            public void Should_Use_Fixie_Runner_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new FixieRunnerFixture(expected);
+                var runner = fixture.CreateRunner();
+
+                // When
+                runner.Run("./Test1.dll", new FixieSettings
+                {
+                    ToolPath = toolPath
+                });
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == expected),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Find_Fixie_Runner_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new FixieRunnerFixture();
+                var runner = fixture.CreateRunner();
+
+                // When
+                runner.Run("./Test1.dll", new FixieSettings());
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == "/Working/tools/Fixie.Console.exe"),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Use_Provided_Assembly_Path_In_Process_Arguments()
+            {
+                // Given
+                var fixture = new FixieRunnerFixture();
+                var runner = fixture.CreateRunner();
+
+                // When
+                runner.Run("./Test1.dll", new FixieSettings());
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(
+                    p => p.Arguments.Render() == "\"/Working/Test1.dll\""));
+            }
+
+            [Fact]
+            public void Should_Use_Provided_Assembly_Paths_In_Process_Arguments()
+            {
+                // Given
+                var fixture = new FixieRunnerFixture();
+                var runner = fixture.CreateRunner();
+
+                // When
+                runner.Run(new List<FilePath> { "./Test1.dll", "./Test2.dll" }, new FixieSettings());
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(
+                    p => p.Arguments.Render() == "\"/Working/Test1.dll\" \"/Working/Test2.dll\""));
+            }
+
+            [Fact]
+            public void Should_Set_Working_Directory()
+            {
+                // Given
+                var fixture = new FixieRunnerFixture();
+                var runner = fixture.CreateRunner();
+
+                // When
+                runner.Run("./Test1.dll", new FixieSettings());
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(
+                    p => p.WorkingDirectory.FullPath == "/Working"));
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new FixieRunnerFixture();
+                fixture.ProcessRunner.Start(Arg.Any<FilePath>(), Arg.Any<ProcessSettings>()).Returns((IProcess)null);
+                var runner = fixture.CreateRunner();
+
+                // When
+                var result = Record.Exception(() => runner.Run("./Test1.dll", new FixieSettings()));
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("Fixie: Process was not started.", result.Message);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new FixieRunnerFixture();
+                fixture.Process.GetExitCode().Returns(1);
+                var runner = fixture.CreateRunner();
+
+                // When
+                var result = Record.Exception(() => runner.Run("./Test1.dll", new FixieSettings()));
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("Fixie: Process returned an error.", result.Message);
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/Fixie/FixieRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Fixie/FixieRunnerTests.cs
@@ -162,7 +162,7 @@ namespace Cake.Common.Tests.Unit.Tools.Fixie
             }
 
             [Fact]
-            public void Should_set_NUnitXml_Output_File()
+            public void Should_Set_NUnitXml_Output_File()
             {
                 // Given
                 var fixture = new FixieRunnerFixture();
@@ -182,7 +182,7 @@ namespace Cake.Common.Tests.Unit.Tools.Fixie
             }
 
             [Fact]
-            public void Should_set_xUnitXml_Output_File()
+            public void Should_Set_xUnitXml_Output_File()
             {
                 // Given
                 var fixture = new FixieRunnerFixture();
@@ -204,7 +204,7 @@ namespace Cake.Common.Tests.Unit.Tools.Fixie
             [Theory]
             [InlineData(TeamCityOutput.On, "on")]
             [InlineData(TeamCityOutput.Off, "off")]
-            public void Should_Set_TeamCity_value(TeamCityOutput? teamCityOutput, string teamCityValue)
+            public void Should_Set_TeamCity_Value(TeamCityOutput? teamCityOutput, string teamCityValue)
             {
                 // Given
                 var fixture = new FixieRunnerFixture();
@@ -224,7 +224,7 @@ namespace Cake.Common.Tests.Unit.Tools.Fixie
             }
 
             [Fact]
-            public void Should_Set_custom_options()
+            public void Should_Set_Custom_Options()
             {
                 // Given
                 var fixture = new FixieRunnerFixture();

--- a/src/Cake.Common.Tests/Unit/Tools/Fixie/FixieRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Fixie/FixieRunnerTests.cs
@@ -200,6 +200,28 @@ namespace Cake.Common.Tests.Unit.Tools.Fixie
                     Arg.Is<ProcessSettings>(p =>
                         p.Arguments.Render() == "\"/Working/blarg.dll\" --xUnitXml \"/Working/xunit-results.xml\""));
             }
+
+            [Theory]
+            [InlineData(TeamCityOutput.On, "on")]
+            [InlineData(TeamCityOutput.Off, "off")]
+            public void Should_Set_TeamCity_value(TeamCityOutput? teamCityOutput, string teamCityValue)
+            {
+                // Given
+                var fixture = new FixieRunnerFixture();
+                var runner = fixture.CreateRunner();
+
+                // When
+                runner.Run("./Tests.dll", new FixieSettings
+                {
+                    TeamCity = teamCityOutput,
+                });
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(),
+                    Arg.Is<ProcessSettings>(
+                        p => p.Arguments.Render() == string.Format("\"/Working/Tests.dll\" --TeamCity {0}", teamCityValue)));
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/Fixie/FixieRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Fixie/FixieRunnerTests.cs
@@ -241,6 +241,26 @@ namespace Cake.Common.Tests.Unit.Tools.Fixie
                     Arg.Is<ProcessSettings>(
                         p => p.Arguments.Render() == string.Format("\"/Working/Tests.dll\" --include CategoryA --include CategoryB")));
             }
+
+            [Fact]
+            public void Should_Set_Multiple_Options()
+            {
+                // Given
+                var fixture = new FixieRunnerFixture();
+                var runner = fixture.CreateRunner();
+
+                // When
+                runner.Run("./Tests.dll", new FixieSettings()
+                    .WithOption("--type", "fast")
+                    .WithOption("--include", "CategoryA", "CategoryB")
+                    .WithOption("--output", "fixie-log.txt"));
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(),
+                    Arg.Is<ProcessSettings>(
+                        p => p.Arguments.Render() == string.Format("\"/Working/Tests.dll\" --type fast --include CategoryA --include CategoryB --output fixie-log.txt")));
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/Fixie/FixieRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Fixie/FixieRunnerTests.cs
@@ -222,6 +222,25 @@ namespace Cake.Common.Tests.Unit.Tools.Fixie
                     Arg.Is<ProcessSettings>(
                         p => p.Arguments.Render() == string.Format("\"/Working/Tests.dll\" --TeamCity {0}", teamCityValue)));
             }
+
+            [Fact]
+            public void Should_Set_custom_options()
+            {
+                // Given
+                var fixture = new FixieRunnerFixture();
+                var runner = fixture.CreateRunner();
+
+                // When
+                runner.Run("./Tests.dll", new FixieSettings()
+                    .WithOption("--include", "CategoryA")
+                    .WithOption("--include", "CategoryB"));
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(),
+                    Arg.Is<ProcessSettings>(
+                        p => p.Arguments.Render() == string.Format("\"/Working/Tests.dll\" --include CategoryA --include CategoryB")));
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/Fixie/FixieRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Fixie/FixieRunnerTests.cs
@@ -89,8 +89,10 @@ namespace Cake.Common.Tests.Unit.Tools.Fixie
                 runner.Run("./Test1.dll", new FixieSettings());
 
                 // Then
-                fixture.ProcessRunner.Received(1).Start(Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(
-                    p => p.Arguments.Render() == "\"/Working/Test1.dll\""));
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(),
+                    Arg.Is<ProcessSettings>(
+                        p => p.Arguments.Render() == "\"/Working/Test1.dll\""));
             }
 
             [Fact]
@@ -104,8 +106,10 @@ namespace Cake.Common.Tests.Unit.Tools.Fixie
                 runner.Run(new List<FilePath> { "./Test1.dll", "./Test2.dll" }, new FixieSettings());
 
                 // Then
-                fixture.ProcessRunner.Received(1).Start(Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(
-                    p => p.Arguments.Render() == "\"/Working/Test1.dll\" \"/Working/Test2.dll\""));
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(),
+                    Arg.Is<ProcessSettings>(
+                        p => p.Arguments.Render() == "\"/Working/Test1.dll\" \"/Working/Test2.dll\""));
             }
 
             [Fact]
@@ -119,8 +123,10 @@ namespace Cake.Common.Tests.Unit.Tools.Fixie
                 runner.Run("./Test1.dll", new FixieSettings());
 
                 // Then
-                fixture.ProcessRunner.Received(1).Start(Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(
-                    p => p.WorkingDirectory.FullPath == "/Working"));
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(),
+                    Arg.Is<ProcessSettings>(
+                        p => p.WorkingDirectory.FullPath == "/Working"));
             }
 
             [Fact]

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Tools\Fixie\FixieAliases.cs" />
     <Compile Include="Tools\Fixie\FixieRunner.cs" />
     <Compile Include="Tools\Fixie\FixieSettings.cs" />
+    <Compile Include="Tools\Fixie\FixieSettingsExtensions.cs" />
     <Compile Include="Tools\Fixie\TeamCityOutput.cs" />
     <Compile Include="Tools\ILMerge\ILMergeAliases.cs" />
     <Compile Include="Tools\ILMerge\ILMergeRunner.cs" />

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Tools\Fixie\FixieAliases.cs" />
     <Compile Include="Tools\Fixie\FixieRunner.cs" />
     <Compile Include="Tools\Fixie\FixieSettings.cs" />
+    <Compile Include="Tools\Fixie\TeamCityOutput.cs" />
     <Compile Include="Tools\ILMerge\ILMergeAliases.cs" />
     <Compile Include="Tools\ILMerge\ILMergeRunner.cs" />
     <Compile Include="Tools\ILMerge\ILMergeSettings.cs" />

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -109,6 +109,9 @@
     <Compile Include="Tools\Cake\CakeAliases.cs" />
     <Compile Include="Tools\Cake\CakeRunner.cs" />
     <Compile Include="Tools\Cake\CakeSettings.cs" />
+    <Compile Include="Tools\Fixie\FixieAliases.cs" />
+    <Compile Include="Tools\Fixie\FixieRunner.cs" />
+    <Compile Include="Tools\Fixie\FixieSettings.cs" />
     <Compile Include="Tools\ILMerge\ILMergeAliases.cs" />
     <Compile Include="Tools\ILMerge\ILMergeRunner.cs" />
     <Compile Include="Tools\ILMerge\ILMergeSettings.cs" />

--- a/src/Cake.Common/Tools/Fixie/FixieAliases.cs
+++ b/src/Cake.Common/Tools/Fixie/FixieAliases.cs
@@ -10,7 +10,7 @@ namespace Cake.Common.Tools.Fixie
     /// <summary>
     /// Contains functionality related to running Fixie tests.
     /// </summary>
-    [CakeAliasCategory("NUnit")]
+    [CakeAliasCategory("Fixie")]
     public static class FixieAliases
     {
         /// <summary>

--- a/src/Cake.Common/Tools/Fixie/FixieAliases.cs
+++ b/src/Cake.Common/Tools/Fixie/FixieAliases.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Fixie
+{
+    /// <summary>
+    /// Contains functionality related to running Fixie tests.
+    /// </summary>
+    [CakeAliasCategory("NUnit")]
+    public static class FixieAliases
+    {
+        /// <summary>
+        /// Runs all Fixie tests in the assemblies matching the specified pattern.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="pattern">The pattern.</param>
+        [CakeMethodAlias]
+        public static void Fixie(this ICakeContext context, string pattern)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var assemblies = context.Globber.GetFiles(pattern);
+            Fixie(context, assemblies, new FixieSettings());
+        }
+
+        /// <summary>
+        /// Runs all Fixie tests in the assemblies matching the specified pattern, 
+        /// using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="pattern">The pattern.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        public static void Fixie(this ICakeContext context, string pattern, FixieSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var assemblies = context.Globber.GetFiles(pattern);
+            Fixie(context, assemblies, settings);
+        }
+
+        /// <summary>
+        /// Runs all Fixie tests in the specified assemblies.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="assemblies">The assemblies.</param>
+        [CakeMethodAlias]
+        public static void Fixie(this ICakeContext context, IEnumerable<string> assemblies)
+        {
+            if (assemblies == null)
+            {
+                throw new ArgumentNullException("assemblies");
+            }
+            var paths = assemblies.Select(p => new FilePath(p));
+            Fixie(context, paths, new FixieSettings());
+        }
+
+        /// <summary>
+        /// Runs all Fixie tests in the specified assemblies.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="assemblies">The assemblies.</param>
+        [CakeMethodAlias]
+        public static void Fixie(this ICakeContext context, IEnumerable<FilePath> assemblies)
+        {
+            Fixie(context, assemblies, new FixieSettings());
+        }
+
+        /// <summary>
+        /// Runs all Fixie tests in the specified assemblies, 
+        /// using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="assemblies">The assemblies.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        public static void Fixie(this ICakeContext context, IEnumerable<string> assemblies, FixieSettings settings)
+        {
+            if (assemblies == null)
+            {
+                throw new ArgumentNullException("assemblies");
+            }
+            var paths = assemblies.Select(p => new FilePath(p));
+            Fixie(context, paths, settings);
+        }
+
+        /// <summary>
+        /// Runs all Fixie tests in the specified assemblies, 
+        /// using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="assemblies">The assemblies.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        public static void Fixie(this ICakeContext context, IEnumerable<FilePath> assemblies, FixieSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            if (assemblies == null)
+            {
+                throw new ArgumentNullException("assemblies");
+            }
+
+            var runner = new FixieRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber);
+            runner.Run(assemblies, settings);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/Fixie/FixieRunner.cs
+++ b/src/Cake.Common/Tools/Fixie/FixieRunner.cs
@@ -74,6 +74,20 @@ namespace Cake.Common.Tools.Fixie
                 builder.AppendQuoted(assemblyPath.MakeAbsolute(_environment).FullPath);
             }
 
+            // Add NUnit style reporting if necessary
+            if (settings.NUnitXml != null)
+            {
+                builder.Append("--NUnitXml");
+                builder.AppendQuoted(settings.NUnitXml.MakeAbsolute(_environment).FullPath);
+            }
+
+            // Add xUnit style reporting if necessary
+            if (settings.XUnitXml != null)
+            {
+                builder.Append("--xUnitXml");
+                builder.AppendQuoted(settings.XUnitXml.MakeAbsolute(_environment).FullPath);
+            }
+
             return builder;
         }
 

--- a/src/Cake.Common/Tools/Fixie/FixieRunner.cs
+++ b/src/Cake.Common/Tools/Fixie/FixieRunner.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Utilities;
+
+namespace Cake.Common.Tools.Fixie
+{
+    /// <summary>
+    /// The Fixie test runner.
+    /// </summary>
+    public sealed class FixieRunner : Tool<FixieSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FixieRunner"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
+        public FixieRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IGlobber globber)
+            : base(fileSystem, environment, processRunner, globber)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Runs the tests in the specified assembly, using the specified settings.
+        /// </summary>
+        /// <param name="assemblyPath">The assembly path.</param>
+        /// <param name="settings">The settings.</param>
+        public void Run(FilePath assemblyPath, FixieSettings settings)
+        {
+            if (assemblyPath == null)
+            {
+                throw new ArgumentNullException("assemblyPath");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            Run(settings, GetArguments(new[] { assemblyPath }, settings), settings.ToolPath);
+        }
+
+        /// <summary>
+        /// Runs the tests in the specified assemblies, using the specified settings.
+        /// </summary>
+        /// <param name="assemblyPaths">The assembly paths.</param>
+        /// <param name="settings">The settings.</param>
+        public void Run(IEnumerable<FilePath> assemblyPaths, FixieSettings settings)
+        {
+            if (assemblyPaths == null)
+            {
+                throw new ArgumentNullException("assemblyPaths");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            Run(settings, GetArguments(assemblyPaths, settings), settings.ToolPath);
+        }
+
+        private ProcessArgumentBuilder GetArguments(IEnumerable<FilePath> assemblyPaths, FixieSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            // Add the assemblies to build.
+            foreach (var assemblyPath in assemblyPaths)
+            {
+                builder.AppendQuoted(assemblyPath.MakeAbsolute(_environment).FullPath);
+            }
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Gets the name of the tool.
+        /// </summary>
+        /// <returns>The name of the tool.</returns>
+        protected override string GetToolName()
+        {
+            return "Fixie";
+        }
+
+        /// <summary>
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return new[] { "Fixie.Console.exe" };
+        }
+    }
+}

--- a/src/Cake.Common/Tools/Fixie/FixieRunner.cs
+++ b/src/Cake.Common/Tools/Fixie/FixieRunner.cs
@@ -88,6 +88,12 @@ namespace Cake.Common.Tools.Fixie
                 builder.AppendQuoted(settings.XUnitXml.MakeAbsolute(_environment).FullPath);
             }
 
+            if (settings.TeamCity != null)
+            {
+                builder.Append("--TeamCity");
+                builder.Append(settings.TeamCity == TeamCityOutput.On ? "on" : "off");
+            }
+
             return builder;
         }
 

--- a/src/Cake.Common/Tools/Fixie/FixieRunner.cs
+++ b/src/Cake.Common/Tools/Fixie/FixieRunner.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Utilities;
@@ -92,6 +93,15 @@ namespace Cake.Common.Tools.Fixie
             {
                 builder.Append("--TeamCity");
                 builder.Append(settings.TeamCity == TeamCityOutput.On ? "on" : "off");
+            }
+
+            if (settings.Options != null && settings.Options.Any())
+            {
+                foreach (var option in settings.Options)
+                {
+                    builder.Append(option.Key);
+                    builder.Append(option.Value);
+                }
             }
 
             return builder;

--- a/src/Cake.Common/Tools/Fixie/FixieRunner.cs
+++ b/src/Cake.Common/Tools/Fixie/FixieRunner.cs
@@ -97,10 +97,13 @@ namespace Cake.Common.Tools.Fixie
 
             if (settings.Options != null && settings.Options.Any())
             {
-                foreach (var option in settings.Options)
+                foreach (var optionGroup in settings.Options.Select(x => new { x.Key, Options = x.Value }))
                 {
-                    builder.Append(option.Key);
-                    builder.Append(option.Value);
+                    foreach (var option in optionGroup.Options)
+                    {
+                        builder.Append(optionGroup.Key);
+                        builder.Append(option);
+                    }
                 }
             }
 

--- a/src/Cake.Common/Tools/Fixie/FixieSettings.cs
+++ b/src/Cake.Common/Tools/Fixie/FixieSettings.cs
@@ -1,0 +1,18 @@
+﻿namespace Cake.Common.Tools.Fixie
+{
+    using Core.IO;
+
+    /// <summary>
+    /// Contains settings used by <see cref="FixieRunner" />.
+    /// </summary>
+    public sealed class FixieSettings
+    {
+        /// <summary>
+        /// Gets or sets the tool path.
+        /// </summary>
+        /// <value>
+        /// The tool path. Defaults to <c>./tools/**/Fixie.Console.exe</c>.
+        /// </value>
+        public FilePath ToolPath { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/Fixie/FixieSettings.cs
+++ b/src/Cake.Common/Tools/Fixie/FixieSettings.cs
@@ -30,5 +30,13 @@
         /// The name of the file to write xUnit style of results.
         /// </value>
         public FilePath XUnitXml { get; set; }
+
+        /// <summary>
+        /// Gets or sets the the option to force TeamCity-formatted output on or off.
+        /// </summary>
+        /// <value>
+        /// The value of TeamCity-formatted output. Either "on" or "off".
+        /// </value>
+        public TeamCityOutput? TeamCity { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/Fixie/FixieSettings.cs
+++ b/src/Cake.Common/Tools/Fixie/FixieSettings.cs
@@ -14,5 +14,21 @@
         /// The tool path. Defaults to <c>./tools/**/Fixie.Console.exe</c>.
         /// </value>
         public FilePath ToolPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the file to be used to output NUnit style of XML results.
+        /// </summary>
+        /// <value>
+        /// The name of the file to write NUnit style of results.
+        /// </value>
+        public FilePath NUnitXml { get; set; }
+
+        /// <summary>
+        /// Gets or sets the file to be used to output xUnit style of XML results.
+        /// </summary>
+        /// <value>
+        /// The name of the file to write xUnit style of results.
+        /// </value>
+        public FilePath XUnitXml { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/Fixie/FixieSettings.cs
+++ b/src/Cake.Common/Tools/Fixie/FixieSettings.cs
@@ -1,12 +1,16 @@
-﻿namespace Cake.Common.Tools.Fixie
-{
-    using Core.IO;
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Cake.Core.IO;
 
+namespace Cake.Common.Tools.Fixie
+{
     /// <summary>
     /// Contains settings used by <see cref="FixieRunner" />.
     /// </summary>
     public sealed class FixieSettings
     {
+        private readonly ICollection<KeyValuePair<string, string>> _options = new Collection<KeyValuePair<string, string>>();
+
         /// <summary>
         /// Gets or sets the tool path.
         /// </summary>
@@ -38,5 +42,28 @@
         /// The value of TeamCity-formatted output. Either "on" or "off".
         /// </value>
         public TeamCityOutput? TeamCity { get; set; }
+
+        /// <summary>
+        /// Gets the collection of Options as KeyValuePairs.
+        /// </summary>
+        /// <value>
+        /// The collection of keys and values.
+        /// </value>
+        public ICollection<KeyValuePair<string, string>> Options
+        {
+            get { return _options; }
+        }
+
+        /// <summary>
+        /// Adds a custom Fixie Option to the settings.
+        /// </summary>
+        /// <param name="key">The key of the Option</param>
+        /// <param name="value">The value of the Option</param>
+        /// <returns>The instance of <see cref="FixieSettings"/> that the Option was added to.</returns>
+        public FixieSettings WithOption(string key, string value)
+        {
+            _options.Add(new KeyValuePair<string, string>(key, value));
+            return this;
+        }
     }
 }

--- a/src/Cake.Common/Tools/Fixie/FixieSettings.cs
+++ b/src/Cake.Common/Tools/Fixie/FixieSettings.cs
@@ -1,10 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Cake.Core.IO;
 
 namespace Cake.Common.Tools.Fixie
 {
-    using System;
-
     /// <summary>
     /// Contains settings used by <see cref="FixieRunner" />.
     /// </summary>

--- a/src/Cake.Common/Tools/Fixie/FixieSettings.cs
+++ b/src/Cake.Common/Tools/Fixie/FixieSettings.cs
@@ -1,15 +1,16 @@
 ﻿using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using Cake.Core.IO;
 
 namespace Cake.Common.Tools.Fixie
 {
+    using System;
+
     /// <summary>
     /// Contains settings used by <see cref="FixieRunner" />.
     /// </summary>
     public sealed class FixieSettings
     {
-        private readonly ICollection<KeyValuePair<string, string>> _options = new Collection<KeyValuePair<string, string>>();
+        private readonly IDictionary<string, IList<string>> _options = new Dictionary<string, IList<string>>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Gets or sets the tool path.
@@ -49,21 +50,9 @@ namespace Cake.Common.Tools.Fixie
         /// <value>
         /// The collection of keys and values.
         /// </value>
-        public ICollection<KeyValuePair<string, string>> Options
+        public IDictionary<string, IList<string>> Options
         {
             get { return _options; }
-        }
-
-        /// <summary>
-        /// Adds a custom Fixie Option to the settings.
-        /// </summary>
-        /// <param name="key">The key of the Option</param>
-        /// <param name="value">The value of the Option</param>
-        /// <returns>The instance of <see cref="FixieSettings"/> that the Option was added to.</returns>
-        public FixieSettings WithOption(string key, string value)
-        {
-            _options.Add(new KeyValuePair<string, string>(key, value));
-            return this;
         }
     }
 }

--- a/src/Cake.Common/Tools/Fixie/FixieSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/Fixie/FixieSettingsExtensions.cs
@@ -1,0 +1,36 @@
+﻿namespace Cake.Common.Tools.Fixie
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Contains functionality related to Fixie settings.
+    /// </summary>
+    public static class FixieSettingsExtensions
+    {
+        /// <summary>
+        /// Adds an option to the settings.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="name">The option name.</param>
+        /// <param name="values">The option values.</param>
+        /// <returns>The same <see cref="FixieSettings"/> instance so that multiple calls can be chained.</returns>
+        public static FixieSettings WithOption(this FixieSettings settings, string name, params string[] values)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            IList<string> currValue;
+            currValue = new List<string>(settings.Options.TryGetValue(name, out currValue) && currValue != null
+                    ? currValue.Concat(values)
+                    : values);
+
+            settings.Options[name] = currValue;
+
+            return settings;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/Fixie/TeamCityOutput.cs
+++ b/src/Cake.Common/Tools/Fixie/TeamCityOutput.cs
@@ -1,0 +1,18 @@
+﻿namespace Cake.Common.Tools.Fixie
+{
+    /// <summary>
+    /// Options to enable TeamCity-formatted output.
+    /// </summary>
+    public enum TeamCityOutput
+    {
+        /// <summary>
+        /// Explicitly enables TeamCity-formatted output.
+        /// </summary>
+        On,
+
+        /// <summary>
+        /// Explicitly disables TeamCity-formatted output.
+        /// </summary>
+        Off,
+    }
+}


### PR DESCRIPTION
Fixie - Conventional Testing for .NET

This adds the bare minimum support for executing tasks with Fixie.

    Task("Tests").Does(() => {
        Fixie(@".\path\tests.dll");
    });