### PR TITLE
Add path to nuget resolver for mono on osx 10.11

### DIFF
--- a/src/Cake.Core/IO/NuGet/NuGetToolResolver.cs
+++ b/src/Cake.Core/IO/NuGet/NuGetToolResolver.cs
@@ -13,6 +13,8 @@ namespace Cake.Core.IO.NuGet
         private readonly IGlobber _globber;
         private IFile _cachedPath;
 
+        private static readonly FilePath[] unixSystemPaths = new[] { new FilePath("/usr/local/bin/nuget"), new FilePath("/usr/bin/nuget") };
+
         /// <summary>
         /// Initializes a new instance of the <see cref="NuGetToolResolver" /> class.
         /// </summary>
@@ -75,16 +77,17 @@ namespace Cake.Core.IO.NuGet
                 }
             }
 
-            // On Unix /usr/bin/nuget is a viable option
+            // On Unix /usr/bin/nuget or /usr/local/bin/nuget are viable options
             if (_environment.IsUnix())
-            {
-                var nugetUnixPath = new FilePath("/usr/bin/nuget");
-
-                if (_fileSystem.Exist(nugetUnixPath))
+            {                
+                foreach (var systemPath in unixSystemPaths)
                 {
-                    _cachedPath = _fileSystem.GetFile(nugetUnixPath);
-                    return _cachedPath.Path;
-                }
+                    if (_fileSystem.Exist(systemPath))
+                    {
+                        _cachedPath = _fileSystem.GetFile(systemPath);
+                        return _cachedPath.Path;
+                    }    
+                }                
             }
 
             // Last resort try path


### PR DESCRIPTION
On OSX 10.11 (El Capitan) we can no longer have `/usr/bin/nuget` as `/usr/bin/` is not writeable.  The new location for this symlink will be `/usr/local/bin/nuget` so we should check for that.