### PR TITLE
MSBuild Platform target was misspelled fixes #359

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -336,7 +336,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             }
 
             [Theory]
-            [InlineData(PlatformTarget.MSIL, "/m /v:normal /p:\"Platform\"=\"AnyCPU\" /target:Build \"/Working/src/Solution.sln\"")]
+            [InlineData(PlatformTarget.MSIL, "/m /v:normal /p:\"Platform\"=\"Any CPU\" /target:Build \"/Working/src/Solution.sln\"")]
             [InlineData(PlatformTarget.x86, "/m /v:normal /p:\"Platform\"=\"x86\" /target:Build \"/Working/src/Solution.sln\"")]
             [InlineData(PlatformTarget.x64, "/m /v:normal /p:\"Platform\"=\"x64\" /target:Build \"/Working/src/Solution.sln\"")]
             public void Should_Append_Platform_As_Property_To_Process_Arguments(PlatformTarget? platform, string argumentsString)
@@ -357,7 +357,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             {
                 // Given
                 var fixture = new MSBuildRunnerFixture(false, true);
-                
+
                 // When
                 fixture.Run();
 

--- a/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
@@ -104,7 +104,7 @@ namespace Cake.Common.Tools.MSBuild
             switch (platform)
             {
                 case PlatformTarget.MSIL:
-                    return "AnyCPU";
+                    return "Any CPU";
                 case PlatformTarget.x86:
                     return "x86";
                 case PlatformTarget.x64:


### PR DESCRIPTION
This fixes an type that caused code like this to fail:
```csharp
        MSBuild(solution, settings =>
            settings.SetPlatformTarget(PlatformTarget.MSIL)
                .WithTarget("Build"));
```