### PR TITLE
Allow setting the AssemblyConfiguration attribute

### DIFF
--- a/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoCreatorTests.cs
+++ b/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoCreatorTests.cs
@@ -311,6 +311,20 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 Assert.True(result.Contains("[assembly: InternalsVisibleTo(\"Assembly1.Tests\"), InternalsVisibleTo(\"Assembly2.Tests\"), InternalsVisibleTo(\"Assembly3.Tests\")]"));
             }
 
+            [Fact]
+            public void Should_Add_Configuration_Attribute_If_Set()
+            {
+                // Given
+                var fixture = new AssemblyInfoFixture();
+                fixture.Settings.Configuration = "TheConfiguration";
+
+                // When
+                var result = fixture.CreateAndReturnContent();
+
+                // Then
+                Assert.True(result.Contains("using System.Reflection;"));
+                Assert.True(result.Contains("[assembly: AssemblyConfiguration(\"TheConfiguration\")]"));
+            }
         }
     }
 }

--- a/src/Cake.Common/Solution/Project/Properties/AssemblyInfoCreator.cs
+++ b/src/Cake.Common/Solution/Project/Properties/AssemblyInfoCreator.cs
@@ -126,6 +126,7 @@ namespace Cake.Common.Solution.Project.Properties
             registration.AddString("AssemblyInformationalVersion", "System.Reflection", settings.InformationalVersion);
             registration.AddString("AssemblyCopyright", "System.Reflection", settings.Copyright);
             registration.AddString("AssemblyTrademark", "System.Reflection", settings.Trademark);
+            registration.AddString("AssemblyConfiguration", "System.Reflection", settings.Configuration);
             registration.AddString("Guid", "System.Runtime.InteropServices", settings.Guid);
             registration.AddBoolean("ComVisible", "System.Runtime.InteropServices", settings.ComVisible);
             registration.AddBoolean("CLSCompliant", "System", settings.CLSCompliant);

--- a/src/Cake.Common/Solution/Project/Properties/AssemblyInfoSettings.cs
+++ b/src/Cake.Common/Solution/Project/Properties/AssemblyInfoSettings.cs
@@ -84,5 +84,11 @@ namespace Cake.Common.Solution.Project.Properties
         /// </summary>
         /// <value>The name(s) of the assembly(s).</value>
         public IEnumerable<string> InternalsVisibleTo { get; set; }
+
+        /// <summary>
+        /// Gets or sets the configuration of the assembly.
+        /// </summary>
+        /// <value>The configuration.</value>
+        public string Configuration { get; set; }
     }
 }


### PR DESCRIPTION
This is useful for checking the configuration (eg Debug, Release) that an assembly was built using