### PR TITLE
Treat a . (dot) in glob pattern as dot instead of character wildcard

### DIFF
--- a/src/Cake.Core.Tests/Fixtures/GlobberFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/GlobberFixture.cs
@@ -37,6 +37,9 @@ namespace Cake.Core.Tests.Fixtures
             // Files
             FileSystem.CreateFile("C:/Working/Foo/Bar/Qux.c");
             FileSystem.CreateFile("C:/Program Files (x86)/Foo.c");
+            FileSystem.CreateFile("C:/Working/Project.A.Test.dll");
+            FileSystem.CreateFile("C:/Working/Project.B.Test.dll");
+            FileSystem.CreateFile("C:/Working/Project.IntegrationTest.dll");
         }
 
         private void PrepareUnixFixture()

--- a/src/Cake.Core.Tests/Unit/IO/GlobberTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/GlobberTests.cs
@@ -364,6 +364,21 @@ namespace Cake.Core.Tests.Unit.IO
             }
 
             [Fact]
+            public void Should_Return_Files_For_Pattern_Ending_With_Character_Wildcard_And_Dot()
+            {
+                // Given
+                var fixture = new GlobberFixture(true);
+
+                // When
+                var result = fixture.Match("C:/Working/*.Test.dll");
+
+                // Then
+                Assert.Equal(2, result.Length);
+                Assert.ContainsFilePath(result, "C:/Working/Project.A.Test.dll");
+                Assert.ContainsFilePath(result, "C:/Working/Project.B.Test.dll");
+            }
+
+            [Fact]
             public void Should_Return_File_For_Recursive_Wildcard_Pattern_Ending_With_Wildcard_Regex()
             {
                 // Given

--- a/src/Cake.Core/IO/Globbing/Nodes/PathSegment.cs
+++ b/src/Cake.Core/IO/Globbing/Nodes/PathSegment.cs
@@ -57,7 +57,7 @@ namespace Cake.Core.IO.Globbing.Nodes
             {
                 if (token.Kind == GlobTokenKind.Identifier)
                 {
-                    builder.Append(token.Value.Replace("+", "\\+"));
+                    builder.Append(token.Value.Replace("+", "\\+").Replace(".", "\\."));
                 }
                 if (token.Kind == GlobTokenKind.Wildcard)
                 {


### PR DESCRIPTION
- A dot inside a pattern token is passed to the regex as common dot, where
  it is treated as an arbitrary character instead of real dot character.
- By prefixing with a backslash in the regex, the dot is treated as real
  character.