### PR TITLE
Extended ProcessAliases with methods returning IProcess

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/ProcessFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/ProcessFixture.cs
@@ -31,9 +31,19 @@ namespace Cake.Common.Tests.Fixtures
             return Context.StartProcess(filename);
         }
 
+        public IProcess StartNewProcess(string filename)
+        {
+            return Context.StartAndReturnProcess(filename);
+        }
+
         public int Start(string filename, ProcessSettings settings)
         {
             return Context.StartProcess(filename, settings);
+        }
+
+        public IProcess StartNewProcess(string filename, ProcessSettings settings)
+        {
+            return Context.StartAndReturnProcess(filename, settings);
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/ProcessAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/ProcessAliasesTests.cs
@@ -227,5 +227,229 @@ namespace Cake.Common.Tests.Unit
                 }
             }
         }
+
+        public sealed class TheStartAndReturnProcessMethod
+        {
+            public sealed class WithoutSettings
+            {
+                [Fact]
+                public void Should_Throw_If_Context_Is_Null()
+                {
+                    // Given
+                    const string fileName = "git";
+
+                    // When
+                    var result = Record.Exception(() =>
+                        ProcessAliases.StartAndReturnProcess(null, fileName));
+
+                    // Then
+                    Assert.IsArgumentNullException(result, "context");
+                }
+
+                [Fact]
+                public void Should_Throw_If_Filename_Is_Null()
+                {
+                    // Given
+                    var context = Substitute.For<ICakeContext>();
+
+                    // When
+                    var result = Record.Exception(() =>
+                        context.StartAndReturnProcess(null));
+
+                    // Then
+                    Assert.IsArgumentNullException(result, "fileName");
+                }
+
+                [Fact]
+                public void Should_Use_Environments_Working_Directory()
+                {
+                    // Given
+                    var fixture = new ProcessFixture();
+
+                    // When
+                    fixture.StartNewProcess("hello.exe");
+
+                    // Then
+                    fixture.ProcessRunner.Received(1).Start(
+                        Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(info =>
+                            info.WorkingDirectory.FullPath == "/Working"));
+                }
+
+                [Fact]
+                public void Should_Throw_If_No_Process_Was_Returned_From_Process_Runner()
+                {
+                    // Given
+                    var fixture = new ProcessFixture();
+                    fixture.ProcessRunner.Start(Arg.Any<FilePath>(), Arg.Any<ProcessSettings>())
+                        .Returns((IProcess)null);
+
+                    // When
+                    var result = Record.Exception(() => fixture.StartNewProcess("hello.exe"));
+
+                    // Then
+                    Assert.IsType<CakeException>(result);
+                    Assert.Equal("Could not start process.", result.Message);
+                }
+
+                [Fact]
+                public void Should_Return_Process_Started_By_ProcessRunner()
+                {
+                    // Given
+                    var fixture = new ProcessFixture();
+                    const string fileName = "hello.exe";
+                    
+                    var expected = fixture.Process;
+                    fixture.ProcessRunner.Start(Arg.Any<FilePath>(), Arg.Any<ProcessSettings>()).Returns(p => expected);
+
+                    // When
+                    var result = fixture.StartNewProcess(fileName);
+
+                    // Then
+                    Assert.Same(expected, result);
+                }
+            }
+
+            public sealed class WithSettings
+            {
+                [Fact]
+                public void Should_Throw_If_Context_Is_Null()
+                {
+                    // Given
+                    const string fileName = "git";
+                    var settings = new ProcessSettings();
+
+                    // When
+                    var result = Record.Exception(() =>
+                        ProcessAliases.StartAndReturnProcess(null, fileName, settings));
+
+                    // Then
+                    Assert.IsArgumentNullException(result, "context");
+                }
+
+                [Fact]
+                public void Should_Throw_If_Filename_Is_Null()
+                {
+                    // Given
+                    var context = Substitute.For<ICakeContext>();
+                    var settings = new ProcessSettings();
+
+                    // When
+                    var result = Record.Exception(() =>
+                        context.StartAndReturnProcess(null, settings));
+
+                    // Then
+                    Assert.IsArgumentNullException(result, "fileName");
+                }
+
+                [Fact]
+                public void Should_Throw_If_Settings_Are_Null()
+                {
+                    // Given
+                    var context = Substitute.For<ICakeContext>();
+                    const string fileName = "git";
+
+                    // When
+                    var result = Record.Exception(() =>
+                        context.StartAndReturnProcess(fileName, null));
+
+                    // Then
+                    Assert.IsArgumentNullException(result, "settings");
+                }
+
+                [Fact]
+                public void Should_Use_Environments_Working_Directory_If_Not_Working_Directory_Is_Set()
+                {
+                    // Given
+                    var fixture = new ProcessFixture();
+                    const string fileName = "hello.exe";
+                    var settings = new ProcessSettings();
+
+                    // When
+                    fixture.StartNewProcess(fileName, settings);
+
+                    // Then
+                    fixture.ProcessRunner.Received(1).Start(
+                        Arg.Any<FilePath>(),
+                        Arg.Is<ProcessSettings>(info =>
+                            info.WorkingDirectory.FullPath == "/Working"));
+                }
+
+                [Fact]
+                public void Should_Use_Provided_Working_Directory_If_Set()
+                {
+                    // Given
+                    var fixture = new ProcessFixture();
+                    const string fileName = "hello.exe";
+                    var settings = new ProcessSettings();
+                    settings.WorkingDirectory = "/OtherWorking";
+
+                    // When
+                    fixture.StartNewProcess(fileName, settings);
+
+                    // Then
+                    fixture.ProcessRunner.Received(1).Start(
+                        Arg.Any<FilePath>(),
+                        Arg.Is<ProcessSettings>(info =>
+                            info.WorkingDirectory.FullPath == "/OtherWorking"));
+                }
+
+                [Fact]
+                public void Should_Make_Working_Directory_Absolute_If_Set()
+                {
+                    // Given
+                    var fixture = new ProcessFixture();
+                    const string fileName = "hello.exe";
+                    var settings = new ProcessSettings();
+                    settings.WorkingDirectory = "OtherWorking";
+
+                    // When
+                    fixture.StartNewProcess(fileName, settings);
+
+                    // Then
+                    fixture.ProcessRunner.Received(1).Start(
+                        Arg.Any<FilePath>(),
+                        Arg.Is<ProcessSettings>(info =>
+                            info.WorkingDirectory.FullPath == "/Working/OtherWorking"));
+                }
+
+                [Fact]
+                public void Should_Throw_If_No_Process_Was_Returned_From_Process_Runner()
+                {
+                    // Given
+                    var fixture = new ProcessFixture();
+                    const string fileName = "hello.exe";
+                    var settings = new ProcessSettings();
+
+                    fixture.ProcessRunner.Start(
+                        Arg.Any<FilePath>(),
+                        Arg.Any<ProcessSettings>()).Returns((IProcess)null);
+
+                    // When
+                    var result = Record.Exception(() => fixture.StartNewProcess(fileName, settings));
+
+                    // Then
+                    Assert.IsType<CakeException>(result);
+                    Assert.Equal("Could not start process.", result.Message);
+                }
+
+                [Fact]
+                public void Should_Return_Process_Started_By_ProcessRunner()
+                {
+                    // Given
+                    var fixture = new ProcessFixture();
+                    const string fileName = "hello.exe";
+                    var settings = new ProcessSettings();
+
+                    var expected = fixture.Process;
+                    fixture.ProcessRunner.Start(Arg.Any<FilePath>(), Arg.Any<ProcessSettings>()).Returns(p => expected);
+
+                    // When
+                    var result = fixture.StartNewProcess(fileName, settings);
+
+                    // Then
+                    Assert.IsAssignableFrom<IProcess>(expected);
+                }
+            }
+        }
     }
 }

--- a/src/Cake.Common/ProcessAliases.cs
+++ b/src/Cake.Common/ProcessAliases.cs
@@ -80,29 +80,7 @@ namespace Cake.Common
         [CakeMethodAlias]
         public static int StartProcess(this ICakeContext context, FilePath fileName, ProcessSettings settings, out IEnumerable<string> redirectedOutput)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException("context");
-            }
-            if (fileName == null)
-            {
-                throw new ArgumentNullException("fileName");
-            }
-            if (settings == null)
-            {
-                throw new ArgumentNullException("settings");
-            }
-
-            // Get the working directory.
-            var workingDirectory = settings.WorkingDirectory ?? context.Environment.WorkingDirectory;
-            settings.WorkingDirectory = workingDirectory.MakeAbsolute(context.Environment);
-
-            // Start the process.
-            var process = context.ProcessRunner.Start(fileName, settings);
-            if (process == null)
-            {
-                throw new CakeException("Could not start process.");
-            }
+            var process = StartAndReturnProcess(context, fileName, settings);
 
             // Wait for the process to stop.
             if (settings.Timeout.HasValue)
@@ -128,6 +106,77 @@ namespace Cake.Common
            
             // Return the exit code.
             return process.GetExitCode();
+        }
+
+        /// <summary>
+        /// Starts the process resource that is specified by the filename and settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="fileName">Name of the file.</param>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The newly started process.</returns>
+        /// <example>
+        /// <code>
+        /// using(var process = StartAndReturnProcess("ping", new ProcessSettings{ Arguments = "localhost" }))
+        /// {
+        ///     process.WaitForExit();
+        ///     // This should output 0 as valid arguments supplied
+        ///     Information("Exit code: {0}", process.GetExitCode());
+        /// }
+        /// </code>
+        /// </example>
+        /// <exception cref="ArgumentNullException"><paramref name="context"/>, <paramref name="fileName"/>, or <paramref name="settings"/>  is null.</exception>
+        [CakeMethodAlias]
+        public static IProcess StartAndReturnProcess(this ICakeContext context, FilePath fileName, ProcessSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            if (fileName == null)
+            {
+                throw new ArgumentNullException("fileName");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            // Get the working directory.
+            var workingDirectory = settings.WorkingDirectory ?? context.Environment.WorkingDirectory;
+            settings.WorkingDirectory = workingDirectory.MakeAbsolute(context.Environment);
+
+            // Start the process.
+            var process = context.ProcessRunner.Start(fileName, settings);
+            if (process == null)
+            {
+                throw new CakeException("Could not start process.");
+            }
+
+            return process;
+        }
+
+        /// <summary>
+        /// Starts the process resource that is specified by the filename.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="fileName">Name of the file.</param>
+        /// <returns>The newly started process.</returns>
+        /// <example>
+        /// <code>
+        /// using(var process = StartAndReturnProcess("ping"))
+        /// {
+        ///     process.WaitForExit();
+        ///     // This should output 0 as valid arguments supplied
+        ///     Information("Exit code: {0}", process.GetExitCode());
+        /// }
+        /// </code>
+        /// </example>
+        /// <exception cref="ArgumentNullException"><paramref name="context"/>, <paramref name="fileName"/> is null.</exception>
+        [CakeMethodAlias]
+        public static IProcess StartAndReturnProcess(this ICakeContext context, FilePath fileName)
+        {
+            return StartAndReturnProcess(context, fileName, new ProcessSettings());
         }
     }
 }


### PR DESCRIPTION
added `StartNewProcess` alias methods to `ProcessAlias`.

Note: I'm not in love with the method name, but I was limited by the existing methods' names.
The existing ones, named `StartProcess` don't just start the process, they really execute the process and report the exit code.
My new ones do actually just start the process, leaving the user to interact with the resulting process in the manner of their choosing.  So in a perfect world where we didn't have to worry about breaking changes, my new methods would be named `StartProcess`, and the old ones would be renamed to `ExecuteCommand` or `ExecuteProcess`.