### PR TITLE
Packaging Cake.Common.dll into Cake.Common.nupkg.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -108,6 +108,7 @@ Task("Copy-Files")
     CopyFileToDirectory(buildDir + File("Cake.Core.pdb"), binDir);
     CopyFileToDirectory(buildDir + File("Cake.Common.dll"), binDir);
     CopyFileToDirectory(buildDir + File("Cake.Common.xml"), binDir);
+    CopyFileToDirectory(buildDir + File("Cake.Common.pdb"), binDir);
     CopyFileToDirectory(buildDir + File("Mono.CSharp.dll"), binDir);
     CopyFileToDirectory(buildDir + File("Autofac.dll"), binDir);
     CopyFileToDirectory(buildDir + File("Nuget.Core.dll"), binDir);
@@ -139,8 +140,17 @@ Task("Create-NuGet-Packages")
         NoPackageAnalysis = true
     });
 
-    // Create core package.
+    // Create Core package.
     NuGetPack("./nuspec/Cake.Core.nuspec", new NuGetPackSettings {
+        Version = semVersion,
+        ReleaseNotes = releaseNotes.Notes.ToArray(),
+        BasePath = binDir,
+        OutputDirectory = nugetRoot,
+        Symbols = false
+    });
+
+    // Create Common package.
+    NuGetPack("./nuspec/Cake.Common.nuspec", new NuGetPackSettings {
         Version = semVersion,
         ReleaseNotes = releaseNotes.Notes.ToArray(),
         BasePath = binDir,

--- a/build.ps1
+++ b/build.ps1
@@ -62,4 +62,5 @@ if (!(Test-Path $CAKE_EXE)) {
 
 # Start Cake
 Invoke-Expression "$CAKE_EXE `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseMono $UseDryRun $UseExperimental"
+pause
 exit $LASTEXITCODE

--- a/build.ps1
+++ b/build.ps1
@@ -62,5 +62,4 @@ if (!(Test-Path $CAKE_EXE)) {
 
 # Start Cake
 Invoke-Expression "$CAKE_EXE `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseMono $UseDryRun $UseExperimental"
-pause
 exit $LASTEXITCODE

--- a/nuspec/Cake.Common.nuspec
+++ b/nuspec/Cake.Common.nuspec
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <id>Cake.Common</id>
+    <version>0.0.0</version>
+    <authors>Patrik Svensson</authors>
+    <owners>Patrik Svensson</owners>
+    <description>The Cake common library.</description>
+    <summary>Cake (C# Make) is a build automation system with a C# DSL to do things like compiling code, copy files/folders, running unit tests, compress files and build NuGet packages.</summary>
+    <licenseUrl>https://github.com/cake-build/cake/blob/develop/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/cake-build/cake</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/cake-build/graphics/master/png/cake-medium.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <copyright>Copyright (c) Patrik Svensson, Mattias Karlsson and contributors</copyright>
+    <tags>Cake Script Build</tags>
+    <dependencies>
+      <dependency id="Cake.Core" version="0.5.2" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="Cake.Common.dll" target="lib/net45" />
+    <file src="Cake.Common.xml" target="lib/net45" />
+    <file src="Cake.Common.pdb" target="lib/net45" />
+    <file src="LICENSE" />
+  </files>
+</package>

--- a/nuspec/Cake.Common.nuspec
+++ b/nuspec/Cake.Common.nuspec
@@ -5,8 +5,8 @@
     <version>0.0.0</version>
     <authors>Patrik Svensson</authors>
     <owners>Patrik Svensson</owners>
-    <description>The Cake common library.</description>
     <summary>Cake (C# Make) is a build automation system with a C# DSL to do things like compiling code, copy files/folders, running unit tests, compress files and build NuGet packages.</summary>
+    <description>Provides aliases (extension methods on Cake context) that support CI, build, unit tests, zip, signing, etc. for Cake.</description>
     <licenseUrl>https://github.com/cake-build/cake/blob/develop/LICENSE</licenseUrl>
     <projectUrl>https://github.com/cake-build/cake</projectUrl>
     <iconUrl>https://raw.githubusercontent.com/cake-build/graphics/master/png/cake-medium.png</iconUrl>
@@ -14,7 +14,7 @@
     <copyright>Copyright (c) Patrik Svensson, Mattias Karlsson and contributors</copyright>
     <tags>Cake Script Build</tags>
     <dependencies>
-      <dependency id="Cake.Core" version="0.5.2" />
+      <dependency id="Cake.Core" version="$version$" />
     </dependencies>
   </metadata>
   <files>

--- a/src/Cake.sln
+++ b/src/Cake.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cake.Core", "Cake.Core\Cake.Core.csproj", "{8074B833-11B8-459F-BB98-BFBA2BC5C698}"
 EndProject
@@ -31,6 +31,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{A01118B7
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "nuspec", "nuspec", "{B38B35F5-812A-4E4C-B267-71254A7EEF17}"
 	ProjectSection(SolutionItems) = preProject
+		..\nuspec\Cake.Common.nuspec = ..\nuspec\Cake.Common.nuspec
 		..\nuspec\Cake.Core.nuspec = ..\nuspec\Cake.Core.nuspec
 		..\nuspec\Cake.nuspec = ..\nuspec\Cake.nuspec
 	EndProjectSection

--- a/src/Cake.sln
+++ b/src/Cake.sln
@@ -1,7 +1,7 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cake.Core", "Cake.Core\Cake.Core.csproj", "{8074B833-11B8-459F-BB98-BFBA2BC5C698}"
 EndProject


### PR DESCRIPTION
Hello everybody,

A very small PR that packages Cake.Common into a .nupkg. This does not change anything to the project except that Cake.Common becomes usable from an autonomous application that may need it (once it will be pushed on nuget.org of course!). 