### PR TITLE
Added main cake repo requirement for MyGet publish

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -15,6 +15,7 @@ var isRunningOnUnix = IsRunningOnUnix();
 var isRunningOnWindows = IsRunningOnWindows();
 var isRunningOnAppVeyor = AppVeyor.IsRunningOnAppVeyor;
 var isPullRequest = AppVeyor.Environment.PullRequest.IsPullRequest;
+var isMainCakeRepo = StringComparer.OrdinalIgnoreCase.Equals("cake-build/cake", AppVeyor.Environment.Repository.Name);
 
 // Parse release notes.
 var releaseNotes = ParseReleaseNotes("./ReleaseNotes.md");
@@ -199,6 +200,7 @@ Task("Publish-MyGet")
     .WithCriteria(() => !local)
     .WithCriteria(() => !isPullRequest)
     .WithCriteria(() => isRunningOnWindows)
+    .WithCriteria(() => isMainCakeRepo)
     .Does(() =>
 {
     // Resolve the API key.


### PR DESCRIPTION
I wan't do be able to automatically build my fork of Cake too on AppVeyor. Currently it fails when trying to publish to MyGet because it lacks the proper ApiKey, obviously forks shouldn't publish to Cake MyGet feed.

So what I propose is that we check which repo is built and only if it's `cake-build/cake` should we publish to MyGet, this enables automatic builds of forks with the standard `build.cake`