### PR TITLE
Added Environment IDictionary<string, string> GetEnvironmentVariables()

### DIFF
--- a/src/Cake.Common/EnviromentAliases.cs
+++ b/src/Cake.Common/EnviromentAliases.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Cake.Core;
 using Cake.Core.Annotations;
 
@@ -34,6 +35,42 @@ namespace Cake.Common
                 throw new ArgumentNullException("variable");
             }
             return context.Environment.GetEnvironmentVariable(variable);
+        }
+
+        /// <summary>
+        /// Retrieves all environment variables
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var envVars = EnvironmentVariables();
+        /// 
+        /// string path;
+        /// if (envVars.TryGetValue("PATH", out path))
+        /// {
+        ///     Information("Path: {0}", path);
+        /// }
+        /// 
+        /// foreach(var envVar in envVars)
+        /// {
+        ///     Information(
+        ///         "Key: {0}\tValue: \"{1}\"",
+        ///         envVar.Key,
+        ///         envVar.Value
+        ///         );
+        /// }
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <returns>The environment varia</returns>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Environment Variables")]
+        public static IDictionary<string, string> EnvironmentVariables(this ICakeContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            return context.Environment.GetEnvironmentVariables();
         }
 
         /// <summary>

--- a/src/Cake.Core/CakeEnvironment.cs
+++ b/src/Cake.Core/CakeEnvironment.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Reflection;
 using Cake.Core.IO;
 
@@ -102,6 +104,20 @@ namespace Cake.Core
         public string GetEnvironmentVariable(string variable)
         {
             return Environment.GetEnvironmentVariable(variable);
+        }
+
+        /// <summary>
+        /// Gets all environment variables.
+        /// </summary>
+        /// <returns>The environment variables as IDictionary&lt;string, string&gt; </returns>
+        public IDictionary<string, string> GetEnvironmentVariables()
+        {
+            return Environment.GetEnvironmentVariables()
+                .Cast<System.Collections.DictionaryEntry>()
+                .ToDictionary(
+                key => (string)key.Key,
+                value => value.Value as string,
+                StringComparer.OrdinalIgnoreCase);
         }
 
         private static void SetWorkingDirectory(DirectoryPath path)

--- a/src/Cake.Core/ICakeEnvironment.cs
+++ b/src/Cake.Core/ICakeEnvironment.cs
@@ -1,4 +1,5 @@
-﻿using Cake.Core.IO;
+﻿using System.Collections.Generic;
+using Cake.Core.IO;
 
 namespace Cake.Core
 {
@@ -44,5 +45,11 @@ namespace Cake.Core
         /// <param name="variable">The variable.</param>
         /// <returns>The value of the environment variable.</returns>
         string GetEnvironmentVariable(string variable);
+
+        /// <summary>
+        /// Gets all environment variables.
+        /// </summary>
+        /// <returns>The environment variables as IDictionary&lt;string, string&gt; </returns>
+        IDictionary<string, string> GetEnvironmentVariables();
     }
 }

--- a/src/Cake.Testing/Fakes/FakeEnvironment.cs
+++ b/src/Cake.Testing/Fakes/FakeEnvironment.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Cake.Core;
 using Cake.Core.IO;
 
@@ -92,6 +93,15 @@ namespace Cake.Testing.Fakes
         /// The value of the environment variable.
         /// </returns>
         public string GetEnvironmentVariable(string variable)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Gets all environment variables.
+        /// </summary>
+        /// <returns>The environment variables as IDictionary&lt;string, string&gt; </returns>
+        public IDictionary<string, string> GetEnvironmentVariables()
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
In some cases you don't know which environment variables exists or you need to work with a set of environment variables.

In this proposal I add a typed version of `System.Environment.GetEnvironmentVariables()` which will give you an case insensitive `IDictionary<string, string>`

Example usage:
```csharp
var envVars = Context.Environment.GetEnvironmentVariables();

string path;
if (envVars.TryGetValue("PATH", out path))
{
    Information("Path: {0}", path);
}

foreach(var envVar in envVars)
{
    Information(
        "Key: {0}\tValue: \"{1}\"",
        envVar.Key,
        envVar.Value
        );
}
```