### PR TITLE
Restored accidental sematic change with globber predicates.

### DIFF
--- a/src/Cake.Core.Tests/Unit/IO/GlobberTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/GlobberTests.cs
@@ -101,19 +101,49 @@ namespace Cake.Core.Tests.Unit.IO
             public sealed class WithPredicate
             {
                 [Fact]
-                public void Should_Return_Single_Path_Glob_Pattern_With_Predicate()
+                public void Should_Return_Paths_Not_Affected_By_Walker_Hints()
                 {
                     // Given
                     var fixture = new GlobberFixture();
-                    var predicate = new Func<IFileSystemInfo, bool>(
-                        i => i.Path.FullPath == "/Working/Foo/Bar/Qux.c");
+                    var predicate = new Func<IFileSystemInfo, bool>(i => 
+                        i.Path.FullPath != "/Working/Bar");
 
                     // When
-                    var result = fixture.Match("./**/*.c", predicate);
+                    var result = fixture.Match("./**/Qux.h", predicate);
 
                     // Then
                     Assert.Equal(1, result.Length);
-                    Assert.ContainsFilePath(result, "/Working/Foo/Bar/Qux.c");
+                    Assert.ContainsFilePath(result, "/Working/Foo/Bar/Qux.h");
+                }
+
+                [Fact]
+                public void Should_Not_Return_Path_If_Walker_Hint_Matches_Part_Of_Pattern()
+                {
+                    // Given
+                    var fixture = new GlobberFixture();
+                    var predicate = new Func<IFileSystemInfo, bool>(i =>
+                        i.Path.FullPath != "/Working/Bar");
+
+                    // When
+                    var result = fixture.Match("/Working/Bar/Qux.h", predicate);
+
+                    // Then
+                    Assert.Equal(0, result.Length);
+                }
+
+                [Fact]
+                public void Should_Not_Return_Path_If_Walker_Hint_Exactly_Match_Pattern()
+                {
+                    // Given
+                    var fixture = new GlobberFixture();
+                    var predicate = new Func<IFileSystemInfo, bool>(i =>
+                        i.Path.FullPath != "/Working/Bar");
+
+                    // When
+                    var result = fixture.Match("/Working/Bar", predicate);
+
+                    // Then
+                    Assert.Equal(0, result.Length);
                 }
             }
 

--- a/src/Cake.Core/IO/Globber.cs
+++ b/src/Cake.Core/IO/Globber.cs
@@ -45,7 +45,7 @@ namespace Cake.Core.IO
         /// <returns>
         ///   <see cref="Path" /> instances matching the specified pattern.
         /// </returns>
-        public IEnumerable<Path> Match(string pattern, Func<IFileSystemInfo, bool> predicate)
+        public IEnumerable<Path> Match(string pattern, Func<IDirectory, bool> predicate)
         {
             if (pattern == null)
             {
@@ -60,8 +60,7 @@ namespace Cake.Core.IO
             var root = _parser.Parse(pattern, _environment.IsUnix());
             
             // Visit all nodes in the parsed patterns and filter the result.
-            return _visitor.Walk(root)
-                .Where(predicate ?? (info => true))
+            return _visitor.Walk(root, predicate)
                 .Select(x => x.Path)
                 .Distinct(_comparer);
         }

--- a/src/Cake.Core/IO/IGlobber.cs
+++ b/src/Cake.Core/IO/IGlobber.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Cake.Core.IO
 {
@@ -15,6 +16,6 @@ namespace Cake.Core.IO
         /// <returns>
         ///   <see cref="Path" /> instances matching the specified pattern.
         /// </returns>
-        IEnumerable<Path> Match(string pattern, System.Func<IFileSystemInfo, bool> predicate);
+        IEnumerable<Path> Match(string pattern, Func<IDirectory, bool> predicate);
     }
 }


### PR DESCRIPTION
Before the Globber rewrite, the predicate was used as a way of
telling the Globber what directories to recurse into when using
double star (`**`) or directory wildcard (`*`). When rewriting
the globber, the predicate was used to determine filtering of
directories and files in the results. This has now been changed.

This will (sadly) lead to a breaking change for people who rely
on filtering the results, but this could be easily corrected by
simply using a `Where` clause on the resulting collection.