### PR TITLE
Added verbose message when glob pattern did not match anything.

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/XmlDocExampleCodeParserFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/XmlDocExampleCodeParserFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using Cake.Common.Solution.Project.XmlDoc;
 using Cake.Common.Tests.Properties;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.Testing.Fakes;
 using NSubstitute;
@@ -11,6 +12,7 @@ namespace Cake.Common.Tests.Fixtures
     {
         public IFileSystem FileSystem { get; set; }
         public IGlobber Globber { get; set; }
+        public ICakeLog Log { get; set; }
         public FilePath XmlFilePath { get; set; }
         public string Pattern { get; set; }
 
@@ -27,17 +29,19 @@ namespace Cake.Common.Tests.Fixtures
 
             Globber = Substitute.For<IGlobber>();
             Globber.GetFiles(Pattern).Returns(new FilePath[] { "/Working/Cake.Common.xml", "/Working/Cake.UnCommon.xml"});
+
+            Log = Substitute.For<ICakeLog>();
         }
 
         public IEnumerable<XmlDocExampleCode> Parse()
         {
-            var parser = new XmlDocExampleCodeParser(FileSystem, Globber);
+            var parser = new XmlDocExampleCodeParser(FileSystem, Globber, Log);
             return parser.Parse(XmlFilePath);
         }
 
         public IEnumerable<XmlDocExampleCode> ParseFiles()
         {
-            var parser = new XmlDocExampleCodeParser(FileSystem, Globber);
+            var parser = new XmlDocExampleCodeParser(FileSystem, Globber, Log);
             return parser.ParseFiles(Pattern);
         }
     }

--- a/src/Cake.Common.Tests/Unit/IO/FileAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/FileAliasesTests.cs
@@ -430,7 +430,7 @@ namespace Cake.Common.Tests.Unit.IO
 
                     // When
                     var result = Record.Exception(() =>
-                        FileAliases.CopyFiles(fixture.Context, "", null));
+                        FileAliases.CopyFiles(fixture.Context, "*", null));
 
                     // Then
                     Assert.IsArgumentNullException(result, "targetDirectoryPath");
@@ -840,7 +840,7 @@ namespace Cake.Common.Tests.Unit.IO
 
                     // When
                     var result = Record.Exception(() =>
-                        FileAliases.MoveFiles(fixture.Context, "", null));
+                        FileAliases.MoveFiles(fixture.Context, "*", null));
 
                     // Then
                     Assert.IsArgumentNullException(result, "targetDirectoryPath");

--- a/src/Cake.Common/IO/DirectoryAliases.cs
+++ b/src/Cake.Common/IO/DirectoryAliases.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Cake.Common.IO.Paths;
 using Cake.Core;
 using Cake.Core.Annotations;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 
 namespace Cake.Common.IO
@@ -140,6 +141,11 @@ namespace Cake.Common.IO
         public static void CleanDirectories(this ICakeContext context, string pattern)
         {
             var directories = context.GetDirectories(pattern);
+            if (directories.Count == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any directories.");
+                return;
+            }
             CleanDirectories(context, directories);
         }
 
@@ -164,6 +170,11 @@ namespace Cake.Common.IO
         public static void CleanDirectories(this ICakeContext context, string pattern, Func<IFileSystemInfo, bool> predicate)
         {
             var directories = context.GetDirectories(pattern, predicate);
+            if (directories.Count == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any directories.");
+                return;
+            }
             CleanDirectories(context, directories);
         }
 

--- a/src/Cake.Common/IO/FileCopier.cs
+++ b/src/Cake.Common/IO/FileCopier.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using Cake.Core;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 
 namespace Cake.Common.IO
@@ -65,6 +66,11 @@ namespace Cake.Common.IO
                 throw new ArgumentNullException("pattern");
             }
             var files = context.GetFiles(pattern);
+            if (files.Count == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any files.");
+                return;
+            }
             CopyFiles(context, files, targetDirectoryPath);
         }
 

--- a/src/Cake.Common/IO/FileDeleter.cs
+++ b/src/Cake.Common/IO/FileDeleter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using Cake.Core;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 
 namespace Cake.Common.IO
@@ -19,7 +20,15 @@ namespace Cake.Common.IO
             {
                 throw new ArgumentNullException("pattern");
             }
-            DeleteFiles(context, context.GetFiles(pattern));
+
+            var files = context.GetFiles(pattern);
+            if (files.Count == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any files.");
+                return;
+            }
+
+            DeleteFiles(context, files);
         }
 
         public static void DeleteFiles(ICakeContext context, IEnumerable<FilePath> filePaths)

--- a/src/Cake.Common/IO/FileMover.cs
+++ b/src/Cake.Common/IO/FileMover.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using Cake.Core;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 
 namespace Cake.Common.IO
@@ -36,7 +37,14 @@ namespace Cake.Common.IO
             {
                 throw new ArgumentNullException("pattern");
             }
+
             var files = context.GetFiles(pattern);
+            if (files.Count == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any files.");
+                return;
+            }
+
             MoveFiles(context, files, targetDirectoryPath);
         }
 
@@ -57,7 +65,7 @@ namespace Cake.Common.IO
 
             targetDirectoryPath = targetDirectoryPath.MakeAbsolute(context.Environment);
 
-            // Make sure the target directory exist.            
+            // Make sure the target directory exist.
             if (!context.FileSystem.Exist(targetDirectoryPath))
             {
                 const string format = "The directory '{0}' do not exist.";

--- a/src/Cake.Common/IO/ZipAliases.cs
+++ b/src/Cake.Common/IO/ZipAliases.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Cake.Core;
 using Cake.Core.Annotations;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 
 namespace Cake.Common.IO
@@ -47,6 +48,11 @@ namespace Cake.Common.IO
         public static void Zip(this ICakeContext context, DirectoryPath rootPath, FilePath outputPath, string pattern)
         {
             var filePaths = context.GetFiles(pattern);
+            if (filePaths.Count == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any files.");
+                return;
+            }
             Zip(context, rootPath, outputPath, filePaths);
         }
 

--- a/src/Cake.Common/Solution/Project/XmlDoc/XmlDocAliases.cs
+++ b/src/Cake.Common/Solution/Project/XmlDoc/XmlDocAliases.cs
@@ -44,7 +44,7 @@ namespace Cake.Common.Solution.Project.XmlDoc
                 throw new ArgumentNullException("xmlFilePath");
             }
 
-            var parser = new XmlDocExampleCodeParser(context.FileSystem, context.Globber);
+            var parser = new XmlDocExampleCodeParser(context.FileSystem, context.Globber, context.Log);
             return parser.Parse(xmlFilePath);
         }
 
@@ -80,7 +80,7 @@ namespace Cake.Common.Solution.Project.XmlDoc
                 throw new ArgumentNullException("pattern");
             }
 
-            var parser = new XmlDocExampleCodeParser(context.FileSystem, context.Globber);
+            var parser = new XmlDocExampleCodeParser(context.FileSystem, context.Globber, context.Log);
             return parser.ParseFiles(pattern);
         }
     }

--- a/src/Cake.Common/Solution/Project/XmlDoc/XmlDocExampleCodeParser.cs
+++ b/src/Cake.Common/Solution/Project/XmlDoc/XmlDocExampleCodeParser.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 
 namespace Cake.Common.Solution.Project.XmlDoc
@@ -16,13 +17,15 @@ namespace Cake.Common.Solution.Project.XmlDoc
     {
         private readonly IFileSystem _fileSystem;
         private readonly IGlobber _globber;
+        private readonly ICakeLog _log;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="XmlDocExampleCodeParser"/> class.
         /// </summary>
         /// <param name="fileSystem">The file system.</param>
         /// <param name="globber">The globber.</param>
-        public XmlDocExampleCodeParser(IFileSystem fileSystem, IGlobber globber)
+        /// <param name="log">The log.</param>
+        public XmlDocExampleCodeParser(IFileSystem fileSystem, IGlobber globber, ICakeLog log)
         {
             if (fileSystem == null)
             {
@@ -36,6 +39,7 @@ namespace Cake.Common.Solution.Project.XmlDoc
 
             _fileSystem = fileSystem;
             _globber = globber;
+            _log = log;
         }
 
         /// <summary>
@@ -89,8 +93,14 @@ namespace Cake.Common.Solution.Project.XmlDoc
                 throw new ArgumentNullException("pattern", "Invalid pattern supplied.");
             }
 
-            return _globber.GetFiles(pattern)
-                .SelectMany(Parse);
+            var files = _globber.GetFiles(pattern).ToArray();
+            if (files.Length == 0)
+            {
+                _log.Verbose("The provided pattern did not match any files.");
+                return Enumerable.Empty<XmlDocExampleCode>();
+            }
+
+            return files.SelectMany(Parse);
         }
     }
 }

--- a/src/Cake.Common/Tools/DupFinder/DupFinderAliases.cs
+++ b/src/Cake.Common/Tools/DupFinder/DupFinderAliases.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Cake.Core;
 using Cake.Core.Annotations;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 
 namespace Cake.Common.Tools.DupFinder
@@ -105,7 +106,13 @@ namespace Cake.Common.Tools.DupFinder
             {
                 throw new ArgumentNullException("pattern");
             }
-            var sourceFiles = context.Globber.Match(pattern).OfType<FilePath>();
+
+            var sourceFiles = context.Globber.GetFiles(pattern).ToArray();
+            if (sourceFiles.Length == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any files.");
+                return;
+            }
 
             var runner = new DupFinderRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber);
             runner.Run(sourceFiles, settings);

--- a/src/Cake.Common/Tools/Fixie/FixieAliases.cs
+++ b/src/Cake.Common/Tools/Fixie/FixieAliases.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Cake.Core;
 using Cake.Core.Annotations;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 
 namespace Cake.Common.Tools.Fixie
@@ -26,7 +27,13 @@ namespace Cake.Common.Tools.Fixie
                 throw new ArgumentNullException("context");
             }
 
-            var assemblies = context.Globber.GetFiles(pattern);
+            var assemblies = context.Globber.GetFiles(pattern).ToArray();
+            if (assemblies.Length == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any files.");
+                return;
+            }
+
             Fixie(context, assemblies, new FixieSettings());
         }
 
@@ -45,7 +52,13 @@ namespace Cake.Common.Tools.Fixie
                 throw new ArgumentNullException("context");
             }
 
-            var assemblies = context.Globber.GetFiles(pattern);
+            var assemblies = context.Globber.GetFiles(pattern).ToArray();
+            if (assemblies.Length == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any files.");
+                return;
+            }
+
             Fixie(context, assemblies, settings);
         }
 

--- a/src/Cake.Common/Tools/MSTest/MSTestAliases.cs
+++ b/src/Cake.Common/Tools/MSTest/MSTestAliases.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Cake.Core;
 using Cake.Core.Annotations;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 
 namespace Cake.Common.Tools.MSTest
@@ -24,7 +26,14 @@ namespace Cake.Common.Tools.MSTest
             {
                 throw new ArgumentNullException("context");
             }
-            var assemblies = context.Globber.GetFiles(pattern);
+
+            var assemblies = context.Globber.GetFiles(pattern).ToArray();
+            if (assemblies.Length == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any files.");
+                return;
+            }
+
             MSTest(context, assemblies);
         }
 
@@ -41,7 +50,14 @@ namespace Cake.Common.Tools.MSTest
             {
                 throw new ArgumentNullException("context");
             }
-            var assemblies = context.Globber.GetFiles(pattern);
+
+            var assemblies = context.Globber.GetFiles(pattern).ToArray();
+            if (assemblies.Length == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any files.");
+                return;
+            }
+
             MSTest(context, assemblies, settings);
         }
 

--- a/src/Cake.Common/Tools/NUnit/NUnitAliases.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnitAliases.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Cake.Core;
 using Cake.Core.Annotations;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 
 namespace Cake.Common.Tools.NUnit
@@ -26,7 +27,13 @@ namespace Cake.Common.Tools.NUnit
                 throw new ArgumentNullException("context");
             }
 
-            var assemblies = context.Globber.GetFiles(pattern);
+            var assemblies = context.Globber.GetFiles(pattern).ToArray();
+            if (assemblies.Length == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any files.");
+                return;
+            }
+
             NUnit(context, assemblies, new NUnitSettings());
         }
 
@@ -45,7 +52,13 @@ namespace Cake.Common.Tools.NUnit
                 throw new ArgumentNullException("context");
             }
 
-            var assemblies = context.Globber.GetFiles(pattern);
+            var assemblies = context.Globber.GetFiles(pattern).ToArray();
+            if (assemblies.Length == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any files.");
+                return;
+            }
+
             NUnit(context, assemblies, settings);
         }
 

--- a/src/Cake.Common/Tools/WiX/WiXAliases.cs
+++ b/src/Cake.Common/Tools/WiX/WiXAliases.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Cake.Core;
 using Cake.Core.Annotations;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 
 namespace Cake.Common.Tools.WiX
@@ -27,7 +29,13 @@ namespace Cake.Common.Tools.WiX
                 throw new ArgumentNullException("context");
             }
 
-            var files = context.Globber.GetFiles(pattern);
+            var files = context.Globber.GetFiles(pattern).ToArray();
+            if (files.Length == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any files.");
+                return;
+            }
+
             WiXCandle(context, files, settings ?? new CandleSettings());
         }
 
@@ -65,7 +73,13 @@ namespace Cake.Common.Tools.WiX
                 throw new ArgumentNullException("context");
             }
 
-            var files = context.Globber.GetFiles(pattern);
+            var files = context.Globber.GetFiles(pattern).ToArray();
+            if (files.Length == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any files.");
+                return;
+            }
+
             WiXLight(context, files, settings ?? new LightSettings());
         }
 

--- a/src/Cake.Common/Tools/XUnit/XUnit2Aliases.cs
+++ b/src/Cake.Common/Tools/XUnit/XUnit2Aliases.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Cake.Core;
 using Cake.Core.Annotations;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 
 namespace Cake.Common.Tools.XUnit
@@ -26,7 +27,13 @@ namespace Cake.Common.Tools.XUnit
                 throw new ArgumentNullException("context");
             }
 
-            var assemblies = context.Globber.GetFiles(pattern);
+            var assemblies = context.Globber.GetFiles(pattern).ToArray();
+            if (assemblies.Length == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any files.");
+                return;
+            }
+
             XUnit2(context, assemblies, new XUnit2Settings());
         }
 
@@ -44,7 +51,13 @@ namespace Cake.Common.Tools.XUnit
                 throw new ArgumentNullException("context");
             }
 
-            var assemblies = context.Globber.GetFiles(pattern);
+            var assemblies = context.Globber.GetFiles(pattern).ToArray();
+            if (assemblies.Length == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any files.");
+                return;
+            }
+
             XUnit2(context, assemblies, settings);
         }
 

--- a/src/Cake.Core.Tests/Unit/IO/GlobberTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/GlobberTests.cs
@@ -206,6 +206,21 @@ namespace Cake.Core.Tests.Unit.IO
             }
 
             [Fact]
+            public void Should_Be_Able_To_Back_Down_One_Directory_Using_Double_Dots()
+            {
+                // Given
+                var fixture = new GlobberFixture();
+
+                // When
+                var result = fixture.Match("/Working/Foo/../Foo/Bar/Qux.c");
+
+                // Then
+                Assert.Equal(1, result.Length);
+                Assert.IsType<FilePath>(result[0]);
+                Assert.ContainsFilePath(result, "/Working/Foo/Bar/Qux.c");
+            }
+
+            [Fact]
             public void Should_Return_Single_Path_For_Absolute_File_Path_Without_Glob_Pattern()
             {
                 // Given

--- a/src/Cake.Core/IO/Globbing/GlobToken.cs
+++ b/src/Cake.Core/IO/Globbing/GlobToken.cs
@@ -5,12 +5,6 @@
         private readonly GlobTokenKind _kind;
         private readonly string _value;
 
-        public GlobToken(GlobTokenKind kind, string value)
-        {
-            _kind = kind;
-            _value = value;
-        }
-
         public GlobTokenKind Kind
         {
             get { return _kind; }
@@ -19,6 +13,12 @@
         public string Value
         {
             get { return _value; }
+        }
+
+        public GlobToken(GlobTokenKind kind, string value)
+        {
+            _kind = kind;
+            _value = value;
         }
     }
 }

--- a/src/Cake.Core/IO/Globbing/GlobVisitorContext.cs
+++ b/src/Cake.Core/IO/Globbing/GlobVisitorContext.cs
@@ -55,10 +55,12 @@ namespace Cake.Core.IO.Globbing
             _path = GenerateFullPath();
         }
 
-        public void Pop()
+        public string Pop()
         {
+            var last = _pathParts.Last;
             _pathParts.RemoveLast();
             _path = GenerateFullPath();
+            return last.Value;
         }
 
         private DirectoryPath GenerateFullPath()


### PR DESCRIPTION
Sometimes when providing a glob pattern to certain aliases such
as NUnit or XUnit, a mistake in the pattern will result in
zero files being matched. This is kind of annoying since the
call to the alias will silently pass. This might be by design
but we should at least write a verbose message saying that no
files or directories were matched.

Closes #408