### PR TITLE
SetTarget implementation (Issue #348).

### DIFF
--- a/src/Cake.Core.Tests/Unit/CakeEngineTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeEngineTests.cs
@@ -86,54 +86,56 @@ namespace Cake.Core.Tests.Unit
 
         public sealed class TheRunTargetMethod
         {
-            public sealed class WithTarget
+            public sealed class HandlingDefaultTarget
             {
                 [Fact]
-                public void Should_Throw_If_Target_Is_Null()
+                public void Should_Run_Engine_Configured_Target_If_Target_Is_Null()
                 {
                     // Given
                     var fixture = new CakeEngineFixture();
                     var engine = fixture.CreateEngine();
+                    engine.Target = "A";
+                    bool targetCalled = false;
+                    engine.RegisterTask("Default").Does(() => { throw new Exception(); });
+                    engine.RegisterTask("A").Does(() => targetCalled = true );
 
                     // When
-                    var result = Record.Exception(() =>
-                        engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, null));
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, null);
 
                     // Then
-                    Assert.IsArgumentNullException(result, "target");
+                    Assert.True(targetCalled);
                 }
+
+                [Fact]
+                public void Should_Run_Default_Target_If_Target_And_Engine_Configured_Target_Are_Both_Null()
+                {
+                    // Given
+                    var fixture = new CakeEngineFixture();
+                    var engine = fixture.CreateEngine();
+                    bool defaultTargetCalled = false;
+                    engine.RegisterTask("Default").Does(() => defaultTargetCalled = true);
+
+                    // When
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, null);
+
+                    // Then
+                    Assert.True(defaultTargetCalled);
+                }
+
             }
 
-            public sealed class WithExecutionStrategy
+            [Fact]
+            public void Should_Throw_If_Execution_Strategy_Is_Null()
             {
-                [Fact]
-                public void Should_Throw_If_Target_Is_Null()
-                {
-                    // Given
-                    var fixture = new CakeEngineFixture();
-                    var engine = fixture.CreateEngine();
+                // Given
+                var fixture = new CakeEngineFixture();
+                var engine = fixture.CreateEngine();
 
-                    // When
-                    var result = Record.Exception(() =>
-                        engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, null));
+                // When
+                var result = Record.Exception(() => engine.RunTarget(fixture.Context, null, "A"));
 
-                    // Then
-                    Assert.IsArgumentNullException(result, "target");
-                }
-
-                [Fact]
-                public void Should_Throw_If_Execution_Strategy_Is_Null()
-                {
-                    // Given
-                    var fixture = new CakeEngineFixture();
-                    var engine = fixture.CreateEngine();
-
-                    // When
-                    var result = Record.Exception(() => engine.RunTarget(fixture.Context, null, "A"));
-
-                    // Then
-                    Assert.IsArgumentNullException(result, "strategy");
-                }
+                // Then
+                Assert.IsArgumentNullException(result, "strategy");
             }
 
             [Fact]

--- a/src/Cake.Core/CakeEngine.cs
+++ b/src/Cake.Core/CakeEngine.cs
@@ -17,6 +17,7 @@ namespace Cake.Core
         private readonly List<CakeTask> _tasks;
         private Action _setupAction;
         private Action _teardownAction;
+        private string _target;
 
         /// <summary>
         /// Gets all registered tasks.
@@ -25,6 +26,23 @@ namespace Cake.Core
         public IReadOnlyList<CakeTask> Tasks
         {
             get { return _tasks; }
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the target to run.
+        /// When null or empty, defaults to "Default".
+        /// </summary>
+        public string Target
+        {
+            get
+            {
+                return string.IsNullOrEmpty(_target) ? "Default" : _target; 
+            }
+
+            set
+            {
+                _target = value;
+            }
         }
 
         /// <summary>
@@ -85,17 +103,17 @@ namespace Cake.Core
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="strategy">The execution strategy.</param>
-        /// <param name="target">The target to run.</param>
+        /// <param name="target">The target to run. When let to null, <see cref="Target"/> property is used.</param>
         /// <returns>The resulting report.</returns>
-        public CakeReport RunTarget(ICakeContext context, IExecutionStrategy strategy, string target)
+        public CakeReport RunTarget(ICakeContext context, IExecutionStrategy strategy, string target = null)
         {
-            if (target == null)
-            {
-                throw new ArgumentNullException("target");
-            }
             if (strategy == null)
             {
                 throw new ArgumentNullException("strategy");
+            }
+            if (target == null)
+            {
+                target = Target;
             }
 
             var graph = CakeGraphBuilder.Build(_tasks);

--- a/src/Cake.Core/ICakeEngine.cs
+++ b/src/Cake.Core/ICakeEngine.cs
@@ -36,12 +36,18 @@ namespace Cake.Core
         void RegisterTeardownAction(Action action);
 
         /// <summary>
+        /// Gets or sets the name of the target to run.
+        /// When null or empty, defaults to "Default".
+        /// </summary>
+        string Target { get; set; }
+
+        /// <summary>
         /// Runs the specified target using the specified <see cref="IExecutionStrategy"/>.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="strategy">The execution strategy.</param>
-        /// <param name="target">The target to run.</param>
+        /// <param name="target">The target to run. When let to null, <see cref="Target"/> property is used.</param>
         /// <returns>The resulting report.</returns>
-        CakeReport RunTarget(ICakeContext context, IExecutionStrategy strategy, string target);
+        CakeReport RunTarget(ICakeContext context, IExecutionStrategy strategy, string target = null);
     }
 }

--- a/src/Cake.Core/Scripting/IScriptHost.cs
+++ b/src/Cake.Core/Scripting/IScriptHost.cs
@@ -46,6 +46,13 @@ namespace Cake.Core.Scripting
         /// </summary>
         /// <param name="target">The target to run.</param>
         /// <returns>The resulting report.</returns>
+        [Obsolete("Use SetTarget instead.")]
         CakeReport RunTarget(string target);
+
+        /// <summary>
+        /// Declares the specified target as the running one.
+        /// </summary>
+        /// <param name="target">The target to run.</param>
+        void SetTarget(string target);
     }
 }

--- a/src/Cake.Core/Scripting/ScriptHost.cs
+++ b/src/Cake.Core/Scripting/ScriptHost.cs
@@ -93,5 +93,15 @@ namespace Cake.Core.Scripting
         /// <param name="target">The target to run.</param>
         /// <returns>The resulting report.</returns>
         public abstract CakeReport RunTarget(string target);
+
+        /// <summary>
+        /// Sets the name of the target to run.
+        /// Can be safely called multiple times.
+        /// </summary>
+        /// <param name="target">The target to run.</param>
+        public void SetTarget(string target)
+        {
+            _engine.Target = target;
+        }
     }
 }


### PR DESCRIPTION
Current Implementation is quite simple (ScriptHost.SetTarget sets the CakeEngine.Target property and the CakeEngine.RunTarget uses it).
Thanks to the default value of CakeEngine.RunTarget target parameter, this is a non breaking change: the parameter can now be null and the Target property is used. I updated the unit tests accordingly.

I did not change ScriptHost.RunTarget (I just marked it obsolete - that is useless for script). IMO it should call SetTarget and emit a warning in a first time and removed in a future release.