### PR TITLE
xUnit: Added support for -noappdomain option.

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/XUnit/XUnit2RunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/XUnit/XUnit2RunnerTests.cs
@@ -139,7 +139,7 @@ namespace Cake.Common.Tests.Unit.Tools.XUnit
 
                 // Then
                 Assert.IsType<CakeException>(result);
-                Assert.Equal("xUnit.net (v2): Process returned an error.", result.Message);                  
+                Assert.Equal("xUnit.net (v2): Process returned an error.", result.Message);
             }
 
             [Fact]
@@ -178,7 +178,7 @@ namespace Cake.Common.Tests.Unit.Tools.XUnit
                 fixture.ProcessRunner.Received(1).Start(
                     Arg.Any<FilePath>(), 
                     Arg.Is<ProcessSettings>(p => 
-                        p.Arguments.Render() == "\"/Working/Test1.dll\" \"-html\" \"/Output/Test1.dll.html\""));
+                        p.Arguments.Render() == "\"/Working/Test1.dll\" -html \"/Output/Test1.dll.html\""));
             }
 
             [Fact]
@@ -217,7 +217,7 @@ namespace Cake.Common.Tests.Unit.Tools.XUnit
                 fixture.ProcessRunner.Received(1).Start(
                     Arg.Any<FilePath>(), 
                     Arg.Is<ProcessSettings>(p => 
-                        p.Arguments.Render() == "\"/Working/Test1.dll\" \"-xml\" \"/Output/Test1.dll.xml\""));
+                        p.Arguments.Render() == "\"/Working/Test1.dll\" -xml \"/Output/Test1.dll.xml\""));
             }
 
 
@@ -257,9 +257,8 @@ namespace Cake.Common.Tests.Unit.Tools.XUnit
                 fixture.ProcessRunner.Received(1).Start(
                     Arg.Any<FilePath>(),
                     Arg.Is<ProcessSettings>(p =>
-                        p.Arguments.Render() == "\"/Working/Test1.dll\" \"-xmlv1\" \"/Output/Test1.dll.xml\""));
+                        p.Arguments.Render() == "\"/Working/Test1.dll\" -xmlv1 \"/Output/Test1.dll.xml\""));
             }
-
 
             [Fact]
             public void Should_Not_Use_Shadow_Copying_If_Disabled_In_Settings()
@@ -278,7 +277,26 @@ namespace Cake.Common.Tests.Unit.Tools.XUnit
                 fixture.ProcessRunner.Received(1).Start(
                     Arg.Any<FilePath>(), 
                     Arg.Is<ProcessSettings>(p => 
-                        p.Arguments.Render() == "\"/Working/Test1.dll\" \"-noshadow\""));
+                        p.Arguments.Render() == "\"/Working/Test1.dll\" -noshadow"));
+            }
+
+            [Fact]
+            public void Should_Not_Use_App_Domains_If_Disabled_In_Settings()
+            {
+                // Given
+                var fixture = new XUnit2RunnerFixture();
+                var runner = fixture.CreateRunner();
+
+                // When
+                runner.Run("./Test1.dll", new XUnit2Settings {
+                    NoAppDomain = true
+                });
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(),
+                    Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "\"/Working/Test1.dll\" -noappdomain"));
             }
         }
     }

--- a/src/Cake.Common.Tests/Unit/Tools/XUnit/XUnit2SettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/XUnit/XUnit2SettingsTests.cs
@@ -46,6 +46,16 @@ namespace Cake.Common.Tests.Unit.Tools.XUnit
                 // Then
                 Assert.True(settings.ShadowCopy);
             }
+
+            [Fact]
+            public void Should_Set_NoAppDomain_To_False_By_Default()
+            {
+                // Given, When
+                var settings = new XUnit2Settings();
+
+                // Then
+                Assert.False(settings.NoAppDomain);
+            }
         }
     }
 }

--- a/src/Cake.Common/Tools/XUnit/XUnit2Runner.cs
+++ b/src/Cake.Common/Tools/XUnit/XUnit2Runner.cs
@@ -71,7 +71,13 @@ namespace Cake.Common.Tools.XUnit
             // No shadow copy?
             if (!settings.ShadowCopy)
             {
-                builder.AppendQuoted("-noshadow");
+                builder.Append("-noshadow");
+            }
+
+            // No app domain?
+            if (settings.NoAppDomain)
+            {
+                builder.Append("-noappdomain");
             }
 
             // Generate HTML report?
@@ -80,7 +86,7 @@ namespace Cake.Common.Tools.XUnit
                 var assemblyFilename = assemblyPath.GetFilename().AppendExtension(".html");
                 var outputPath = settings.OutputDirectory.MakeAbsolute(_environment).GetFilePath(assemblyFilename);
 
-                builder.AppendQuoted("-html");
+                builder.Append("-html");
                 builder.AppendQuoted(outputPath.FullPath);
             }
 
@@ -90,7 +96,7 @@ namespace Cake.Common.Tools.XUnit
                 var assemblyFilename = assemblyPath.GetFilename().AppendExtension(".xml");
                 var outputPath = settings.OutputDirectory.MakeAbsolute(_environment).GetFilePath(assemblyFilename);
 
-                builder.AppendQuoted(settings.XmlReportV1 ? "-xmlv1" : "-xml");
+                builder.Append(settings.XmlReportV1 ? "-xmlv1" : "-xml");
                 builder.AppendQuoted(outputPath.FullPath);
             }
 

--- a/src/Cake.Common/Tools/XUnit/XUnit2Settings.cs
+++ b/src/Cake.Common/Tools/XUnit/XUnit2Settings.cs
@@ -44,6 +44,14 @@ namespace Cake.Common.Tools.XUnit
         public bool HtmlReport { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to not use app domains to run test code.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> to not use app domains to run test code; otherwise, <c>false</c>.
+        /// </value>
+        public bool NoAppDomain { get; set; }
+
+        /// <summary>
         /// Gets or sets the tool path.
         /// </summary>
         /// <value>The tool path.</value>


### PR DESCRIPTION
Added support for the -noappdomain option to enable tests
to run on Mono. Currently only supported in 2.1.0-beta4-build3109.
Also removed quoting of xUnit options.

Closes #329