### PR TITLE
changed msbuild verbosity

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -385,7 +385,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             [InlineData(Verbosity.Quiet, "quiet")]
             [InlineData(Verbosity.Minimal, "minimal")]
             [InlineData(Verbosity.Normal, "normal")]
-            [InlineData(Verbosity.Verbose, "verbose")]
+            [InlineData(Verbosity.Verbose, "detailed")]
             [InlineData(Verbosity.Diagnostic, "diagnostic")]
             public void Should_Append_Correct_Verbosity(Verbosity verbosity, string expected)
             {

--- a/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
@@ -101,8 +101,8 @@ namespace Cake.Common.Tools.MSBuild
                 case Verbosity.Normal:
                     return "normal";
                 case Verbosity.Verbose:
-                    return "verbose";
-                case Verbosity.Diagnostic: 
+                    return "detailed";
+                case Verbosity.Diagnostic:
                     return "diagnostic";
             }
             throw new CakeException("Encountered unknown MSBuild build log verbosity.");


### PR DESCRIPTION
MSBuild uses the flag 'detailed' instead of 'verbose'. This applies
the correct mapping to fix the discrepancy.

Closes #282 - "Cake uses wrong MSBuild verbosity parameter"