### PR TITLE
Remove nuspec requirement if sufficent parameters supplied

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/NuGet/NuGetPackerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/NuGet/NuGetPackerFixture.cs
@@ -33,7 +33,7 @@ namespace Cake.Common.Tests.Fixtures.Tools.NuGet
             FileSystem.CreateFile("/Working/existing.temp.nuspec");
         }
 
-        public string Pack()
+        public string Pack(bool nuspec = true)
         {
             string content = null;
             ProcessRunner.When(p => p.Start(Arg.Any<FilePath>(), Arg.Any<ProcessSettings>()))
@@ -42,7 +42,14 @@ namespace Cake.Common.Tests.Fixtures.Tools.NuGet
                 });
 
             var tool = new NuGetPacker(FileSystem, Environment, ProcessRunner, Log, Globber, NuGetToolResolver);
-            tool.Pack(NuSpecFilePath, Settings);
+            if (nuspec)
+            {
+                tool.Pack(NuSpecFilePath, Settings);
+            }
+            else
+            {
+                tool.Pack(Settings);
+            }
 
             // Return the content.
             return content;

--- a/src/Cake.Common.Tests/Unit/Tools/NuGet/Pack/NuGetPackerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NuGet/Pack/NuGetPackerTests.cs
@@ -431,5 +431,133 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Pack
                 Resources.Nuspec_Metadata_WithoutNamespaces.NormalizeLineEndings(),
                 result.NormalizeLineEndings());
         }
+
+        public sealed class TheSettingsPackMethod
+        {
+
+
+            [Fact]
+            public void Should_Pack_If_Sufficent_Settings_Specified()
+            {
+                // Given
+                var fixture = new NuGetPackerFixture();
+                fixture.NuSpecFilePath = null;
+                fixture.Settings.OutputDirectory = "/Working/";
+                fixture.Settings.Id = "nonexisting";
+                fixture.Settings.Version = "1.0.0";
+                fixture.Settings.Description = "The description";
+                fixture.Settings.Authors = new[] { "Author #1", "Author #2" };
+                fixture.Settings.Files = new NuSpecContent[] {
+                    new NuSpecContent { Source = "LICENSE" }
+                };
+
+                // When
+                fixture.Pack(false);
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(),
+                    Arg.Is<ProcessSettings>(p => p.Arguments.Render() == "pack -Version \"1.0.0\" -OutputDirectory \"/Working\" \"/Working/nonexisting.temp.nuspec\""));
+            }
+
+            [Fact]
+            public void Should_Throw_If_OutputDirectory_Setting_Not_Specified()
+            {
+                // Given
+                var fixture = new NuGetPackerFixture();
+                fixture.NuSpecFilePath = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Pack(false));
+
+                // Then
+                Assert.IsCakeException(result, "Required setting OutputDirectory not specified or doesn't exists.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Id_Setting_Not_Specified()
+            {
+                // Given
+                var fixture = new NuGetPackerFixture();
+                fixture.NuSpecFilePath = null;
+                fixture.Settings.OutputDirectory = "/Working/";
+
+                // When
+                var result = Record.Exception(() => fixture.Pack(false));
+
+                // Then
+                Assert.IsCakeException(result, "Required setting Id not specified.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Version_Setting_Not_Specified()
+            {
+                // Given
+                var fixture = new NuGetPackerFixture();
+                fixture.NuSpecFilePath = null;
+                fixture.Settings.OutputDirectory = "/Working/";
+                fixture.Settings.Id = "nonexisting";
+
+                // When
+                var result = Record.Exception(() => fixture.Pack(false));
+
+                // Then
+                Assert.IsCakeException(result, "Required setting Version not specified.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Authors_Setting_Not_Specified()
+            {
+                // Given
+                var fixture = new NuGetPackerFixture();
+                fixture.NuSpecFilePath = null;
+                fixture.Settings.OutputDirectory = "/Working/";
+                fixture.Settings.Id = "nonexisting";
+                fixture.Settings.Version = "1.0.0";
+
+                // When
+                var result = Record.Exception(() => fixture.Pack(false));
+
+                // Then
+                Assert.IsCakeException(result, "Required setting Authors not specified.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Description_Setting_Not_Specified()
+            {
+                // Given
+                var fixture = new NuGetPackerFixture();
+                fixture.NuSpecFilePath = null;
+                fixture.Settings.OutputDirectory = "/Working/";
+                fixture.Settings.Id = "nonexisting";
+                fixture.Settings.Version = "1.0.0";
+                fixture.Settings.Authors = new[] { "Author #1", "Author #2" };
+
+                // When
+                var result = Record.Exception(() => fixture.Pack(false));
+
+                // Then
+                Assert.IsCakeException(result, "Required setting Description not specified.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Files_Setting_Not_Specified()
+            {
+                // Given
+                var fixture = new NuGetPackerFixture();
+                fixture.NuSpecFilePath = null;
+                fixture.Settings.OutputDirectory = "/Working/";
+                fixture.Settings.Id = "nonexisting";
+                fixture.Settings.Version = "1.0.0";
+                fixture.Settings.Authors = new[] { "Author #1", "Author #2" };
+                fixture.Settings.Description = "The description";
+
+                // When
+                var result = Record.Exception(() => fixture.Pack(false));
+
+                // Then
+                Assert.IsCakeException(result, "Required setting Files not specified.");
+            }
+        }
     }
 }

--- a/src/Cake.Common/Tools/NuGet/NuGetAliases.cs
+++ b/src/Cake.Common/Tools/NuGet/NuGetAliases.cs
@@ -34,24 +34,24 @@ namespace Cake.Common.Tools.NuGet
         ///                                     Authors                 = new[] {"John Doe"},
         ///                                     Owners                  = new[] {"Contoso"},
         ///                                     Description             = "The description of the package",
-        ///                                     Summary                 = "Excellent summare of what the package does", 
+        ///                                     Summary                 = "Excellent summare of what the package does",
         ///                                     ProjectUrl              = new Uri("https://github.com/SomeUser/TestNuget/"),
         ///                                     IconUrl                 = new Uri("http://cdn.rawgit.com/SomeUser/TestNuget/master/icons/testnuget.png"),
         ///                                     LicenseUrl              = new Uri("https://github.com/SomeUser/TestNuget/blob/master/LICENSE.md"),
         ///                                     Copyright               = "Some company 2015",
         ///                                     ReleaseNotes            = new [] {"Bug fixes", "Issue fixes", "Typos"},
         ///                                     Tags                    = new [] {"Cake", "Script", "Build"},
-        ///                                     RequireLicenseAcceptance= false,        
+        ///                                     RequireLicenseAcceptance= false,
         ///                                     Symbols                 = false,
         ///                                     NoPackageAnalysis       = true,
         ///                                     Files                   = new [] {
-        ///                                                                          new NuSpecContent {Source = "bin/SlackPRTGCommander.dll", Target = "bin"},
+        ///                                                                          new NuSpecContent {Source = "bin/TestNuget.dll", Target = "bin"},
         ///                                                                       },
-        ///                                     BasePath                = "./src/TestNuget/bin/release", 
+        ///                                     BasePath                = "./src/TestNuget/bin/release",
         ///                                     OutputDirectory         = "./nuget"
         ///                                 };
-        ///     
-        ///     NuGetPack("./nuspec/SlackPRTGCommander.nuspec", nuGetPackSettings);
+        ///
+        ///     NuGetPack("./nuspec/TestNuget.nuspec", nuGetPackSettings);
         /// </code>
         /// </example>
         [CakeMethodAlias]
@@ -64,9 +64,58 @@ namespace Cake.Common.Tools.NuGet
                 throw new ArgumentNullException("context");
             }
 
-            var packer = new NuGetPacker(context.FileSystem, context.Environment, 
+            var packer = new NuGetPacker(context.FileSystem, context.Environment,
                 context.ProcessRunner, context.Log, context.Globber, context.GetToolResolver("NuGet"));
             packer.Pack(nuspecFilePath, settings);
+        }
+
+        /// <summary>
+        /// Creates a NuGet package using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        ///     var nuGetPackSettings   = new NuGetPackSettings {
+        ///                                     Id                      = "TestNuget",
+        ///                                     Version                 = "0.0.0.1",
+        ///                                     Title                   = "The tile of the package",
+        ///                                     Authors                 = new[] {"John Doe"},
+        ///                                     Owners                  = new[] {"Contoso"},
+        ///                                     Description             = "The description of the package",
+        ///                                     Summary                 = "Excellent summare of what the package does",
+        ///                                     ProjectUrl              = new Uri("https://github.com/SomeUser/TestNuget/"),
+        ///                                     IconUrl                 = new Uri("http://cdn.rawgit.com/SomeUser/TestNuget/master/icons/testnuget.png"),
+        ///                                     LicenseUrl              = new Uri("https://github.com/SomeUser/TestNuget/blob/master/LICENSE.md"),
+        ///                                     Copyright               = "Some company 2015",
+        ///                                     ReleaseNotes            = new [] {"Bug fixes", "Issue fixes", "Typos"},
+        ///                                     Tags                    = new [] {"Cake", "Script", "Build"},
+        ///                                     RequireLicenseAcceptance= false,
+        ///                                     Symbols                 = false,
+        ///                                     NoPackageAnalysis       = true,
+        ///                                     Files                   = new [] {
+        ///                                                                          new NuSpecContent {Source = "bin/TestNuget.dll", Target = "bin"},
+        ///                                                                       },
+        ///                                     BasePath                = "./src/TestNuget/bin/release",
+        ///                                     OutputDirectory         = "./nuget"
+        ///                                 };
+        ///
+        ///     NuGetPack(nuGetPackSettings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Pack")]
+        [CakeNamespaceImport("Cake.Common.Tools.NuGet.Pack")]
+        public static void NuGetPack(this ICakeContext context, NuGetPackSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var packer = new NuGetPacker(context.FileSystem, context.Environment,
+                context.ProcessRunner, context.Log, context.Globber, context.GetToolResolver("NuGet"));
+            packer.Pack(settings);
         }
 
         /// <summary>
@@ -135,12 +184,12 @@ namespace Cake.Common.Tools.NuGet
         /// <code>
         /// // Get the path to the package.
         /// var package = "./nuget/SlackPRTGCommander.0.0.1.nupkg";
-        /// 
+        ///
         /// // Push the package.
         /// NuGetPush(package, new NuGetPushSettings {
         ///     Source = "http://example.com/nugetfeed",
         ///     ApiKey = "4003d786-cc37-4004-bfdf-c4f3e8ef9b3a"
-        /// }); 
+        /// });
         /// </code>
         /// </example>
         [CakeMethodAlias]
@@ -170,7 +219,7 @@ namespace Cake.Common.Tools.NuGet
         ///                 Name = EnvironmentVariable("PUBLIC_FEED_NAME"),
         ///                 Source = EnvironmentVariable("PUBLIC_FEED_SOURCE")
         ///             };
-        /// 
+        ///
         /// NuGetAddSource(
         ///     name:feed.Name,
         ///     source:feed.Source
@@ -201,13 +250,13 @@ namespace Cake.Common.Tools.NuGet
         ///                                 IsSensitiveSource = true,
         ///                                 Verbosity = NuGetVerbosity.Detailed
         ///                             };
-        /// 
+        ///
         /// var feed = new
         ///             {
         ///                 Name = EnvironmentVariable("PRIVATE_FEED_NAME"),
         ///                 Source = EnvironmentVariable("PRIVATE_FEED_SOURCE")
         ///             };
-        /// 
+        ///
         /// NuGetAddSource(
         ///     name:feed.Name,
         ///     source:feed.Source,
@@ -242,7 +291,7 @@ namespace Cake.Common.Tools.NuGet
         ///                 Name = EnvironmentVariable("PRIVATE_FEED_NAME"),
         ///                 Source = EnvironmentVariable("PRIVATE_FEED_SOURCE")
         ///             };
-        /// 
+        ///
         /// NuGetRemoveSource(
         ///    name:feed.Name,
         ///    source:feed.Source
@@ -273,13 +322,13 @@ namespace Cake.Common.Tools.NuGet
         ///                                 IsSensitiveSource = true,
         ///                                 Verbosity = NuGetVerbosity.Detailed
         ///                             };
-        /// 
+        ///
         /// var feed = new
         ///             {
         ///                 Name = EnvironmentVariable("PRIVATE_FEED_NAME"),
         ///                 Source = EnvironmentVariable("PRIVATE_FEED_SOURCE")
         ///             };
-        /// 
+        ///
         /// NuGetRemoveSource(
         ///    name:feed.Name,
         ///    source:feed.Source,
@@ -428,7 +477,7 @@ namespace Cake.Common.Tools.NuGet
             var runner = new NuGetInstaller(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, context.GetToolResolver("NuGet"));
             runner.Install(packageId, settings);
         }
-        
+
         /// <summary>
         /// Installs NuGet packages using the specified package configuration.
         /// </summary>

--- a/src/Cake.Common/Tools/NuGet/Pack/NuspecProcessor.cs
+++ b/src/Cake.Common/Tools/NuGet/Pack/NuspecProcessor.cs
@@ -19,6 +19,17 @@ namespace Cake.Common.Tools.NuGet.Pack
             _log = log;
         }
 
+        public FilePath Process(NuGetPackSettings settings)
+        {
+            var nuspecFilePath = settings.OutputDirectory
+                                    .CombineWithFilePath(string.Concat(settings.Id, ".nuspec"))
+                                    .MakeAbsolute(_environment);
+
+            var xml = LoadEmptyNuSpec();
+
+            return ProcessXml(nuspecFilePath, settings, xml);
+        }
+
         public FilePath Process(FilePath nuspecFilePath, NuGetPackSettings settings)
         {
             // Make the nuspec file path absolute.
@@ -36,6 +47,11 @@ namespace Cake.Common.Tools.NuGet.Pack
             _log.Debug("Parsing nuspec...");
             var xml = LoadNuspecXml(nuspecFile);
 
+            return ProcessXml(nuspecFilePath, settings, xml);
+        }
+
+        private FilePath ProcessXml(FilePath nuspecFilePath, NuGetPackSettings settings, XmlDocument xml)
+        {
             // Process the XML.
             _log.Debug("Transforming nuspec...");
             NuspecTransformer.Transform(xml, settings);
@@ -53,6 +69,23 @@ namespace Cake.Common.Tools.NuGet.Pack
                 document.Load(stream);
                 return document;
             }
+        }
+
+        private static XmlDocument LoadEmptyNuSpec()
+        {
+            XmlDocument xml = new XmlDocument();
+            xml.LoadXml(@"<?xml version=""1.0"" encoding=""utf-8""?>
+<package xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
+  <metadata xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
+    <id></id>
+    <version>0.0.0</version>
+    <authors></authors>
+    <description></description>
+  </metadata>
+  <files>
+  </files>
+</package>");
+            return xml;
         }
 
         private FilePath SaveNuspecXml(FilePath nuspecFilePath, XmlDocument document)


### PR DESCRIPTION
This will allow to pack Nuget packages without having a nuspec file as long as enough parameters supplied in the Cake file and nuspec directory exists making less friction to create packages and cleaner repos.