### PR TITLE
Allow referencing parent directory in glob expression

### DIFF
--- a/src/Cake.Core.Tests/Unit/IO/GlobberTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/GlobberTests.cs
@@ -206,7 +206,7 @@ namespace Cake.Core.Tests.Unit.IO
             }
 
             [Fact]
-            public void Should_Be_Able_To_Back_Down_One_Directory_Using_Double_Dots()
+            public void Should_Be_Able_To_Visit_Parent_Using_Double_Dots()
             {
                 // Given
                 var fixture = new GlobberFixture();
@@ -218,6 +218,21 @@ namespace Cake.Core.Tests.Unit.IO
                 Assert.Equal(1, result.Length);
                 Assert.IsType<FilePath>(result[0]);
                 Assert.ContainsFilePath(result, "/Working/Foo/Bar/Qux.c");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Visiting_Parent_That_Is_Recursive_Wildcard()
+            {
+                // Given
+                var fixture = new GlobberFixture();
+
+                // When
+                var result = Record.Exception(() => fixture.Match("/Working/Foo/**/../Foo/Bar/Qux.c"));
+
+                // Then
+                Assert.NotNull(result);
+                Assert.IsType<NotSupportedException>(result);
+                Assert.Equal("Visiting a parent that is a recursive wildcard is not supported.", result.Message);
             }
 
             [Fact]

--- a/src/Cake.Core/Cake.Core.csproj
+++ b/src/Cake.Core/Cake.Core.csproj
@@ -103,10 +103,12 @@
     <Compile Include="IO\File.cs" />
     <Compile Include="IO\FileSystem.cs" />
     <Compile Include="IO\Globber.cs" />
+    <Compile Include="IO\Globbing\GlobNodeValidator.cs" />
     <Compile Include="IO\Globbing\Nodes\MatchableNode.cs" />
     <Compile Include="IO\Globbing\GlobNode.cs" />
     <Compile Include="IO\Globbing\GlobNodeRewriter.cs" />
     <Compile Include="IO\Globbing\GlobParserContext.cs" />
+    <Compile Include="IO\Globbing\Nodes\ParentSegment.cs" />
     <Compile Include="IO\Globbing\Nodes\RecursiveWildcardSegment.cs" />
     <Compile Include="IO\Globbing\Nodes\RelativeRoot.cs" />
     <Compile Include="IO\Globbing\Nodes\UnixRoot.cs" />

--- a/src/Cake.Core/IO/Globbing/GlobNodeValidator.cs
+++ b/src/Cake.Core/IO/Globbing/GlobNodeValidator.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Cake.Core.IO.Globbing.Nodes;
+
+namespace Cake.Core.IO.Globbing
+{
+    internal static class GlobNodeValidator
+    {
+        public static void Validate(GlobNode node)
+        {
+            var previous = (GlobNode)null;
+            var current = node;
+            while (current != null)
+            {
+                if (previous != null && previous is RecursiveWildcardSegment)
+                {
+                    if (current is ParentSegment)
+                    {
+                        throw new NotSupportedException("Visiting a parent that is a recursive wildcard is not supported.");
+                    }
+                }
+                previous = current;
+                current = current.Next;
+            }
+        }
+    }
+}

--- a/src/Cake.Core/IO/Globbing/GlobParser.cs
+++ b/src/Cake.Core/IO/Globbing/GlobParser.cs
@@ -48,8 +48,10 @@ namespace Cake.Core.IO.Globbing
                 throw new InvalidOperationException("Expected EOT");
             }
 
-            // Return the path node.
-            return GlobNodeRewriter.Rewrite(items);
+            // Rewrite the items into a linked list.
+            var result = GlobNodeRewriter.Rewrite(items);
+            GlobNodeValidator.Validate(result);
+            return result;
         }
 
         private GlobNode ParseRoot(GlobParserContext context)
@@ -113,6 +115,11 @@ namespace Cake.Core.IO.Globbing
             {
                 context.Accept();
                 return new RecursiveWildcardSegment();
+            }
+            if (context.CurrentToken.Kind == GlobTokenKind.Parent)
+            {
+                context.Accept();
+                return new ParentSegment();
             }
 
             var items = new List<GlobToken>();

--- a/src/Cake.Core/IO/Globbing/GlobTokenKind.cs
+++ b/src/Cake.Core/IO/Globbing/GlobTokenKind.cs
@@ -8,6 +8,7 @@
         PathSeparator,
         Identifier,
         WindowsRoot,
+        Parent,
         EndOfText
     }
 }

--- a/src/Cake.Core/IO/Globbing/GlobTokenizer.cs
+++ b/src/Cake.Core/IO/Globbing/GlobTokenizer.cs
@@ -48,6 +48,15 @@ namespace Cake.Core.IO.Globbing
         {
             if (IsAlphaNumberic(_currentCharacter))
             {
+                if (_currentCharacter == '.')
+                {
+                    TakeCharacter();
+                    if (_currentCharacter == '.')
+                    {
+                        TakeCharacter();
+                        return GlobTokenKind.Parent;
+                    }
+                }
                 while (IsAlphaNumberic(_currentCharacter))
                 {
                     TakeCharacter();

--- a/src/Cake.Core/IO/Globbing/GlobVisitor.cs
+++ b/src/Cake.Core/IO/Globbing/GlobVisitor.cs
@@ -118,23 +118,10 @@ namespace Cake.Core.IO.Globbing
                 }
                 else
                 {
-                    if (node.GetPath() == "..")
-                    {
-                        // Back up one level.
-                        var last = context.Pop();
-                        node.Next.Accept(this, context);
-
-                        // Push the segment back so pop/push 
-                        // count remains balanced.
-                        context.Push(last);
-                    }
-                    else
-                    {
-                        // Push the current node to the context.
-                        context.Push(node.GetPath());
-                        node.Next.Accept(this, context);
-                        context.Pop();
-                    }
+                    // Push the current node to the context.
+                    context.Push(node.GetPath());
+                    node.Next.Accept(this, context);
+                    context.Pop();
                 }
             }
             else
@@ -195,6 +182,17 @@ namespace Cake.Core.IO.Globbing
             context.Push(node.Drive + ":");
             node.Next.Accept(this, context);
             context.Pop();
+        }
+
+        public void VisitParent(ParentSegment node, GlobVisitorContext context)
+        {
+            // Back up one level.
+            var last = context.Pop();
+            node.Next.Accept(this, context);
+
+            // Push the segment back so pop/push 
+            // count remains balanced.
+            context.Push(last);
         }
 
         private static IEnumerable<IFileSystemInfo> FindCandidates(

--- a/src/Cake.Core/IO/Globbing/Nodes/ParentSegment.cs
+++ b/src/Cake.Core/IO/Globbing/Nodes/ParentSegment.cs
@@ -1,0 +1,13 @@
+﻿using System.Diagnostics;
+
+namespace Cake.Core.IO.Globbing.Nodes
+{
+    internal sealed class ParentSegment : GlobNode
+    {
+        [DebuggerStepThrough]
+        public override void Accept(GlobVisitor visitor, GlobVisitorContext context)
+        {
+            visitor.VisitParent(this, context);
+        }
+    }
+}


### PR DESCRIPTION
Parent directory references `..` could not be used properly which
required using work arounds for patterns like `../path`.

Closes #390