### PR TITLE
Change the way assembly references are loaded.

### DIFF
--- a/src/Cake.Core/Scripting/ScriptRunner.cs
+++ b/src/Cake.Core/Scripting/ScriptRunner.cs
@@ -77,7 +77,7 @@ namespace Cake.Core.Scripting
             {
                 if (host.Context.FileSystem.Exist((FilePath)reference))
                 {
-                    var assembly = Assembly.LoadFile(reference);
+                    var assembly = Assembly.LoadFrom(reference);
                     assemblies.Add(assembly);
                 }
                 else
@@ -144,7 +144,7 @@ namespace Cake.Core.Scripting
                 var cakeAssemblies = assemblyDirectory.GetFiles(pattern, SearchScope.Current);
                 foreach (var cakeAssembly in cakeAssemblies)
                 {
-                    var assembly = Assembly.LoadFile(cakeAssembly.Path.FullPath);
+                    var assembly = Assembly.LoadFrom(cakeAssembly.Path.FullPath);
                     defaultAssemblies.Add(assembly);
                     loaded.Add(pattern);
                 }

--- a/src/Cake/Scripting/Mono/MonoScriptSession.cs
+++ b/src/Cake/Scripting/Mono/MonoScriptSession.cs
@@ -56,7 +56,7 @@ namespace Cake.Scripting.Mono
                 throw new ArgumentNullException("path");
             }
             _log.Debug("Adding reference to {0}...", path.FullPath);
-            _evaluator.ReferenceAssembly(Assembly.LoadFile(path.FullPath));
+            _evaluator.ReferenceAssembly(Assembly.LoadFrom(path.FullPath));
         }
 
         public void AddReference(Assembly assembly)


### PR DESCRIPTION
We've been using Assembly.LoadFile to load script assembly references
which work great until you load an assembly where there is a
dependency to a previously loaded assembly. By using Assembly.LoadFrom
we make sure that assemblies are loaded properly.

Closes #415