### PR TITLE
Removed quotes from MSBuild arguments

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -301,7 +301,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
 
                 // Then
                 fixture.AssertReceivedArguments(
-                    "/m /v:normal /p:\"A\"=\"B\" /p:\"C\"=\"D\" /target:Build \"/Working/src/Solution.sln\"");
+                    "/m /v:normal /p:A=B /p:C=D /target:Build \"/Working/src/Solution.sln\"");
             }
 
             [Fact]
@@ -317,7 +317,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
 
                 // Then
                 fixture.AssertReceivedArguments(
-                    "/m /v:normal /p:\"A\"=\"B\" /p:\"A\"=\"E\" /p:\"C\"=\"D\" /target:Build \"/Working/src/Solution.sln\"");
+                    "/m /v:normal /p:A=B /p:A=E /p:C=D /target:Build \"/Working/src/Solution.sln\"");
             }
 
             [Fact]
@@ -332,13 +332,13 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
 
                 // Then
                 fixture.AssertReceivedArguments(
-                    "/m /v:normal /p:\"Configuration\"=\"Release\" /target:Build \"/Working/src/Solution.sln\"");
+                    "/m /v:normal /p:Configuration=Release /target:Build \"/Working/src/Solution.sln\"");
             }
 
             [Theory]
-            [InlineData(PlatformTarget.MSIL, "/m /v:normal /p:\"Platform\"=\"Any CPU\" /target:Build \"/Working/src/Solution.sln\"")]
-            [InlineData(PlatformTarget.x86, "/m /v:normal /p:\"Platform\"=\"x86\" /target:Build \"/Working/src/Solution.sln\"")]
-            [InlineData(PlatformTarget.x64, "/m /v:normal /p:\"Platform\"=\"x64\" /target:Build \"/Working/src/Solution.sln\"")]
+            [InlineData(PlatformTarget.MSIL, "/m /v:normal /p:Platform=\"Any CPU\" /target:Build \"/Working/src/Solution.sln\"")]
+            [InlineData(PlatformTarget.x86, "/m /v:normal /p:Platform=x86 /target:Build \"/Working/src/Solution.sln\"")]
+            [InlineData(PlatformTarget.x64, "/m /v:normal /p:Platform=x64 /target:Build \"/Working/src/Solution.sln\"")]
             public void Should_Append_Platform_As_Property_To_Process_Arguments(PlatformTarget? platform, string argumentsString)
             {
                 // Given

--- a/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
@@ -62,14 +62,14 @@ namespace Cake.Common.Tools.MSBuild
             {
                 // Add the configuration as a property.
                 var configuration = settings.Configuration;
-                builder.Append(string.Concat("/p:\"Configuration\"=", configuration.Quote()));
+                builder.Append(string.Concat("/p:Configuration=", configuration));
             }
 
             // Buid for a specific platform?
             if (settings.PlatformTarget.HasValue)
             {
                 var platform = settings.PlatformTarget.Value;
-                builder.Append(string.Concat("/p:\"Platform\"=", GetPlatformName(platform).Quote()));
+                builder.Append(string.Concat("/p:Platform=", GetPlatformName(platform)));
             }
 
             // Got any properties?
@@ -104,7 +104,7 @@ namespace Cake.Common.Tools.MSBuild
             switch (platform)
             {
                 case PlatformTarget.MSIL:
-                    return "Any CPU";
+                    return "\"Any CPU\"";
                 case PlatformTarget.x86:
                     return "x86";
                 case PlatformTarget.x64:
@@ -138,7 +138,7 @@ namespace Cake.Common.Tools.MSBuild
             {
                 foreach (var propertyValue in properties[propertyKey])
                 {
-                    yield return string.Concat("/p:", propertyKey.Quote(), "=", propertyValue.Quote());
+                    yield return string.Concat("/p:", propertyKey, "=", propertyValue);
                 }
             }
         }


### PR DESCRIPTION
This is a semantic change to how the MSBuild runner works, but it will allow
for more flexibility.

Closes #412