### PR TITLE
Added using-alias-directive support.

### DIFF
--- a/src/Cake.Core.Tests/Unit/Scripting/ScriptProcessorTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/ScriptProcessorTests.cs
@@ -190,7 +190,7 @@ namespace Cake.Core.Tests.Unit.Scripting
             public void Should_Process_Using_Directives()
             {
                 // Given
-                var source = "using System.IO\r\nConsole.WriteLine();";
+                var source = "using System.IO;\r\nConsole.WriteLine();";
                 var fixture = new ScriptProcessorFixture(scriptSource: source);
 
                 // When
@@ -198,6 +198,21 @@ namespace Cake.Core.Tests.Unit.Scripting
 
                 // Then
                 Assert.Contains("System.IO", result.Namespaces);
+            }
+
+            [Fact]
+            public void Should_Process_Using_Alias_Directives()
+            {
+                // Given
+                var fixture = new ScriptProcessorFixture(scriptSource: "using ClassAlias = N1.N2.Class;\r\nConsole.WriteLine();");
+
+                // When
+                var result = fixture.Process();
+
+                // Then
+                Assert.Equal(2, result.Lines.Count);
+                Assert.Equal("#line 1 \"/Working/build.cake\"", result.Lines.ElementAt(0));
+                Assert.Equal("Console.WriteLine();", result.Lines.ElementAt(1));
             }
 
             [Fact]
@@ -216,21 +231,6 @@ namespace Cake.Core.Tests.Unit.Scripting
                 Assert.Equal("{", result.Lines.ElementAt(2));
                 Assert.Equal("}", result.Lines.ElementAt(3));
                 Assert.Equal("Console.WriteLine();", result.Lines.ElementAt(4));
-            }
-
-            [Fact]
-            public void Should_Keep_Using_Alias_Directives()
-            {
-                // Given
-                var fixture = new ScriptProcessorFixture(scriptSource: "using ClassAlias = N1.N2.Class;\r\nConsole.WriteLine();");
-
-                // When
-                var result = fixture.Process();
-
-                // Then
-                Assert.Equal(2, result.Lines.Count);
-                Assert.Equal("#line 1 \"/Working/build.cake\"", result.Lines.ElementAt(0));
-                Assert.Equal("Console.WriteLine();", result.Lines.ElementAt(1));
             }
 
             [Fact]

--- a/src/Cake.Core.Tests/Unit/Scripting/ScriptProcessorTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/ScriptProcessorTests.cs
@@ -187,6 +187,53 @@ namespace Cake.Core.Tests.Unit.Scripting
             }
 
             [Fact]
+            public void Should_Process_Using_Directives()
+            {
+                // Given
+                var source = "using System.IO\r\nConsole.WriteLine();";
+                var fixture = new ScriptProcessorFixture(scriptSource: source);
+
+                // When
+                var result = fixture.Process();
+
+                // Then
+                Assert.Contains("System.IO", result.Namespaces);
+            }
+
+            [Fact]
+            public void Should_Keep_Using_Block()
+            {
+                // Given
+                var fixture = new ScriptProcessorFixture(scriptSource: "using (ClassAlias)\r\n{\r\n}\r\nConsole.WriteLine();");
+
+                // When
+                var result = fixture.Process();
+
+                // Then
+                Assert.Equal(5, result.Lines.Count);
+                Assert.Equal("#line 1 \"/Working/build.cake\"", result.Lines.ElementAt(0));
+                Assert.Equal("using (ClassAlias)", result.Lines.ElementAt(1));
+                Assert.Equal("{", result.Lines.ElementAt(2));
+                Assert.Equal("}", result.Lines.ElementAt(3));
+                Assert.Equal("Console.WriteLine();", result.Lines.ElementAt(4));
+            }
+
+            [Fact]
+            public void Should_Keep_Using_Alias_Directives()
+            {
+                // Given
+                var fixture = new ScriptProcessorFixture(scriptSource: "using ClassAlias = N1.N2.Class;\r\nConsole.WriteLine();");
+
+                // When
+                var result = fixture.Process();
+
+                // Then
+                Assert.Equal(2, result.Lines.Count);
+                Assert.Equal("#line 1 \"/Working/build.cake\"", result.Lines.ElementAt(0));
+                Assert.Equal("Console.WriteLine();", result.Lines.ElementAt(1));
+            }
+
+            [Fact]
             public void Should_Remove_Shebang()
             {
                 // Given

--- a/src/Cake.Core.Tests/Unit/Scripting/ScriptTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/ScriptTests.cs
@@ -11,7 +11,7 @@ namespace Cake.Core.Tests.Unit.Scripting
             public void Should_Not_Throw_If_Namespaces_Are_Null()
             {
                 // Given, When
-                var script = new Script(null, new string[] { }, new ScriptAlias[] { });
+                var script = new Script(null, new string[] { }, new ScriptAlias[] { }, new string[] { });
 
                 // Then
                 Assert.Equal(0, script.Namespaces.Count);
@@ -21,7 +21,7 @@ namespace Cake.Core.Tests.Unit.Scripting
             public void Should_Not_Throw_If_Lines_Are_Null()
             {
                 // Given, When
-                var script = new Script(new string[] { }, null, new ScriptAlias[] { });
+                var script = new Script(new string[] { }, null, new ScriptAlias[] { }, new string[] { });
 
                 // Then
                 Assert.Equal(0, script.Lines.Count);
@@ -31,7 +31,7 @@ namespace Cake.Core.Tests.Unit.Scripting
             public void Should_Not_Throw_If_Aliases_Are_Null()
             {
                 // Given, When
-                var script = new Script(new string[] { }, new string[] { }, null);
+                var script = new Script(new string[] { }, new string[] { }, null, new string[] { });
 
                 // Then
                 Assert.Equal(0, script.Aliases.Count);

--- a/src/Cake.Core.Tests/Unit/Scripting/ScriptTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/ScriptTests.cs
@@ -36,6 +36,16 @@ namespace Cake.Core.Tests.Unit.Scripting
                 // Then
                 Assert.Equal(0, script.Aliases.Count);
             }
+
+            [Fact]
+            public void Should_Not_Throw_If_Using_Alias_Directives_Are_Null()
+            {
+                // Given, When
+                var script = new Script(new string[] { }, new string[] { }, new ScriptAlias[] { }, null);
+
+                // Then
+                Assert.Equal(0, script.UsingAliasDirectives.Count);
+            }
         }
     }
 }

--- a/src/Cake.Core/Scripting/Processors/UsingStatementProcessor.cs
+++ b/src/Cake.Core/Scripting/Processors/UsingStatementProcessor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Cake.Core.IO;
 
 namespace Cake.Core.Scripting.Processors
@@ -45,15 +46,22 @@ namespace Cake.Core.Scripting.Processors
                 return false;
             }
 
+            // Using block?
             var @namespace = tokens[1].TrimEnd(';');
-
             if (@namespace.StartsWith("("))
             {
                 return false;
             }
 
-            context.AddNamespace(@namespace);
+            // Using alias directive?
+            if (tokens.Any(t => t == "="))
+            {
+                context.AddUsingAliasDirective(string.Join(" ", tokens));
+                return true;
+            }
 
+            // Namespace
+            context.AddNamespace(@namespace);
             return true;
         }
     }

--- a/src/Cake.Core/Scripting/Script.cs
+++ b/src/Cake.Core/Scripting/Script.cs
@@ -11,6 +11,7 @@ namespace Cake.Core.Scripting
         private readonly List<string> _namespaces;
         private readonly List<string> _lines;
         private readonly List<ScriptAlias> _aliases;
+        private readonly List<string> _usingAliasDirectives;
 
         /// <summary>
         /// Gets the namespaces imported via the <c>using</c> statement.
@@ -42,16 +43,31 @@ namespace Cake.Core.Scripting
         }
 
         /// <summary>
+        /// Gets the using alias directives.
+        /// </summary>
+        /// <value>The using alias directives.</value>
+        public List<string> UsingAliasDirectives
+        {
+            get { return _usingAliasDirectives; }
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Script" /> class.
         /// </summary>
         /// <param name="namespaces">The namespaces.</param>
         /// <param name="lines">The scrip lines.</param>
         /// <param name="aliases">The script aliases.</param>
-        public Script(IEnumerable<string> namespaces, IEnumerable<string> lines, IEnumerable<ScriptAlias> aliases)
+        /// <param name="usingAliasDirectives">The using alias directives.</param>
+        public Script(
+            IEnumerable<string> namespaces, 
+            IEnumerable<string> lines, 
+            IEnumerable<ScriptAlias> aliases,
+            IEnumerable<string> usingAliasDirectives)
         {
             _namespaces = new List<string>(namespaces ?? Enumerable.Empty<string>());
             _lines = new List<string>(lines ?? Enumerable.Empty<string>());
             _aliases = new List<ScriptAlias>(aliases ?? Enumerable.Empty<ScriptAlias>());
+            _usingAliasDirectives = new List<string>(usingAliasDirectives);
         }
     }
 }

--- a/src/Cake.Core/Scripting/Script.cs
+++ b/src/Cake.Core/Scripting/Script.cs
@@ -67,7 +67,7 @@ namespace Cake.Core.Scripting
             _namespaces = new List<string>(namespaces ?? Enumerable.Empty<string>());
             _lines = new List<string>(lines ?? Enumerable.Empty<string>());
             _aliases = new List<ScriptAlias>(aliases ?? Enumerable.Empty<ScriptAlias>());
-            _usingAliasDirectives = new List<string>(usingAliasDirectives);
+            _usingAliasDirectives = new List<string>(usingAliasDirectives ?? Enumerable.Empty<string>());
         }
     }
 }

--- a/src/Cake.Core/Scripting/ScriptProcessorContext.cs
+++ b/src/Cake.Core/Scripting/ScriptProcessorContext.cs
@@ -14,6 +14,7 @@ namespace Cake.Core.Scripting
         private readonly HashSet<string> _namespaces;
         private readonly LinkedList<string> _lines;
         private readonly HashSet<ScriptAlias> _aliases;
+        private readonly LinkedList<string> _usingAliasDirectives;
 
         /// <summary>
         /// Gets the script's assembly references 
@@ -65,6 +66,15 @@ namespace Cake.Core.Scripting
         }
 
         /// <summary>
+        /// Gets the using alias directives.
+        /// </summary>
+        /// <value>The using alias directives.</value>
+        public LinkedList<string> UsingAliasDirectives
+        {
+            get { return _usingAliasDirectives; }
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ScriptProcessorContext"/> class.
         /// </summary>
         public ScriptProcessorContext()
@@ -74,6 +84,7 @@ namespace Cake.Core.Scripting
             _namespaces = new HashSet<string>(StringComparer.Ordinal);
             _lines = new LinkedList<string>();
             _aliases = new HashSet<ScriptAlias>();
+            _usingAliasDirectives = new LinkedList<string>();
         }
 
         /// <summary>
@@ -129,6 +140,15 @@ namespace Cake.Core.Scripting
         public void AppendScriptLine(string line)
         {
             _lines.AddLast(line);
+        }
+
+        /// <summary>
+        /// Adds a using alias directive.
+        /// </summary>
+        /// <param name="line">The using alias directive.</param>
+        public void AddUsingAliasDirective(string line)
+        {
+            _usingAliasDirectives.AddLast(line);
         }
     }
 }

--- a/src/Cake.Core/Scripting/ScriptRunner.cs
+++ b/src/Cake.Core/Scripting/ScriptRunner.cs
@@ -116,7 +116,7 @@ namespace Cake.Core.Scripting
             }
 
             // Execute the script.
-            var script = new Script(context.Namespaces, context.Lines, aliases);
+            var script = new Script(context.Namespaces, context.Lines, aliases, context.UsingAliasDirectives);
             session.Execute(script);
         }
 

--- a/src/Cake.Tests/Fixtures/MonoScriptProcessorFixture.cs
+++ b/src/Cake.Tests/Fixtures/MonoScriptProcessorFixture.cs
@@ -32,7 +32,11 @@ namespace Cake.Tests.Fixtures
             }
 
             // Create the script.
-            var script = new Script(Enumerable.Empty<string>(), lines, Enumerable.Empty<ScriptAlias>());
+            var script = new Script(
+                Enumerable.Empty<string>(), 
+                lines, 
+                Enumerable.Empty<ScriptAlias>(),
+                Enumerable.Empty<string>());
 
             // Process the script.
             IReadOnlyList<ScriptBlock> blocks;

--- a/src/Cake/Scripting/Mono/CodeGen/MonoCodeGenerator.cs
+++ b/src/Cake/Scripting/Mono/CodeGen/MonoCodeGenerator.cs
@@ -14,6 +14,16 @@ namespace Cake.Scripting.Mono.CodeGen
             script = MonoScriptProcessor.Process(script, out blocks);
 
             var code = new StringBuilder();
+
+            if (script.UsingAliasDirectives.Count > 0)
+            {
+                foreach (var usingAliasDirective in script.UsingAliasDirectives)
+                {
+                    code.AppendLine(usingAliasDirective);
+                }
+                code.AppendLine();
+            }
+
             code.AppendLine("public class CakeBuildScriptImpl");
             code.AppendLine("{");
             code.AppendLine("    public CakeBuildScriptImpl (IScriptHost scriptHost)");

--- a/src/Cake/Scripting/Mono/CodeGen/MonoScriptProcessor.cs
+++ b/src/Cake/Scripting/Mono/CodeGen/MonoScriptProcessor.cs
@@ -24,7 +24,7 @@ namespace Cake.Scripting.Mono.CodeGen
                 }
             }
             blocks = result; // Assign the parsed blocks.
-            return new Script(script.Namespaces, lines, script.Aliases);
+            return new Script(script.Namespaces, lines, script.Aliases, script.UsingAliasDirectives);
         }
 
         private static IEnumerable<ScriptBlock> ParseBlocks(Script script)

--- a/src/Cake/Scripting/Mono/MonoScriptSession.cs
+++ b/src/Cake/Scripting/Mono/MonoScriptSession.cs
@@ -86,6 +86,11 @@ namespace Cake.Scripting.Mono
 
         public void Execute(Script script)
         {
+            if (script.UsingAliasDirectives.Count > 0)
+            {
+                throw new CakeException("The Mono scripting engine do not support using alias directives.");
+            }
+
             var code = MonoCodeGenerator.Generate(script);
 
             try

--- a/src/Cake/Scripting/Roslyn/RoslynCodeGenerator.cs
+++ b/src/Cake/Scripting/Roslyn/RoslynCodeGenerator.cs
@@ -7,9 +7,10 @@ namespace Cake.Scripting.Roslyn
     {
         public string Generate(Script script)
         {
+            var usingDirectives = string.Join("\r\n", script.UsingAliasDirectives);
             var aliases = GetAliasCode(script);
             var code = string.Join("\r\n", script.Lines);
-            return string.Join("\r\n", aliases, code);
+            return string.Join("\r\n", usingDirectives, aliases, code);
         }
 
         private static string GetAliasCode(Script context)


### PR DESCRIPTION
Seems to work correctly with Roslyn, but on Mono there seem to
be a bug in the Evaluator that throws a NullReferenceException.
Since the exception is so vague, I added a better error message
for the user.

I've filed a bug report with Xamarin for this that can
be found at https://bugzilla.xamarin.com/show_bug.cgi?id=32894#c0

Resolves #328