### PR TITLE
Enhanced ProcessArgumentListExtensions with overloads to accept strin…

### DIFF
--- a/src/Cake.Core.Tests/Cake.Core.Tests.csproj
+++ b/src/Cake.Core.Tests/Cake.Core.Tests.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Unit\Diagnostics\VerbosityTypeConverterTests.cs" />
     <Compile Include="Fixtures\CakeEngineFixture.cs" />
     <Compile Include="Fixtures\GlobberFixture.cs" />
+    <Compile Include="Unit\Extensions\ProcessArgumentListExtensionsTests.cs" />
     <Compile Include="Unit\Graph\CakeGraphBuilderTests.cs" />
     <Compile Include="Unit\Graph\CakeGraphTests.cs" />
     <Compile Include="Unit\IO\Arguments\QuotedArgumentTests.cs" />

--- a/src/Cake.Core.Tests/Unit/Extensions/ProcessArgumentListExtensionsTests.cs
+++ b/src/Cake.Core.Tests/Unit/Extensions/ProcessArgumentListExtensionsTests.cs
@@ -1,0 +1,130 @@
+﻿using Cake.Core.IO;
+using Cake.Core.IO.Arguments;
+using Xunit;
+
+namespace Cake.Core.Tests.Unit.Extensions
+{
+    public class ProcessArgumentListExtensionsTests
+    {
+        public class TheAppendMethods
+        {
+            [Fact]
+            public void ShouldAppendTextArgument()
+            {
+                var result = new ProcessArgumentBuilder()
+                    .Append("string arg")
+                    .RenderSafe();
+
+                Assert.Equal("string arg", result);
+            }
+
+            [Fact]
+            public void ShouldAppendFormattedTextArgument()
+            {
+                var result = new ProcessArgumentBuilder()
+                    .Append("/arg1:{0} /arg2:{1}", "Value1", "Value2")
+                    .RenderSafe();
+
+                Assert.Equal("/arg1:Value1 /arg2:Value2", result);
+            }
+        }
+        public class TheAppendQuotedMethods
+        {
+            [Fact]
+            public void ShouldAppendTextArgument()
+            {
+                var result = new ProcessArgumentBuilder()
+                    .AppendQuoted("string arg")
+                    .RenderSafe();
+
+                Assert.Equal("\"string arg\"", result);
+            }
+
+            [Fact]
+            public void ShouldAppendProcessArgument()
+            {
+                var result = new ProcessArgumentBuilder()
+                    .AppendQuoted(new TextArgument("text arg"))
+                    .RenderSafe();
+
+                Assert.Equal("\"text arg\"", result);
+            }
+
+            [Fact]
+            public void ShouldAppendFormattedTextArgument()
+            {
+                var result = new ProcessArgumentBuilder()
+                    .AppendQuoted("/arg1:{0}", "Value1")
+                    .RenderSafe();
+
+                Assert.Equal("\"/arg1:Value1\"", result);
+            }
+        }
+
+        public class TheAppendSecretMethods
+        {
+            [Fact]
+            public void ShouldAppendTextArgument()
+            {
+                var result = new ProcessArgumentBuilder()
+                    .AppendSecret("string arg")
+                    .Render();
+
+                Assert.Equal("string arg", result);
+            }
+
+            [Fact]
+            public void ShouldAppendProcessArgument()
+            {
+                var result = new ProcessArgumentBuilder()
+                    .AppendSecret(new TextArgument("text arg"))
+                    .Render();
+
+                Assert.Equal("text arg", result);
+            }
+
+            [Fact]
+            public void ShouldAppendFormattedTextArgument()
+            {
+                var result = new ProcessArgumentBuilder()
+                    .AppendSecret("/arg1:{0}", "Value1")
+                    .Render();
+
+                Assert.Equal("/arg1:Value1", result);
+            }
+        }
+
+        public class TheAppendQuotedSecretMethods
+        {
+            [Fact]
+            public void ShouldAppendTextArgument()
+            {
+                var result = new ProcessArgumentBuilder()
+                    .AppendQuotedSecret("string arg")
+                    .Render();
+
+                Assert.Equal("\"string arg\"", result);
+            }
+
+            [Fact]
+            public void ShouldAppendProcessArgument()
+            {
+                var result = new ProcessArgumentBuilder()
+                    .AppendQuotedSecret(new TextArgument("text arg"))
+                    .Render();
+
+                Assert.Equal("\"text arg\"", result);
+            }
+
+            [Fact]
+            public void ShouldAppendFormattedTextArgument()
+            {
+                var result = new ProcessArgumentBuilder()
+                    .AppendQuotedSecret("/arg1:{0} /arg2:{1}", "Value1","Value2")
+                    .Render();
+
+                Assert.Equal("\"/arg1:Value1 /arg2:Value2\"", result);
+            }
+        }
+    }
+}

--- a/src/Cake.Core/Extensions/ProcessArgumentListExtensions.cs
+++ b/src/Cake.Core/Extensions/ProcessArgumentListExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Cake.Core.IO;
+﻿using System;
+using System.Globalization;
+using Cake.Core.IO;
 using Cake.Core.IO.Arguments;
 
 // ReSharper disable once CheckNamespace
@@ -25,6 +27,21 @@ namespace Cake.Core
         }
 
         /// <summary>
+        /// Formats and appends the specified text to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="format" /> or <paramref name="args" /> is null. </exception>
+        /// <exception cref="FormatException"><paramref name="format" /> is invalid.-or- The index of a format item is less than zero, or greater than or equal to the length of the <paramref name="args" /> array. </exception>
+        public static ProcessArgumentBuilder Append(this ProcessArgumentBuilder builder, string format, params object[] args)
+        {
+            var text = string.Format(CultureInfo.InvariantCulture, format, args);
+            return Append(builder, text);
+        }
+
+        /// <summary>
         /// Quotes and appends the specified text to the argument builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
@@ -37,6 +54,21 @@ namespace Cake.Core
                 builder.Append(new QuotedArgument(new TextArgument(text)));
             }
             return builder;
+        }
+
+        /// <summary>
+        /// Formats, quotes and appends the specified text to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="format">A composite format string to be quoted and appended.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="format" /> or <paramref name="args" /> is null. </exception>
+        /// <exception cref="FormatException"><paramref name="format" /> is invalid.-or- The index of a format item is less than zero, or greater than or equal to the length of the <paramref name="args" /> array. </exception>
+        public static ProcessArgumentBuilder AppendQuoted(this ProcessArgumentBuilder builder, string format, params object[] args)
+        {
+            var text = string.Format(CultureInfo.InvariantCulture, format, args);
+            return AppendQuoted(builder, text);
         }
 
         /// <summary>
@@ -70,6 +102,22 @@ namespace Cake.Core
         }
 
         /// <summary>
+        /// Formats and appends the specified secret text to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="format">A composite format string for the secret text to be appended.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="format" /> or <paramref name="args" /> is null. </exception>
+        /// <exception cref="FormatException"><paramref name="format" /> is invalid.-or- The index of a format item is less than zero, or greater than or equal to the length of the <paramref name="args" /> array. </exception>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder AppendSecret(this ProcessArgumentBuilder builder, string format, params object[] args)
+        {
+            var text = string.Format(CultureInfo.InvariantCulture, format, args);
+            return AppendSecret(builder, text);
+        }
+
+        /// <summary>
         /// Appends the specified secret text to the argument builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
@@ -97,6 +145,22 @@ namespace Cake.Core
                 builder.AppendQuoted(new SecretArgument(new TextArgument(text)));
             }
             return builder;
+        }
+
+        /// <summary>
+        /// Formats, quotes and appends the specified secret text to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="format">A composite format string for the secret text to be quoted and appended.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="format" /> or <paramref name="args" /> is null. </exception>
+        /// <exception cref="FormatException"><paramref name="format" /> is invalid.-or- The index of a format item is less than zero, or greater than or equal to the length of the <paramref name="args" /> array. </exception>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder AppendQuotedSecret(this ProcessArgumentBuilder builder, string format, params object[] args)
+        {
+            var text = string.Format(CultureInfo.InvariantCulture, format, args);
+            return AppendQuotedSecret(builder, text);
         }
 
         /// <summary>


### PR DESCRIPTION
Enhanced ProcessArgumentListExtensions with overloads to accept string formats for text args.

Now, this code
```C#
builder.Append(string.Concat("-verbosity=", settings.Verbosity.ToString()));
```
Can be written like this:
```C#
builder.Append("-verbosity={0}", settings.Verbosity));
```