### PR TITLE
Closes #389: TaskSetup, TaskTeardown functionality

### DIFF
--- a/src/Cake.Core.Tests/Cake.Core.Tests.csproj
+++ b/src/Cake.Core.Tests/Cake.Core.Tests.csproj
@@ -101,6 +101,8 @@
     <Compile Include="Unit\Scripting\ScriptProcessorTests.cs" />
     <Compile Include="Unit\Scripting\ScriptRunnerTests.cs" />
     <Compile Include="Unit\Scripting\ScriptTests.cs" />
+    <Compile Include="Unit\TaskSetupContextTests.cs" />
+    <Compile Include="Unit\TaskTeardownContextTests.cs" />
     <Compile Include="Unit\Text\TextTransformationTemplateTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Cake.Core.Tests/Unit/CakeEngineTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeEngineTests.cs
@@ -629,6 +629,260 @@ namespace Cake.Core.Tests.Unit
                 // Then
                 Assert.Equal("Error", result.Message);
             }
+
+            [Fact]
+            public void Should_Run_Task_Setup_Before_Each_Task()
+            {
+                // Given
+                var result = new List<string>();
+                var fixture = new CakeEngineFixture();
+                var engine = fixture.CreateEngine();
+                engine.RegisterTaskSetupAction((cc, sc) => result.Add("TASK_SETUP:" + sc.Task.Name));
+                engine.RegisterTask("A").Does(()=>result.Add("Executing A"));
+                engine.RegisterTask("B").Does(() => result.Add("Executing B")).IsDependentOn("A");
+
+                // When
+                engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "B");
+
+                // Then
+                Assert.Equal(new List<string> { "TASK_SETUP:A", "Executing A", "TASK_SETUP:B", "Executing B" }, result);
+            }
+
+            [Fact]
+            public void Should_Not_Run_Task_If_Task_Setup_Failed()
+            {
+                // Given
+                var result = new List<string>();
+                var fixture = new CakeEngineFixture();
+                var engine = fixture.CreateEngine();
+                engine.RegisterTaskSetupAction((cc, sc) => { throw new Exception("fake exception"); });
+                engine.RegisterTask("A").Does(() => result.Add("Executing A"));
+                engine.RegisterTask("B").Does(() => result.Add("Executing B")).IsDependentOn("A");
+
+                // When
+                Record.Exception(() => engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "B"));
+
+                // Then
+                Assert.Equal(new List<string>(), result);
+                
+                Assert.True(fixture.Log.Messages.Contains("Executing custom task setup action (A)..."));
+                Assert.False(fixture.Log.Messages.Contains("Executing custom task setup action (B)..."));
+            }
+
+            [Fact]
+            public void Should_Run_Task_Teardown_After_Each_Running_Task()
+            {
+                // Given
+                var result = new List<string>();
+                var fixture = new CakeEngineFixture();
+                var engine = fixture.CreateEngine();
+                engine.RegisterTaskSetupAction((cc, sc) => result.Add("TASK_SETUP:" + sc.Task.Name));
+                engine.RegisterTaskTeardownAction((cc, sc) => result.Add("TASK_TEARDOWN:" + sc.Task.Name));
+                engine.RegisterTask("A").Does(() => result.Add("Executing A"));
+                engine.RegisterTask("B").Does(() => result.Add("Executing B")).IsDependentOn("A");
+
+                // When
+                engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "B");
+
+                // Then
+                Assert.Equal(new List<string> { "TASK_SETUP:A", "Executing A", "TASK_TEARDOWN:A", "TASK_SETUP:B", "Executing B", "TASK_TEARDOWN:B" }, result);
+            }
+
+            [Fact]
+            public void Should_Run_Task_Teardown_After_Each_Running_Task_Even_If_Task_Is_Skipped()
+            {
+                // Given
+                var result = new List<string>();
+                var fixture = new CakeEngineFixture();
+                var engine = fixture.CreateEngine();
+                engine.RegisterTaskSetupAction((cc, sc) => result.Add("TASK_SETUP:" + sc.Task.Name));
+                engine.RegisterTaskTeardownAction((cc, sc) => result.Add("TASK_TEARDOWN:" + sc.Task.Name));
+                engine.RegisterTask("A").Does(() => result.Add("Executing A"));
+                engine.RegisterTask("B").Does(() => result.Add("Executing B")).WithCriteria(() => false).IsDependentOn("A");
+                engine.RegisterTask("C").Does(() => result.Add("Executing C")).IsDependentOn("B");
+
+                // When
+                engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "C");
+
+                // Then
+                Assert.Equal(
+                    new List<string>
+                    {
+                        "TASK_SETUP:A",
+                        "Executing A",
+                        "TASK_TEARDOWN:A",
+                        "TASK_SETUP:B",
+                        "TASK_TEARDOWN:B",
+                        "TASK_SETUP:C",
+                        "Executing C",
+                        "TASK_TEARDOWN:C"
+                    }, result);
+            }
+
+            [Fact]
+            public void Should_Run_Task_Teardown_After_Each_Running_Task_Even_If_Task_Failed()
+            {
+                // Given
+                var result = new List<string>();
+                var fixture = new CakeEngineFixture();
+                var engine = fixture.CreateEngine();
+                engine.RegisterTaskSetupAction((cc, sc) => result.Add("TASK_SETUP:" + sc.Task.Name));
+                engine.RegisterTaskTeardownAction((cc, sc) => result.Add("TASK_TEARDOWN:" + sc.Task.Name));
+                engine.RegisterTask("A").Does(() =>
+                {
+                    result.Add("FAILING (A)");
+                    throw new InvalidOperationException("Fail");
+                });
+
+                // When
+                var exception = Record.Exception(() =>
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
+
+                // Then
+                Assert.NotNull(exception);
+                Assert.IsType<InvalidOperationException>(exception);
+                Assert.Equal("Fail", exception.Message);
+                Assert.Equal(
+                    new List<string>
+                    {
+                        "TASK_SETUP:A",
+                        "FAILING (A)",
+                        "TASK_TEARDOWN:A"
+                    }, result);
+            }
+
+            [Fact]
+            public void Should_Run_Task_Teardown_If_Task_Setup_Failed()
+            {
+                // Given
+                var result = new List<string>();
+                var fixture = new CakeEngineFixture();
+                var engine = fixture.CreateEngine();
+                engine.RegisterTaskSetupAction((cc, sc) =>
+                {
+                    throw new InvalidOperationException("Fail");
+                });
+                engine.RegisterTaskTeardownAction((cc, sc) => result.Add("TASK_TEARDOWN:" + sc.Task.Name));
+                engine.RegisterTask("A").Does(() =>
+                {
+                    result.Add("Executing A");
+                });
+
+                // When
+                var exception = Record.Exception(() =>
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
+
+                // Then
+                Assert.NotNull(exception);
+                Assert.IsType<InvalidOperationException>(exception);
+                Assert.Equal("Fail", exception.Message);
+                Assert.Equal(
+                    new List<string>
+                    {
+                        "TASK_TEARDOWN:A"
+                    }, result);
+            }
+
+            [Fact]
+            public void Should_Throw_Exception_Thrown_From_Task_Setup_Action_If_Both_Task_Setup_And_Task_Teardown_Actions_Throw()
+            {
+                // Given
+                var fixture = new CakeEngineFixture();
+                var engine = fixture.CreateEngine();
+
+                engine.RegisterTaskSetupAction((cc,sc) => { throw new InvalidOperationException("Task Setup: " + sc.Task.Name); });
+                engine.RegisterTaskTeardownAction((cc, tc) => { throw new InvalidOperationException("Task Teardown: " + tc.Task.Name); });
+                engine.RegisterTask("A").Does(() => { });
+
+                // When
+                var result = Record.Exception(() =>
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
+
+                // Then
+                Assert.NotNull(result);
+                Assert.IsType<InvalidOperationException>(result);
+                Assert.Equal("Task Setup: A", result.Message);
+            }
+
+            [Fact]
+            public void Should_Throw_Exception_Occuring_In_Task_Teardown_If_No_Previous_Exception_Was_Thrown()
+            {
+                // Given
+                var fixture = new CakeEngineFixture();
+                var engine = fixture.CreateEngine();
+
+                engine.RegisterTaskTeardownAction((cc, tc) => { throw new InvalidOperationException("Task Teardown: " + tc.Task.Name); });
+                engine.RegisterTask("A");
+
+                // When
+                var result = Record.Exception(() =>
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
+
+                // Then
+                Assert.NotNull(result);
+                Assert.IsType<InvalidOperationException>(result);
+                Assert.Equal("Task Teardown: A", result.Message);
+            }
+
+            [Fact]
+            public void Should_Log_Task_Teardown_Exception_If_Both_Task_Setup_And_Task_Teardown_Actions_Throw()
+            {
+                // Given
+                var fixture = new CakeEngineFixture();
+                var engine = fixture.CreateEngine();
+
+                engine.RegisterTaskSetupAction((cc, sc) => { throw new InvalidOperationException("Task Setup: " + sc.Task.Name); });
+                engine.RegisterTaskTeardownAction((cc, tc) => { throw new InvalidOperationException("Task Teardown: " + tc.Task.Name); });
+                engine.RegisterTask("A").Does(() => { });
+
+                // When
+                var result = Record.Exception(() =>
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
+
+                // Then
+                Assert.NotNull(result);
+                Assert.IsType<InvalidOperationException>(result);
+                Assert.Equal("Task Setup: A", result.Message);
+                Assert.True(fixture.Log.Messages.Any(x => x.StartsWith("Task Teardown error (A):")));
+            }
+
+            [Fact]
+            public void Should_Log_Exception_Thrown_From_Task_If_Both_Task_And_Task_Teardown_Actions_Throw()
+            {
+                // Given
+                var fixture = new CakeEngineFixture();
+                var engine = fixture.CreateEngine();
+
+                engine.RegisterTaskTeardownAction((cc, tc) => { throw new InvalidOperationException("Task Teardown: " + tc.Task.Name); });
+                engine.RegisterTask("A").Does(() => { throw new InvalidOperationException("Task: A"); });
+
+                // When
+                var result = Record.Exception(() =>
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
+
+                // Then
+                Assert.NotNull(result);
+                Assert.IsType<InvalidOperationException>(result);
+                Assert.Equal("Task: A", result.Message);
+            }
+
+            [Fact]
+            public void Should_Log_Task_Teardown_Exception_If_Both_Task_And_Task_Teardown_Actions_Throw()
+            {
+                // Given
+                var fixture = new CakeEngineFixture();
+                var engine = fixture.CreateEngine();
+
+                engine.RegisterTaskTeardownAction((cc, tc) => { throw new InvalidOperationException("Task Teardown: " + tc.Task.Name); });
+                engine.RegisterTask("A").Does(() => { throw new InvalidOperationException("Task: A"); });
+
+                // When
+                var result = Record.Exception(() =>
+                    engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
+
+                // Then
+                Assert.True(fixture.Log.Messages.Any(x => x.StartsWith("Task Teardown error (A):")));
+            }
         }
     }
 }

--- a/src/Cake.Core.Tests/Unit/CakeTaskTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeTaskTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Xunit;
 
 namespace Cake.Core.Tests.Unit
@@ -225,6 +226,25 @@ namespace Cake.Core.Tests.Unit
                 Assert.IsType<CakeException>(result);
                 Assert.Equal("There can only be one error reporter per task.", result.Message);
             }
+        }
+        
+        [Fact]
+        public void Should_Implement_ICakeTaskInfo()
+        {
+            // Given
+            var task = new ActionTask("task");
+            task.AddDependency("dependency1");
+            task.AddDependency("dependency2");
+            task.Description = "my description";
+
+            // When
+            ICakeTaskInfo result = task;
+
+            // Then
+            Assert.IsAssignableFrom<ICakeTaskInfo>(task);
+            Assert.Equal("task", result.Name);
+            Assert.Equal("my description", result.Description);
+            Assert.Equal(new[] { "dependency1", "dependency2" }, result.Dependencies.ToArray());
         }
     }
 }

--- a/src/Cake.Core.Tests/Unit/Scripting/ScriptHostTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/ScriptHostTests.cs
@@ -1,4 +1,5 @@
-﻿using Cake.Core.Tests.Fixtures;
+﻿using System;
+using Cake.Core.Tests.Fixtures;
 using NSubstitute;
 using Xunit;
 
@@ -53,6 +54,42 @@ namespace Cake.Core.Tests.Unit.Scripting
 
                 // Then
                 fixture.Engine.Received(1).RegisterTask("Task");
+            }
+        }
+
+        public sealed class TheTaskSetupMethod
+        {
+            [Fact]
+            public void Should_Proxy_Call_To_Engine()
+            {
+                // Given
+                var fixture = new ScriptHostFixture();
+                var host = fixture.CreateHost();
+                Action<ICakeContext, ITaskSetupContext> action = (context, setupContext) => { };
+
+                // When
+                host.TaskSetup(action);
+
+                // Then
+                fixture.Engine.Received().RegisterTaskSetupAction(action);
+            }
+        }
+
+        public sealed class TheTaskTeardownMethod
+        {
+            [Fact]
+            public void Should_Proxy_Call_To_Engine()
+            {
+                // Given
+                var fixture = new ScriptHostFixture();
+                var host = fixture.CreateHost();
+                Action<ICakeContext, ITaskTeardownContext> action = (context, setupContext) => { };
+
+                // When
+                host.TaskTeardown(action);
+
+                // Then
+                fixture.Engine.Received().RegisterTaskTeardownAction(action);
             }
         }
     }

--- a/src/Cake.Core.Tests/Unit/TaskSetupContextTests.cs
+++ b/src/Cake.Core.Tests/Unit/TaskSetupContextTests.cs
@@ -1,0 +1,21 @@
+using System;
+using Xunit;
+
+namespace Cake.Core.Tests.Unit
+{
+    public sealed class TaskSetupContextTests
+    {
+        public sealed class TheConstructor
+        {
+            [Fact]
+            public void Should_Throw_If_Task_Is_Null()
+            {
+                // Given, When
+                var result = Record.Exception(() => new TaskTeardownContext(null,TimeSpan.Zero, false));
+
+                // Then
+                Assert.IsArgumentNullException(result, "task");
+            }
+        }
+    }
+}

--- a/src/Cake.Core.Tests/Unit/TaskTeardownContextTests.cs
+++ b/src/Cake.Core.Tests/Unit/TaskTeardownContextTests.cs
@@ -1,0 +1,20 @@
+using Xunit;
+
+namespace Cake.Core.Tests.Unit
+{
+    public sealed class TaskTeardownContextTests
+    {
+        public sealed class TheConstructor
+        {
+            [Fact]
+            public void Should_Throw_If_Task_Is_Null()
+            {
+                // Given, When
+                var result = Record.Exception(() => new TaskSetupContext(null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "task");
+            }
+        }
+    }
+}

--- a/src/Cake.Core/Cake.Core.csproj
+++ b/src/Cake.Core/Cake.Core.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="Extensions\TypeExtensions.cs" />
     <Compile Include="ICakeArguments.cs" />
+    <Compile Include="ICakeTaskInfo.cs" />
     <Compile Include="IExecutionStrategy.cs" />
     <Compile Include="ICakeReportPrinter.cs" />
     <Compile Include="IConsole.cs" />
@@ -144,6 +145,8 @@
     <Compile Include="IO\Arguments\TextArgument.cs" />
     <Compile Include="IO\WindowsRegistry.cs" />
     <Compile Include="IO\WindowsRegistryKey.cs" />
+    <Compile Include="ITaskSetupContext.cs" />
+    <Compile Include="ITaskTeardownContext.cs" />
     <Compile Include="Properties\Namespaces.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -174,6 +177,8 @@
     <Compile Include="Scripting\ScriptProcessor.cs" />
     <Compile Include="Scripting\ScriptProcessorContext.cs" />
     <Compile Include="Scripting\ScriptRunner.cs" />
+    <Compile Include="TaskSetupContext.cs" />
+    <Compile Include="TaskTeardownContext.cs" />
     <Compile Include="Text\ITextTransformationTemplate.cs" />
     <Compile Include="Text\TextTransformationTemplate.cs" />
     <Compile Include="Utilities\Tool.cs" />

--- a/src/Cake.Core/CakeTask.cs
+++ b/src/Cake.Core/CakeTask.cs
@@ -8,7 +8,7 @@ namespace Cake.Core
     /// <summary>
     /// A <see cref="CakeTask"/> represents a unit of work.
     /// </summary>
-    public abstract class CakeTask
+    public abstract class CakeTask : ICakeTaskInfo
     {
         private readonly string _name;
         private readonly List<string> _dependencies;

--- a/src/Cake.Core/DefaultExecutionStrategy.cs
+++ b/src/Cake.Core/DefaultExecutionStrategy.cs
@@ -129,5 +129,45 @@ namespace Cake.Core
                 action();
             }
         }
+
+        /// <summary>
+        /// Performs the specified setup action before each task is invoked.
+        /// </summary>
+        /// <param name="action">The action.</param>
+        /// <param name="context">The context.</param>
+        /// <param name="setupContext">The setup context.</param>
+        public void PerformTaskSetup(Action<ICakeContext, ITaskSetupContext> action, ICakeContext context, ITaskSetupContext setupContext)
+        {
+            if (action != null)
+            {
+                _log.Information(string.Empty);
+                _log.Information("----------------------------------------");
+                _log.Information("Task Setup ({0})", setupContext.Task.Name);
+                _log.Information("----------------------------------------");
+                _log.Verbose("Executing custom task setup action ({0})...", setupContext.Task.Name);
+
+                action(context, setupContext);
+            }
+        }
+
+        /// <summary>
+        /// Performs the specified teardown action after each task is invoked.
+        /// </summary>
+        /// <param name="action">The action.</param>
+        /// <param name="context">The context.</param>
+        /// <param name="teardownContext">The teardown context.</param>
+        public void PerformTaskTeardown(Action<ICakeContext, ITaskTeardownContext> action, ICakeContext context, ITaskTeardownContext teardownContext)
+        {
+            if (action != null)
+            {
+                _log.Information(string.Empty);
+                _log.Information("----------------------------------------");
+                _log.Information("Task Teardown ({0})", teardownContext.Task.Name);
+                _log.Information("----------------------------------------");
+                _log.Verbose("Executing custom task teardown action ({0})...", teardownContext.Task.Name);
+
+                action(context, teardownContext);
+            }
+        }
     }
 }

--- a/src/Cake.Core/ICakeEngine.cs
+++ b/src/Cake.Core/ICakeEngine.cs
@@ -43,5 +43,19 @@ namespace Cake.Core
         /// <param name="target">The target to run.</param>
         /// <returns>The resulting report.</returns>
         CakeReport RunTarget(ICakeContext context, IExecutionStrategy strategy, string target);
+
+        /// <summary>
+        /// Allows registration of an action that's executed before each task is run.
+        /// If the task setup fails, the task will not be executed but the task's teardown will be performed.
+        /// </summary>
+        /// <param name="action">The action to be executed.</param>
+        void RegisterTaskSetupAction(Action<ICakeContext, ITaskSetupContext> action);
+
+        /// <summary>
+        /// Allows registration of an action that's executed after each task has been run.
+        /// If a task setup action or a task fails with or without recovery, the specified task teardown action will still be executed.
+        /// </summary>
+        /// <param name="action">The action to be executed.</param>
+        void RegisterTaskTeardownAction(Action<ICakeContext, ITaskTeardownContext> action);
     }
 }

--- a/src/Cake.Core/ICakeTaskInfo.cs
+++ b/src/Cake.Core/ICakeTaskInfo.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+
+namespace Cake.Core
+{
+    /// <summary>
+    /// Provides descriptive properties about a cake task
+    /// </summary>
+    public interface ICakeTaskInfo
+    {
+        /// <summary>
+        /// Gets the name of the task.
+        /// </summary>
+        /// <value>The name of the task.</value>
+        string Name { get; }
+
+        /// <summary>
+        /// Gets the description of the task.
+        /// </summary>
+        /// <value>The description of the task.</value>
+        string Description { get; }
+
+        /// <summary>
+        /// Gets the task's dependencies.
+        /// </summary>
+        /// <value>The task's dependencies.</value>
+        IReadOnlyList<string> Dependencies { get; }
+    }
+}

--- a/src/Cake.Core/IExecutionStrategy.cs
+++ b/src/Cake.Core/IExecutionStrategy.cs
@@ -51,5 +51,21 @@ namespace Cake.Core
         /// </summary>
         /// <param name="action">The action.</param>
         void InvokeFinally(Action action);
+        
+        /// <summary>
+        /// Performs the specified setup action before each task is invoked.
+        /// </summary>
+        /// <param name="action">The action.</param>
+        /// <param name="context">The context.</param>
+        /// <param name="setupContext">The setup context.</param>
+        void PerformTaskSetup(Action<ICakeContext, ITaskSetupContext> action, ICakeContext context, ITaskSetupContext setupContext);
+
+        /// <summary>
+        /// Performs the specified teardown action after each task is invoked.
+        /// </summary>
+        /// <param name="action">The action.</param>
+        /// <param name="context">The context.</param>
+        /// <param name="teardownContext">The teardown context.</param>
+        void PerformTaskTeardown(Action<ICakeContext, ITaskTeardownContext> action, ICakeContext context, ITaskTeardownContext teardownContext);
     }
 }

--- a/src/Cake.Core/ITaskSetupContext.cs
+++ b/src/Cake.Core/ITaskSetupContext.cs
@@ -1,0 +1,16 @@
+﻿namespace Cake.Core
+{
+    /// <summary>
+    /// Acts as a context providing info about a <see cref="CakeTask"/> before its invocation.
+    /// </summary>
+    public interface ITaskSetupContext
+    {
+        /// <summary>
+        /// Gets the <see cref="ICakeTaskInfo"/> describing the <see cref="CakeTask"/> that has just been invoked.
+        /// </summary>
+        /// <value>
+        /// The task.
+        /// </value>
+        ICakeTaskInfo Task { get; }
+    }
+}

--- a/src/Cake.Core/ITaskTeardownContext.cs
+++ b/src/Cake.Core/ITaskTeardownContext.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Cake.Core
+{    
+    /// <summary>
+    /// Acts as a context providing info about a <see cref="CakeTask"/> following its invocation.
+    /// </summary>
+    public interface ITaskTeardownContext
+    {
+        /// <summary>
+        /// Gets the <see cref="ICakeTaskInfo"/> describing the <see cref="CakeTask"/> that has just been invoked.
+        /// </summary>
+        /// <value>
+        /// The task.
+        /// </value>
+        ICakeTaskInfo Task { get; }
+
+        /// <summary>
+        /// Gets the duration of the <see cref="CakeTask"/>'s execution.
+        /// </summary>
+        /// <value>
+        /// The duration of the <see cref="CakeTask"/>'s execution.
+        /// </value>
+        TimeSpan Duration { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this <see cref="CakeTask"/> was skipped (not executed).
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if skipped; otherwise, <c>false</c>.
+        /// </value>
+        bool Skipped { get; }
+    }
+}

--- a/src/Cake.Core/Scripting/IScriptHost.cs
+++ b/src/Cake.Core/Scripting/IScriptHost.cs
@@ -42,6 +42,20 @@ namespace Cake.Core.Scripting
         void Teardown(Action action);
 
         /// <summary>
+        /// Allows registration of an action that's executed before each task is run.
+        /// If the task setup fails, its task will not be executed but the task teardown will be performed.
+        /// </summary>
+        /// <param name="action">The action to be executed.</param>
+        void TaskSetup(Action<ICakeContext, ITaskSetupContext> action);
+
+        /// <summary>
+        /// Allows registration of an action that's executed after each task has been run.
+        /// If a task setup action or a task fails with or without recovery, the specified task teardown action will still be executed.
+        /// </summary>
+        /// <param name="action">The action to be executed.</param>
+        void TaskTeardown(Action<ICakeContext, ITaskTeardownContext> action);
+
+        /// <summary>
         /// Runs the specified target.
         /// </summary>
         /// <param name="target">The target to run.</param>

--- a/src/Cake.Core/Scripting/ScriptHost.cs
+++ b/src/Cake.Core/Scripting/ScriptHost.cs
@@ -88,6 +88,26 @@ namespace Cake.Core.Scripting
         }
 
         /// <summary>
+        /// Allows registration of an action that's executed before each task is run.
+        /// If the task setup fails, its task will not be executed but the task teardown will be performed.
+        /// </summary>
+        /// <param name="action">The action to be executed.</param>
+        public void TaskSetup(Action<ICakeContext, ITaskSetupContext> action)
+        {
+            _engine.RegisterTaskSetupAction(action);
+        }
+
+        /// <summary>
+        /// Allows registration of an action that's executed after each task has been run.
+        /// If a task setup action or a task fails with or without recovery, the specified task teardown action will still be executed.
+        /// </summary>
+        /// <param name="action">The action to be executed.</param>
+        public void TaskTeardown(Action<ICakeContext, ITaskTeardownContext> action)
+        {
+            _engine.RegisterTaskTeardownAction(action);
+        }
+
+        /// <summary>
         /// Runs the specified target.
         /// </summary>
         /// <param name="target">The target to run.</param>

--- a/src/Cake.Core/TaskSetupContext.cs
+++ b/src/Cake.Core/TaskSetupContext.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace Cake.Core
+{
+    /// <summary>
+    /// Acts as a context providing info about a <see cref="CakeTask"/> before its invocation.
+    /// </summary>
+    public sealed class TaskSetupContext : ITaskSetupContext
+    {
+        private readonly ICakeTaskInfo _task;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TaskSetupContext"/> class.
+        /// </summary>
+        /// <param name="task">The task.</param>
+        public TaskSetupContext(ICakeTaskInfo task)
+        {
+            if (task == null)
+            {
+                throw new ArgumentNullException("task");
+            }
+
+            _task = task;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ICakeTaskInfo"/> describing the <see cref="CakeTask"/> that has just been invoked.
+        /// </summary>
+        /// <value>
+        /// The task.
+        /// </value>
+        public ICakeTaskInfo Task
+        {
+            get { return _task; }
+        }
+    }
+}

--- a/src/Cake.Core/TaskTeardownContext.cs
+++ b/src/Cake.Core/TaskTeardownContext.cs
@@ -1,0 +1,65 @@
+using System;
+
+namespace Cake.Core
+{
+    /// <summary>
+    /// Acts as a context providing info about a <see cref="ICakeTaskInfo"/> following its invocation.
+    /// </summary>
+    public sealed class TaskTeardownContext : ITaskTeardownContext
+    {
+        private readonly ICakeTaskInfo _task;
+        private readonly TimeSpan _duration;
+        private readonly bool _skipped;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TaskTeardownContext"/> class.
+        /// </summary>
+        /// <param name="task">The task.</param>
+        /// <param name="duration">The duration of the task.</param>
+        /// <param name="skipped">if set to <c>true</c>, the task was not executed.</param>
+        public TaskTeardownContext(ICakeTaskInfo task, TimeSpan duration, bool skipped)
+        {
+            if (task == null)
+            {
+                throw new ArgumentNullException("task");
+            }
+
+            _task = task;
+            _duration = duration;
+            _skipped = skipped;
+        }
+        
+        /// <summary>
+        /// Gets the <see cref="ICakeTaskInfo" /> describing the <see cref="CakeTask" /> that has just been invoked.
+        /// </summary>
+        /// <value>
+        /// The task.
+        /// </value>
+        public ICakeTaskInfo Task
+        {
+            get { return _task; }
+        }
+
+        /// <summary>
+        /// Gets the duration of the <see cref="CakeTask"/>'s execution.
+        /// </summary>
+        /// <value>
+        /// The duration of the <see cref="CakeTask"/>'s execution.
+        /// </value>
+        public TimeSpan Duration
+        {
+            get { return _duration; }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="CakeTask"/> was skipped (not executed).
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if skipped; otherwise, <c>false</c>.
+        /// </value>
+        public bool Skipped
+        {
+            get { return _skipped; }
+        }
+    }
+}

--- a/src/Cake/Scripting/DryRunExecutionStrategy.cs
+++ b/src/Cake/Scripting/DryRunExecutionStrategy.cs
@@ -51,5 +51,13 @@ namespace Cake.Scripting
         public void InvokeFinally(Action action)
         {
         }
+
+        public void PerformTaskSetup(Action<ICakeContext, ITaskSetupContext> action, ICakeContext context, ITaskSetupContext setupContext)
+        {
+        }
+
+        public void PerformTaskTeardown(Action<ICakeContext, ITaskTeardownContext> action, ICakeContext context, ITaskTeardownContext teardownContext)
+        {
+        }
     }
 }


### PR DESCRIPTION
Initial design approach for #389, submitted for feedback. Code is not tested or documented.

I'm not in love with the procedural logic in `CakeEngine` -- I think my implementation could benefit from a bit of internal refactoring of that class's existing code.