### PR TITLE
Fix for PlatformTarget not used in MSBuild runner

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -335,6 +335,36 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                     "/m /v:normal /p:\"Configuration\"=\"Release\" /target:Build \"/Working/src/Solution.sln\"");
             }
 
+            [Theory]
+            [InlineData(PlatformTarget.MSIL, "/m /v:normal /p:\"Platform\"=\"AnyCPU\" /target:Build \"/Working/src/Solution.sln\"")]
+            [InlineData(PlatformTarget.x86, "/m /v:normal /p:\"Platform\"=\"x86\" /target:Build \"/Working/src/Solution.sln\"")]
+            [InlineData(PlatformTarget.x64, "/m /v:normal /p:\"Platform\"=\"x64\" /target:Build \"/Working/src/Solution.sln\"")]
+            public void Should_Append_Platform_As_Property_To_Process_Arguments(PlatformTarget? platform, string argumentsString)
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, true);
+                fixture.Settings.SetPlatformTarget(platform.Value);
+
+                // When
+                fixture.Run();
+
+                // Then
+                fixture.AssertReceivedArguments(argumentsString);
+            }
+
+            [Fact]
+            public void Should_Omit_Platform_Property_In_Process_Arguments_If_It_Is_Null()
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, true);
+                
+                // When
+                fixture.Run();
+
+                // Then
+                fixture.AssertReceivedArguments("/m /v:normal /target:Build \"/Working/src/Solution.sln\"");
+            }
+
             [Fact]
             public void Should_Set_Working_Directory()
             {

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsTests.cs
@@ -18,14 +18,14 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 Assert.Equal(MSBuildToolVersion.Default, settings.ToolVersion);
             }
 
-            [Fact]
-            public void Should_Set_Default_Platform_Target_To_MSIL()
+            [Fact()]
+            public void Should_Set_Default_Platform_Target_To_Null()
             {
                 // Given, When
                 var settings = new MSBuildSettings();
 
                 // Then
-                Assert.Equal(PlatformTarget.MSIL, settings.PlatformTarget);
+                Assert.Null(settings.PlatformTarget);
             }
 
             [Fact]
@@ -81,6 +81,19 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
 
                 // Then
                 Assert.Equal(string.Empty, settings.Configuration);
+            }
+        }
+
+        public sealed class ThePlatformProperty
+        {
+            [Fact]
+            public void Should_Be_Null_By_Default()
+            {
+                // Given, When
+                var settings = new MSBuildSettings();
+
+                // Then
+                Assert.Null(settings.PlatformTarget);
             }
         }
 

--- a/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using Cake.Core;
@@ -64,6 +65,13 @@ namespace Cake.Common.Tools.MSBuild
                 builder.Append(string.Concat("/p:\"Configuration\"=", configuration.Quote()));
             }
 
+            // Buid for a specific platform?
+            if (settings.PlatformTarget.HasValue)
+            {
+                var platform = settings.PlatformTarget.Value;
+                builder.Append(string.Concat("/p:\"Platform\"=", GetPlatformName(platform).Quote()));
+            }
+
             // Got any properties?
             if (settings.Properties.Count > 0)
             {
@@ -89,6 +97,21 @@ namespace Cake.Common.Tools.MSBuild
             builder.AppendQuoted(solution.MakeAbsolute(_environment).FullPath);
 
             return builder;
+        }
+
+        private static string GetPlatformName(PlatformTarget platform)
+        {
+            switch (platform)
+            {
+                case PlatformTarget.MSIL:
+                    return "AnyCPU";
+                case PlatformTarget.x86:
+                    return "x86";
+                case PlatformTarget.x64:
+                    return "x64";
+                default:
+                    throw new InvalidEnumArgumentException("platform", (int)platform, typeof(PlatformTarget));
+            }
         }
 
         private static string GetVerbosityName(Verbosity verbosity)
@@ -150,7 +173,7 @@ namespace Cake.Common.Tools.MSBuild
                 throw new ArgumentNullException("settings");
             }
 
-            var path = MSBuildResolver.GetMSBuildPath(_fileSystem, _environment, settings.ToolVersion, settings.PlatformTarget);
+            var path = MSBuildResolver.GetMSBuildPath(_fileSystem, _environment, settings.ToolVersion, settings.PlatformTarget ?? PlatformTarget.MSIL);
             if (path != null)
             {
                 return new[] { path };

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Cake.Core.Diagnostics;
-using Cake.Core.IO;
 
 namespace Cake.Common.Tools.MSBuild
 {
@@ -35,7 +34,7 @@ namespace Cake.Common.Tools.MSBuild
         /// Gets or sets the platform target.
         /// </summary>
         /// <value>The platform target.</value>
-        public PlatformTarget PlatformTarget { get; set; }
+        public PlatformTarget? PlatformTarget { get; set; }
 
         /// <summary>
         /// Gets or sets the tool version.
@@ -77,7 +76,6 @@ namespace Cake.Common.Tools.MSBuild
             _targets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             _properties = new Dictionary<string, IList<string>>(StringComparer.OrdinalIgnoreCase);
 
-            PlatformTarget = PlatformTarget.MSIL;
             ToolVersion = MSBuildToolVersion.Default;
             Configuration = string.Empty;
             Verbosity = Verbosity.Normal;


### PR DESCRIPTION
Implemented PlatformTarget specification in MSBuild arguments string. MSBuildRunner.cs simply doesn't have it.

Closes #332

UPD: set it to WIP state, to implement Patrik's suggestions (see comments)