### PR TITLE
Fix for using (IDisposable) statement

### DIFF
--- a/src/Cake.Core/Scripting/Processors/UsingStatementProcessor.cs
+++ b/src/Cake.Core/Scripting/Processors/UsingStatementProcessor.cs
@@ -12,7 +12,7 @@ namespace Cake.Core.Scripting.Processors
         /// Initializes a new instance of the <see cref="UsingStatementProcessor"/> class.
         /// </summary>
         /// <param name="environment">The environment.</param>
-        public UsingStatementProcessor(ICakeEnvironment environment) 
+        public UsingStatementProcessor(ICakeEnvironment environment)
             : base(environment)
         {
         }
@@ -35,7 +35,7 @@ namespace Cake.Core.Scripting.Processors
             }
 
             var tokens = Split(line);
-            if (tokens.Length <= 0)
+            if (tokens.Length <= 1)
             {
                 return false;
             }
@@ -46,6 +46,12 @@ namespace Cake.Core.Scripting.Processors
             }
 
             var @namespace = tokens[1].TrimEnd(';');
+
+            if (@namespace.StartsWith("("))
+            {
+                return false;
+            }
+
             context.AddNamespace(@namespace);
 
             return true;


### PR DESCRIPTION
if space comes between `using` and `(` in using `IDisposable` statement it gets treated as an namespace. example
```csharp
using (new MemoryStream())
{
    new StringBuilder();
}
```

fails before this fix.