### PR TITLE
Fix for glob paths containing parentheses.

### DIFF
--- a/src/Cake.Core.Tests/Fixtures/GlobberFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/GlobberFixture.cs
@@ -31,9 +31,12 @@ namespace Cake.Core.Tests.Fixtures
             FileSystem.CreateDirectory("C://Working");
             FileSystem.CreateDirectory("C://Working/Foo");
             FileSystem.CreateDirectory("C://Working/Foo/Bar");
+            FileSystem.CreateDirectory("C:");
+            FileSystem.CreateDirectory("C:/Program Files (x86)");
 
             // Files
             FileSystem.CreateFile("C:/Working/Foo/Bar/Qux.c");
+            FileSystem.CreateFile("C:/Program Files (x86)/Foo.c");
         }
 
         private void PrepareUnixFixture()
@@ -47,6 +50,7 @@ namespace Cake.Core.Tests.Fixtures
             FileSystem.CreateDirectory("/Working/Foo/Bar");
             FileSystem.CreateDirectory("/Working/Bar");
             FileSystem.CreateDirectory("/Foo/Bar");
+            FileSystem.CreateDirectory("/Foo (Bar)");
 
             // Files
             FileSystem.CreateFile("/Working/Foo/Bar/Qux.c");
@@ -57,6 +61,7 @@ namespace Cake.Core.Tests.Fixtures
             FileSystem.CreateFile("/Working/Bar/Qux.c");
             FileSystem.CreateFile("/Working/Bar/Qux.h");
             FileSystem.CreateFile("/Foo/Bar.baz");
+            FileSystem.CreateFile("/Foo (Bar)/Baz.c");
         }
 
         public void SetWorkingDirectory(DirectoryPath path)

--- a/src/Cake.Core.Tests/Unit/IO/GlobberTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/GlobberTests.cs
@@ -82,6 +82,20 @@ namespace Cake.Core.Tests.Unit.IO
                     Assert.IsType<FilePath>(result[0]);
                     Assert.ContainsFilePath(result, "C:/Working/Foo/Bar/Qux.c");
                 }
+
+                [Fact]
+                public void Should_Parse_Glob_Expressions_With_Parenthesis_In_Them()
+                {
+                    // Given
+                    var fixture = new GlobberFixture(windows: true);
+
+                    // When
+                    var result = fixture.Match("C:/Program Files (x86)/Foo.*");
+
+                    // Then
+                    Assert.Equal(1, result.Length);
+                    Assert.ContainsFilePath(result, "C:/Program Files (x86)/Foo.c");
+                }
             }
 
             public sealed class WithPredicate
@@ -352,6 +366,20 @@ namespace Cake.Core.Tests.Unit.IO
                 // Then
                 Assert.Equal(1, result.Length);
                 Assert.ContainsDirectoryPath(result, "/Foo/Bar");
+            }
+
+            [Fact]
+            public void Should_Parse_Glob_Expressions_With_Parenthesis_In_Them()
+            {
+                // Given
+                var fixture = new GlobberFixture();
+
+                // When
+                var result = fixture.Match("/Foo (Bar)/Baz.*");
+
+                // Then
+                Assert.Equal(1, result.Length);
+                Assert.ContainsFilePath(result, "/Foo (Bar)/Baz.c");
             }
         }
     }

--- a/src/Cake.Core/IO/Globbing/GlobTokenizer.cs
+++ b/src/Cake.Core/IO/Globbing/GlobTokenizer.cs
@@ -24,7 +24,7 @@ namespace Cake.Core.IO.Globbing
             _sourceIndex = 0;
             _currentContent = string.Empty;
             _currentCharacter = _pattern[_sourceIndex];
-            _identifierRegex = new Regex("^[0-9a-zA-Z\\. _-]$", RegexOptions.Compiled);
+            _identifierRegex = new Regex("^[0-9a-zA-Z(). _-]$", RegexOptions.Compiled);
         }
 
         public GlobToken Scan()


### PR DESCRIPTION
Fixes issue where using a pattern like C:/Program Files (x86)/*
will fail due to lacking parenthesis support.

Fixes #368