### PR TITLE
Chocolatey Addin for Cake

### DIFF
--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyInstallerFixture.cs" />
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyPackerFixture.cs" />
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyPinnerFixture.cs" />
+    <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyPusherFixture.cs" />
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateySourcesFixture.cs" />
     <Compile Include="Fixtures\Tools\DupFinderRunnerFixture.cs" />
     <Compile Include="Fixtures\Tools\FixieRunnerFixture.cs" />
@@ -146,6 +147,7 @@
     <Compile Include="Unit\Tools\Chocolatey\Pack\ChocolateyPackSettingsTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\Pin\ChocolateyPinnerTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\Pin\ChocolateyPinSettingsTests.cs" />
+    <Compile Include="Unit\Tools\Chocolatey\Push\ChocolateyPusherTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\Sources\ChocolateySourcesSettingsTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\Sources\ChocolateySourcesTests.cs" />
     <Compile Include="Unit\Tools\DupFinder\DupFinderRunnerTests.cs" />
@@ -230,7 +232,6 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Unit\Tools\Chocolatey\Push\" />
     <Folder Include="Unit\Tools\Chocolatey\Upgrade\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyInstallerFixture.cs" />
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyPackerFixture.cs" />
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyPinnerFixture.cs" />
+    <Compile Include="Fixtures\Tools\Chocolatey\ChocolateySourcesFixture.cs" />
     <Compile Include="Fixtures\Tools\DupFinderRunnerFixture.cs" />
     <Compile Include="Fixtures\Tools\FixieRunnerFixture.cs" />
     <Compile Include="Fixtures\Tools\ILMergeRunnerFixture.cs" />
@@ -145,6 +146,8 @@
     <Compile Include="Unit\Tools\Chocolatey\Pack\ChocolateyPackSettingsTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\Pin\ChocolateyPinnerTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\Pin\ChocolateyPinSettingsTests.cs" />
+    <Compile Include="Unit\Tools\Chocolatey\Sources\ChocolateySourcesSettingsTests.cs" />
+    <Compile Include="Unit\Tools\Chocolatey\Sources\ChocolateySourcesTests.cs" />
     <Compile Include="Unit\Tools\DupFinder\DupFinderRunnerTests.cs" />
     <Compile Include="Unit\Tools\Fixie\FixieRunnerTests.cs" />
     <Compile Include="Unit\Tools\ILMerge\ILMergeRunnerTests.cs" />
@@ -228,7 +231,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Unit\Tools\Chocolatey\Push\" />
-    <Folder Include="Unit\Tools\Chocolatey\Sources\" />
     <Folder Include="Unit\Tools\Chocolatey\Upgrade\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyPinnerFixture.cs" />
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyPusherFixture.cs" />
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateySourcesFixture.cs" />
+    <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyUpgraderFixture.cs" />
     <Compile Include="Fixtures\Tools\DupFinderRunnerFixture.cs" />
     <Compile Include="Fixtures\Tools\FixieRunnerFixture.cs" />
     <Compile Include="Fixtures\Tools\ILMergeRunnerFixture.cs" />
@@ -150,6 +151,8 @@
     <Compile Include="Unit\Tools\Chocolatey\Push\ChocolateyPusherTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\Sources\ChocolateySourcesSettingsTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\Sources\ChocolateySourcesTests.cs" />
+    <Compile Include="Unit\Tools\Chocolatey\Upgrade\ChocolateyUpgraderTests.cs" />
+    <Compile Include="Unit\Tools\Chocolatey\Upgrade\ChocolateyUpgradeSettingsTests.cs" />
     <Compile Include="Unit\Tools\DupFinder\DupFinderRunnerTests.cs" />
     <Compile Include="Unit\Tools\Fixie\FixieRunnerTests.cs" />
     <Compile Include="Unit\Tools\ILMerge\ILMergeRunnerTests.cs" />
@@ -231,9 +234,7 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Unit\Tools\Chocolatey\Upgrade\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -64,6 +64,8 @@
     <Compile Include="Fixtures\IO\FileCopyFixture.cs" />
     <Compile Include="Fixtures\IO\FileDeleteFixture.cs" />
     <Compile Include="Fixtures\IO\FileSystemFixture.cs" />
+    <Compile Include="Fixtures\Tools\ChocolateyFixture.cs" />
+    <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyPackerFixture.cs" />
     <Compile Include="Fixtures\Tools\DupFinderRunnerFixture.cs" />
     <Compile Include="Fixtures\Tools\FixieRunnerFixture.cs" />
     <Compile Include="Fixtures\Tools\ILMergeRunnerFixture.cs" />
@@ -126,6 +128,8 @@
     <Compile Include="Unit\Text\TextTransformationExtensionsTests.cs" />
     <Compile Include="Unit\Text\TextTransformationTests.cs" />
     <Compile Include="Unit\Tools\Cake\CakeRunnerTests.cs" />
+    <Compile Include="Unit\Tools\Chocolatey\Pack\ChocolateyPackerTests.cs" />
+    <Compile Include="Unit\Tools\Chocolatey\Pack\ChocolateyPackSettingsTests.cs" />
     <Compile Include="Unit\Tools\DupFinder\DupFinderRunnerTests.cs" />
     <Compile Include="Unit\Tools\Fixie\FixieRunnerTests.cs" />
     <Compile Include="Unit\Tools\ILMerge\ILMergeRunnerTests.cs" />
@@ -206,6 +210,13 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Unit\Tools\Chocolatey\Install\" />
+    <Folder Include="Unit\Tools\Chocolatey\Push\" />
+    <Folder Include="Unit\Tools\Chocolatey\SetApiKey\" />
+    <Folder Include="Unit\Tools\Chocolatey\Sources\" />
+    <Folder Include="Unit\Tools\Chocolatey\Upgrade\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Fixtures\IO\FileDeleteFixture.cs" />
     <Compile Include="Fixtures\IO\FileSystemFixture.cs" />
     <Compile Include="Fixtures\Tools\ChocolateyFixture.cs" />
+    <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyApiKeySetterFixture.cs" />
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyInstallerFixture.cs" />
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyPackerFixture.cs" />
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyPinnerFixture.cs" />
@@ -130,6 +131,8 @@
     <Compile Include="Unit\Text\TextTransformationExtensionsTests.cs" />
     <Compile Include="Unit\Text\TextTransformationTests.cs" />
     <Compile Include="Unit\Tools\Cake\CakeRunnerTests.cs" />
+    <Compile Include="Unit\Tools\Chocolatey\ApiKey\ChocolateyApiKeySetterTests.cs" />
+    <Compile Include="Unit\Tools\Chocolatey\ApiKey\ChocolateyApiKeySettingsTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\Install\ChocolateyInstallerSettingsTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\Install\ChocolateyInstallerTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\Pack\ChocolateyPackerTests.cs" />
@@ -219,7 +222,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Unit\Tools\Chocolatey\Push\" />
-    <Folder Include="Unit\Tools\Chocolatey\SetApiKey\" />
     <Folder Include="Unit\Tools\Chocolatey\Sources\" />
     <Folder Include="Unit\Tools\Chocolatey\Upgrade\" />
   </ItemGroup>

--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Fixtures\Tools\ChocolateyFixture.cs" />
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyApiKeySetterFixture.cs" />
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyConfigSetterFixture.cs" />
+    <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyFeatureTogglerFixture.cs" />
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyInstallerFixture.cs" />
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyPackerFixture.cs" />
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyPinnerFixture.cs" />
@@ -136,6 +137,8 @@
     <Compile Include="Unit\Tools\Chocolatey\ApiKey\ChocolateyApiKeySettingsTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\Config\ChocolateyConfigSetterTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\Config\ChocolateyConfigSettingsTests.cs" />
+    <Compile Include="Unit\Tools\Chocolatey\Features\ChocolateyFeatureSettingsTests.cs" />
+    <Compile Include="Unit\Tools\Chocolatey\Features\ChocolateyFeatureTogglerTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\Install\ChocolateyInstallerSettingsTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\Install\ChocolateyInstallerTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\Pack\ChocolateyPackerTests.cs" />

--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Fixtures\IO\FileDeleteFixture.cs" />
     <Compile Include="Fixtures\IO\FileSystemFixture.cs" />
     <Compile Include="Fixtures\Tools\ChocolateyFixture.cs" />
+    <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyInstallerFixture.cs" />
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyPackerFixture.cs" />
     <Compile Include="Fixtures\Tools\DupFinderRunnerFixture.cs" />
     <Compile Include="Fixtures\Tools\FixieRunnerFixture.cs" />
@@ -128,6 +129,8 @@
     <Compile Include="Unit\Text\TextTransformationExtensionsTests.cs" />
     <Compile Include="Unit\Text\TextTransformationTests.cs" />
     <Compile Include="Unit\Tools\Cake\CakeRunnerTests.cs" />
+    <Compile Include="Unit\Tools\Chocolatey\Install\ChocolateyInstallerSettingsTests.cs" />
+    <Compile Include="Unit\Tools\Chocolatey\Install\ChocolateyInstallerTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\Pack\ChocolateyPackerTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\Pack\ChocolateyPackSettingsTests.cs" />
     <Compile Include="Unit\Tools\DupFinder\DupFinderRunnerTests.cs" />
@@ -212,7 +215,6 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Unit\Tools\Chocolatey\Install\" />
     <Folder Include="Unit\Tools\Chocolatey\Push\" />
     <Folder Include="Unit\Tools\Chocolatey\SetApiKey\" />
     <Folder Include="Unit\Tools\Chocolatey\Sources\" />

--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Fixtures\IO\FileSystemFixture.cs" />
     <Compile Include="Fixtures\Tools\ChocolateyFixture.cs" />
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyApiKeySetterFixture.cs" />
+    <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyConfigSetterFixture.cs" />
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyInstallerFixture.cs" />
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyPackerFixture.cs" />
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyPinnerFixture.cs" />
@@ -133,6 +134,8 @@
     <Compile Include="Unit\Tools\Cake\CakeRunnerTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\ApiKey\ChocolateyApiKeySetterTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\ApiKey\ChocolateyApiKeySettingsTests.cs" />
+    <Compile Include="Unit\Tools\Chocolatey\Config\ChocolateyConfigSetterTests.cs" />
+    <Compile Include="Unit\Tools\Chocolatey\Config\ChocolateyConfigSettingsTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\Install\ChocolateyInstallerSettingsTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\Install\ChocolateyInstallerTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\Pack\ChocolateyPackerTests.cs" />

--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Fixtures\Tools\ChocolateyFixture.cs" />
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyInstallerFixture.cs" />
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyPackerFixture.cs" />
+    <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyPinnerFixture.cs" />
     <Compile Include="Fixtures\Tools\DupFinderRunnerFixture.cs" />
     <Compile Include="Fixtures\Tools\FixieRunnerFixture.cs" />
     <Compile Include="Fixtures\Tools\ILMergeRunnerFixture.cs" />
@@ -133,6 +134,8 @@
     <Compile Include="Unit\Tools\Chocolatey\Install\ChocolateyInstallerTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\Pack\ChocolateyPackerTests.cs" />
     <Compile Include="Unit\Tools\Chocolatey\Pack\ChocolateyPackSettingsTests.cs" />
+    <Compile Include="Unit\Tools\Chocolatey\Pin\ChocolateyPinnerTests.cs" />
+    <Compile Include="Unit\Tools\Chocolatey\Pin\ChocolateyPinSettingsTests.cs" />
     <Compile Include="Unit\Tools\DupFinder\DupFinderRunnerTests.cs" />
     <Compile Include="Unit\Tools\Fixie\FixieRunnerTests.cs" />
     <Compile Include="Unit\Tools\ILMerge\ILMergeRunnerTests.cs" />

--- a/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/ChocolateyApiKeySetterFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/ChocolateyApiKeySetterFixture.cs
@@ -1,0 +1,24 @@
+﻿using Cake.Common.Tools.Chocolatey.ApiKey;
+
+namespace Cake.Common.Tests.Fixtures.Tools.Chocolatey
+{
+    public sealed class ChocolateyApiKeySetterFixture : ChocolateyFixture
+    {
+        public string ApiKey { get; set; }
+        public string Source { get; set; }
+        public ChocolateyApiKeySettings Settings { get; set; }
+
+        public ChocolateyApiKeySetterFixture()
+        {
+            Settings = new ChocolateyApiKeySettings();
+            Source = "source1";
+            ApiKey = "apikey1";
+        }
+
+        public void Set()
+        {
+            var tool = new ChocolateyApiKeySetter(FileSystem, Environment, ProcessRunner, Globber, ChocolateyToolResolver);
+            tool.Set(ApiKey, Source, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/ChocolateyConfigSetterFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/ChocolateyConfigSetterFixture.cs
@@ -1,0 +1,24 @@
+﻿using Cake.Common.Tools.Chocolatey.Config;
+
+namespace Cake.Common.Tests.Fixtures.Tools.Chocolatey
+{
+    public sealed class ChocolateyConfigSetterFixture : ChocolateyFixture
+    {
+        public string Name { get; set; }
+        public string Value { get; set; }
+        public ChocolateyConfigSettings Settings { get; set; }
+
+        public ChocolateyConfigSetterFixture()
+        {
+            Settings = new ChocolateyConfigSettings();
+            Name = "cacheLocation";
+            Value = @"c:\temp";
+        }
+
+        public void Set()
+        {
+            var tool = new ChocolateyConfigSetter(FileSystem, Environment, ProcessRunner, Globber, ChocolateyToolResolver);
+            tool.Set(Name, Value, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/ChocolateyFeatureTogglerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/ChocolateyFeatureTogglerFixture.cs
@@ -1,0 +1,28 @@
+﻿using Cake.Common.Tools.Chocolatey.Features;
+
+namespace Cake.Common.Tests.Fixtures.Tools.Chocolatey
+{
+    public sealed class ChocolateyFeatureTogglerFixture : ChocolateyFixture
+    {
+        public string Name { get; set; }
+        public ChocolateyFeatureSettings Settings { get; set; }
+
+        public ChocolateyFeatureTogglerFixture()
+        {
+            Name = "checkSumFiles";
+            Settings = new ChocolateyFeatureSettings();
+        }
+
+        public void EnableFeature()
+        {
+            var tool = new ChocolateyFeatureToggler(FileSystem, Environment, ProcessRunner, Globber, ChocolateyToolResolver);
+            tool.EnableFeature(Name, Settings);
+        }
+
+        public void DisableFeature()
+        {
+            var tool = new ChocolateyFeatureToggler(FileSystem, Environment, ProcessRunner, Globber, ChocolateyToolResolver);
+            tool.DisableFeature(Name, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/ChocolateyInstallerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/ChocolateyInstallerFixture.cs
@@ -1,0 +1,31 @@
+﻿using Cake.Common.Tools.Chocolatey.Install;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tests.Fixtures.Tools.Chocolatey
+{
+    public sealed class ChocolateyInstallerFixture : ChocolateyFixture
+    {
+        public string PackageId { get; set; }
+        public FilePath PackageConfigPath { get; set; }
+        public ChocolateyInstallSettings Settings { get; set; }
+
+        public ChocolateyInstallerFixture()
+        {
+            PackageId = "Cake";
+            PackageConfigPath = "./packages.config";
+            Settings = new ChocolateyInstallSettings();
+        }
+
+        public void Install()
+        {
+            var tool = new ChocolateyInstaller(FileSystem, Environment, ProcessRunner, Globber, ChocolateyToolResolver);
+            tool.Install(PackageId, Settings);
+        }
+
+        public void InstallFromConfig()
+        {
+            var tool = new ChocolateyInstaller(FileSystem, Environment, ProcessRunner, Globber, ChocolateyToolResolver);
+            tool.InstallFromConfig(PackageConfigPath, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/ChocolateyPackerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/ChocolateyPackerFixture.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using Cake.Common.Tests.Properties;
+using Cake.Common.Tools.Chocolatey.Pack;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Testing;
+using NSubstitute;
+
+namespace Cake.Common.Tests.Fixtures.Tools.Chocolatey
+{
+    public sealed class ChocolateyPackerFixture : ChocolateyFixture
+    {
+        public FilePath NuSpecFilePath { get; set; }
+        public ChocolateyPackSettings Settings { get; set; }
+
+        public ChocolateyPackerFixture()
+        {
+            NuSpecFilePath = "./existing.nuspec";
+            Settings = new ChocolateyPackSettings();
+
+            FileSystem.CreateFile("/Working/existing.nuspec").SetContent(Resources.ChocolateyNuspec_NoMetadataValues);
+        }
+
+        public void WithNuSpecXml(string xml)
+        {
+            FileSystem.CreateFile("/Working/existing.nuspec").SetContent(xml);
+        }
+
+        public void GivenTemporaryNuSpecAlreadyExist()
+        {
+            FileSystem.CreateFile("/Working/existing.temp.nuspec");
+        }
+
+        public string Pack(bool nuspec = true)
+        {
+            string content = null;
+            ProcessRunner.When(p => p.Start(Arg.Any<FilePath>(), Arg.Any<ProcessSettings>()))
+                .Do(info => {
+                    content = GetContent(info[1] as ProcessSettings);
+                });
+
+            var tool = new ChocolateyPacker(FileSystem, Environment, ProcessRunner, Log, Globber, ChocolateyToolResolver);
+            if (nuspec)
+            {
+                tool.Pack(NuSpecFilePath, Settings);
+            }
+            else
+            {
+                tool.Pack(Settings);
+            }
+
+            // Return the content.
+            return content;
+        }
+
+        private string GetContent(ProcessSettings settings)
+        {
+            var args = settings.Arguments.Render();
+            var parts = args.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            var last = parts.Last();
+
+            var file = FileSystem.GetFile(last.UnQuote());
+            if (file.Exists)
+            {
+                using (var stream = file.OpenRead())
+                using (var reader = new StreamReader(stream))
+                {
+                    return reader.ReadToEnd();
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/ChocolateyPinnerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/ChocolateyPinnerFixture.cs
@@ -1,0 +1,22 @@
+﻿using Cake.Common.Tools.Chocolatey.Pin;
+
+namespace Cake.Common.Tests.Fixtures.Tools.Chocolatey
+{
+    public sealed class ChocolateyPinnerFixture : ChocolateyFixture
+    {
+        public string Name { get; set; }
+        public ChocolateyPinSettings Settings { get; set; }
+
+        public ChocolateyPinnerFixture()
+        {
+            Settings = new ChocolateyPinSettings();
+            Name = "Cake";
+        }
+
+        public void Pin()
+        {
+            var tool = new ChocolateyPinner(FileSystem, Environment, ProcessRunner, Globber, ChocolateyToolResolver);
+            tool.Pin(Name, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/ChocolateyPusherFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/ChocolateyPusherFixture.cs
@@ -1,0 +1,23 @@
+﻿using Cake.Common.Tools.Chocolatey.Push;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tests.Fixtures.Tools.Chocolatey
+{
+    public sealed class ChocolateyPusherFixture : ChocolateyFixture
+    {
+        public FilePath PackageFilePath { get; set; }
+        public ChocolateyPushSettings Settings { get; set; }
+
+        public ChocolateyPusherFixture()
+        {
+            PackageFilePath = "./existing.nupkg";
+            Settings = new ChocolateyPushSettings();
+        }
+
+        public void Push()
+        {
+            var tool = new ChocolateyPusher(FileSystem, Environment, ProcessRunner, Globber, ChocolateyToolResolver);
+            tool.Push(PackageFilePath, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/ChocolateySourcesFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/ChocolateySourcesFixture.cs
@@ -1,0 +1,42 @@
+﻿using Cake.Common.Tools.Chocolatey.Sources;
+
+namespace Cake.Common.Tests.Fixtures.Tools.Chocolatey
+{
+    public sealed class ChocolateySourcesFixture : ChocolateyFixture
+    {
+        public string Name { get; set; }
+        public string Source { get; set; }
+        public ChocolateySourcesSettings Settings { get; set; }
+
+        public ChocolateySourcesFixture()
+        {
+            Name = "name";
+            Source = "source";
+            Settings = new ChocolateySourcesSettings();
+        }
+
+        public void AddSource()
+        {
+            var tool = new ChocolateySources(FileSystem, Environment, ProcessRunner, Globber, ChocolateyToolResolver);
+            tool.AddSource(Name, Source, Settings);
+        }
+
+        public void RemoveSource()
+        {
+            var tool = new ChocolateySources(FileSystem, Environment, ProcessRunner, Globber, ChocolateyToolResolver);
+            tool.RemoveSource(Name, Settings);
+        }
+
+        public void EnableSource()
+        {
+            var tool = new ChocolateySources(FileSystem, Environment, ProcessRunner, Globber, ChocolateyToolResolver);
+            tool.EnableSource(Name, Settings);
+        }
+
+        public void DisableSource()
+        {
+            var tool = new ChocolateySources(FileSystem, Environment, ProcessRunner, Globber, ChocolateyToolResolver);
+            tool.DisableSource(Name, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/ChocolateyUpgraderFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/ChocolateyUpgraderFixture.cs
@@ -1,0 +1,22 @@
+﻿using Cake.Common.Tools.Chocolatey.Upgrade;
+
+namespace Cake.Common.Tests.Fixtures.Tools.Chocolatey
+{
+    public sealed class ChocolateyUpgraderFixture : ChocolateyFixture
+    {
+        public string PackageId { get; set; }
+        public ChocolateyUpgradeSettings Settings { get; set; }
+
+        public ChocolateyUpgraderFixture()
+        {
+            PackageId = "Cake";
+            Settings = new ChocolateyUpgradeSettings();
+        }
+
+        public void Upgrade()
+        {
+            var tool = new ChocolateyUpgrader(FileSystem, Environment, ProcessRunner, Globber, ChocolateyToolResolver);
+            tool.Upgrade(PackageId, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Fixtures/Tools/ChocolateyFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/ChocolateyFixture.cs
@@ -1,0 +1,67 @@
+﻿using Cake.Common.Tools.Chocolatey;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using Cake.Testing;
+using NSubstitute;
+
+namespace Cake.Common.Tests.Fixtures.Tools
+{
+    public abstract class ChocolateyFixture
+    {
+        public FakeFileSystem FileSystem { get; set; }
+        public ICakeEnvironment Environment { get; set; }
+        public IProcessRunner ProcessRunner { get; set; }
+        public IProcess Process { get; set; }
+        public ICakeLog Log { get; set; }
+        public IChocolateyToolResolver ChocolateyToolResolver { get; set; }
+        public IGlobber Globber { get; set; }
+
+        protected ChocolateyFixture()
+        {
+            Environment = Substitute.For<ICakeEnvironment>();
+            Environment.WorkingDirectory = "/Working";
+
+            Process = Substitute.For<IProcess>();
+            Process.GetExitCode().Returns(0);
+            ProcessRunner = Substitute.For<IProcessRunner>();
+            ProcessRunner.Start(Arg.Any<FilePath>(), Arg.Any<ProcessSettings>()).Returns(Process);
+
+            Globber = Substitute.For<IGlobber>();
+
+            ChocolateyToolResolver = Substitute.For<IChocolateyToolResolver>();
+
+            Log = Substitute.For<ICakeLog>();
+            FileSystem = new FakeFileSystem(Environment);
+
+            // By default, there is a default tool.
+            ChocolateyToolResolver.ResolvePath().Returns("/Working/tools/choco.exe");
+            FileSystem.CreateFile("/Working/tools/choco.exe");
+
+            // Set standard output.
+            Process.GetStandardOutput().Returns(new string[0]);
+        }
+
+        public void GivenCustomToolPathExist(FilePath toolPath)
+        {
+            FileSystem.CreateFile(toolPath);
+        }
+
+        public void GivenDefaultToolDoNotExist()
+        {
+            var toolPath = new FilePath("/Working/tools/choco.exe");
+            FileSystem.EnsureFileDoNotExist(toolPath);
+            ChocolateyToolResolver.ResolvePath().Returns("/NonWorking/tools/choco.exe");
+        }
+
+        public void GivenProcessCannotStart()
+        {
+            ProcessRunner.Start(Arg.Any<FilePath>(), Arg.Any<ProcessSettings>()).Returns((IProcess)null);
+        }
+
+        public void GivenProcessReturnError()
+        {
+            Process.GetExitCode().Returns(1);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Properties/Resources.Designer.cs
+++ b/src/Cake.Common.Tests/Properties/Resources.Designer.cs
@@ -62,6 +62,91 @@ namespace Cake.Common.Tests.Properties {
         
         /// <summary>
         ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;
+        ///&lt;!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. --&gt;
+        ///&lt;package xmlns=&quot;http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd&quot;&gt;
+        ///  &lt;metadata&gt;
+        ///    &lt;id&gt;The ID&lt;/id&gt;
+        ///    &lt;title&gt;The title&lt;/title&gt;
+        ///    &lt;version&gt;The version&lt;/version&gt;
+        ///    &lt;authors&gt;Author #1,Author #2&lt;/authors&gt;
+        ///    &lt;owners&gt;Owner #1,Owner #2&lt;/owners&gt;
+        ///    &lt;summary&gt;The summa [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string ChocolateyNuspec_Metadata {
+            get {
+                return ResourceManager.GetString("ChocolateyNuspec_Metadata", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;
+        ///&lt;!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. --&gt;
+        ///&lt;package&gt;
+        ///  &lt;metadata&gt;
+        ///    &lt;id&gt;The ID&lt;/id&gt;
+        ///    &lt;title&gt;The title&lt;/title&gt;
+        ///    &lt;version&gt;The version&lt;/version&gt;
+        ///    &lt;authors&gt;Author #1,Author #2&lt;/authors&gt;
+        ///    &lt;owners&gt;Owner #1,Owner #2&lt;/owners&gt;
+        ///    &lt;summary&gt;The summary&lt;/summary&gt;
+        ///    &lt;description&gt;The description&lt;/description&gt;
+        ///     [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string ChocolateyNuspec_Metadata_WithoutNamespaces {
+            get {
+                return ResourceManager.GetString("ChocolateyNuspec_Metadata_WithoutNamespaces", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;
+        ///&lt;!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. --&gt;
+        ///&lt;package xmlns=&quot;http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd&quot;&gt;
+        ///  &lt;files&gt;
+        ///    &lt;file src=&quot;tools\**&quot; target=&quot;tools&quot; /&gt;
+        ///  &lt;/files&gt;
+        ///&lt;/package&gt;.
+        /// </summary>
+        internal static string ChocolateyNuspec_NoMetadataElement {
+            get {
+                return ResourceManager.GetString("ChocolateyNuspec_NoMetadataElement", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;
+        ///&lt;!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. --&gt;
+        ///&lt;package xmlns=&quot;http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd&quot;&gt;
+        ///  &lt;metadata /&gt;
+        ///  &lt;files&gt;
+        ///    &lt;file src=&quot;tools\**&quot; target=&quot;tools&quot; /&gt;
+        ///  &lt;/files&gt;
+        ///&lt;/package&gt;.
+        /// </summary>
+        internal static string ChocolateyNuspec_NoMetadataValues {
+            get {
+                return ResourceManager.GetString("ChocolateyNuspec_NoMetadataValues", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;
+        ///&lt;!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. --&gt;
+        ///&lt;package&gt;
+        ///  &lt;metadata /&gt;
+        ///  &lt;files&gt;
+        ///    &lt;file src=&quot;tools\**&quot; target=&quot;tools&quot; /&gt;
+        ///  &lt;/files&gt;
+        ///&lt;/package&gt;.
+        /// </summary>
+        internal static string ChocolateyNuspec_NoMetadataValues_WithoutNamespaces {
+            get {
+                return ResourceManager.GetString("ChocolateyNuspec_NoMetadataValues_WithoutNamespaces", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;
         ///&lt;package xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot;&gt;
         ///  &lt;metadata xmlns=&quot;http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd&quot;&gt;
         ///    &lt;id&gt;The ID&lt;/id&gt;

--- a/src/Cake.Common.Tests/Properties/Resources.resx
+++ b/src/Cake.Common.Tests/Properties/Resources.resx
@@ -117,6 +117,99 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ChocolateyNuspec_Metadata" xml:space="preserve">
+    <value>&lt;?xml version="1.0" encoding="utf-8"?&gt;
+&lt;!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. --&gt;
+&lt;package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd"&gt;
+  &lt;metadata&gt;
+    &lt;id&gt;The ID&lt;/id&gt;
+    &lt;title&gt;The title&lt;/title&gt;
+    &lt;version&gt;The version&lt;/version&gt;
+    &lt;authors&gt;Author #1,Author #2&lt;/authors&gt;
+    &lt;owners&gt;Owner #1,Owner #2&lt;/owners&gt;
+    &lt;summary&gt;The summary&lt;/summary&gt;
+    &lt;description&gt;The description&lt;/description&gt;
+    &lt;projectUrl&gt;https://project.com&lt;/projectUrl&gt;
+    &lt;packageSourceUrl&gt;https://packagesource.com&lt;/packageSourceUrl&gt;
+    &lt;projectSourceUrl&gt;https://projectsource.com&lt;/projectSourceUrl&gt;
+    &lt;docsUrl&gt;https://docs.com&lt;/docsUrl&gt;
+    &lt;mailingListUrl&gt;https://mailing.com&lt;/mailingListUrl&gt;
+    &lt;bugTrackerUrl&gt;https://bug.com&lt;/bugTrackerUrl&gt;
+    &lt;tags&gt;Tag1 Tag2 Tag3&lt;/tags&gt;
+    &lt;copyright&gt;The copyright&lt;/copyright&gt;
+    &lt;licenseUrl&gt;https://license.com&lt;/licenseUrl&gt;
+    &lt;requireLicenseAcceptance&gt;true&lt;/requireLicenseAcceptance&gt;
+    &lt;iconUrl&gt;https://icon.com&lt;/iconUrl&gt;
+    &lt;releaseNotes&gt;Line #1
+Line #2
+Line #3&lt;/releaseNotes&gt;
+  &lt;/metadata&gt;
+  &lt;files&gt;
+    &lt;file src="tools\**" target="tools" /&gt;
+  &lt;/files&gt;
+&lt;/package&gt;</value>
+  </data>
+  <data name="ChocolateyNuspec_Metadata_WithoutNamespaces" xml:space="preserve">
+    <value>&lt;?xml version="1.0" encoding="utf-8"?&gt;
+&lt;!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. --&gt;
+&lt;package&gt;
+  &lt;metadata&gt;
+    &lt;id&gt;The ID&lt;/id&gt;
+    &lt;title&gt;The title&lt;/title&gt;
+    &lt;version&gt;The version&lt;/version&gt;
+    &lt;authors&gt;Author #1,Author #2&lt;/authors&gt;
+    &lt;owners&gt;Owner #1,Owner #2&lt;/owners&gt;
+    &lt;summary&gt;The summary&lt;/summary&gt;
+    &lt;description&gt;The description&lt;/description&gt;
+    &lt;projectUrl&gt;https://project.com&lt;/projectUrl&gt;
+    &lt;packageSourceUrl&gt;https://packagesource.com&lt;/packageSourceUrl&gt;
+    &lt;projectSourceUrl&gt;https://projectsource.com&lt;/projectSourceUrl&gt;
+    &lt;docsUrl&gt;https://docs.com&lt;/docsUrl&gt;
+    &lt;mailingListUrl&gt;https://mailing.com&lt;/mailingListUrl&gt;
+    &lt;bugTrackerUrl&gt;https://bug.com&lt;/bugTrackerUrl&gt;
+    &lt;tags&gt;Tag1 Tag2 Tag3&lt;/tags&gt;
+    &lt;copyright&gt;The copyright&lt;/copyright&gt;
+    &lt;licenseUrl&gt;https://license.com&lt;/licenseUrl&gt;
+    &lt;requireLicenseAcceptance&gt;true&lt;/requireLicenseAcceptance&gt;
+    &lt;iconUrl&gt;https://icon.com&lt;/iconUrl&gt;
+    &lt;releaseNotes&gt;Line #1
+Line #2
+Line #3&lt;/releaseNotes&gt;
+  &lt;/metadata&gt;
+  &lt;files&gt;
+    &lt;file src="tools\**" target="tools" /&gt;
+  &lt;/files&gt;
+&lt;/package&gt;</value>
+  </data>
+  <data name="ChocolateyNuspec_NoMetadataElement" xml:space="preserve">
+    <value>&lt;?xml version="1.0" encoding="utf-8"?&gt;
+&lt;!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. --&gt;
+&lt;package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd"&gt;
+  &lt;files&gt;
+    &lt;file src="tools\**" target="tools" /&gt;
+  &lt;/files&gt;
+&lt;/package&gt;</value>
+  </data>
+  <data name="ChocolateyNuspec_NoMetadataValues" xml:space="preserve">
+    <value>&lt;?xml version="1.0" encoding="utf-8"?&gt;
+&lt;!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. --&gt;
+&lt;package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd"&gt;
+  &lt;metadata /&gt;
+  &lt;files&gt;
+    &lt;file src="tools\**" target="tools" /&gt;
+  &lt;/files&gt;
+&lt;/package&gt;</value>
+  </data>
+  <data name="ChocolateyNuspec_NoMetadataValues_WithoutNamespaces" xml:space="preserve">
+    <value>&lt;?xml version="1.0" encoding="utf-8"?&gt;
+&lt;!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. --&gt;
+&lt;package&gt;
+  &lt;metadata /&gt;
+  &lt;files&gt;
+    &lt;file src="tools\**" target="tools" /&gt;
+  &lt;/files&gt;
+&lt;/package&gt;</value>
+  </data>
   <data name="Nuspec_Metadata" xml:space="preserve">
     <value>&lt;?xml version="1.0" encoding="utf-8"?&gt;
 &lt;package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/ApiKey/ChocolateyApiKeySetterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/ApiKey/ChocolateyApiKeySetterTests.cs
@@ -1,0 +1,261 @@
+﻿using Cake.Common.Tests.Fixtures.Tools.Chocolatey;
+using Cake.Core.IO;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.Chocolatey.ApiKey
+{
+    public sealed class ChocolateyApiKeySetterTests
+    {
+        public sealed class TheSetMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Set());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Chocolatey_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Set());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Could not locate executable.");
+            }
+
+            [Theory]
+            [InlineData("C:/ProgramData/chocolatey/choco.exe", "C:/ProgramData/chocolatey/choco.exe")]
+            public void Should_Use_Chocolatey_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.GivenCustomToolPathExist(expected);
+                fixture.Settings.ToolPath = toolPath;
+
+                // When
+                fixture.Set();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == expected),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Set());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.GivenProcessReturnError();
+
+                // When
+                var result = Record.Exception(() => fixture.Set());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process returned an error.");
+            }
+
+            [Fact]
+            public void Should_Find_Chocolatey_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+
+                // When
+                fixture.Set();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == "/Working/tools/choco.exe"),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+
+                // When
+                fixture.Set();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "apikey -s \"source1\" -k \"apikey1\" -y"));
+            }
+
+            [Theory]
+            [InlineData(true, "apikey -s \"source1\" -k \"apikey1\" -d -y")]
+            [InlineData(false, "apikey -s \"source1\" -k \"apikey1\" -y")]
+            public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.Settings.Debug = debug;
+
+                // When
+                fixture.Set();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "apikey -s \"source1\" -k \"apikey1\" -v -y")]
+            [InlineData(false, "apikey -s \"source1\" -k \"apikey1\" -y")]
+            public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.Settings.Verbose = verbose;
+
+                // When
+                fixture.Set();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "apikey -s \"source1\" -k \"apikey1\" -y -f")]
+            [InlineData(false, "apikey -s \"source1\" -k \"apikey1\" -y")]
+            public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.Settings.Force = force;
+
+                // When
+                fixture.Set();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "apikey -s \"source1\" -k \"apikey1\" -y --noop")]
+            [InlineData(false, "apikey -s \"source1\" -k \"apikey1\" -y")]
+            public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.Settings.Noop = noop;
+
+                // When
+                fixture.Set();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "apikey -s \"source1\" -k \"apikey1\" -y -r")]
+            [InlineData(false, "apikey -s \"source1\" -k \"apikey1\" -y")]
+            public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.Settings.LimitOutput = limitOutput;
+
+                // When
+                fixture.Set();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(5, "apikey -s \"source1\" -k \"apikey1\" -y --execution-timeout \"5\"")]
+            [InlineData(0, "apikey -s \"source1\" -k \"apikey1\" -y")]
+            public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.Settings.ExecutionTimeout = executionTimeout;
+
+                // When
+                fixture.Set();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(@"c:\temp", "apikey -s \"source1\" -k \"apikey1\" -y -c \"c:\\temp\"")]
+            [InlineData("", "apikey -s \"source1\" -k \"apikey1\" -y")]
+            public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.Settings.CacheLocation = cacheLocation;
+
+                // When
+                fixture.Set();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "apikey -s \"source1\" -k \"apikey1\" -y --allowunofficial")]
+            [InlineData(false, "apikey -s \"source1\" -k \"apikey1\" -y")]
+            public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.Settings.AllowUnoffical = allowUnofficial;
+
+                // When
+                fixture.Set();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/ApiKey/ChocolateyApiKeySettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/ApiKey/ChocolateyApiKeySettingsTests.cs
@@ -1,0 +1,6 @@
+﻿namespace Cake.Common.Tests.Unit.Tools.Chocolatey.ApiKey
+{
+    class ChocolateyApiKeySettingsTests
+    {
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Config/ChocolateyConfigSetterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Config/ChocolateyConfigSetterTests.cs
@@ -1,0 +1,261 @@
+﻿using Cake.Common.Tests.Fixtures.Tools.Chocolatey;
+using Cake.Core.IO;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Config
+{
+    public sealed class ChocolateyConfigSetterTests
+    {
+        public sealed class TheSetMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Set());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Chocolatey_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Set());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Could not locate executable.");
+            }
+
+            [Theory]
+            [InlineData("C:/ProgramData/chocolatey/choco.exe", "C:/ProgramData/chocolatey/choco.exe")]
+            public void Should_Use_Chocolatey_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.GivenCustomToolPathExist(expected);
+                fixture.Settings.ToolPath = toolPath;
+
+                // When
+                fixture.Set();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == expected),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Set());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.GivenProcessReturnError();
+
+                // When
+                var result = Record.Exception(() => fixture.Set());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process returned an error.");
+            }
+
+            [Fact]
+            public void Should_Find_Chocolatey_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+
+                // When
+                fixture.Set();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == "/Working/tools/choco.exe"),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+
+                // When
+                fixture.Set();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "config set --name \"cacheLocation\" --value \"c:\\temp\" -y"));
+            }
+
+            [Theory]
+            [InlineData(true, "config set --name \"cacheLocation\" --value \"c:\\temp\" -d -y")]
+            [InlineData(false, "config set --name \"cacheLocation\" --value \"c:\\temp\" -y")]
+            public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.Settings.Debug = debug;
+
+                // When
+                fixture.Set();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "config set --name \"cacheLocation\" --value \"c:\\temp\" -v -y")]
+            [InlineData(false, "config set --name \"cacheLocation\" --value \"c:\\temp\" -y")]
+            public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.Settings.Verbose = verbose;
+
+                // When
+                fixture.Set();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "config set --name \"cacheLocation\" --value \"c:\\temp\" -y -f")]
+            [InlineData(false, "config set --name \"cacheLocation\" --value \"c:\\temp\" -y")]
+            public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.Settings.Force = force;
+
+                // When
+                fixture.Set();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "config set --name \"cacheLocation\" --value \"c:\\temp\" -y --noop")]
+            [InlineData(false, "config set --name \"cacheLocation\" --value \"c:\\temp\" -y")]
+            public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.Settings.Noop = noop;
+
+                // When
+                fixture.Set();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "config set --name \"cacheLocation\" --value \"c:\\temp\" -y -r")]
+            [InlineData(false, "config set --name \"cacheLocation\" --value \"c:\\temp\" -y")]
+            public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.Settings.LimitOutput = limitOutput;
+
+                // When
+                fixture.Set();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(5, "config set --name \"cacheLocation\" --value \"c:\\temp\" -y --execution-timeout \"5\"")]
+            [InlineData(0, "config set --name \"cacheLocation\" --value \"c:\\temp\" -y")]
+            public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.Settings.ExecutionTimeout = executionTimeout;
+
+                // When
+                fixture.Set();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(@"c:\temp", "config set --name \"cacheLocation\" --value \"c:\\temp\" -y -c \"c:\\temp\"")]
+            [InlineData("", "config set --name \"cacheLocation\" --value \"c:\\temp\" -y")]
+            public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.Settings.CacheLocation = cacheLocation;
+
+                // When
+                fixture.Set();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "config set --name \"cacheLocation\" --value \"c:\\temp\" -y --allowunofficial")]
+            [InlineData(false, "config set --name \"cacheLocation\" --value \"c:\\temp\" -y")]
+            public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.Settings.AllowUnoffical = allowUnofficial;
+
+                // When
+                fixture.Set();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Config/ChocolateyConfigSettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Config/ChocolateyConfigSettingsTests.cs
@@ -1,0 +1,6 @@
+﻿namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Config
+{
+    class ChocolateyConfigSettingsTests
+    {
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Features/ChocolateyFeatureSettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Features/ChocolateyFeatureSettingsTests.cs
@@ -1,0 +1,6 @@
+﻿namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Features
+{
+    class ChocolateyFeatureSettingsTests
+    {
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Features/ChocolateyFeatureTogglerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Features/ChocolateyFeatureTogglerTests.cs
@@ -1,0 +1,512 @@
+﻿using Cake.Common.Tests.Fixtures.Tools.Chocolatey;
+using Cake.Core.IO;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Features
+{
+    public sealed class ChocolateyFeatureTogglerTests
+    {
+        public sealed class TheEnableFeatureMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.EnableFeature());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Chocolatey_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.EnableFeature());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Could not locate executable.");
+            }
+
+            [Theory]
+            [InlineData("C:/ProgramData/chocolatey/choco.exe", "C:/ProgramData/chocolatey/choco.exe")]
+            public void Should_Use_Chocolatey_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.GivenCustomToolPathExist(expected);
+                fixture.Settings.ToolPath = toolPath;
+
+                // When
+                fixture.EnableFeature();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == expected),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.EnableFeature());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.GivenProcessReturnError();
+
+                // When
+                var result = Record.Exception(() => fixture.EnableFeature());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process returned an error.");
+            }
+
+            [Fact]
+            public void Should_Find_Chocolatey_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+
+                // When
+                fixture.EnableFeature();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == "/Working/tools/choco.exe"),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+
+                // When
+                fixture.EnableFeature();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "feature enable -n \"checkSumFiles\" -y"));
+            }
+
+            [Theory]
+            [InlineData(true, "feature enable -n \"checkSumFiles\" -d -y")]
+            [InlineData(false, "feature enable -n \"checkSumFiles\" -y")]
+            public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.Settings.Debug = debug;
+
+                // When
+                fixture.EnableFeature();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "feature enable -n \"checkSumFiles\" -v -y")]
+            [InlineData(false, "feature enable -n \"checkSumFiles\" -y")]
+            public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.Settings.Verbose = verbose;
+
+                // When
+                fixture.EnableFeature();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "feature enable -n \"checkSumFiles\" -y -f")]
+            [InlineData(false, "feature enable -n \"checkSumFiles\" -y")]
+            public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.Settings.Force = force;
+
+                // When
+                fixture.EnableFeature();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "feature enable -n \"checkSumFiles\" -y --noop")]
+            [InlineData(false, "feature enable -n \"checkSumFiles\" -y")]
+            public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.Settings.Noop = noop;
+
+                // When
+                fixture.EnableFeature();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "feature enable -n \"checkSumFiles\" -y -r")]
+            [InlineData(false, "feature enable -n \"checkSumFiles\" -y")]
+            public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.Settings.LimitOutput = limitOutput;
+
+                // When
+                fixture.EnableFeature();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(5, "feature enable -n \"checkSumFiles\" -y --execution-timeout \"5\"")]
+            [InlineData(0, "feature enable -n \"checkSumFiles\" -y")]
+            public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.Settings.ExecutionTimeout = executionTimeout;
+
+                // When
+                fixture.EnableFeature();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(@"c:\temp", "feature enable -n \"checkSumFiles\" -y -c \"c:\\temp\"")]
+            [InlineData("", "feature enable -n \"checkSumFiles\" -y")]
+            public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.Settings.CacheLocation = cacheLocation;
+
+                // When
+                fixture.EnableFeature();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "feature enable -n \"checkSumFiles\" -y --allowunofficial")]
+            [InlineData(false, "feature enable -n \"checkSumFiles\" -y")]
+            public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.Settings.AllowUnoffical = allowUnofficial;
+
+                // When
+                fixture.EnableFeature();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+        }
+
+        public sealed class TheDisableFeatureMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.DisableFeature());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Chocolatey_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.DisableFeature());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Could not locate executable.");
+            }
+
+            [Theory]
+            [InlineData("C:/ProgramData/chocolatey/choco.exe", "C:/ProgramData/chocolatey/choco.exe")]
+            public void Should_Use_Chocolatey_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.GivenCustomToolPathExist(expected);
+                fixture.Settings.ToolPath = toolPath;
+
+                // When
+                fixture.DisableFeature();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == expected),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.DisableFeature());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.GivenProcessReturnError();
+
+                // When
+                var result = Record.Exception(() => fixture.DisableFeature());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process returned an error.");
+            }
+
+            [Fact]
+            public void Should_Find_Chocolatey_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+
+                // When
+                fixture.DisableFeature();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == "/Working/tools/choco.exe"),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+
+                // When
+                fixture.DisableFeature();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "feature disable -n \"checkSumFiles\" -y"));
+            }
+
+            [Theory]
+            [InlineData(true, "feature disable -n \"checkSumFiles\" -d -y")]
+            [InlineData(false, "feature disable -n \"checkSumFiles\" -y")]
+            public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.Settings.Debug = debug;
+
+                // When
+                fixture.DisableFeature();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "feature disable -n \"checkSumFiles\" -v -y")]
+            [InlineData(false, "feature disable -n \"checkSumFiles\" -y")]
+            public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.Settings.Verbose = verbose;
+
+                // When
+                fixture.DisableFeature();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "feature disable -n \"checkSumFiles\" -y -f")]
+            [InlineData(false, "feature disable -n \"checkSumFiles\" -y")]
+            public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.Settings.Force = force;
+
+                // When
+                fixture.DisableFeature();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "feature disable -n \"checkSumFiles\" -y --noop")]
+            [InlineData(false, "feature disable -n \"checkSumFiles\" -y")]
+            public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.Settings.Noop = noop;
+
+                // When
+                fixture.DisableFeature();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "feature disable -n \"checkSumFiles\" -y -r")]
+            [InlineData(false, "feature disable -n \"checkSumFiles\" -y")]
+            public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.Settings.LimitOutput = limitOutput;
+
+                // When
+                fixture.DisableFeature();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(5, "feature disable -n \"checkSumFiles\" -y --execution-timeout \"5\"")]
+            [InlineData(0, "feature disable -n \"checkSumFiles\" -y")]
+            public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.Settings.ExecutionTimeout = executionTimeout;
+
+                // When
+                fixture.DisableFeature();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(@"c:\temp", "feature disable -n \"checkSumFiles\" -y -c \"c:\\temp\"")]
+            [InlineData("", "feature disable -n \"checkSumFiles\" -y")]
+            public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.Settings.CacheLocation = cacheLocation;
+
+                // When
+                fixture.DisableFeature();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "feature disable -n \"checkSumFiles\" -y --allowunofficial")]
+            [InlineData(false, "feature disable -n \"checkSumFiles\" -y")]
+            public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyFeatureTogglerFixture();
+                fixture.Settings.AllowUnoffical = allowUnofficial;
+
+                // When
+                fixture.DisableFeature();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Install/ChocolateyInstallerSettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Install/ChocolateyInstallerSettingsTests.cs
@@ -1,0 +1,18 @@
+﻿using Cake.Common.Tools.Chocolatey.Install;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
+{
+    public sealed class ChocolateyInstallerSettingsTests
+    {
+        [Fact]
+        public void Should_Set_Prerelease_To_False_By_Default()
+        {
+            // Given, When
+            var settings = new ChocolateyInstallSettings();
+
+            // Then
+            Assert.False(settings.Prerelease);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Install/ChocolateyInstallerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Install/ChocolateyInstallerTests.cs
@@ -1,0 +1,859 @@
+﻿using Cake.Common.Tests.Fixtures.Tools.Chocolatey;
+using Cake.Core.IO;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
+{
+    public sealed class ChocolateyInstallerTests
+    {
+        public sealed class TheInstallMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Target_Package_Id_Is_Null()
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.PackageId = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Install());
+
+                // Then
+                Assert.IsArgumentNullException(result, "packageId");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Install());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Chocolatey_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Install());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Could not locate executable.");
+            }
+
+            [Theory]
+            [InlineData("C:/ProgramData/chocolatey/choco.exe", "C:/ProgramData/chocolatey/choco.exe")]
+            public void Should_Use_Chocolatey_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.GivenCustomToolPathExist(expected);
+                fixture.Settings.ToolPath = toolPath;
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == expected),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Install());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.GivenProcessReturnError();
+
+                // When
+                var result = Record.Exception(() => fixture.Install());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process returned an error.");
+            }
+
+            [Fact]
+            public void Should_Find_Chocolatey_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == "/Working/tools/choco.exe"),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "install \"Cake\" -y"));
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" -d -y")]
+            [InlineData(false, "install \"Cake\" -y")]
+            public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.Debug = debug;
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" -v -y")]
+            [InlineData(false, "install \"Cake\" -y")]
+            public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.Verbose = verbose;
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --acceptLicense -y")]
+            [InlineData(false, "install \"Cake\" -y")]
+            public void Should_Add_AcceptLicense_Flag_To_Arguments_If_Set(bool acceptLicense, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.AcceptLicense = acceptLicense;
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" -y -f")]
+            [InlineData(false, "install \"Cake\" -y")]
+            public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.Force = force;
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" -y --noop")]
+            [InlineData(false, "install \"Cake\" -y")]
+            public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.Noop = noop;
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" -y -r")]
+            [InlineData(false, "install \"Cake\" -y")]
+            public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.LimitOutput = limitOutput;
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(5, "install \"Cake\" -y --execution-timeout \"5\"")]
+            [InlineData(0, "install \"Cake\" -y")]
+            public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.ExecutionTimeout = executionTimeout;
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(@"c:\temp", "install \"Cake\" -y -c \"c:\\temp\"")]
+            [InlineData("", "install \"Cake\" -y")]
+            public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.CacheLocation = cacheLocation;
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" -y --allowunofficial")]
+            [InlineData(false, "install \"Cake\" -y")]
+            public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.AllowUnoffical = allowUnofficial;
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Fact]
+            public void Should_Add_Source_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.Source = "A";
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "install \"Cake\" -y -s \"A\""));
+            }
+
+            [Fact]
+            public void Should_Add_Version_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.Version = "1.0.0";
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(),
+                    Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "install \"Cake\" -y --version \"1.0.0\""));
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" -y --pre")]
+            [InlineData(false, "install \"Cake\" -y")]
+            public void Should_Add_Prerelease_Flag_To_Arguments_If_Set(bool prerelease, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.Prerelease = prerelease;
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" -y --x86")]
+            [InlineData(false, "install \"Cake\" -y")]
+            public void Should_Add_Forcex86_Flag_To_Arguments_If_Set(bool forcex86, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.Forcex86 = forcex86;
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData("args1", "install \"Cake\" -y --ia \"args1\"")]
+            [InlineData("", "install \"Cake\" -y")]
+            public void Should_Add_InstallArguments_To_Arguments_If_Set(string installArgs, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.InstallArguments = installArgs;
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" -y -o")]
+            [InlineData(false, "install \"Cake\" -y")]
+            public void Should_Add_OverrideArguments_Flag_To_Arguments_If_Set(bool overrideArguments, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.OverrideArguments = overrideArguments;
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" -y --notSilent")]
+            [InlineData(false, "install \"Cake\" -y")]
+            public void Should_Add_NotSilent_Flag_To_Arguments_If_Set(bool notSilent, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.NotSilent = notSilent;
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData("param1", "install \"Cake\" -y --params \"param1\"")]
+            [InlineData("", "install \"Cake\" -y")]
+            public void Should_Add_PackageParameters_To_Arguments_If_Set(string packageParamters, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.PackageParameters = packageParamters;
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" -y --allowdowngrade")]
+            [InlineData(false, "install \"Cake\" -y")]
+            public void Should_Add_AllowDowngrade_Flag_To_Arguments_If_Set(bool allowDowngrade, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.AllowDowngrade = allowDowngrade;
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" -y -m")]
+            [InlineData(false, "install \"Cake\" -y")]
+            public void Should_Add_SideBySide_Flag_To_Arguments_If_Set(bool sideBySide, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.SideBySide = sideBySide;
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" -y -i")]
+            [InlineData(false, "install \"Cake\" -y")]
+            public void Should_Add_IgnoreDependencies_Flag_To_Arguments_If_Set(bool ignoreDependencies, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.IgnoreDependencies = ignoreDependencies;
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" -y -x")]
+            [InlineData(false, "install \"Cake\" -y")]
+            public void Should_Add_ForceDependencies_Flag_To_Arguments_If_Set(bool forceDependencies, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.ForceDependencies = forceDependencies;
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" -y -n")]
+            [InlineData(false, "install \"Cake\" -y")]
+            public void Should_Add_SkipPowerShell_Flag_To_Arguments_If_Set(bool skipPowerShell, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.SkipPowerShell = skipPowerShell;
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData("user1", "install \"Cake\" -y -u \"user1\"")]
+            [InlineData("", "install \"Cake\" -y")]
+            public void Should_Add_User_To_Arguments_If_Set(string user, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.User = user;
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData("password1", "install \"Cake\" -y -p \"password1\"")]
+            [InlineData("", "install \"Cake\" -y")]
+            public void Should_Add_Password_To_Arguments_If_Set(string password, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.Password = password;
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" -y --ignorechecksums")]
+            [InlineData(false, "install \"Cake\" -y")]
+            public void Should_Add_IgnoreChecksums_Flag_To_Arguments_If_Set(bool ignoreChecksums, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.IgnoreChecksums = ignoreChecksums;
+
+                // When
+                fixture.Install();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+        }
+
+        public sealed class TheInstallFromConfigMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Target_Package_Config_Path_Is_Null()
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.PackageConfigPath = null;
+
+                // When
+                var result = Record.Exception(() => fixture.InstallFromConfig());
+
+                // Then
+                Assert.IsArgumentNullException(result, "packageConfigPath");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.InstallFromConfig());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Chocolatey_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.InstallFromConfig());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Could not locate executable.");
+            }
+
+            [Theory]
+            [InlineData("C:/ProgramData/chocolatey/choco.exe", "C:/ProgramData/chocolatey/choco.exe")]
+            public void Should_Use_Chocolatey_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.ToolPath = toolPath;
+                fixture.GivenCustomToolPathExist(expected);
+
+                // When
+                fixture.InstallFromConfig();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == expected),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.InstallFromConfig());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.GivenProcessReturnError();
+
+                // When
+                var result = Record.Exception(() => fixture.InstallFromConfig());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process returned an error.");
+            }
+
+            [Fact]
+            public void Should_Find_Chocolatey_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+
+                // When
+                fixture.InstallFromConfig();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == "/Working/tools/choco.exe"),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+
+                // When
+                fixture.InstallFromConfig();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "install \"/Working/packages.config\" -y"));
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" -d -y")]
+            [InlineData(false, "install \"/Working/packages.config\" -y")]
+            public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.Debug = debug;
+
+                // When
+                fixture.InstallFromConfig();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" -v -y")]
+            [InlineData(false, "install \"/Working/packages.config\" -y")]
+            public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.Verbose = verbose;
+
+                // When
+                fixture.InstallFromConfig();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" -y -f")]
+            [InlineData(false, "install \"/Working/packages.config\" -y")]
+            public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.Force = force;
+
+                // When
+                fixture.InstallFromConfig();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" -y --noop")]
+            [InlineData(false, "install \"/Working/packages.config\" -y")]
+            public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.Noop = noop;
+
+                // When
+                fixture.InstallFromConfig();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" -y -r")]
+            [InlineData(false, "install \"/Working/packages.config\" -y")]
+            public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.LimitOutput = limitOutput;
+
+                // When
+                fixture.InstallFromConfig();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(5, "install \"/Working/packages.config\" -y --execution-timeout \"5\"")]
+            [InlineData(0, "install \"/Working/packages.config\" -y")]
+            public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.ExecutionTimeout = executionTimeout;
+
+                // When
+                fixture.InstallFromConfig();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(@"c:\temp", "install \"/Working/packages.config\" -y -c \"c:\\temp\"")]
+            [InlineData("", "install \"/Working/packages.config\" -y")]
+            public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.CacheLocation = cacheLocation;
+
+                // When
+                fixture.InstallFromConfig();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" -y --allowunofficial")]
+            [InlineData(false, "install \"/Working/packages.config\" -y")]
+            public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.AllowUnoffical = allowUnofficial;
+
+                // When
+                fixture.InstallFromConfig();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Fact]
+            public void Should_Add_Source_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new ChocolateyInstallerFixture();
+                fixture.Settings.Source = "A";
+
+                // When
+                fixture.InstallFromConfig();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "install \"/Working/packages.config\" -y -s \"A\""));
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Pack/ChocolateyPackSettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Pack/ChocolateyPackSettingsTests.cs
@@ -1,6 +1,4 @@
-﻿using Xunit;
-
-namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pack
+﻿namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pack
 {
     public sealed class ChocolateyPackSettingsTests
     {

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Pack/ChocolateyPackSettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Pack/ChocolateyPackSettingsTests.cs
@@ -1,0 +1,11 @@
+﻿using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pack
+{
+    public sealed class ChocolateyPackSettingsTests
+    {
+        public sealed class TheConstructor
+        {
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Pack/ChocolateyPackerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Pack/ChocolateyPackerTests.cs
@@ -1,0 +1,577 @@
+﻿using System;
+using Cake.Common.Tests.Fixtures.Tools.Chocolatey;
+using Cake.Common.Tests.Properties;
+using Cake.Common.Tools.Chocolatey.Pack;
+using Cake.Core;
+using Cake.Core.IO;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pack
+{
+    public sealed class ChocolateyPackerTests
+    {
+        public sealed class ThePackMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Nuspec_File_Path_Is_Null()
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.NuSpecFilePath = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Pack());
+
+                // Then
+                Assert.IsArgumentNullException(result, "nuspecFilePath");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Is_Null()
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Pack());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Chocolatey_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Pack());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Could not locate executable.");
+            }
+
+            [Theory]
+            [InlineData("C:/ProgramData/chocolatey/choco.exe", "C:/ProgramData/chocolatey/choco.exe")]
+            public void Should_Use_Chocolatey_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.Settings.ToolPath = toolPath;
+                fixture.GivenCustomToolPathExist(expected);
+
+                // When
+                fixture.Pack();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == expected),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Find_Chocolatey_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+
+                // When
+                fixture.Pack();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == "/Working/tools/choco.exe"),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Pack());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.GivenProcessReturnError();
+
+                // When
+                var result = Record.Exception(() => fixture.Pack());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process returned an error.");
+            }
+
+            [Fact]
+            public void Should_Delete_Transformed_Nuspec()
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+
+                // When
+                fixture.Pack();
+
+                // Then
+                Assert.False(fixture.FileSystem.Exist((FilePath)"/Working/existing.temp.nuspec"));
+            }
+
+            [Fact]
+            public void Should_Throw_If_Nuspec_Do_Not_Exist()
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.NuSpecFilePath = "./nonexisting.nuspec";
+
+                // When
+                var result = Record.Exception(() => fixture.Pack());
+
+                // Then
+                Assert.IsCakeException(result, "Could not find nuspec file '/Working/nonexisting.nuspec'.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Temporary_Nuspec_Already_Exist()
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.GivenTemporaryNuSpecAlreadyExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Pack());
+
+                // Then
+                Assert.IsCakeException(result, "Could not create the nuspec file '/Working/existing.temp.nuspec' since it already exist.");
+            }
+
+            [Theory]
+            [InlineData(true, "pack -d -y \"/Working/existing.temp.nuspec\"")]
+            [InlineData(false, "pack -y \"/Working/existing.temp.nuspec\"")]
+            public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.Settings.Debug = debug;
+
+                // When
+                fixture.Pack();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "pack -v -y \"/Working/existing.temp.nuspec\"")]
+            [InlineData(false, "pack -y \"/Working/existing.temp.nuspec\"")]
+            public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.Settings.Verbose = verbose;
+
+                // When
+                fixture.Pack();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "pack -y -f \"/Working/existing.temp.nuspec\"")]
+            [InlineData(false, "pack -y \"/Working/existing.temp.nuspec\"")]
+            public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.Settings.Force = force;
+
+                // When
+                fixture.Pack();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "pack -y -r \"/Working/existing.temp.nuspec\"")]
+            [InlineData(false, "pack -y \"/Working/existing.temp.nuspec\"")]
+            public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.Settings.LimitOutput = limitOutput;
+
+                // When
+                fixture.Pack();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(@"c:\temp", "pack -y -c \"c:\\temp\" \"/Working/existing.temp.nuspec\"")]
+            [InlineData("", "pack -y \"/Working/existing.temp.nuspec\"")]
+            public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.Settings.CacheLocation = cacheLocation;
+
+                // When
+                fixture.Pack();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "pack -y --allowunofficial \"/Working/existing.temp.nuspec\"")]
+            [InlineData(false, "pack -y \"/Working/existing.temp.nuspec\"")]
+            public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.Settings.AllowUnoffical = allowUnofficial;
+
+                // When
+                fixture.Pack();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Fact]
+            public void Should_Add_Version_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.Settings.Version = "1.0.0";
+
+                // When
+                fixture.Pack();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(),
+                    Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "pack -y --version \"1.0.0\" \"/Working/existing.temp.nuspec\""));
+            }
+
+            [Fact]
+            public void Should_Add_Metadata_Element_To_Nuspec_If_Missing()
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.WithNuSpecXml(Resources.ChocolateyNuspec_NoMetadataElement);
+
+                fixture.Settings.Id = "The ID";
+                fixture.Settings.Title = "The title";
+                fixture.Settings.Version = "The version";
+                fixture.Settings.Authors = new[] { "Author #1", "Author #2" };
+                fixture.Settings.Owners = new[] { "Owner #1", "Owner #2" };
+                fixture.Settings.Summary = "The summary";
+                fixture.Settings.Description = "The description";
+                fixture.Settings.ProjectUrl = new Uri("https://project.com");
+                fixture.Settings.PackageSourceUrl = new Uri("https://packagesource.com");
+                fixture.Settings.ProjectSourceUrl = new Uri("https://projectsource.com");
+                fixture.Settings.DocsUrl = new Uri("https://docs.com");
+                fixture.Settings.MailingListUrl = new Uri("https://mailing.com");
+                fixture.Settings.BugTrackerUrl = new Uri("https://bug.com");
+                fixture.Settings.Tags = new[] { "Tag1", "Tag2", "Tag3" };
+                fixture.Settings.Copyright = "The copyright";
+                fixture.Settings.LicenseUrl = new Uri("https://license.com");
+                fixture.Settings.RequireLicenseAcceptance = true;
+                fixture.Settings.IconUrl = new Uri("https://icon.com");
+                fixture.Settings.ReleaseNotes = new[] { "Line #1", "Line #2", "Line #3" };
+
+                // When
+                var result = fixture.Pack();
+
+                // Then
+                Assert.Equal(
+                    Resources.ChocolateyNuspec_Metadata.NormalizeLineEndings(),
+                    result.NormalizeLineEndings());
+            }
+
+            [Fact]
+            public void Should_Replace_Template_Tokens_In_Nuspec()
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+
+                fixture.Settings.Id = "The ID";
+                fixture.Settings.Title = "The title";
+                fixture.Settings.Version = "The version";
+                fixture.Settings.Authors = new[] { "Author #1", "Author #2" };
+                fixture.Settings.Owners = new[] { "Owner #1", "Owner #2" };
+                fixture.Settings.Summary = "The summary";
+                fixture.Settings.Description = "The description";
+                fixture.Settings.ProjectUrl = new Uri("https://project.com");
+                fixture.Settings.PackageSourceUrl = new Uri("https://packagesource.com");
+                fixture.Settings.ProjectSourceUrl = new Uri("https://projectsource.com");
+                fixture.Settings.DocsUrl = new Uri("https://docs.com");
+                fixture.Settings.MailingListUrl = new Uri("https://mailing.com");
+                fixture.Settings.BugTrackerUrl = new Uri("https://bug.com");
+                fixture.Settings.Tags = new[] { "Tag1", "Tag2", "Tag3" };
+                fixture.Settings.Copyright = "The copyright";
+                fixture.Settings.LicenseUrl = new Uri("https://license.com");
+                fixture.Settings.RequireLicenseAcceptance = true;
+                fixture.Settings.IconUrl = new Uri("https://icon.com");
+                fixture.Settings.ReleaseNotes = new[] { "Line #1", "Line #2", "Line #3" };
+
+                // When
+                var result = fixture.Pack();
+
+                // Then
+                Assert.Equal(
+                    Resources.ChocolateyNuspec_Metadata.NormalizeLineEndings(),
+                    result.NormalizeLineEndings());
+            }
+
+            [Fact]
+            public void Should_Replace_Template_Tokens_In_Nuspec_Without_Namespaces()
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.WithNuSpecXml(Resources.ChocolateyNuspec_NoMetadataValues_WithoutNamespaces);
+
+                fixture.Settings.Id = "The ID";
+                fixture.Settings.Title = "The title";
+                fixture.Settings.Version = "The version";
+                fixture.Settings.Authors = new[] { "Author #1", "Author #2" };
+                fixture.Settings.Owners = new[] { "Owner #1", "Owner #2" };
+                fixture.Settings.Summary = "The summary";
+                fixture.Settings.Description = "The description";
+                fixture.Settings.ProjectUrl = new Uri("https://project.com");
+                fixture.Settings.PackageSourceUrl = new Uri("https://packagesource.com");
+                fixture.Settings.ProjectSourceUrl = new Uri("https://projectsource.com");
+                fixture.Settings.DocsUrl = new Uri("https://docs.com");
+                fixture.Settings.MailingListUrl = new Uri("https://mailing.com");
+                fixture.Settings.BugTrackerUrl = new Uri("https://bug.com");
+                fixture.Settings.Tags = new[] { "Tag1", "Tag2", "Tag3" };
+                fixture.Settings.Copyright = "The copyright";
+                fixture.Settings.LicenseUrl = new Uri("https://license.com");
+                fixture.Settings.RequireLicenseAcceptance = true;
+                fixture.Settings.IconUrl = new Uri("https://icon.com");
+                fixture.Settings.ReleaseNotes = new[] { "Line #1", "Line #2", "Line #3" };
+
+                // When
+                var result = fixture.Pack();
+
+                // Then
+                Assert.Equal(
+                    Resources.ChocolateyNuspec_Metadata_WithoutNamespaces.NormalizeLineEndings(),
+                    result.NormalizeLineEndings());
+            }
+        }
+
+        [Fact]
+        public void Should_Replace_Template_Tokens_In_Nuspec_With_Files()
+        {
+            // Given
+            var fixture = new ChocolateyPackerFixture();
+
+            fixture.Settings.Id = "The ID";
+            fixture.Settings.Title = "The title";
+            fixture.Settings.Version = "The version";
+            fixture.Settings.Authors = new[] { "Author #1", "Author #2" };
+            fixture.Settings.Owners = new[] { "Owner #1", "Owner #2" };
+            fixture.Settings.Summary = "The summary";
+            fixture.Settings.Description = "The description";
+            fixture.Settings.ProjectUrl = new Uri("https://project.com");
+            fixture.Settings.PackageSourceUrl = new Uri("https://packagesource.com");
+            fixture.Settings.ProjectSourceUrl = new Uri("https://projectsource.com");
+            fixture.Settings.DocsUrl = new Uri("https://docs.com");
+            fixture.Settings.MailingListUrl = new Uri("https://mailing.com");
+            fixture.Settings.BugTrackerUrl = new Uri("https://bug.com");
+            fixture.Settings.Tags = new[] { "Tag1", "Tag2", "Tag3" };
+            fixture.Settings.Copyright = "The copyright";
+            fixture.Settings.LicenseUrl = new Uri("https://license.com");
+            fixture.Settings.RequireLicenseAcceptance = true;
+            fixture.Settings.IconUrl = new Uri("https://icon.com");
+            fixture.Settings.ReleaseNotes = new[] { "Line #1", "Line #2", "Line #3" };
+            fixture.Settings.Files = new[]
+            {
+                new ChocolateyNuSpecContent { Source = @"tools\**", Target = "tools" },
+            };
+
+            // When
+            var result = fixture.Pack();
+
+            // Then
+            Assert.Equal(
+                Resources.ChocolateyNuspec_Metadata.NormalizeLineEndings(),
+                result.NormalizeLineEndings());
+        }
+
+        [Fact]
+        public void Should_Replace_Template_Tokens_In_Nuspec_With_Files_Without_Namespaces()
+        {
+            // Given
+            var fixture = new ChocolateyPackerFixture();
+            fixture.WithNuSpecXml(Resources.ChocolateyNuspec_NoMetadataValues_WithoutNamespaces);
+
+            fixture.Settings.Id = "The ID";
+            fixture.Settings.Title = "The title";
+            fixture.Settings.Version = "The version";
+            fixture.Settings.Authors = new[] { "Author #1", "Author #2" };
+            fixture.Settings.Owners = new[] { "Owner #1", "Owner #2" };
+            fixture.Settings.Summary = "The summary";
+            fixture.Settings.Description = "The description";
+            fixture.Settings.ProjectUrl = new Uri("https://project.com");
+            fixture.Settings.PackageSourceUrl = new Uri("https://packagesource.com");
+            fixture.Settings.ProjectSourceUrl = new Uri("https://projectsource.com");
+            fixture.Settings.DocsUrl = new Uri("https://docs.com");
+            fixture.Settings.MailingListUrl = new Uri("https://mailing.com");
+            fixture.Settings.BugTrackerUrl = new Uri("https://bug.com");
+            fixture.Settings.Tags = new[] { "Tag1", "Tag2", "Tag3" };
+            fixture.Settings.Copyright = "The copyright";
+            fixture.Settings.LicenseUrl = new Uri("https://license.com");
+            fixture.Settings.RequireLicenseAcceptance = true;
+            fixture.Settings.IconUrl = new Uri("https://icon.com");
+            fixture.Settings.ReleaseNotes = new[] { "Line #1", "Line #2", "Line #3" };
+            fixture.Settings.Files = new[]
+            {
+                new ChocolateyNuSpecContent { Source = @"tools\**", Target = "tools" },
+            };
+
+            // When
+            var result = fixture.Pack();
+
+            // Then
+            Assert.Equal(
+                Resources.ChocolateyNuspec_Metadata_WithoutNamespaces.NormalizeLineEndings(),
+                result.NormalizeLineEndings());
+        }
+
+        public sealed class TheSettingsPackMethod
+        {
+            [Fact]
+            public void Should_Pack_If_Sufficent_Settings_Specified()
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.NuSpecFilePath = null;
+                fixture.Settings.Id = "nonexisting";
+                fixture.Settings.Version = "1.0.0";
+                fixture.Settings.Description = "The description";
+                fixture.Settings.Authors = new[] { "Author #1", "Author #2" };
+                fixture.Settings.Files = new[] { new ChocolateyNuSpecContent { Source = @"tools\**" }
+                };
+
+                // When
+                fixture.Pack(false);
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(),
+                    Arg.Is<ProcessSettings>(p => p.Arguments.Render() == "pack -y --version \"1.0.0\" \"/Working/nonexisting.temp.nuspec\""));
+            }
+
+            [Fact]
+            public void Should_Throw_If_Id_Setting_Not_Specified()
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.NuSpecFilePath = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Pack(false));
+
+                // Then
+                Assert.IsCakeException(result, "Required setting Id not specified.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Version_Setting_Not_Specified()
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.NuSpecFilePath = null;
+                fixture.Settings.Id = "nonexisting";
+
+                // When
+                var result = Record.Exception(() => fixture.Pack(false));
+
+                // Then
+                Assert.IsCakeException(result, "Required setting Version not specified.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Authors_Setting_Not_Specified()
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.NuSpecFilePath = null;
+                fixture.Settings.Id = "nonexisting";
+                fixture.Settings.Version = "1.0.0";
+
+                // When
+                var result = Record.Exception(() => fixture.Pack(false));
+
+                // Then
+                Assert.IsCakeException(result, "Required setting Authors not specified.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Description_Setting_Not_Specified()
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.NuSpecFilePath = null;
+                fixture.Settings.Id = "nonexisting";
+                fixture.Settings.Version = "1.0.0";
+                fixture.Settings.Authors = new[] { "Author #1", "Author #2" };
+
+                // When
+                var result = Record.Exception(() => fixture.Pack(false));
+
+                // Then
+                Assert.IsCakeException(result, "Required setting Description not specified.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Files_Setting_Not_Specified()
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.NuSpecFilePath = null;
+                fixture.Settings.Id = "nonexisting";
+                fixture.Settings.Version = "1.0.0";
+                fixture.Settings.Authors = new[] { "Author #1", "Author #2" };
+                fixture.Settings.Description = "The description";
+
+                // When
+                var result = Record.Exception(() => fixture.Pack(false));
+
+                // Then
+                Assert.IsCakeException(result, "Required setting Files not specified.");
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Pack/ChocolateyPackerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Pack/ChocolateyPackerTests.cs
@@ -212,6 +212,24 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pack
             }
 
             [Theory]
+            [InlineData(true, "pack -y --noop \"/Working/existing.temp.nuspec\"")]
+            [InlineData(false, "pack -y \"/Working/existing.temp.nuspec\"")]
+            public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.Settings.Noop = noop;
+
+                // When
+                fixture.Pack();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
             [InlineData(true, "pack -y -r \"/Working/existing.temp.nuspec\"")]
             [InlineData(false, "pack -y \"/Working/existing.temp.nuspec\"")]
             public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
@@ -219,6 +237,24 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pack
                 // Given
                 var fixture = new ChocolateyPackerFixture();
                 fixture.Settings.LimitOutput = limitOutput;
+
+                // When
+                fixture.Pack();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(5, "pack -y --execution-timeout \"5\" \"/Working/existing.temp.nuspec\"")]
+            [InlineData(0, "pack -y \"/Working/existing.temp.nuspec\"")]
+            public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPackerFixture();
+                fixture.Settings.ExecutionTimeout = executionTimeout;
 
                 // When
                 fixture.Pack();

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Pin/ChocolateyPinSettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Pin/ChocolateyPinSettingsTests.cs
@@ -1,0 +1,6 @@
+﻿namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pin
+{
+    class ChocolateyPinSettingsTests
+    {
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Pin/ChocolateyPinnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Pin/ChocolateyPinnerTests.cs
@@ -1,0 +1,278 @@
+﻿using Cake.Common.Tests.Fixtures.Tools.Chocolatey;
+using Cake.Core.IO;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pin
+{
+    public sealed class ChocolateyPinnerTests
+    {
+        public sealed class ThePinMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Pin());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Chocolatey_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Pin());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Could not locate executable.");
+            }
+
+            [Theory]
+            [InlineData("C:/ProgramData/chocolatey/choco.exe", "C:/ProgramData/chocolatey/choco.exe")]
+            public void Should_Use_Chocolatey_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.GivenCustomToolPathExist(expected);
+                fixture.Settings.ToolPath = toolPath;
+
+                // When
+                fixture.Pin();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == expected),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Pin());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.GivenProcessReturnError();
+
+                // When
+                var result = Record.Exception(() => fixture.Pin());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process returned an error.");
+            }
+
+            [Fact]
+            public void Should_Find_Chocolatey_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+
+                // When
+                fixture.Pin();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == "/Working/tools/choco.exe"),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+
+                // When
+                fixture.Pin();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "pin add -n \"Cake\" -y"));
+            }
+
+            [Theory]
+            [InlineData(true, "pin add -n \"Cake\" -d -y")]
+            [InlineData(false, "pin add -n \"Cake\" -y")]
+            public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.Settings.Debug = debug;
+
+                // When
+                fixture.Pin();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "pin add -n \"Cake\" -v -y")]
+            [InlineData(false, "pin add -n \"Cake\" -y")]
+            public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.Settings.Verbose = verbose;
+
+                // When
+                fixture.Pin();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "pin add -n \"Cake\" -y -f")]
+            [InlineData(false, "pin add -n \"Cake\" -y")]
+            public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.Settings.Force = force;
+
+                // When
+                fixture.Pin();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "pin add -n \"Cake\" -y --noop")]
+            [InlineData(false, "pin add -n \"Cake\" -y")]
+            public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.Settings.Noop = noop;
+
+                // When
+                fixture.Pin();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "pin add -n \"Cake\" -y -r")]
+            [InlineData(false, "pin add -n \"Cake\" -y")]
+            public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.Settings.LimitOutput = limitOutput;
+
+                // When
+                fixture.Pin();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(5, "pin add -n \"Cake\" -y --execution-timeout \"5\"")]
+            [InlineData(0, "pin add -n \"Cake\" -y")]
+            public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.Settings.ExecutionTimeout = executionTimeout;
+
+                // When
+                fixture.Pin();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(@"c:\temp", "pin add -n \"Cake\" -y -c \"c:\\temp\"")]
+            [InlineData("", "pin add -n \"Cake\" -y")]
+            public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.Settings.CacheLocation = cacheLocation;
+
+                // When
+                fixture.Pin();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "pin add -n \"Cake\" -y --allowunofficial")]
+            [InlineData(false, "pin add -n \"Cake\" -y")]
+            public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.Settings.AllowUnoffical = allowUnofficial;
+
+                // When
+                fixture.Pin();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Fact]
+            public void Should_Add_Version_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.Settings.Version = "1.0.0";
+
+                // When
+                fixture.Pin();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(),
+                    Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "pin add -n \"Cake\" --version \"1.0.0\" -y"));
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Sources/ChocolateySourcesSettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Sources/ChocolateySourcesSettingsTests.cs
@@ -1,0 +1,6 @@
+﻿namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
+{
+    class ChocolateySourcesSettingsTests
+    {
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Sources/ChocolateySourcesTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Sources/ChocolateySourcesTests.cs
@@ -1,0 +1,1032 @@
+﻿using Cake.Common.Tests.Fixtures.Tools.Chocolatey;
+using Cake.Core.IO;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
+{
+    public sealed class ChocolateySourcesTests
+    {
+        public sealed class TheAddSourceMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.AddSource());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Chocolatey_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.AddSource());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Could not locate executable.");
+            }
+
+            [Theory]
+            [InlineData("C:/ProgramData/chocolatey/choco.exe", "C:/ProgramData/chocolatey/choco.exe")]
+            public void Should_Use_Chocolatey_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.GivenCustomToolPathExist(expected);
+                fixture.Settings.ToolPath = toolPath;
+
+                // When
+                fixture.AddSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == expected),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.AddSource());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.GivenProcessReturnError();
+
+                // When
+                var result = Record.Exception(() => fixture.AddSource());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process returned an error.");
+            }
+
+            [Fact]
+            public void Should_Find_Chocolatey_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+
+                // When
+                fixture.AddSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == "/Working/tools/choco.exe"),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+
+                // When
+                fixture.AddSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "source add -n \"name\" -s \"source\" -y"));
+            }
+
+            [Theory]
+            [InlineData(true, "source add -n \"name\" -s \"source\" -d -y")]
+            [InlineData(false, "source add -n \"name\" -s \"source\" -y")]
+            public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.Debug = debug;
+
+                // When
+                fixture.AddSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "source add -n \"name\" -s \"source\" -v -y")]
+            [InlineData(false, "source add -n \"name\" -s \"source\" -y")]
+            public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.Verbose = verbose;
+
+                // When
+                fixture.AddSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "source add -n \"name\" -s \"source\" -y -f")]
+            [InlineData(false, "source add -n \"name\" -s \"source\" -y")]
+            public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.Force = force;
+
+                // When
+                fixture.AddSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "source add -n \"name\" -s \"source\" -y --noop")]
+            [InlineData(false, "source add -n \"name\" -s \"source\" -y")]
+            public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.Noop = noop;
+
+                // When
+                fixture.AddSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "source add -n \"name\" -s \"source\" -y -r")]
+            [InlineData(false, "source add -n \"name\" -s \"source\" -y")]
+            public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.LimitOutput = limitOutput;
+
+                // When
+                fixture.AddSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(5, "source add -n \"name\" -s \"source\" -y --execution-timeout \"5\"")]
+            [InlineData(0, "source add -n \"name\" -s \"source\" -y")]
+            public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.ExecutionTimeout = executionTimeout;
+
+                // When
+                fixture.AddSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(@"c:\temp", "source add -n \"name\" -s \"source\" -y -c \"c:\\temp\"")]
+            [InlineData("", "source add -n \"name\" -s \"source\" -y")]
+            public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.CacheLocation = cacheLocation;
+
+                // When
+                fixture.AddSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "source add -n \"name\" -s \"source\" -y --allowunofficial")]
+            [InlineData(false, "source add -n \"name\" -s \"source\" -y")]
+            public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.AllowUnoffical = allowUnofficial;
+
+                // When
+                fixture.AddSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(2, "source add -n \"name\" -s \"source\" -y --priority \"2\"")]
+            [InlineData(0, "source add -n \"name\" -s \"source\" -y")]
+            public void Should_Add_Priority_To_Arguments_If_Set(int priority, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.Priority = priority;
+
+                // When
+                fixture.AddSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+        }
+
+        public sealed class TheRemoveSourceMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.RemoveSource());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Chocolatey_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.RemoveSource());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Could not locate executable.");
+            }
+
+            [Theory]
+            [InlineData("C:/ProgramData/chocolatey/choco.exe", "C:/ProgramData/chocolatey/choco.exe")]
+            public void Should_Use_Chocolatey_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.GivenCustomToolPathExist(expected);
+                fixture.Settings.ToolPath = toolPath;
+
+                // When
+                fixture.RemoveSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == expected),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.RemoveSource());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.GivenProcessReturnError();
+
+                // When
+                var result = Record.Exception(() => fixture.RemoveSource());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process returned an error.");
+            }
+
+            [Fact]
+            public void Should_Find_Chocolatey_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+
+                // When
+                fixture.RemoveSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == "/Working/tools/choco.exe"),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+
+                // When
+                fixture.RemoveSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "source remove -n \"name\" -y"));
+            }
+
+            [Theory]
+            [InlineData(true, "source remove -n \"name\" -d -y")]
+            [InlineData(false, "source remove -n \"name\" -y")]
+            public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.Debug = debug;
+
+                // When
+                fixture.RemoveSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "source remove -n \"name\" -v -y")]
+            [InlineData(false, "source remove -n \"name\" -y")]
+            public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.Verbose = verbose;
+
+                // When
+                fixture.RemoveSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "source remove -n \"name\" -y -f")]
+            [InlineData(false, "source remove -n \"name\" -y")]
+            public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.Force = force;
+
+                // When
+                fixture.RemoveSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "source remove -n \"name\" -y --noop")]
+            [InlineData(false, "source remove -n \"name\" -y")]
+            public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.Noop = noop;
+
+                // When
+                fixture.RemoveSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "source remove -n \"name\" -y -r")]
+            [InlineData(false, "source remove -n \"name\" -y")]
+            public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.LimitOutput = limitOutput;
+
+                // When
+                fixture.RemoveSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(5, "source remove -n \"name\" -y --execution-timeout \"5\"")]
+            [InlineData(0, "source remove -n \"name\" -y")]
+            public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.ExecutionTimeout = executionTimeout;
+
+                // When
+                fixture.RemoveSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(@"c:\temp", "source remove -n \"name\" -y -c \"c:\\temp\"")]
+            [InlineData("", "source remove -n \"name\" -y")]
+            public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.CacheLocation = cacheLocation;
+
+                // When
+                fixture.RemoveSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "source remove -n \"name\" -y --allowunofficial")]
+            [InlineData(false, "source remove -n \"name\" -y")]
+            public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.AllowUnoffical = allowUnofficial;
+
+                // When
+                fixture.RemoveSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+        }
+
+        public sealed class TheEnableSourceMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.EnableSource());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Chocolatey_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.EnableSource());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Could not locate executable.");
+            }
+
+            [Theory]
+            [InlineData("C:/ProgramData/chocolatey/choco.exe", "C:/ProgramData/chocolatey/choco.exe")]
+            public void Should_Use_Chocolatey_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.GivenCustomToolPathExist(expected);
+                fixture.Settings.ToolPath = toolPath;
+
+                // When
+                fixture.EnableSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == expected),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.EnableSource());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.GivenProcessReturnError();
+
+                // When
+                var result = Record.Exception(() => fixture.EnableSource());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process returned an error.");
+            }
+
+            [Fact]
+            public void Should_Find_Chocolatey_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+
+                // When
+                fixture.EnableSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == "/Working/tools/choco.exe"),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+
+                // When
+                fixture.EnableSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "source enable -n \"name\" -y"));
+            }
+
+            [Theory]
+            [InlineData(true, "source enable -n \"name\" -d -y")]
+            [InlineData(false, "source enable -n \"name\" -y")]
+            public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.Debug = debug;
+
+                // When
+                fixture.EnableSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "source enable -n \"name\" -v -y")]
+            [InlineData(false, "source enable -n \"name\" -y")]
+            public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.Verbose = verbose;
+
+                // When
+                fixture.EnableSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "source enable -n \"name\" -y -f")]
+            [InlineData(false, "source enable -n \"name\" -y")]
+            public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.Force = force;
+
+                // When
+                fixture.EnableSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "source enable -n \"name\" -y --noop")]
+            [InlineData(false, "source enable -n \"name\" -y")]
+            public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.Noop = noop;
+
+                // When
+                fixture.EnableSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "source enable -n \"name\" -y -r")]
+            [InlineData(false, "source enable -n \"name\" -y")]
+            public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.LimitOutput = limitOutput;
+
+                // When
+                fixture.EnableSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(5, "source enable -n \"name\" -y --execution-timeout \"5\"")]
+            [InlineData(0, "source enable -n \"name\" -y")]
+            public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.ExecutionTimeout = executionTimeout;
+
+                // When
+                fixture.EnableSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(@"c:\temp", "source enable -n \"name\" -y -c \"c:\\temp\"")]
+            [InlineData("", "source enable -n \"name\" -y")]
+            public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.CacheLocation = cacheLocation;
+
+                // When
+                fixture.EnableSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "source enable -n \"name\" -y --allowunofficial")]
+            [InlineData(false, "source enable -n \"name\" -y")]
+            public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.AllowUnoffical = allowUnofficial;
+
+                // When
+                fixture.EnableSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+        }
+
+        public sealed class TheDisableSourceMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.DisableSource());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Chocolatey_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.DisableSource());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Could not locate executable.");
+            }
+
+            [Theory]
+            [InlineData("C:/ProgramData/chocolatey/choco.exe", "C:/ProgramData/chocolatey/choco.exe")]
+            public void Should_Use_Chocolatey_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.GivenCustomToolPathExist(expected);
+                fixture.Settings.ToolPath = toolPath;
+
+                // When
+                fixture.DisableSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == expected),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.DisableSource());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.GivenProcessReturnError();
+
+                // When
+                var result = Record.Exception(() => fixture.DisableSource());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process returned an error.");
+            }
+
+            [Fact]
+            public void Should_Find_Chocolatey_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+
+                // When
+                fixture.DisableSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == "/Working/tools/choco.exe"),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+
+                // When
+                fixture.DisableSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "source disable -n \"name\" -y"));
+            }
+
+            [Theory]
+            [InlineData(true, "source disable -n \"name\" -d -y")]
+            [InlineData(false, "source disable -n \"name\" -y")]
+            public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.Debug = debug;
+
+                // When
+                fixture.DisableSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "source disable -n \"name\" -v -y")]
+            [InlineData(false, "source disable -n \"name\" -y")]
+            public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.Verbose = verbose;
+
+                // When
+                fixture.DisableSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "source disable -n \"name\" -y -f")]
+            [InlineData(false, "source disable -n \"name\" -y")]
+            public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.Force = force;
+
+                // When
+                fixture.DisableSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "source disable -n \"name\" -y --noop")]
+            [InlineData(false, "source disable -n \"name\" -y")]
+            public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.Noop = noop;
+
+                // When
+                fixture.DisableSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "source disable -n \"name\" -y -r")]
+            [InlineData(false, "source disable -n \"name\" -y")]
+            public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.LimitOutput = limitOutput;
+
+                // When
+                fixture.DisableSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(5, "source disable -n \"name\" -y --execution-timeout \"5\"")]
+            [InlineData(0, "source disable -n \"name\" -y")]
+            public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.ExecutionTimeout = executionTimeout;
+
+                // When
+                fixture.DisableSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(@"c:\temp", "source disable -n \"name\" -y -c \"c:\\temp\"")]
+            [InlineData("", "source disable -n \"name\" -y")]
+            public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.CacheLocation = cacheLocation;
+
+                // When
+                fixture.DisableSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "source disable -n \"name\" -y --allowunofficial")]
+            [InlineData(false, "source disable -n \"name\" -y")]
+            public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
+            {
+                // Given
+                var fixture = new ChocolateySourcesFixture();
+                fixture.Settings.AllowUnoffical = allowUnofficial;
+
+                // When
+                fixture.DisableSource();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Upgrade/ChocolateyUpgradeSettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Upgrade/ChocolateyUpgradeSettingsTests.cs
@@ -1,0 +1,18 @@
+﻿using Cake.Common.Tools.Chocolatey.Upgrade;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
+{
+    public sealed class ChocolateyUpgradeSettingsTests
+    {
+        [Fact]
+        public void Should_Set_Prerelease_To_False_By_Default()
+        {
+            // Given, When
+            var settings = new ChocolateyUpgradeSettings();
+
+            // Then
+            Assert.False(settings.Prerelease);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Upgrade/ChocolateyUpgraderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Upgrade/ChocolateyUpgraderTests.cs
@@ -1,0 +1,596 @@
+﻿using Cake.Common.Tests.Fixtures.Tools.Chocolatey;
+using Cake.Core.IO;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
+{
+    public sealed class ChocolateyUpgraderTests
+    {
+        public sealed class TheInstallMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Target_Package_Id_Is_Null()
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.PackageId = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Upgrade());
+
+                // Then
+                Assert.IsArgumentNullException(result, "packageId");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Upgrade());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Chocolatey_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Upgrade());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Could not locate executable.");
+            }
+
+            [Theory]
+            [InlineData("C:/ProgramData/chocolatey/choco.exe", "C:/ProgramData/chocolatey/choco.exe")]
+            public void Should_Use_Chocolatey_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.GivenCustomToolPathExist(expected);
+                fixture.Settings.ToolPath = toolPath;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == expected),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Upgrade());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.GivenProcessReturnError();
+
+                // When
+                var result = Record.Exception(() => fixture.Upgrade());
+
+                // Then
+                Assert.IsCakeException(result, "Chocolatey: Process returned an error.");
+            }
+
+            [Fact]
+            public void Should_Find_Chocolatey_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == "/Working/tools/choco.exe"),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "upgrade \"Cake\" -y"));
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" -d -y")]
+            [InlineData(false, "upgrade \"Cake\" -y")]
+            public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.Debug = debug;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" -v -y")]
+            [InlineData(false, "upgrade \"Cake\" -y")]
+            public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.Verbose = verbose;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --acceptLicense -y")]
+            [InlineData(false, "upgrade \"Cake\" -y")]
+            public void Should_Add_AcceptLicense_Flag_To_Arguments_If_Set(bool acceptLicense, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.AcceptLicense = acceptLicense;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" -y -f")]
+            [InlineData(false, "upgrade \"Cake\" -y")]
+            public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.Force = force;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" -y --noop")]
+            [InlineData(false, "upgrade \"Cake\" -y")]
+            public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.Noop = noop;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" -y -r")]
+            [InlineData(false, "upgrade \"Cake\" -y")]
+            public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.LimitOutput = limitOutput;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(5, "upgrade \"Cake\" -y --execution-timeout \"5\"")]
+            [InlineData(0, "upgrade \"Cake\" -y")]
+            public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.ExecutionTimeout = executionTimeout;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(@"c:\temp", "upgrade \"Cake\" -y -c \"c:\\temp\"")]
+            [InlineData("", "upgrade \"Cake\" -y")]
+            public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.CacheLocation = cacheLocation;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" -y --allowunofficial")]
+            [InlineData(false, "upgrade \"Cake\" -y")]
+            public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.AllowUnoffical = allowUnofficial;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Fact]
+            public void Should_Add_Source_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.Source = "A";
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "upgrade \"Cake\" -y -s \"A\""));
+            }
+
+            [Fact]
+            public void Should_Add_Version_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.Version = "1.0.0";
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(),
+                    Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "upgrade \"Cake\" -y --version \"1.0.0\""));
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" -y --pre")]
+            [InlineData(false, "upgrade \"Cake\" -y")]
+            public void Should_Add_Prerelease_Flag_To_Arguments_If_Set(bool prerelease, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.Prerelease = prerelease;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" -y --x86")]
+            [InlineData(false, "upgrade \"Cake\" -y")]
+            public void Should_Add_Forcex86_Flag_To_Arguments_If_Set(bool forcex86, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.Forcex86 = forcex86;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData("args1", "upgrade \"Cake\" -y --ia \"args1\"")]
+            [InlineData("", "upgrade \"Cake\" -y")]
+            public void Should_Add_InstallArguments_To_Arguments_If_Set(string installArgs, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.InstallArguments = installArgs;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" -y -o")]
+            [InlineData(false, "upgrade \"Cake\" -y")]
+            public void Should_Add_OverrideArguments_Flag_To_Arguments_If_Set(bool overrideArguments, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.OverrideArguments = overrideArguments;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" -y --notSilent")]
+            [InlineData(false, "upgrade \"Cake\" -y")]
+            public void Should_Add_NotSilent_Flag_To_Arguments_If_Set(bool notSilent, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.NotSilent = notSilent;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData("param1", "upgrade \"Cake\" -y --params \"param1\"")]
+            [InlineData("", "upgrade \"Cake\" -y")]
+            public void Should_Add_PackageParameters_To_Arguments_If_Set(string packageParamters, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.PackageParameters = packageParamters;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" -y --allowdowngrade")]
+            [InlineData(false, "upgrade \"Cake\" -y")]
+            public void Should_Add_AllowDowngrade_Flag_To_Arguments_If_Set(bool allowDowngrade, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.AllowDowngrade = allowDowngrade;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" -y -m")]
+            [InlineData(false, "upgrade \"Cake\" -y")]
+            public void Should_Add_SideBySide_Flag_To_Arguments_If_Set(bool sideBySide, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.SideBySide = sideBySide;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" -y -i")]
+            [InlineData(false, "upgrade \"Cake\" -y")]
+            public void Should_Add_IgnoreDependencies_Flag_To_Arguments_If_Set(bool ignoreDependencies, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.IgnoreDependencies = ignoreDependencies;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" -y -n")]
+            [InlineData(false, "upgrade \"Cake\" -y")]
+            public void Should_Add_SkipPowerShell_Flag_To_Arguments_If_Set(bool skipPowerShell, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.SkipPowerShell = skipPowerShell;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" -y --failonunfound")]
+            [InlineData(false, "upgrade \"Cake\" -y")]
+            public void Should_Add_FailOnUnfound_Flag_To_Arguments_If_Set(bool failOnUnfound, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.FailOnUnfound = failOnUnfound;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" -y --failonnotinstalled")]
+            [InlineData(false, "upgrade \"Cake\" -y")]
+            public void Should_Add_FailOnNotInstalled_Flag_To_Arguments_If_Set(bool failOnNotInstalled, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.FailOnNotInstalled = failOnNotInstalled;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData("user1", "upgrade \"Cake\" -y -u \"user1\"")]
+            [InlineData("", "upgrade \"Cake\" -y")]
+            public void Should_Add_User_To_Arguments_If_Set(string user, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.User = user;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData("password1", "upgrade \"Cake\" -y -p \"password1\"")]
+            [InlineData("", "upgrade \"Cake\" -y")]
+            public void Should_Add_Password_To_Arguments_If_Set(string password, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.Password = password;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" -y --ignorechecksums")]
+            [InlineData(false, "upgrade \"Cake\" -y")]
+            public void Should_Add_IgnoreChecksums_Flag_To_Arguments_If_Set(bool ignoreChecksums, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.IgnoreChecksums = ignoreChecksums;
+
+                // When
+                fixture.Upgrade();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == expected));
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -117,6 +117,8 @@
     <Compile Include="Tools\Chocolatey\ChocolateyTool.cs" />
     <Compile Include="Tools\Chocolatey\Config\ChocolateyConfigSetter.cs" />
     <Compile Include="Tools\Chocolatey\Config\ChocolateyConfigSettings.cs" />
+    <Compile Include="Tools\Chocolatey\Features\ChocolateyFeatureSettings.cs" />
+    <Compile Include="Tools\Chocolatey\Features\ChocolateyFeatureToggler.cs" />
     <Compile Include="Tools\Chocolatey\IChocolateyToolResolver.cs" />
     <Compile Include="Tools\Chocolatey\Install\ChocolateyInstaller.cs" />
     <Compile Include="Tools\Chocolatey\Install\ChocolateyInstallSettings.cs" />

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -133,6 +133,8 @@
     <Compile Include="Tools\Chocolatey\Push\ChocolateyPushSettings.cs" />
     <Compile Include="Tools\Chocolatey\Sources\ChocolateySources.cs" />
     <Compile Include="Tools\Chocolatey\Sources\ChocolateySourcesSettings.cs" />
+    <Compile Include="Tools\Chocolatey\Upgrade\ChocolateyUpgrader.cs" />
+    <Compile Include="Tools\Chocolatey\Upgrade\ChocolateyUpgradeSettings.cs" />
     <Compile Include="Tools\DupFinder\DupFinderAliases.cs" />
     <Compile Include="Tools\DupFinder\DupFinderRunner.cs" />
     <Compile Include="Tools\DupFinder\DupFinderSettings.cs" />
@@ -260,9 +262,7 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Tools\Chocolatey\Upgrade\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets" Condition="Exists('..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets') and $(Configuration)=='Release'" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -115,6 +115,8 @@
     <Compile Include="Tools\Chocolatey\ChocolateyAliases.cs" />
     <Compile Include="Tools\Chocolatey\ChocolateyToolResolver.cs" />
     <Compile Include="Tools\Chocolatey\ChocolateyTool.cs" />
+    <Compile Include="Tools\Chocolatey\Config\ChocolateyConfigSetter.cs" />
+    <Compile Include="Tools\Chocolatey\Config\ChocolateyConfigSettings.cs" />
     <Compile Include="Tools\Chocolatey\IChocolateyToolResolver.cs" />
     <Compile Include="Tools\Chocolatey\Install\ChocolateyInstaller.cs" />
     <Compile Include="Tools\Chocolatey\Install\ChocolateyInstallSettings.cs" />

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -129,6 +129,8 @@
     <Compile Include="Tools\Chocolatey\Pack\ChocolateyPackSettings.cs" />
     <Compile Include="Tools\Chocolatey\Pin\ChocolateyPinner.cs" />
     <Compile Include="Tools\Chocolatey\Pin\ChocolateyPinSettings.cs" />
+    <Compile Include="Tools\Chocolatey\Sources\ChocolateySources.cs" />
+    <Compile Include="Tools\Chocolatey\Sources\ChocolateySourcesSettings.cs" />
     <Compile Include="Tools\DupFinder\DupFinderAliases.cs" />
     <Compile Include="Tools\DupFinder\DupFinderRunner.cs" />
     <Compile Include="Tools\DupFinder\DupFinderSettings.cs" />
@@ -258,7 +260,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Tools\Chocolatey\Push\" />
-    <Folder Include="Tools\Chocolatey\Sources\" />
     <Folder Include="Tools\Chocolatey\Upgrade\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -110,6 +110,8 @@
     <Compile Include="Tools\Cake\CakeAliases.cs" />
     <Compile Include="Tools\Cake\CakeRunner.cs" />
     <Compile Include="Tools\Cake\CakeSettings.cs" />
+    <Compile Include="Tools\Chocolatey\ApiKey\ChocolateyApiKeySetter.cs" />
+    <Compile Include="Tools\Chocolatey\ApiKey\ChocolateyApiKeySettings.cs" />
     <Compile Include="Tools\Chocolatey\ChocolateyAliases.cs" />
     <Compile Include="Tools\Chocolatey\ChocolateyToolResolver.cs" />
     <Compile Include="Tools\Chocolatey\ChocolateyTool.cs" />
@@ -252,7 +254,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Tools\Chocolatey\Push\" />
-    <Folder Include="Tools\Chocolatey\SetApiKey\" />
     <Folder Include="Tools\Chocolatey\Sources\" />
     <Folder Include="Tools\Chocolatey\Upgrade\" />
   </ItemGroup>

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -129,6 +129,8 @@
     <Compile Include="Tools\Chocolatey\Pack\ChocolateyPackSettings.cs" />
     <Compile Include="Tools\Chocolatey\Pin\ChocolateyPinner.cs" />
     <Compile Include="Tools\Chocolatey\Pin\ChocolateyPinSettings.cs" />
+    <Compile Include="Tools\Chocolatey\Push\ChocolateyPusher.cs" />
+    <Compile Include="Tools\Chocolatey\Push\ChocolateyPushSettings.cs" />
     <Compile Include="Tools\Chocolatey\Sources\ChocolateySources.cs" />
     <Compile Include="Tools\Chocolatey\Sources\ChocolateySourcesSettings.cs" />
     <Compile Include="Tools\DupFinder\DupFinderAliases.cs" />
@@ -259,7 +261,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Tools\Chocolatey\Push\" />
     <Folder Include="Tools\Chocolatey\Upgrade\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -110,6 +110,15 @@
     <Compile Include="Tools\Cake\CakeAliases.cs" />
     <Compile Include="Tools\Cake\CakeRunner.cs" />
     <Compile Include="Tools\Cake\CakeSettings.cs" />
+    <Compile Include="Tools\Chocolatey\ChocolateyAliases.cs" />
+    <Compile Include="Tools\Chocolatey\ChocolateyToolResolver.cs" />
+    <Compile Include="Tools\Chocolatey\ChocolateyTool.cs" />
+    <Compile Include="Tools\Chocolatey\IChocolateyToolResolver.cs" />
+    <Compile Include="Tools\Chocolatey\Pack\ChocolateyNuSpecContent.cs" />
+    <Compile Include="Tools\Chocolatey\Pack\ChocolateyNuSpecProcessor.cs" />
+    <Compile Include="Tools\Chocolatey\Pack\ChocolateyNuSpecTransformer.cs" />
+    <Compile Include="Tools\Chocolatey\Pack\ChocolateyPacker.cs" />
+    <Compile Include="Tools\Chocolatey\Pack\ChocolateyPackSettings.cs" />
     <Compile Include="Tools\DupFinder\DupFinderAliases.cs" />
     <Compile Include="Tools\DupFinder\DupFinderRunner.cs" />
     <Compile Include="Tools\DupFinder\DupFinderSettings.cs" />
@@ -236,6 +245,13 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Tools\Chocolatey\Install\" />
+    <Folder Include="Tools\Chocolatey\Push\" />
+    <Folder Include="Tools\Chocolatey\SetApiKey\" />
+    <Folder Include="Tools\Chocolatey\Sources\" />
+    <Folder Include="Tools\Chocolatey\Upgrade\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets" Condition="Exists('..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets') and $(Configuration)=='Release'" />

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -114,6 +114,8 @@
     <Compile Include="Tools\Chocolatey\ChocolateyToolResolver.cs" />
     <Compile Include="Tools\Chocolatey\ChocolateyTool.cs" />
     <Compile Include="Tools\Chocolatey\IChocolateyToolResolver.cs" />
+    <Compile Include="Tools\Chocolatey\Install\ChocolateyInstaller.cs" />
+    <Compile Include="Tools\Chocolatey\Install\ChocolateyInstallSettings.cs" />
     <Compile Include="Tools\Chocolatey\Pack\ChocolateyNuSpecContent.cs" />
     <Compile Include="Tools\Chocolatey\Pack\ChocolateyNuSpecProcessor.cs" />
     <Compile Include="Tools\Chocolatey\Pack\ChocolateyNuSpecTransformer.cs" />
@@ -247,7 +249,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Tools\Chocolatey\Install\" />
     <Folder Include="Tools\Chocolatey\Push\" />
     <Folder Include="Tools\Chocolatey\SetApiKey\" />
     <Folder Include="Tools\Chocolatey\Sources\" />

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -121,6 +121,8 @@
     <Compile Include="Tools\Chocolatey\Pack\ChocolateyNuSpecTransformer.cs" />
     <Compile Include="Tools\Chocolatey\Pack\ChocolateyPacker.cs" />
     <Compile Include="Tools\Chocolatey\Pack\ChocolateyPackSettings.cs" />
+    <Compile Include="Tools\Chocolatey\Pin\ChocolateyPinner.cs" />
+    <Compile Include="Tools\Chocolatey\Pin\ChocolateyPinSettings.cs" />
     <Compile Include="Tools\DupFinder\DupFinderAliases.cs" />
     <Compile Include="Tools\DupFinder\DupFinderRunner.cs" />
     <Compile Include="Tools\DupFinder\DupFinderSettings.cs" />

--- a/src/Cake.Common/Tools/Chocolatey/ApiKey/ChocolateyApiKeySetter.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ApiKey/ChocolateyApiKeySetter.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Globalization;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Chocolatey.ApiKey
+{
+    /// <summary>
+    /// The Chocolatey package pinner used to pin Chocolatey packages.
+    /// </summary>
+    public sealed class ChocolateyApiKeySetter : ChocolateyTool<ChocolateyApiKeySettings>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChocolateyApiKeySetter"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
+        /// <param name="resolver">The Chocolatey tool resolver.</param>
+        public ChocolateyApiKeySetter(IFileSystem fileSystem, ICakeEnvironment environment,
+            IProcessRunner processRunner, IGlobber globber, IChocolateyToolResolver resolver)
+            : base(fileSystem, environment, processRunner, globber, resolver)
+        {
+        }
+
+        /// <summary>
+        /// Pins Chocolatey packages using the specified package id and settings.
+        /// </summary>
+        /// <param name="apiKey">The API key.</param>
+        /// <param name="source">The Server URL where the API key is valid.</param>
+        /// <param name="settings">The settings.</param>
+        public void Set(string apiKey, string source, ChocolateyApiKeySettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                throw new ArgumentNullException("apiKey");
+            }
+
+            if (string.IsNullOrWhiteSpace(source))
+            {
+                throw new ArgumentNullException("source");
+            }
+
+            Run(settings, GetArguments(apiKey, source, settings), settings.ToolPath);
+        }
+
+        private ProcessArgumentBuilder GetArguments(string apiKey, string source, ChocolateyApiKeySettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("apikey");
+
+            builder.Append("-s");
+            builder.AppendQuoted(source);
+
+            builder.Append("-k");
+            builder.AppendQuoted(apiKey);
+
+            // Debug
+            if (settings.Debug)
+            {
+                builder.Append("-d");
+            }
+
+            // Verbose
+            if (settings.Verbose)
+            {
+                builder.Append("-v");
+            }
+
+            // Always say yes, so as to not show interactive prompt
+            builder.Append("-y");
+
+            // Force
+            if (settings.Force)
+            {
+                builder.Append("-f");
+            }
+
+            // Noop
+            if (settings.Noop)
+            {
+                builder.Append("--noop");
+            }
+
+            // Limit Output
+            if (settings.LimitOutput)
+            {
+                builder.Append("-r");
+            }
+
+            // Execution Timeout
+            if (settings.ExecutionTimeout != 0)
+            {
+                builder.Append("--execution-timeout");
+                builder.AppendQuoted(settings.ExecutionTimeout.ToString(CultureInfo.InvariantCulture));
+            }
+
+            // Cache Location
+            if (!string.IsNullOrWhiteSpace(settings.CacheLocation))
+            {
+                builder.Append("-c");
+                builder.AppendQuoted(settings.CacheLocation);
+            }
+
+            // Allow Unoffical
+            if (settings.AllowUnoffical)
+            {
+                builder.Append("--allowunofficial");
+            }
+
+            return builder;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/ApiKey/ChocolateyApiKeySettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ApiKey/ChocolateyApiKeySettings.cs
@@ -1,0 +1,65 @@
+﻿using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Chocolatey.ApiKey
+{
+    /// <summary>
+    /// Contains settings used by <see cref="ChocolateyApiKeySetter"/>.
+    /// </summary>
+    public sealed class ChocolateyApiKeySettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in debug mode.
+        /// </summary>
+        /// <value>The debug flag</value>
+        public bool Debug { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in verbose mode.
+        /// </summary>
+        /// <value>The verbose flag.</value>
+        public bool Verbose { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in forced mode.
+        /// </summary>
+        /// <value>The force flag</value>
+        public bool Force { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in noop mode.
+        /// </summary>
+        /// <value>The noop flag.</value>
+        public bool Noop { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in limited output mode.
+        /// </summary>
+        /// <value>The limit output flag</value>
+        public bool LimitOutput { get; set; }
+
+        /// <summary>
+        /// Gets or sets the execution timeout value.
+        /// </summary>
+        /// <value>The execution timeout</value>
+        /// <remarks>Default is 2700 seconds</remarks>
+        public int ExecutionTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the location of the download cache.
+        /// </summary>
+        /// <value>The download cache location</value>
+        public string CacheLocation { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in allow unofficial mode.
+        /// </summary>
+        /// <value>The allow unofficial flag</value>
+        public bool AllowUnoffical { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tool path.
+        /// </summary>
+        /// <value>The tool path.</value>
+        public FilePath ToolPath { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
@@ -10,6 +10,9 @@ using Cake.Core.IO;
 
 namespace Cake.Common.Tools.Chocolatey
 {
+    using global::Cake.Common.Tools.Chocolatey.Features;
+    using global::Cake.Common.Tools.NuGet.Sources;
+
     /// <summary>
     /// Contains functionality for working with Chocolatey.
     /// </summary>
@@ -190,6 +193,74 @@ namespace Cake.Common.Tools.Chocolatey
             var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
             var packer = new ChocolateyConfigSetter(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
             packer.Set(name, value, settings);
+        }
+
+        /// <summary>
+        /// Enables a Chocolatey Feature using the specified name
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="name">Name of the feature.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("EnableFeature")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Features")]
+        public static void ChocolateyEnableFeature(this ICakeContext context, string name)
+        {
+            context.ChocolateyEnableFeature(name, new ChocolateyFeatureSettings());
+        }
+
+        /// <summary>
+        /// Enables a Chocolatey Feature using the specified name and settings
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="name">Name of the feature.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("EnableFeature")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Features")]
+        public static void ChocolateyEnableFeature(this ICakeContext context, string name, ChocolateyFeatureSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
+            var runner = new ChocolateyFeatureToggler(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
+            runner.EnableFeature(name, settings);
+        }
+
+        /// <summary>
+        /// Disables a Chocolatey Feature using the specified name
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="name">Name of the feature.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("DisableFeature")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Features")]
+        public static void ChocolateyDisableFeature(this ICakeContext context, string name)
+        {
+            context.ChocolateyDisableFeature(name, new ChocolateyFeatureSettings());
+        }
+
+        /// <summary>
+        /// Disables a Chocolatey Feature using the specified name and settings
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="name">Name of the feature.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("DisableFeature")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Features")]
+        public static void ChocolateyDisableFeature(this ICakeContext context, string name, ChocolateyFeatureSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
+            var runner = new ChocolateyFeatureToggler(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
+            runner.DisableFeature(name, settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Cake.Common.Tools.Chocolatey.Install;
 using Cake.Common.Tools.Chocolatey.Pack;
+using Cake.Common.Tools.Chocolatey.Pin;
 using Cake.Core;
 using Cake.Core.Annotations;
 using Cake.Core.IO;
@@ -122,6 +123,27 @@ namespace Cake.Common.Tools.Chocolatey
             var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
             var runner = new ChocolateyInstaller(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
             runner.InstallFromConfig(packageConfigPath, settings);
+        }
+
+        /// <summary>
+        /// Pins a Chocolatey package using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="name">The name.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Pin")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Pin")]
+        public static void ChocolateyPin(this ICakeContext context, string name, ChocolateyPinSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
+            var packer = new ChocolateyPinner(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
+            packer.Pin(name, settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
@@ -5,6 +5,7 @@ using Cake.Common.Tools.Chocolatey.Features;
 using Cake.Common.Tools.Chocolatey.Install;
 using Cake.Common.Tools.Chocolatey.Pack;
 using Cake.Common.Tools.Chocolatey.Pin;
+using Cake.Common.Tools.Chocolatey.Push;
 using Cake.Common.Tools.Chocolatey.Sources;
 using Cake.Core;
 using Cake.Core.Annotations;
@@ -398,6 +399,27 @@ namespace Cake.Common.Tools.Chocolatey
             var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
             var runner = new ChocolateySources(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
             runner.DisableSource(name, settings);
+        }
+
+        /// <summary>
+        /// Pushes a Chocolatey package to a Chocolatey server and publishes it.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="packageFilePath">The <c>.nupkg</c> file path.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Push")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Push")]
+        public static void ChocolateyPush(this ICakeContext context, FilePath packageFilePath, ChocolateyPushSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
+            var packer = new ChocolateyPusher(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
+            packer.Push(packageFilePath, settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
@@ -7,6 +7,7 @@ using Cake.Common.Tools.Chocolatey.Pack;
 using Cake.Common.Tools.Chocolatey.Pin;
 using Cake.Common.Tools.Chocolatey.Push;
 using Cake.Common.Tools.Chocolatey.Sources;
+using Cake.Common.Tools.Chocolatey.Upgrade;
 using Cake.Core;
 using Cake.Core.Annotations;
 using Cake.Core.IO;
@@ -420,6 +421,47 @@ namespace Cake.Common.Tools.Chocolatey
             var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
             var packer = new ChocolateyPusher(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
             packer.Push(packageFilePath, settings);
+        }
+
+        /// <summary>
+        /// Upgrades Chocolatey package.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="packageId">The id of the package to upgrade.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Upgrade")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Upgrade")]
+        public static void ChocolateyUpgrade(this ICakeContext context, string packageId)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
+            var runner = new ChocolateyUpgrader(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
+            runner.Upgrade(packageId, new ChocolateyUpgradeSettings());
+        }
+
+        /// <summary>
+        /// Upgrades Chocolatey package using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="packageId">The id of the package to upgrade.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Update")]
+        [CakeNamespaceImport("Cake.Common.Tools.NuGet.Update")]
+        public static void ChocolateyUpgrade(this ICakeContext context, string packageId, ChocolateyUpgradeSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
+            var runner = new ChocolateyUpgrader(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
+            runner.Upgrade(packageId, settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
@@ -26,6 +26,44 @@ namespace Cake.Common.Tools.Chocolatey
         /// <param name="context">The context.</param>
         /// <param name="nuspecFilePath">The nuspec file path.</param>
         /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        ///     var chocolateyPackSettings   = new ChocolateyPackSettings {
+        ///                                     Id                      = "TestChocolatey",
+        ///                                     Title                   = "The tile of the package",
+        ///                                     Version                 = "0.0.0.1",
+        ///                                     Authors                 = new[] {"John Doe"},
+        ///                                     Owners                  = new[] {"Contoso"},
+        ///                                     Summary                 = "Excellent summary of what the package does",
+        ///                                     Description             = "The description of the package",
+        ///                                     ProjectUrl              = new Uri("https://github.com/SomeUser/TestChocolatey/"),
+        ///                                     PackageSourceUrl        = new Uri("https://github.com/SomeUser/TestChocolatey/"),
+        ///                                     ProjectSourceUrl        = new Uri("https://github.com/SomeUser/TestChocolatey/"),
+        ///                                     DocsUrl                 = new Uri("https://github.com/SomeUser/TestChocolatey/"),
+        ///                                     MailingListUrl          = new Uri("https://github.com/SomeUser/TestChocolatey/"),
+        ///                                     BugTrackerUrl           = new Uri("https://github.com/SomeUser/TestChocolatey/"),
+        ///                                     Tags                    = new [] {"Cake", "Script", "Build"},
+        ///                                     Copyright               = "Some company 2015",
+        ///                                     LicenseUrl              = new Uri("https://github.com/SomeUser/TestChocolatey/blob/master/LICENSE.md"),
+        ///                                     RequireLicenseAcceptance= false,
+        ///                                     IconUrl                 = new Uri("http://cdn.rawgit.com/SomeUser/TestChocolatey/master/icons/testchocolatey.png"),
+        ///                                     ReleaseNotes            = new [] {"Bug fixes", "Issue fixes", "Typos"},
+        ///                                     Files                   = new [] {
+        ///                                                                          new ChocolateyNuSpecContent {Source = "bin/TestChocolatey.dll", Target = "bin"},
+        ///                                                                       },
+        ///                                     Debug                   = false,
+        ///                                     Verbose                 = false,
+        ///                                     Force                   = false,
+        ///                                     Noop                    = false,
+        ///                                     LimitOutput             = false,
+        ///                                     ExecutionTimeout        = 13,
+        ///                                     CacheLocation           = @"C:\temp",
+        ///                                     AllowUnoffical          = false
+        ///                                 };
+        ///
+        ///     ChocolateyPack("./nuspec/TestChocolatey.nuspec", chocolateyPackSettings);
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Pack")]
         [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Pack")]
@@ -46,6 +84,44 @@ namespace Cake.Common.Tools.Chocolatey
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        ///     var chocolateyPackSettings   = new ChocolateyPackSettings {
+        ///                                     Id                      = "TestChocolatey",
+        ///                                     Title                   = "The tile of the package",
+        ///                                     Version                 = "0.0.0.1",
+        ///                                     Authors                 = new[] {"John Doe"},
+        ///                                     Owners                  = new[] {"Contoso"},
+        ///                                     Summary                 = "Excellent summary of what the package does",
+        ///                                     Description             = "The description of the package",
+        ///                                     ProjectUrl              = new Uri("https://github.com/SomeUser/TestChocolatey/"),
+        ///                                     PackageSourceUrl        = new Uri("https://github.com/SomeUser/TestChocolatey/"),
+        ///                                     ProjectSourceUrl        = new Uri("https://github.com/SomeUser/TestChocolatey/"),
+        ///                                     DocsUrl                 = new Uri("https://github.com/SomeUser/TestChocolatey/"),
+        ///                                     MailingListUrl          = new Uri("https://github.com/SomeUser/TestChocolatey/"),
+        ///                                     BugTrackerUrl           = new Uri("https://github.com/SomeUser/TestChocolatey/"),
+        ///                                     Tags                    = new [] {"Cake", "Script", "Build"},
+        ///                                     Copyright               = "Some company 2015",
+        ///                                     LicenseUrl              = new Uri("https://github.com/SomeUser/TestChocolatey/blob/master/LICENSE.md"),
+        ///                                     RequireLicenseAcceptance= false,
+        ///                                     IconUrl                 = new Uri("http://cdn.rawgit.com/SomeUser/TestChocolatey/master/icons/testchocolatey.png"),
+        ///                                     ReleaseNotes            = new [] {"Bug fixes", "Issue fixes", "Typos"},
+        ///                                     Files                   = new [] {
+        ///                                                                          new ChocolateyNuSpecContent {Source = "bin/TestChocolatey.dll", Target = "bin"},
+        ///                                                                       },
+        ///                                     Debug                   = false,
+        ///                                     Verbose                 = false,
+        ///                                     Force                   = false,
+        ///                                     Noop                    = false,
+        ///                                     LimitOutput             = false,
+        ///                                     ExecutionTimeout        = 13,
+        ///                                     CacheLocation           = @"C:\temp",
+        ///                                     AllowUnoffical          = false
+        ///                                 };
+        ///
+        ///     ChocolateyPack(chocolateyPackSettings);
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Pack")]
         [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Pack")]
@@ -66,6 +142,11 @@ namespace Cake.Common.Tools.Chocolatey
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="packageId">The id of the package to install.</param>
+        /// <example>
+        /// <code>
+        /// ChocolateyInstall("MyChocolateyPackage");
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Install")]
         [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Install")]
@@ -81,6 +162,36 @@ namespace Cake.Common.Tools.Chocolatey
         /// <param name="context">The context.</param>
         /// <param name="packageId">The id of the package to install.</param>
         /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// ChocolateyInstall("MyChocolateyPackage", new ChocolateyInstallSettings {
+        ///     Source                = true,
+        ///     Version               = "1.2.3",
+        ///     Prerelease            = false,
+        ///     Forcex86              = false,
+        ///     InstallArguments      = "arg1",
+        ///     OverrideArguments     = false,
+        ///     NotSilent             = false,
+        ///     PackageParameters     = "param1",
+        ///     AllowDowngrade        = false,
+        ///     SideBySide            = false,
+        ///     IgnoreDependencies    = false,
+        ///     ForceDependencies     = false,
+        ///     SkipPowerShell        = false,
+        ///     User                  = "user",
+        ///     Password              = "password",
+        ///     IgnoreChecksums       = false,
+        ///     Debug                 = false,
+        ///     Verbose               = false,
+        ///     Force                 = false,
+        ///     Noop                  = false,
+        ///     LimitOutput           = false,
+        ///     ExecutionTimeout      = 13,
+        ///     CacheLocation         = @"C:\temp",
+        ///     AllowUnoffical        = false
+        ///     });
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Install")]
         [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Install")]
@@ -101,6 +212,11 @@ namespace Cake.Common.Tools.Chocolatey
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="packageConfigPath">The package configuration to install.</param>
+        /// <example>
+        /// <code>
+        /// ChocolateyInstallFromConfig("./tools/packages.config");
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Install")]
         [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Install")]
@@ -116,6 +232,36 @@ namespace Cake.Common.Tools.Chocolatey
         /// <param name="context">The context.</param>
         /// <param name="packageConfigPath">The package configuration to install.</param>
         /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// ChocolateyInstallFromConfig("./tools/packages.config", new ChocolateyInstallSettings {
+        ///     Source                = true,
+        ///     Version               = "1.2.3",
+        ///     Prerelease            = false,
+        ///     Forcex86              = false,
+        ///     InstallArguments      = "arg1",
+        ///     OverrideArguments     = false,
+        ///     NotSilent             = false,
+        ///     PackageParameters     = "param1",
+        ///     AllowDowngrade        = false,
+        ///     SideBySide            = false,
+        ///     IgnoreDependencies    = false,
+        ///     ForceDependencies     = false,
+        ///     SkipPowerShell        = false,
+        ///     User                  = "user",
+        ///     Password              = "password",
+        ///     IgnoreChecksums       = false,
+        ///     Debug                 = false,
+        ///     Verbose               = false,
+        ///     Force                 = false,
+        ///     Noop                  = false,
+        ///     LimitOutput           = false,
+        ///     ExecutionTimeout      = 13,
+        ///     CacheLocation         = @"C:\temp",
+        ///     AllowUnoffical        = false
+        ///     });
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Install")]
         [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Install")]
@@ -137,6 +283,21 @@ namespace Cake.Common.Tools.Chocolatey
         /// <param name="context">The context.</param>
         /// <param name="name">The name.</param>
         /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// ChocolateyPin("MyChocolateyPackage", new ChocolateyPinSettings {
+        ///     Version               = "1.2.3",
+        ///     Debug                 = false,
+        ///     Verbose               = false,
+        ///     Force                 = false,
+        ///     Noop                  = false,
+        ///     LimitOutput           = false,
+        ///     ExecutionTimeout      = 13,
+        ///     CacheLocation         = @"C:\temp",
+        ///     AllowUnoffical        = false
+        /// });
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Pin")]
         [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Pin")]
@@ -159,6 +320,20 @@ namespace Cake.Common.Tools.Chocolatey
         /// <param name="apiKey">The API Key.</param>
         /// <param name="source">The source.</param>
         /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// ChocolateyApiKey("myApiKey", "http://www.mysource.com", new ChocolateyApiKeySettings {
+        ///     Debug                 = false,
+        ///     Verbose               = false,
+        ///     Force                 = false,
+        ///     Noop                  = false,
+        ///     LimitOutput           = false,
+        ///     ExecutionTimeout      = 13,
+        ///     CacheLocation         = @"C:\temp",
+        ///     AllowUnoffical        = false
+        /// });
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("ApiKey")]
         [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.ApiKey")]
@@ -181,6 +356,20 @@ namespace Cake.Common.Tools.Chocolatey
         /// <param name="name">The name.</param>
         /// <param name="value">The value.</param>
         /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// ChocolateyConfig("cacheLocation", @"c:\temp", new ChocolateyConfigSettings {
+        ///     Debug                 = false,
+        ///     Verbose               = false,
+        ///     Force                 = false,
+        ///     Noop                  = false,
+        ///     LimitOutput           = false,
+        ///     ExecutionTimeout      = 13,
+        ///     CacheLocation         = @"C:\temp",
+        ///     AllowUnoffical        = false
+        /// });
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Config")]
         [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Config")]
@@ -201,6 +390,11 @@ namespace Cake.Common.Tools.Chocolatey
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="name">Name of the feature.</param>
+        /// <example>
+        /// <code>
+        /// ChocolateyEnableFeature("checkSumFiles");
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("EnableFeature")]
         [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Features")]
@@ -215,6 +409,20 @@ namespace Cake.Common.Tools.Chocolatey
         /// <param name="context">The context.</param>
         /// <param name="name">Name of the feature.</param>
         /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// ChocolateyEnableFeature("checkSumFiles", new ChocolateyFeatureSettings {
+        ///     Debug                 = false,
+        ///     Verbose               = false,
+        ///     Force                 = false,
+        ///     Noop                  = false,
+        ///     LimitOutput           = false,
+        ///     ExecutionTimeout      = 13,
+        ///     CacheLocation         = @"C:\temp",
+        ///     AllowUnoffical        = false
+        /// });
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("EnableFeature")]
         [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Features")]
@@ -235,6 +443,11 @@ namespace Cake.Common.Tools.Chocolatey
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="name">Name of the feature.</param>
+        /// <example>
+        /// <code>
+        /// ChocolateyDisableFeature("checkSumFiles");
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("DisableFeature")]
         [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Features")]
@@ -249,6 +462,20 @@ namespace Cake.Common.Tools.Chocolatey
         /// <param name="context">The context.</param>
         /// <param name="name">Name of the feature.</param>
         /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// ChocolateyDisableFeature("checkSumFiles", new ChocolateyFeatureSettings {
+        ///     Debug                 = false,
+        ///     Verbose               = false,
+        ///     Force                 = false,
+        ///     Noop                  = false,
+        ///     LimitOutput           = false,
+        ///     ExecutionTimeout      = 13,
+        ///     CacheLocation         = @"C:\temp",
+        ///     AllowUnoffical        = false
+        /// });
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("DisableFeature")]
         [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Features")]
@@ -270,6 +497,11 @@ namespace Cake.Common.Tools.Chocolatey
         /// <param name="context">The context.</param>
         /// <param name="name">Name of the source.</param>
         /// <param name="source">Path to the package(s) source.</param>
+        /// <example>
+        /// <code>
+        /// ChocolateyAddSource("MySource", "http://www.mysource.com");
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("AddSource")]
         [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Sources")]
@@ -285,6 +517,23 @@ namespace Cake.Common.Tools.Chocolatey
         /// <param name="name">Name of the source.</param>
         /// <param name="source">Path to the package(s) source.</param>
         /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// ChocolateyAddSource("MySource", "http://www.mysource.com", new ChocolateySourcesSettings {
+        ///     UserName              = "user",
+        ///     Password              = "password",
+        ///     Priority              = 13,
+        ///     Debug                 = false,
+        ///     Verbose               = false,
+        ///     Force                 = false,
+        ///     Noop                  = false,
+        ///     LimitOutput           = false,
+        ///     ExecutionTimeout      = 13,
+        ///     CacheLocation         = @"C:\temp",
+        ///     AllowUnoffical        = false
+        /// });
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("AddSource")]
         [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Sources")]
@@ -305,6 +554,11 @@ namespace Cake.Common.Tools.Chocolatey
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="name">Name of the source.</param>
+        /// <example>
+        /// <code>
+        /// ChocolateyRemoveSource("MySource");
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("RemoveSource")]
         [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Sources")]
@@ -319,6 +573,20 @@ namespace Cake.Common.Tools.Chocolatey
         /// <param name="context">The context.</param>
         /// <param name="name">Name of the source.</param>
         /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// ChocolateyRemoveSource("MySource", new ChocolateySourcesSettings {
+        ///     Debug                 = false,
+        ///     Verbose               = false,
+        ///     Force                 = false,
+        ///     Noop                  = false,
+        ///     LimitOutput           = false,
+        ///     ExecutionTimeout      = 13,
+        ///     CacheLocation         = @"C:\temp",
+        ///     AllowUnoffical        = false
+        /// });
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("RemoveSource")]
         [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Sources")]
@@ -339,6 +607,11 @@ namespace Cake.Common.Tools.Chocolatey
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="name">Name of the source.</param>
+        /// <example>
+        /// <code>
+        /// ChocolateyEnableSource("MySource");
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("EnableSource")]
         [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Sources")]
@@ -353,6 +626,20 @@ namespace Cake.Common.Tools.Chocolatey
         /// <param name="context">The context.</param>
         /// <param name="name">Name of the source.</param>
         /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// ChocolateyEnableSource("MySource", new ChocolateySourcesSettings {
+        ///     Debug                 = false,
+        ///     Verbose               = false,
+        ///     Force                 = false,
+        ///     Noop                  = false,
+        ///     LimitOutput           = false,
+        ///     ExecutionTimeout      = 13,
+        ///     CacheLocation         = @"C:\temp",
+        ///     AllowUnoffical        = false
+        /// });
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("EnableSource")]
         [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Sources")]
@@ -373,6 +660,11 @@ namespace Cake.Common.Tools.Chocolatey
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="name">Name of the source.</param>
+        /// <example>
+        /// <code>
+        /// ChocolateyDisableSource("MySource");
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("DisableSource")]
         [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Sources")]
@@ -387,6 +679,20 @@ namespace Cake.Common.Tools.Chocolatey
         /// <param name="context">The context.</param>
         /// <param name="name">Name of the source.</param>
         /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// ChocolateyDisableSource("MySource", new ChocolateySourcesSettings {
+        ///     Debug                 = false,
+        ///     Verbose               = false,
+        ///     Force                 = false,
+        ///     Noop                  = false,
+        ///     LimitOutput           = false,
+        ///     ExecutionTimeout      = 13,
+        ///     CacheLocation         = @"C:\temp",
+        ///     AllowUnoffical        = false
+        /// });
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("DisableSource")]
         [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Sources")]
@@ -408,6 +714,27 @@ namespace Cake.Common.Tools.Chocolatey
         /// <param name="context">The context.</param>
         /// <param name="packageFilePath">The <c>.nupkg</c> file path.</param>
         /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// // Get the path to the package.
+        /// var package = "./chocolatey/MyChocolateyPackage.0.0.1.nupkg";
+        ///
+        /// // Push the package.
+        /// ChocolateyPush(package, new ChocolateyPushSettings {
+        ///     Source                = "http://example.com/chocolateyfeed",
+        ///     ApiKey                = "4003d786-cc37-4004-bfdf-c4f3e8ef9b3a"
+        ///     Timeout               = 300
+        ///     Debug                 = false,
+        ///     Verbose               = false,
+        ///     Force                 = false,
+        ///     Noop                  = false,
+        ///     LimitOutput           = false,
+        ///     ExecutionTimeout      = 13,
+        ///     CacheLocation         = @"C:\temp",
+        ///     AllowUnoffical        = false
+        /// });
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Push")]
         [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Push")]
@@ -428,6 +755,11 @@ namespace Cake.Common.Tools.Chocolatey
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="packageId">The id of the package to upgrade.</param>
+        /// <example>
+        /// <code>
+        /// ChocolateyUpgrade("MyChocolateyPackage");
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Upgrade")]
         [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Upgrade")]
@@ -449,9 +781,40 @@ namespace Cake.Common.Tools.Chocolatey
         /// <param name="context">The context.</param>
         /// <param name="packageId">The id of the package to upgrade.</param>
         /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// ChocolateyUpgrade("MyChocolateyPackage", new ChocolateyUpgradeSettings {
+        ///     Source                = true,
+        ///     Version               = "1.2.3",
+        ///     Prerelease            = false,
+        ///     Forcex86              = false,
+        ///     InstallArguments      = "arg1",
+        ///     OverrideArguments     = false,
+        ///     NotSilent             = false,
+        ///     PackageParameters     = "param1",
+        ///     AllowDowngrade        = false,
+        ///     SideBySide            = false,
+        ///     IgnoreDependencies    = false,
+        ///     SkipPowerShell        = false,
+        ///     FailOnUnfound        = false,
+        ///     FailOnNotInstalled        = false,
+        ///     User                  = "user",
+        ///     Password              = "password",
+        ///     IgnoreChecksums       = false,
+        ///     Debug                 = false,
+        ///     Verbose               = false,
+        ///     Force                 = false,
+        ///     Noop                  = false,
+        ///     LimitOutput           = false,
+        ///     ExecutionTimeout      = 13,
+        ///     CacheLocation         = @"C:\temp",
+        ///     AllowUnoffical        = false
+        /// });
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
-        [CakeAliasCategory("Update")]
-        [CakeNamespaceImport("Cake.Common.Tools.NuGet.Update")]
+        [CakeAliasCategory("Upgrade")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Upgrade")]
         public static void ChocolateyUpgrade(this ICakeContext context, string packageId, ChocolateyUpgradeSettings settings)
         {
             if (context == null)

--- a/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Cake.Common.Tools.Chocolatey.ApiKey;
 using Cake.Common.Tools.Chocolatey.Install;
 using Cake.Common.Tools.Chocolatey.Pack;
 using Cake.Common.Tools.Chocolatey.Pin;
@@ -144,6 +145,28 @@ namespace Cake.Common.Tools.Chocolatey
             var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
             var packer = new ChocolateyPinner(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
             packer.Pin(name, settings);
+        }
+
+        /// <summary>
+        /// Sets the Api Key for a Chocolatey Source using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="apiKey">The API Key.</param>
+        /// <param name="source">The source.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("ApiKey")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.ApiKey")]
+        public static void ChocolateyApiKey(this ICakeContext context, string apiKey, string source, ChocolateyApiKeySettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
+            var packer = new ChocolateyApiKeySetter(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
+            packer.Set(apiKey, source, settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
@@ -1,18 +1,17 @@
 ﻿using System;
 using Cake.Common.Tools.Chocolatey.ApiKey;
 using Cake.Common.Tools.Chocolatey.Config;
+using Cake.Common.Tools.Chocolatey.Features;
 using Cake.Common.Tools.Chocolatey.Install;
 using Cake.Common.Tools.Chocolatey.Pack;
 using Cake.Common.Tools.Chocolatey.Pin;
+using Cake.Common.Tools.Chocolatey.Sources;
 using Cake.Core;
 using Cake.Core.Annotations;
 using Cake.Core.IO;
 
 namespace Cake.Common.Tools.Chocolatey
 {
-    using global::Cake.Common.Tools.Chocolatey.Features;
-    using global::Cake.Common.Tools.NuGet.Sources;
-
     /// <summary>
     /// Contains functionality for working with Chocolatey.
     /// </summary>
@@ -261,6 +260,144 @@ namespace Cake.Common.Tools.Chocolatey
             var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
             var runner = new ChocolateyFeatureToggler(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
             runner.DisableFeature(name, settings);
+        }
+
+        /// <summary>
+        /// Adds Chocolatey package source using the specified name &amp;source to global user config
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="name">Name of the source.</param>
+        /// <param name="source">Path to the package(s) source.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("AddSource")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Sources")]
+        public static void ChocolateyAddSource(this ICakeContext context, string name, string source)
+        {
+            context.ChocolateyAddSource(name, source, new ChocolateySourcesSettings());
+        }
+
+        /// <summary>
+        /// Adds Chocolatey package source using the specified name, source &amp; settings to global user config
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="name">Name of the source.</param>
+        /// <param name="source">Path to the package(s) source.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("AddSource")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Sources")]
+        public static void ChocolateyAddSource(this ICakeContext context, string name, string source, ChocolateySourcesSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
+            var runner = new ChocolateySources(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
+            runner.AddSource(name, source, settings);
+        }
+
+        /// <summary>
+        /// Removes Chocolatey package source using the specified name &amp; source from global user config
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="name">Name of the source.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("RemoveSource")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Sources")]
+        public static void ChocolateyRemoveSource(this ICakeContext context, string name)
+        {
+            context.ChocolateyRemoveSource(name, new ChocolateySourcesSettings());
+        }
+
+        /// <summary>
+        /// Removes Chocolatey package source using the specified name, source &amp; settings from global user config
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="name">Name of the source.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("RemoveSource")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Sources")]
+        public static void ChocolateyRemoveSource(this ICakeContext context, string name, ChocolateySourcesSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
+            var runner = new ChocolateySources(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
+            runner.RemoveSource(name, settings);
+        }
+
+        /// <summary>
+        /// Enables a Chocolatey Source using the specified name
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="name">Name of the source.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("EnableSource")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Sources")]
+        public static void ChocolateyEnableSource(this ICakeContext context, string name)
+        {
+            context.ChocolateyEnableSource(name, new ChocolateySourcesSettings());
+        }
+
+        /// <summary>
+        /// Enables a Chocolatey Source using the specified name and settings
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="name">Name of the source.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("EnableSource")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Sources")]
+        public static void ChocolateyEnableSource(this ICakeContext context, string name, ChocolateySourcesSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
+            var runner = new ChocolateySources(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
+            runner.EnableSource(name, settings);
+        }
+
+        /// <summary>
+        /// Disables a Chocolatey Source using the specified name
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="name">Name of the source.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("DisableSource")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Sources")]
+        public static void ChocolateyDisableSource(this ICakeContext context, string name)
+        {
+            context.ChocolateyDisableSource(name, new ChocolateySourcesSettings());
+        }
+
+        /// <summary>
+        /// Disables a Chocolatey Source using the specified name and settings
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="name">Name of the source.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("DisableSource")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Sources")]
+        public static void ChocolateyDisableSource(this ICakeContext context, string name, ChocolateySourcesSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
+            var runner = new ChocolateySources(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
+            runner.DisableSource(name, settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Cake.Common.Tools.Chocolatey.Install;
 using Cake.Common.Tools.Chocolatey.Pack;
 using Cake.Core;
 using Cake.Core.Annotations;
@@ -51,6 +52,76 @@ namespace Cake.Common.Tools.Chocolatey
             var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
             var packer = new ChocolateyPacker(context.FileSystem, context.Environment, context.ProcessRunner, context.Log, context.Globber, resolver);
             packer.Pack(settings);
+        }
+
+        /// <summary>
+        /// Installs a Chocolatey package.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="packageId">The id of the package to install.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Install")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Install")]
+        public static void ChocolateyInstall(this ICakeContext context, string packageId)
+        {
+            var settings = new ChocolateyInstallSettings();
+            ChocolateyInstall(context, packageId, settings);
+        }
+
+        /// <summary>
+        /// Installs a Chocolatey package using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="packageId">The id of the package to install.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Install")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Install")]
+        public static void ChocolateyInstall(this ICakeContext context, string packageId, ChocolateyInstallSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
+            var runner = new ChocolateyInstaller(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
+            runner.Install(packageId, settings);
+        }
+
+        /// <summary>
+        /// Installs Chocolatey packages using the specified package configuration.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="packageConfigPath">The package configuration to install.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Install")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Install")]
+        public static void ChocolateyInstallFromConfig(this ICakeContext context, FilePath packageConfigPath)
+        {
+            var settings = new ChocolateyInstallSettings();
+            ChocolateyInstallFromConfig(context, packageConfigPath, settings);
+        }
+
+        /// <summary>
+        /// Installs Chocolatey packages using the specified package configuration and settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="packageConfigPath">The package configuration to install.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Install")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Install")]
+        public static void ChocolateyInstallFromConfig(this ICakeContext context, FilePath packageConfigPath, ChocolateyInstallSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
+            var runner = new ChocolateyInstaller(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
+            runner.InstallFromConfig(packageConfigPath, settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Cake.Common.Tools.Chocolatey.Pack;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Chocolatey
+{
+    /// <summary>
+    /// Contains functionality for working with Chocolatey.
+    /// </summary>
+    [CakeAliasCategory("Chocolatey")]
+    public static class ChocolateyAliases
+    {
+        /// <summary>
+        /// Creates a Chocolatey package using the specified Nuspec file.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="nuspecFilePath">The nuspec file path.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Pack")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Pack")]
+        public static void ChocolateyPack(this ICakeContext context, FilePath nuspecFilePath, ChocolateyPackSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
+            var packer = new ChocolateyPacker(context.FileSystem, context.Environment, context.ProcessRunner, context.Log, context.Globber, resolver);
+            packer.Pack(nuspecFilePath, settings);
+        }
+
+        /// <summary>
+        /// Creates a Chocolatey package using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Pack")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Pack")]
+        public static void ChocolateyPack(this ICakeContext context, ChocolateyPackSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
+            var packer = new ChocolateyPacker(context.FileSystem, context.Environment, context.ProcessRunner, context.Log, context.Globber, resolver);
+            packer.Pack(settings);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Cake.Common.Tools.Chocolatey.ApiKey;
+using Cake.Common.Tools.Chocolatey.Config;
 using Cake.Common.Tools.Chocolatey.Install;
 using Cake.Common.Tools.Chocolatey.Pack;
 using Cake.Common.Tools.Chocolatey.Pin;
@@ -167,6 +168,28 @@ namespace Cake.Common.Tools.Chocolatey
             var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
             var packer = new ChocolateyApiKeySetter(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
             packer.Set(apiKey, source, settings);
+        }
+
+        /// <summary>
+        /// Sets the config parameter using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="name">The name.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Config")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Config")]
+        public static void ChocolateyConfig(this ICakeContext context, string name, string value, ChocolateyConfigSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
+            var packer = new ChocolateyConfigSetter(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
+            packer.Set(name, value, settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/Chocolatey/ChocolateyTool.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ChocolateyTool.cs
@@ -1,0 +1,70 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Utilities;
+
+namespace Cake.Common.Tools.Chocolatey
+{
+    /// <summary>
+    /// Base class for all Chocolatey related tools.
+    /// </summary>
+    /// <typeparam name="TSettings">The settings type.</typeparam>
+    public abstract class ChocolateyTool<TSettings> : Tool<TSettings>
+    {
+        private readonly IChocolateyToolResolver _resolver;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChocolateyTool{TSettings}"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
+        /// <param name="resolver">The Chocolatey tool resolver.</param>
+        protected ChocolateyTool(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IGlobber globber,
+            IChocolateyToolResolver resolver)
+            : base(fileSystem, environment, processRunner, globber)
+        {
+            _resolver = resolver;
+        }
+
+        /// <summary>
+        /// Gets the name of the tool.
+        /// </summary>
+        /// <returns>The name of the tool.</returns>
+        protected sealed override string GetToolName()
+        {
+            return "Chocolatey";
+        }
+
+        /// <summary>
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected sealed override IEnumerable<string> GetToolExecutableNames()
+        {
+            return new[] { "Choco.exe", "choco.exe" };
+        }
+
+        /// <summary>
+        /// Gets alternative file paths which the tool may exist in
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The default tool path.</returns>
+        protected sealed override IEnumerable<FilePath> GetAlternativeToolPaths(TSettings settings)
+        {
+            var path = _resolver.ResolvePath();
+            if (path != null)
+            {
+                return new[] { path };
+            }
+
+            return Enumerable.Empty<FilePath>();
+        }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/ChocolateyToolResolver.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ChocolateyToolResolver.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Linq;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Chocolatey
+{
+    /// <summary>
+    /// Contains Chocolatey path resolver functionality
+    /// </summary>
+    public sealed class ChocolateyToolResolver : IChocolateyToolResolver
+    {
+        private readonly IFileSystem _fileSystem;
+        private readonly ICakeEnvironment _environment;
+        private IFile _cachedPath;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChocolateyToolResolver" /> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        public ChocolateyToolResolver(IFileSystem fileSystem, ICakeEnvironment environment)
+        {
+            _fileSystem = fileSystem;
+            _environment = environment;
+
+            if (fileSystem == null)
+            {
+                throw new ArgumentNullException("fileSystem");
+            }
+            if (environment == null)
+            {
+                throw new ArgumentNullException("environment");
+            }
+        }
+
+        /// <summary>
+        /// Resolves the path to choco.exe.
+        /// </summary>
+        /// <returns>The path to choco.exe.</returns>
+        public FilePath ResolvePath()
+        {
+            // Check if path allready resolved
+            if (_cachedPath != null && _cachedPath.Exists)
+            {
+                return _cachedPath.Path;
+            }
+
+            // Check if path set to environment variable
+            var chocolateyInstallationFolder = _environment.GetEnvironmentVariable("ChocolateyInstall");
+            if (!string.IsNullOrWhiteSpace(chocolateyInstallationFolder))
+            {
+                var envFile = _fileSystem.GetFile(System.IO.Path.Combine(chocolateyInstallationFolder, "choco.exe"));
+                if (envFile.Exists)
+                {
+                    _cachedPath = envFile;
+                    return _cachedPath.Path;
+                }
+            }
+
+            // Last resort try path
+            var envPath = _environment.GetEnvironmentVariable("path");
+            if (!string.IsNullOrWhiteSpace(envPath))
+            {
+                var pathFile = envPath
+                    .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(path => _fileSystem.GetDirectory(path))
+                    .Where(path => path.Exists)
+                    .Select(path => path.Path.CombineWithFilePath("choco.exe"))
+                    .Select(_fileSystem.GetFile)
+                    .FirstOrDefault(file => file.Exists);
+
+                if (pathFile != null)
+                {
+                    _cachedPath = pathFile;
+                    return _cachedPath.Path;
+                }
+            }
+
+            throw new CakeException("Could not locate choco.exe.");
+        }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/Config/ChocolateyConfigSetter.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Config/ChocolateyConfigSetter.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Globalization;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Chocolatey.Config
+{
+    /// <summary>
+    /// The Chocolatey configuration setter.
+    /// </summary>
+    public sealed class ChocolateyConfigSetter : ChocolateyTool<ChocolateyConfigSettings>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChocolateyConfigSetter"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
+        /// <param name="resolver">The Chocolatey tool resolver.</param>
+        public ChocolateyConfigSetter(IFileSystem fileSystem, ICakeEnvironment environment,
+            IProcessRunner processRunner, IGlobber globber, IChocolateyToolResolver resolver)
+            : base(fileSystem, environment, processRunner, globber, resolver)
+        {
+        }
+
+        /// <summary>
+        /// Sets Chocolatey configuration paramaters using the settings.
+        /// </summary>
+        /// <param name="name">The name of the config parameter.</param>
+        /// <param name="value">The value to assign to the parameter.</param>
+        /// <param name="settings">The settings.</param>
+        public void Set(string name, string value, ChocolateyConfigSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentNullException("name");
+            }
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentNullException("value");
+            }
+
+            Run(settings, GetArguments(name, value, settings), settings.ToolPath);
+        }
+
+        private ProcessArgumentBuilder GetArguments(string name, string value, ChocolateyConfigSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("config");
+            builder.Append("set");
+
+            builder.Append("--name");
+            builder.AppendQuoted(name);
+
+            builder.Append("--value");
+            builder.AppendQuoted(value);
+
+            // Debug
+            if (settings.Debug)
+            {
+                builder.Append("-d");
+            }
+
+            // Verbose
+            if (settings.Verbose)
+            {
+                builder.Append("-v");
+            }
+
+            // Always say yes, so as to not show interactive prompt
+            builder.Append("-y");
+
+            // Force
+            if (settings.Force)
+            {
+                builder.Append("-f");
+            }
+
+            // Noop
+            if (settings.Noop)
+            {
+                builder.Append("--noop");
+            }
+
+            // Limit Output
+            if (settings.LimitOutput)
+            {
+                builder.Append("-r");
+            }
+
+            // Execution Timeout
+            if (settings.ExecutionTimeout != 0)
+            {
+                builder.Append("--execution-timeout");
+                builder.AppendQuoted(settings.ExecutionTimeout.ToString(CultureInfo.InvariantCulture));
+            }
+
+            // Cache Location
+            if (!string.IsNullOrWhiteSpace(settings.CacheLocation))
+            {
+                builder.Append("-c");
+                builder.AppendQuoted(settings.CacheLocation);
+            }
+
+            // Allow Unoffical
+            if (settings.AllowUnoffical)
+            {
+                builder.Append("--allowunofficial");
+            }
+
+            return builder;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/Config/ChocolateyConfigSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Config/ChocolateyConfigSettings.cs
@@ -1,0 +1,65 @@
+﻿using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Chocolatey.Config
+{
+    /// <summary>
+    /// Contains settings used by <see cref="ChocolateyConfigSetter"/>.
+    /// </summary>
+    public sealed class ChocolateyConfigSettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in debug mode.
+        /// </summary>
+        /// <value>The debug flag</value>
+        public bool Debug { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in verbose mode.
+        /// </summary>
+        /// <value>The verbose flag.</value>
+        public bool Verbose { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in forced mode.
+        /// </summary>
+        /// <value>The force flag</value>
+        public bool Force { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in noop mode.
+        /// </summary>
+        /// <value>The noop flag.</value>
+        public bool Noop { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in limited output mode.
+        /// </summary>
+        /// <value>The limit output flag</value>
+        public bool LimitOutput { get; set; }
+
+        /// <summary>
+        /// Gets or sets the execution timeout value.
+        /// </summary>
+        /// <value>The execution timeout</value>
+        /// <remarks>Default is 2700 seconds</remarks>
+        public int ExecutionTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the location of the download cache.
+        /// </summary>
+        /// <value>The download cache location</value>
+        public string CacheLocation { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in allow unofficial mode.
+        /// </summary>
+        /// <value>The allow unofficial flag</value>
+        public bool AllowUnoffical { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tool path.
+        /// </summary>
+        /// <value>The tool path.</value>
+        public FilePath ToolPath { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/Features/ChocolateyFeatureSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Features/ChocolateyFeatureSettings.cs
@@ -1,0 +1,65 @@
+﻿using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Chocolatey.Features
+{
+    /// <summary>
+    /// Contains settings used by <see cref="ChocolateyFeatureToggler"/>.
+    /// </summary>
+    public sealed class ChocolateyFeatureSettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in debug mode.
+        /// </summary>
+        /// <value>The debug flag</value>
+        public bool Debug { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in verbose mode.
+        /// </summary>
+        /// <value>The verbose flag.</value>
+        public bool Verbose { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in forced mode.
+        /// </summary>
+        /// <value>The force flag</value>
+        public bool Force { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in noop mode.
+        /// </summary>
+        /// <value>The noop flag.</value>
+        public bool Noop { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in limited output mode.
+        /// </summary>
+        /// <value>The limit output flag</value>
+        public bool LimitOutput { get; set; }
+
+        /// <summary>
+        /// Gets or sets the execution timeout value.
+        /// </summary>
+        /// <value>The execution timeout</value>
+        /// <remarks>Default is 2700 seconds</remarks>
+        public int ExecutionTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the location of the download cache.
+        /// </summary>
+        /// <value>The download cache location</value>
+        public string CacheLocation { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in allow unofficial mode.
+        /// </summary>
+        /// <value>The allow unofficial flag</value>
+        public bool AllowUnoffical { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tool path.
+        /// </summary>
+        /// <value>The tool path.</value>
+        public FilePath ToolPath { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/Features/ChocolateyFeatureToggler.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Features/ChocolateyFeatureToggler.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Globalization;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Chocolatey.Features
+{
+    /// <summary>
+    /// The Chocolatey feature toggler used to enable/disable Chocolatey Features.
+    /// </summary>
+    public sealed class ChocolateyFeatureToggler : ChocolateyTool<ChocolateyFeatureSettings>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChocolateyFeatureToggler"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
+        /// <param name="resolver">The Chocolatey tool resolver.</param>
+        public ChocolateyFeatureToggler(IFileSystem fileSystem, ICakeEnvironment environment,
+            IProcessRunner processRunner, IGlobber globber, IChocolateyToolResolver resolver)
+            : base(fileSystem, environment, processRunner, globber, resolver)
+        {
+        }
+
+        /// <summary>
+        /// Pins Chocolatey packages using the specified package id and settings.
+        /// </summary>
+        /// <param name="name">The name of the feature.</param>
+        /// <param name="settings">The settings.</param>
+        public void EnableFeature(string name, ChocolateyFeatureSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentNullException("name");
+            }
+
+            Run(settings, GetArguments(true, name, settings), settings.ToolPath);
+        }
+
+        /// <summary>
+        /// Pins Chocolatey packages using the specified package id and settings.
+        /// </summary>
+        /// <param name="name">The name of the feature.</param>
+        /// <param name="settings">The settings.</param>
+        public void DisableFeature(string name, ChocolateyFeatureSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentNullException("name");
+            }
+
+            Run(settings, GetArguments(false, name, settings), settings.ToolPath);
+        }
+
+        private ProcessArgumentBuilder GetArguments(bool enableDisableToggle, string name, ChocolateyFeatureSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("feature");
+
+            if (enableDisableToggle)
+            {
+                builder.Append("enable");
+            }
+            else
+            {
+                builder.Append("disable");
+            }
+
+            builder.Append("-n");
+            builder.AppendQuoted(name);
+
+            // Debug
+            if (settings.Debug)
+            {
+                builder.Append("-d");
+            }
+
+            // Verbose
+            if (settings.Verbose)
+            {
+                builder.Append("-v");
+            }
+
+            // Always say yes, so as to not show interactive prompt
+            builder.Append("-y");
+
+            // Force
+            if (settings.Force)
+            {
+                builder.Append("-f");
+            }
+
+            // Noop
+            if (settings.Noop)
+            {
+                builder.Append("--noop");
+            }
+
+            // Limit Output
+            if (settings.LimitOutput)
+            {
+                builder.Append("-r");
+            }
+
+            // Execution Timeout
+            if (settings.ExecutionTimeout != 0)
+            {
+                builder.Append("--execution-timeout");
+                builder.AppendQuoted(settings.ExecutionTimeout.ToString(CultureInfo.InvariantCulture));
+            }
+
+            // Cache Location
+            if (!string.IsNullOrWhiteSpace(settings.CacheLocation))
+            {
+                builder.Append("-c");
+                builder.AppendQuoted(settings.CacheLocation);
+            }
+
+            // Allow Unoffical
+            if (settings.AllowUnoffical)
+            {
+                builder.Append("--allowunofficial");
+            }
+
+            return builder;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/IChocolateyToolResolver.cs
+++ b/src/Cake.Common/Tools/Chocolatey/IChocolateyToolResolver.cs
@@ -1,0 +1,16 @@
+﻿using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Chocolatey
+{
+    /// <summary>
+    /// Represents a Chocolatey path resolver.
+    /// </summary>
+    public interface IChocolateyToolResolver
+    {
+        /// <summary>
+        /// Resolves the path to choco.exe.
+        /// </summary>
+        /// <returns>The path to choco.exe.</returns>
+        FilePath ResolvePath();
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/Install/ChocolateyInstallSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Install/ChocolateyInstallSettings.cs
@@ -1,0 +1,166 @@
+﻿using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Chocolatey.Install
+{
+    /// <summary>
+    /// Contains settings used by <see cref="ChocolateyInstaller"/>.
+    /// </summary>
+    public sealed class ChocolateyInstallSettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in debug mode.
+        /// </summary>
+        /// <value>The debug flag</value>
+        public bool Debug { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in verbose mode.
+        /// </summary>
+        /// <value>The verbose flag.</value>
+        public bool Verbose { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to accept license for package.
+        /// </summary>
+        /// <value>The accept license flag</value>
+        public bool AcceptLicense { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in forced mode.
+        /// </summary>
+        /// <value>The force flag</value>
+        public bool Force { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in noop mode.
+        /// </summary>
+        /// <value>The noop flag.</value>
+        public bool Noop { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in limited output mode.
+        /// </summary>
+        /// <value>The limit output flag</value>
+        public bool LimitOutput { get; set; }
+
+        /// <summary>
+        /// Gets or sets the execution timeout value.
+        /// </summary>
+        /// <value>The execution timeout</value>
+        /// <remarks>Default is 2700 seconds</remarks>
+        public int ExecutionTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the location of the download cache.
+        /// </summary>
+        /// <value>The download cache location</value>
+        public string CacheLocation { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in allow unofficial mode.
+        /// </summary>
+        /// <value>The allow unofficial flag</value>
+        public bool AllowUnoffical { get; set; }
+
+        /// <summary>
+        /// Gets or sets a package sources to use for this command.
+        /// </summary>
+        /// <value>The package source to use for this command.</value>
+        public string Source { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version of the package to install.
+        /// If none specified, the latest will be used.
+        /// </summary>
+        public string Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow installation of prerelease packages.
+        /// This flag is not required when restoring packages by installing from packages.config.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> to allow installation of prerelease packages; otherwise, <c>false</c>.
+        /// </value>
+        public bool Prerelease { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to force installation of the x86 version of package.
+        /// </summary>
+        /// <value>The force x86 flag</value>
+        public bool Forcex86 { get; set; }
+
+        /// <summary>
+        /// Gets or sets the install arguments to pass to native installer.
+        /// </summary>
+        public string InstallArguments { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to override the passed arguments.
+        /// </summary>
+        /// <value>The override arguments flag</value>
+        public bool OverrideArguments { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not to install silently.
+        /// </summary>
+        /// <value>The not silent flag</value>
+        public bool NotSilent { get; set; }
+
+        /// <summary>
+        /// Gets or sets the parameters to pass to the package.
+        /// </summary>
+        public string PackageParameters { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow downgrade of package.
+        /// </summary>
+        /// <value>The downgrade package flag</value>
+        public bool AllowDowngrade { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow side by side installation.
+        /// </summary>
+        /// <value>The side by side installation flag</value>
+        public bool SideBySide { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to ignore dependencies.
+        /// </summary>
+        /// <value>The ignore dependencies flag</value>
+        public bool IgnoreDependencies { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to force dependencies.
+        /// </summary>
+        /// <value>The force dependencies flag</value>
+        public bool ForceDependencies { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to skip the PowerShell installation of package.
+        /// </summary>
+        /// <value>The skip powershell flag</value>
+        public bool SkipPowerShell { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user for authenticated feeds.
+        /// </summary>
+        public string User { get; set; }
+
+        /// <summary>
+        /// Gets or sets the password for authenticated feeds.
+        /// </summary>
+        public string Password { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to ignore checksums.
+        /// </summary>
+        /// <value>The ignore checksums flag</value>
+        public bool IgnoreChecksums { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tool path.
+        /// </summary>
+        /// <value>The tool path.</value>
+        public FilePath ToolPath { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/Install/ChocolateyInstaller.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Install/ChocolateyInstaller.cs
@@ -1,0 +1,241 @@
+﻿using System;
+using System.Globalization;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Chocolatey.Install
+{
+    /// <summary>
+    /// The Chocolatey package installer used to install Chocolatey packages.
+    /// </summary>
+    public sealed class ChocolateyInstaller : ChocolateyTool<ChocolateyInstallSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChocolateyInstaller"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
+        /// <param name="resolver">The Chocolatey tool resolver.</param>
+        public ChocolateyInstaller(IFileSystem fileSystem, ICakeEnvironment environment,
+            IProcessRunner processRunner, IGlobber globber, IChocolateyToolResolver resolver)
+            : base(fileSystem, environment, processRunner, globber, resolver)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Installs Chocolatey packages using the specified package configuration file and settings.
+        /// </summary>
+        /// <param name="packageConfigPath">Path to package configuration to use for install.</param>
+        /// <param name="settings">The settings.</param>
+        public void InstallFromConfig(FilePath packageConfigPath, ChocolateyInstallSettings settings)
+        {
+            if (packageConfigPath == null)
+            {
+                throw new ArgumentNullException("packageConfigPath");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            var packageId = packageConfigPath.MakeAbsolute(_environment).FullPath;
+
+            Run(settings, GetArguments(packageId, settings), settings.ToolPath);
+        }
+
+        /// <summary>
+        /// Installs Chocolatey packages using the specified package id and settings.
+        /// </summary>
+        /// <param name="packageId">The source package id.</param>
+        /// <param name="settings">The settings.</param>
+        public void Install(string packageId, ChocolateyInstallSettings settings)
+        {
+            if (string.IsNullOrWhiteSpace(packageId))
+            {
+                throw new ArgumentNullException("packageId");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            Run(settings, GetArguments(packageId, settings), settings.ToolPath);
+        }
+
+        private ProcessArgumentBuilder GetArguments(string packageId, ChocolateyInstallSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("install");
+            builder.AppendQuoted(packageId);
+
+            // Debug
+            if (settings.Debug)
+            {
+                builder.Append("-d");
+            }
+
+            // Verbose
+            if (settings.Verbose)
+            {
+                builder.Append("-v");
+            }
+
+            // Accept License
+            if (settings.AcceptLicense)
+            {
+                builder.Append("--acceptLicense");
+            }
+
+            // Always say yes, so as to not show interactive prompt
+            builder.Append("-y");
+
+            // Force
+            if (settings.Force)
+            {
+                builder.Append("-f");
+            }
+
+            // Noop
+            if (settings.Noop)
+            {
+                builder.Append("--noop");
+            }
+
+            // Limit Output
+            if (settings.LimitOutput)
+            {
+                builder.Append("-r");
+            }
+
+            // Execution Timeout
+            if (settings.ExecutionTimeout != 0)
+            {
+                builder.Append("--execution-timeout");
+                builder.AppendQuoted(settings.ExecutionTimeout.ToString(CultureInfo.InvariantCulture));
+            }
+
+            // Cache Location
+            if (!string.IsNullOrWhiteSpace(settings.CacheLocation))
+            {
+                builder.Append("-c");
+                builder.AppendQuoted(settings.CacheLocation);
+            }
+
+            // Allow Unoffical
+            if (settings.AllowUnoffical)
+            {
+                builder.Append("--allowunofficial");
+            }
+
+            // Package source
+            if (!string.IsNullOrWhiteSpace(settings.Source))
+            {
+                builder.Append("-s");
+                builder.AppendQuoted(settings.Source);
+            }
+
+            // Version
+            if (settings.Version != null)
+            {
+                builder.Append("--version");
+                builder.AppendQuoted(settings.Version);
+            }
+
+            // Prerelease
+            if (settings.Prerelease)
+            {
+                builder.Append("--pre");
+            }
+
+            // Forcex86
+            if (settings.Forcex86)
+            {
+                builder.Append("--x86");
+            }
+
+            // Install Arguments
+            if (!string.IsNullOrWhiteSpace(settings.InstallArguments))
+            {
+                builder.Append("--ia");
+                builder.AppendQuoted(settings.InstallArguments);
+            }
+
+            // OverrideArguments
+            if (settings.OverrideArguments)
+            {
+                builder.Append("-o");
+            }
+
+            // NotSilent
+            if (settings.NotSilent)
+            {
+                builder.Append("--notSilent");
+            }
+
+            // Package Parameters
+            if (!string.IsNullOrWhiteSpace(settings.PackageParameters))
+            {
+                builder.Append("--params");
+                builder.AppendQuoted(settings.PackageParameters);
+            }
+
+            // Allow Downgrade
+            if (settings.AllowDowngrade)
+            {
+                builder.Append("--allowdowngrade");
+            }
+
+            // Side by side installation
+            if (settings.SideBySide)
+            {
+                builder.Append("-m");
+            }
+
+            // Ignore Dependencies
+            if (settings.IgnoreDependencies)
+            {
+                builder.Append("-i");
+            }
+
+            // Force Dependencies
+            if (settings.ForceDependencies)
+            {
+                builder.Append("-x");
+            }
+
+            // Skip PowerShell
+            if (settings.SkipPowerShell)
+            {
+                builder.Append("-n");
+            }
+
+            // User
+            if (!string.IsNullOrWhiteSpace(settings.User))
+            {
+                builder.Append("-u");
+                builder.AppendQuoted(settings.User);
+            }
+
+            // Password
+            if (!string.IsNullOrWhiteSpace(settings.Password))
+            {
+                builder.Append("-p");
+                builder.AppendQuoted(settings.Password);
+            }
+
+            // Ignore Checksums
+            if (settings.IgnoreChecksums)
+            {
+                builder.Append("--ignorechecksums");
+            }
+
+            return builder;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyNuSpecContent.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyNuSpecContent.cs
@@ -1,0 +1,29 @@
+﻿namespace Cake.Common.Tools.Chocolatey.Pack
+{
+    /// <summary>
+    /// Represents a Chocolatey nuspec file
+    /// </summary>
+    public sealed class ChocolateyNuSpecContent
+    {
+        /// <summary>
+        /// Gets or sets the location of the file or files to include.
+        /// The path is relative to the NuSpec file unless an absolute path is specified.
+        /// The wildcard character - <c>*</c> - is allowed.
+        /// Using a double wildcard - <c>**</c> implies a recursive directory search.
+        /// </summary>
+        public string Source { get; set; }
+
+        /// <summary>
+        /// Gets or sets the relative path to the directory within the package where the source files will be placed.
+        /// </summary>
+        public string Target { get; set; }
+
+        /// <summary>
+        /// Gets or sets the file or files to exclude.
+        /// This is usually combined with a wildcard value in the <c>src</c> attribute.
+        /// The <c>exclude</c> attribute can contain a semi-colon delimited list of files or a file pattern.
+        /// Using a double wildcard - <c>**</c> - implies a recursive exclude pattern.
+        /// </summary>
+        public string Exclude { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyNuSpecProcessor.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyNuSpecProcessor.cs
@@ -1,0 +1,116 @@
+﻿namespace Cake.Common.Tools.Chocolatey.Pack
+{
+    using System.Globalization;
+    using System.Xml;
+    using global::Cake.Core;
+    using global::Cake.Core.Diagnostics;
+    using global::Cake.Core.IO;
+
+    internal sealed class ChocolateyNuSpecProcessor
+    {
+        private readonly IFileSystem _fileSystem;
+        private readonly ICakeEnvironment _environment;
+        private readonly ICakeLog _log;
+
+        public ChocolateyNuSpecProcessor(IFileSystem fileSystem, ICakeEnvironment environment, ICakeLog log)
+        {
+            _fileSystem = fileSystem;
+            _environment = environment;
+            _log = log;
+        }
+
+        public FilePath Process(ChocolateyPackSettings settings)
+        {
+            var nuspecFilePath = _environment.WorkingDirectory
+                                    .CombineWithFilePath(string.Concat(settings.Id, ".nuspec"))
+                                    .MakeAbsolute(_environment);
+
+            var xml = LoadEmptyNuSpec();
+
+            return ProcessXml(nuspecFilePath, settings, xml);
+        }
+
+        public FilePath Process(FilePath nuspecFilePath, ChocolateyPackSettings settings)
+        {
+            // Make the nuspec file path absolute.
+            nuspecFilePath = nuspecFilePath.MakeAbsolute(_environment);
+
+            // Make sure the nuspec file exist.
+            var nuspecFile = _fileSystem.GetFile(nuspecFilePath);
+            if (!nuspecFile.Exists)
+            {
+                const string format = "Could not find nuspec file '{0}'.";
+                throw new CakeException(string.Format(CultureInfo.InvariantCulture, format, nuspecFilePath.FullPath));
+            }
+
+            // Load the content of the nuspec file.
+            _log.Debug("Parsing nuspec...");
+            var xml = LoadNuspecXml(nuspecFile);
+
+            return ProcessXml(nuspecFilePath, settings, xml);
+        }
+
+        private FilePath ProcessXml(FilePath nuspecFilePath, ChocolateyPackSettings settings, XmlDocument xml)
+        {
+            // Process the XML.
+            _log.Debug("Transforming nuspec...");
+            ChocolateyNuSpecTransformer.Transform(xml, settings);
+
+            // Return the file of the new nuspec.
+            _log.Debug("Writing temporary nuspec...");
+            return SaveNuspecXml(nuspecFilePath, xml);
+        }
+
+        private static XmlDocument LoadNuspecXml(IFile nuspecFile)
+        {
+            using (var stream = nuspecFile.OpenRead())
+            {
+                var document = new XmlDocument();
+                document.Load(stream);
+                return document;
+            }
+        }
+
+        private static XmlDocument LoadEmptyNuSpec()
+        {
+            XmlDocument xml = new XmlDocument();
+            xml.LoadXml(@"<?xml version=""1.0"" encoding=""utf-8""?>
+<package xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
+  <metadata xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
+    <id></id>
+    <version>0.0.0</version>
+    <authors></authors>
+    <description></description>
+  </metadata>
+  <files>
+  </files>
+</package>");
+            return xml;
+        }
+
+        private FilePath SaveNuspecXml(FilePath nuspecFilePath, XmlDocument document)
+        {
+            // Get the new nuspec path.
+            var filename = nuspecFilePath.GetFilename();
+            filename = filename.ChangeExtension("temp.nuspec");
+            var resultPath = nuspecFilePath.GetDirectory().GetFilePath(filename).MakeAbsolute(_environment);
+
+            // Make sure the new nuspec file does not exist.
+            var nuspecFile = _fileSystem.GetFile(resultPath);
+            if (nuspecFile.Exists)
+            {
+                const string format = "Could not create the nuspec file '{0}' since it already exist.";
+                throw new CakeException(string.Format(CultureInfo.InvariantCulture, format, resultPath.FullPath));
+            }
+
+            // Now create the file.
+            using (var stream = nuspecFile.OpenWrite())
+            {
+                document.Save(stream);
+            }
+
+            // Return the new path.
+            return nuspecFile.Path;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyNuSpecProcessor.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyNuSpecProcessor.cs
@@ -1,11 +1,11 @@
-﻿namespace Cake.Common.Tools.Chocolatey.Pack
-{
-    using System.Globalization;
-    using System.Xml;
-    using global::Cake.Core;
-    using global::Cake.Core.Diagnostics;
-    using global::Cake.Core.IO;
+﻿using System.Globalization;
+using System.Xml;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
 
+namespace Cake.Common.Tools.Chocolatey.Pack
+{
     internal sealed class ChocolateyNuSpecProcessor
     {
         private readonly IFileSystem _fileSystem;

--- a/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyNuSpecTransformer.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyNuSpecTransformer.cs
@@ -1,0 +1,173 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Xml;
+using Cake.Core;
+
+namespace Cake.Common.Tools.Chocolatey.Pack
+{
+    internal static class ChocolateyNuSpecTransformer
+    {
+        private static readonly Dictionary<string, Func<ChocolateyPackSettings, string>> _mappings;
+        private const string ChocolateyNuSpecXsd = "http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd";
+
+        static ChocolateyNuSpecTransformer()
+        {
+            _mappings = new Dictionary<string, Func<ChocolateyPackSettings, string>>
+            {
+                { "id", settings => ToString(settings.Id) },
+                { "title", settings => ToString(settings.Title) },
+                { "version", settings => ToString(settings.Version) },
+                { "authors", settings => ToCommaSeparatedString(settings.Authors) },
+                { "owners", settings => ToCommaSeparatedString(settings.Owners) },
+                { "summary", settings => ToString(settings.Summary) },
+                { "description", settings => ToString(settings.Description) },
+                { "projectUrl", settings => ToString(settings.ProjectUrl) },
+                { "packageSourceUrl", settings => ToString(settings.PackageSourceUrl) },
+                { "projectSourceUrl", settings => ToString(settings.ProjectSourceUrl) },
+                { "docsUrl", settings => ToString(settings.DocsUrl) },
+                { "mailingListUrl", settings => ToString(settings.MailingListUrl) },
+                { "bugTrackerUrl", settings => ToString(settings.BugTrackerUrl) },
+                { "tags", settings => ToSpaceSeparatedString(settings.Tags) },
+                { "copyright", settings => ToString(settings.Copyright) },
+                { "licenseUrl", settings => ToString(settings.LicenseUrl) },
+                { "requireLicenseAcceptance", settings => ToString(settings.RequireLicenseAcceptance) },
+                { "iconUrl", settings => ToString(settings.IconUrl) },
+                { "releaseNotes", settings => ToMultiLineString(settings.ReleaseNotes) }
+            };
+        }
+
+        public static void Transform(XmlDocument document, ChocolateyPackSettings settings)
+        {
+            // Create the namespace manager.
+            var namespaceManager = new XmlNamespaceManager(document.NameTable);
+            namespaceManager.AddNamespace("nu", ChocolateyNuSpecXsd);
+
+            foreach (var elementName in _mappings.Keys)
+            {
+                var content = _mappings[elementName](settings);
+                if (content != null)
+                {
+                    // Replace the node content.
+                    var node = FindOrCreateElement(document, namespaceManager, elementName);
+                    node.InnerText = content;
+                }
+            }
+
+            if (settings.Files != null && settings.Files.Count > 0)
+            {
+                var filesPath = string.Format(CultureInfo.InvariantCulture, "//*[local-name()='package']//*[local-name()='files']");
+                var filesElement = document.SelectSingleNode(filesPath, namespaceManager);
+                if (filesElement == null)
+                {
+                    // Get the package element.
+                    var package = GetPackageElement(document);
+                    filesElement = document.CreateAndAppendElement(package, "files");
+                }
+
+                // Add the files
+                filesElement.RemoveAll();
+                foreach (var file in settings.Files)
+                {
+                    var fileElement = document.CreateAndAppendElement(filesElement, "file");
+                    fileElement.AddAttributeIfSpecified(file.Source, "src");
+                    fileElement.AddAttributeIfSpecified(file.Exclude, "exclude");
+                    fileElement.AddAttributeIfSpecified(file.Target, "target");
+                }
+            }
+        }
+
+        private static XmlNode GetPackageElement(XmlDocument document)
+        {
+            var package = document.SelectSingleNode("//*[local-name()='package']");
+            if (package == null)
+            {
+                throw new CakeException("Nuspec file is missing package root.");
+            }
+            return package;
+        }
+
+        private static XmlNode FindOrCreateElement(XmlDocument document, XmlNamespaceManager ns, string name)
+        {
+            var path = string.Format(CultureInfo.InvariantCulture, "//*[local-name()='package']//*[local-name()='metadata']//*[local-name()='{0}']", name);
+            var node = document.SelectSingleNode(path, ns);
+            if (node == null)
+            {
+                var parent = document.SelectSingleNode("//*[local-name()='package']//*[local-name()='metadata']", ns);
+                if (parent == null)
+                {
+                    // Get the package element.
+                    var package = GetPackageElement(document);
+
+                    // Create the metadata element.
+                    parent = document.CreateElement("metadata", ChocolateyNuSpecXsd);
+                    package.PrependChild(parent);
+                }
+
+                node = document.CreateAndAppendElement(parent, name);
+            }
+            return node;
+        }
+
+        private static XmlNode CreateAndAppendElement(this XmlDocument document, XmlNode parent, string name)
+        {
+            // If the parent didn't have a namespace specified, then skip adding one.
+            // Otherwise add the parent's namespace. This is a little hackish, but it
+            // will avoid empty namespaces. This should probably be done better...
+            return parent.AppendChild(
+                string.IsNullOrWhiteSpace(parent.NamespaceURI)
+                    ? document.CreateElement(name)
+                    : document.CreateElement(name, parent.NamespaceURI));
+        }
+
+        private static void AddAttributeIfSpecified(this XmlNode element, string value, string name)
+        {
+            if (string.IsNullOrWhiteSpace(value) || element.OwnerDocument == null || element.Attributes == null)
+            {
+                return;
+            }
+            var attr = element.OwnerDocument.CreateAttribute(name);
+            attr.Value = value;
+            element.Attributes.Append(attr);
+        }
+
+        private static string ToString(string value)
+        {
+            return string.IsNullOrWhiteSpace(value)
+                ? null
+                : value;
+        }
+
+        private static string ToString(Uri value)
+        {
+            return value == null ? null : value.ToString().TrimEnd('/');
+        }
+
+        private static string ToString(bool value)
+        {
+            return value.ToString(CultureInfo.InvariantCulture).ToLowerInvariant();
+        }
+
+        private static string ToCommaSeparatedString(IEnumerable<string> values)
+        {
+            return values != null
+                ? string.Join(",", values)
+                : null;
+        }
+
+        private static string ToMultiLineString(IEnumerable<string> values)
+        {
+            return values != null
+                ? string.Join("\r\n", values).NormalizeLineEndings()
+                : null;
+        }
+
+        private static string ToSpaceSeparatedString(IEnumerable<string> values)
+        {
+            return values != null
+                ? string.Join(" ", values.Select(x => x.Replace(" ", "-")))
+                : null;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyPackSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyPackSettings.cs
@@ -1,0 +1,191 @@
+﻿using System;
+using System.Collections.Generic;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Chocolatey.Pack
+{
+    /// <summary>
+    /// Contains settings used by <see cref="ChocolateyPacker"/>.
+    /// </summary>
+    public sealed class ChocolateyPackSettings
+    {
+        /// <summary>
+        /// Gets or sets the package ID.
+        /// </summary>
+        /// <value>The package ID.</value>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the package title.
+        /// </summary>
+        /// <value>The package title.</value>
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Nuspec version.
+        /// </summary>
+        /// <value>The Nuspec version.</value>
+        public string Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets the package authors.
+        /// </summary>
+        /// <value>The package authors.</value>
+        public ICollection<string> Authors { get; set; }
+
+        /// <summary>
+        /// Gets or sets the package owners.
+        /// </summary>
+        /// <value>The package owners.</value>
+        public ICollection<string> Owners { get; set; }
+
+        /// <summary>
+        /// Gets or sets the package summary.
+        /// </summary>
+        /// <value>The package summary.</value>
+        public string Summary { get; set; }
+
+        /// <summary>
+        /// Gets or sets the package description.
+        /// </summary>
+        /// <value>The package description.</value>
+        /// <remarks>Markdown format is allowed for this property</remarks>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the package project URL.
+        /// </summary>
+        /// <value>The package project URL.</value>
+        public Uri ProjectUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the package Source URL.
+        /// </summary>
+        /// <value>The package Source URL.</value>
+        public Uri PackageSourceUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the package project Source URL.
+        /// </summary>
+        /// <value>The package project Source URL.</value>
+        public Uri ProjectSourceUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the package documentation URL.
+        /// </summary>
+        /// <value>The package documenation URL.</value>
+        public Uri DocsUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the package mailing list URL.
+        /// </summary>
+        /// <value>The package mailing list URL.</value>
+        public Uri MailingListUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the package bug tracker URL.
+        /// </summary>
+        /// <value>The package bug tracker URL.</value>
+        public Uri BugTrackerUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the package tags.
+        /// </summary>
+        /// <value>The package tags.</value>
+        public ICollection<string> Tags { get; set; }
+
+        /// <summary>
+        /// Gets or sets the package copyright.
+        /// </summary>
+        /// <value>The package copyright.</value>
+        public string Copyright { get; set; }
+
+        /// <summary>
+        /// Gets or sets the package license URL.
+        /// </summary>
+        /// <value>The package license URL.</value>
+        public Uri LicenseUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether users has to accept the package license.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if users has to accept the package license; otherwise, <c>false</c>.
+        /// </value>
+        public bool RequireLicenseAcceptance { get; set; }
+
+        /// <summary>
+        /// Gets or sets the package icon URL.
+        /// </summary>
+        /// <value>The package icon URL.</value>
+        public Uri IconUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the package release notes.
+        /// </summary>
+        /// <value>The package release notes.</value>
+        /// <remarks>Markdown format is allowed for this property</remarks>
+        public ICollection<string> ReleaseNotes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tool path.
+        /// </summary>
+        /// <value>The tool path.</value>
+        public FilePath ToolPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the package files.
+        /// </summary>
+        /// <value>The package files.</value>
+        public ICollection<ChocolateyNuSpecContent> Files { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in debug mode.
+        /// </summary>
+        /// <value>The debug flag</value>
+        public bool Debug { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in verbose mode.
+        /// </summary>
+        /// <value>The verbose flag.</value>
+        public bool Verbose { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in forced mode.
+        /// </summary>
+        /// <value>The force flag</value>
+        public bool Force { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in noop mode.
+        /// </summary>
+        /// <value>The noop flag.</value>
+        public bool Noop { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in limited output mode.
+        /// </summary>
+        /// <value>The limit output flag</value>
+        public bool LimitOutput { get; set; }
+
+        /// <summary>
+        /// Gets or sets the execution timeout value.
+        /// </summary>
+        /// <value>The execution timeout</value>
+        /// <remarks>Default is 2700 seconds</remarks>
+        public int ExecutionTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the location of the download cache.
+        /// </summary>
+        /// <value>The download cache location</value>
+        public string CacheLocation { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in allow unofficial mode.
+        /// </summary>
+        /// <value>The allow unofficial flag</value>
+        public bool AllowUnoffical { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyPackSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyPackSettings.cs
@@ -62,30 +62,35 @@ namespace Cake.Common.Tools.Chocolatey.Pack
         /// Gets or sets the package Source URL.
         /// </summary>
         /// <value>The package Source URL.</value>
+        /// <remarks>Requires at least Chocolatey 0.9.9.7.</remarks>
         public Uri PackageSourceUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the package project Source URL.
         /// </summary>
         /// <value>The package project Source URL.</value>
+        /// <remarks>Requires at least Chocolatey 0.9.9.7.</remarks>
         public Uri ProjectSourceUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the package documentation URL.
         /// </summary>
         /// <value>The package documenation URL.</value>
+        /// <remarks>Requires at least Chocolatey 0.9.9.7.</remarks>
         public Uri DocsUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the package mailing list URL.
         /// </summary>
         /// <value>The package mailing list URL.</value>
+        /// <remarks>Requires at least Chocolatey 0.9.9.7.</remarks>
         public Uri MailingListUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the package bug tracker URL.
         /// </summary>
         /// <value>The package bug tracker URL.</value>
+        /// <remarks>Requires at least Chocolatey 0.9.9.7.</remarks>
         public Uri BugTrackerUrl { get; set; }
 
         /// <summary>

--- a/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyPacker.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyPacker.cs
@@ -1,0 +1,185 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Chocolatey.Pack
+{
+    /// <summary>
+    /// The Chocolatey packer.
+    /// </summary>
+    public sealed class ChocolateyPacker : ChocolateyTool<ChocolateyPackSettings>
+    {
+        private readonly IFileSystem _fileSystem;
+        private readonly ICakeEnvironment _environment;
+        private readonly ChocolateyNuSpecProcessor _processor;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChocolateyPacker"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="log">The log.</param>
+        /// <param name="globber">The globber.</param>
+        /// <param name="resolver">The Chocolatey tool resolver</param>
+        public ChocolateyPacker(IFileSystem fileSystem, ICakeEnvironment environment,
+            IProcessRunner processRunner, ICakeLog log, IGlobber globber,
+            IChocolateyToolResolver resolver)
+            : base(fileSystem, environment, processRunner, globber, resolver)
+        {
+            _fileSystem = fileSystem;
+            _environment = environment;
+            _processor = new ChocolateyNuSpecProcessor(_fileSystem, _environment, log);
+        }
+
+        /// <summary>
+        /// Creates a Chocolatey package from the specified settings.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        public void Pack(ChocolateyPackSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+            if (string.IsNullOrWhiteSpace(settings.Id))
+            {
+                throw new CakeException("Required setting Id not specified.");
+            }
+            if (string.IsNullOrWhiteSpace(settings.Version))
+            {
+                throw new CakeException("Required setting Version not specified.");
+            }
+            if (settings.Authors == null || settings.Authors.Count == 0)
+            {
+                throw new CakeException("Required setting Authors not specified.");
+            }
+            if (string.IsNullOrWhiteSpace(settings.Description))
+            {
+                throw new CakeException("Required setting Description not specified.");
+            }
+            if (settings.Files == null || settings.Files.Count == 0)
+            {
+                throw new CakeException("Required setting Files not specified.");
+            }
+
+            Pack(settings, () => _processor.Process(settings));
+        }
+
+        /// <summary>
+        /// Creates a Chocolatey package from the specified Nuspec file.
+        /// </summary>
+        /// <param name="nuspecFilePath">The nuspec file path.</param>
+        /// <param name="settings">The settings.</param>
+        public void Pack(FilePath nuspecFilePath, ChocolateyPackSettings settings)
+        {
+            if (nuspecFilePath == null)
+            {
+                throw new ArgumentNullException("nuspecFilePath");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            Pack(settings, () => _processor.Process(nuspecFilePath, settings));
+        }
+
+        private void Pack(ChocolateyPackSettings settings, Func<FilePath> process)
+        {
+            FilePath procesedNuspecFilePath = null;
+            try
+            {
+                // Transform the nuspec and return the new filename.
+                procesedNuspecFilePath = process();
+
+                // Start the process.
+                Run(settings, GetArguments(procesedNuspecFilePath, settings), settings.ToolPath);
+            }
+            finally
+            {
+                if (procesedNuspecFilePath != null)
+                {
+                    // Delete the processed file.
+                    var file = _fileSystem.GetFile(procesedNuspecFilePath);
+                    if (file.Exists)
+                    {
+                        file.Delete();
+                    }
+                }
+            }
+        }
+
+        private ProcessArgumentBuilder GetArguments(FilePath nuspecFilePath, ChocolateyPackSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+            builder.Append("pack");
+
+            // Debug
+            if (settings.Debug)
+            {
+                builder.Append("-d");
+            }
+
+            // Verbose
+            if (settings.Verbose)
+            {
+                builder.Append("-v");
+            }
+
+            // Always say yes, so as to not show interactive prompt
+            builder.Append("-y");
+
+            // Force
+            if (settings.Force)
+            {
+                builder.Append("-f");
+            }
+
+            // Noop
+            if (settings.Noop)
+            {
+                builder.Append("--noop");
+            }
+
+            // Limit Output
+            if (settings.LimitOutput)
+            {
+                builder.Append("-r");
+            }
+
+            // Execution Timeout
+            if (settings.ExecutionTimeout != 0)
+            {
+                builder.Append("--execution-timeout");
+                builder.AppendQuoted(settings.ExecutionTimeout.ToString());
+            }
+
+            // Cache Location
+            if (!string.IsNullOrWhiteSpace(settings.CacheLocation))
+            {
+                builder.Append("-c");
+                builder.AppendQuoted(settings.CacheLocation);
+            }
+
+            // Allow Unoffical
+            if (settings.AllowUnoffical)
+            {
+                builder.Append("--allowunofficial");
+            }
+
+            // Version
+            if (!string.IsNullOrWhiteSpace(settings.Version))
+            {
+                builder.Append("--version");
+                builder.AppendQuoted(settings.Version);
+            }
+
+            // Nuspec file
+            builder.AppendQuoted(nuspecFilePath.MakeAbsolute(_environment).FullPath);
+
+            return builder;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyPacker.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyPacker.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
@@ -153,7 +154,7 @@ namespace Cake.Common.Tools.Chocolatey.Pack
             if (settings.ExecutionTimeout != 0)
             {
                 builder.Append("--execution-timeout");
-                builder.AppendQuoted(settings.ExecutionTimeout.ToString());
+                builder.AppendQuoted(settings.ExecutionTimeout.ToString(CultureInfo.InvariantCulture));
             }
 
             // Cache Location

--- a/src/Cake.Common/Tools/Chocolatey/Pin/ChocolateyPinSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Pin/ChocolateyPinSettings.cs
@@ -1,0 +1,71 @@
+﻿using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Chocolatey.Pin
+{
+    /// <summary>
+    /// Contains settings used by <see cref="ChocolateyPinner"/>.
+    /// </summary>
+    public sealed class ChocolateyPinSettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in debug mode.
+        /// </summary>
+        /// <value>The debug flag</value>
+        public bool Debug { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in verbose mode.
+        /// </summary>
+        /// <value>The verbose flag.</value>
+        public bool Verbose { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in forced mode.
+        /// </summary>
+        /// <value>The force flag</value>
+        public bool Force { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in noop mode.
+        /// </summary>
+        /// <value>The noop flag.</value>
+        public bool Noop { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in limited output mode.
+        /// </summary>
+        /// <value>The limit output flag</value>
+        public bool LimitOutput { get; set; }
+
+        /// <summary>
+        /// Gets or sets the execution timeout value.
+        /// </summary>
+        /// <value>The execution timeout</value>
+        /// <remarks>Default is 2700 seconds</remarks>
+        public int ExecutionTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the location of the download cache.
+        /// </summary>
+        /// <value>The download cache location</value>
+        public string CacheLocation { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in allow unofficial mode.
+        /// </summary>
+        /// <value>The allow unofficial flag</value>
+        public bool AllowUnoffical { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version of the package to install.
+        /// If none specified, the latest will be used.
+        /// </summary>
+        public string Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tool path.
+        /// </summary>
+        /// <value>The tool path.</value>
+        public FilePath ToolPath { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/Pin/ChocolateyPinner.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Pin/ChocolateyPinner.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Globalization;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Chocolatey.Pin
+{
+    /// <summary>
+    /// The Chocolatey package pinner used to pin Chocolatey packages.
+    /// </summary>
+    public sealed class ChocolateyPinner : ChocolateyTool<ChocolateyPinSettings>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChocolateyPinner"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
+        /// <param name="resolver">The Chocolatey tool resolver.</param>
+        public ChocolateyPinner(IFileSystem fileSystem, ICakeEnvironment environment,
+            IProcessRunner processRunner, IGlobber globber, IChocolateyToolResolver resolver)
+            : base(fileSystem, environment, processRunner, globber, resolver)
+        {
+        }
+
+        /// <summary>
+        /// Pins Chocolatey packages using the specified package id and settings.
+        /// </summary>
+        /// <param name="name">The name of the package.</param>
+        /// <param name="settings">The settings.</param>
+        public void Pin(string name, ChocolateyPinSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentNullException("name");
+            }
+
+            Run(settings, GetArguments(name, settings), settings.ToolPath);
+        }
+
+        private ProcessArgumentBuilder GetArguments(string name, ChocolateyPinSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("pin");
+            builder.Append("add");
+
+            builder.Append("-n");
+            builder.AppendQuoted(name);
+
+            // Version
+            if (settings.Version != null)
+            {
+                builder.Append("--version");
+                builder.AppendQuoted(settings.Version);
+            }
+
+            // Debug
+            if (settings.Debug)
+            {
+                builder.Append("-d");
+            }
+
+            // Verbose
+            if (settings.Verbose)
+            {
+                builder.Append("-v");
+            }
+
+            // Always say yes, so as to not show interactive prompt
+            builder.Append("-y");
+
+            // Force
+            if (settings.Force)
+            {
+                builder.Append("-f");
+            }
+
+            // Noop
+            if (settings.Noop)
+            {
+                builder.Append("--noop");
+            }
+
+            // Limit Output
+            if (settings.LimitOutput)
+            {
+                builder.Append("-r");
+            }
+
+            // Execution Timeout
+            if (settings.ExecutionTimeout != 0)
+            {
+                builder.Append("--execution-timeout");
+                builder.AppendQuoted(settings.ExecutionTimeout.ToString(CultureInfo.InvariantCulture));
+            }
+
+            // Cache Location
+            if (!string.IsNullOrWhiteSpace(settings.CacheLocation))
+            {
+                builder.Append("-c");
+                builder.AppendQuoted(settings.CacheLocation);
+            }
+
+            // Allow Unoffical
+            if (settings.AllowUnoffical)
+            {
+                builder.Append("--allowunofficial");
+            }
+
+            return builder;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/Push/ChocolateyPushSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Push/ChocolateyPushSettings.cs
@@ -1,0 +1,86 @@
+﻿using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Chocolatey.Push
+{
+    using System;
+
+    /// <summary>
+    /// Contains settings used by <see cref="ChocolateyPusher"/>.
+    /// </summary>
+    public sealed class ChocolateyPushSettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in debug mode.
+        /// </summary>
+        /// <value>The debug flag</value>
+        public bool Debug { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in verbose mode.
+        /// </summary>
+        /// <value>The verbose flag.</value>
+        public bool Verbose { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in forced mode.
+        /// </summary>
+        /// <value>The force flag</value>
+        public bool Force { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in noop mode.
+        /// </summary>
+        /// <value>The noop flag.</value>
+        public bool Noop { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in limited output mode.
+        /// </summary>
+        /// <value>The limit output flag</value>
+        public bool LimitOutput { get; set; }
+
+        /// <summary>
+        /// Gets or sets the execution timeout value.
+        /// </summary>
+        /// <value>The execution timeout</value>
+        /// <remarks>Default is 2700 seconds</remarks>
+        public int ExecutionTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the location of the download cache.
+        /// </summary>
+        /// <value>The download cache location</value>
+        public string CacheLocation { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in allow unofficial mode.
+        /// </summary>
+        /// <value>The allow unofficial flag</value>
+        public bool AllowUnoffical { get; set; }
+
+        /// <summary>
+        /// Gets or sets the server URL. If not specified, chocolatey.org is used.
+        /// </summary>
+        /// <value>The server URL.</value>
+        public string Source { get; set; }
+
+        /// <summary>
+        /// Gets or sets the API key for the server.
+        /// </summary>
+        /// <value>The API key for the server.</value>
+        public string ApiKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timeout for pushing to a server.
+        /// Defaults to 300 seconds (5 minutes).
+        /// </summary>
+        /// <value>The timeout for pushing to a server.</value>
+        public TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tool path.
+        /// </summary>
+        /// <value>The tool path.</value>
+        public FilePath ToolPath { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/Push/ChocolateyPusher.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Push/ChocolateyPusher.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Globalization;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Chocolatey.Push
+{
+    /// <summary>
+    /// The Chocolatey package pusher.
+    /// </summary>
+    public sealed class ChocolateyPusher : ChocolateyTool<ChocolateyPushSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChocolateyPusher"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
+        /// <param name="resolver">The Chocolatey tool resolver.</param>
+        public ChocolateyPusher(IFileSystem fileSystem, ICakeEnvironment environment,
+            IProcessRunner processRunner, IGlobber globber, IChocolateyToolResolver resolver)
+            : base(fileSystem, environment, processRunner, globber, resolver)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Pushes a Chocolatey package to a Chocolatey server and publishes it.
+        /// </summary>
+        /// <param name="packageFilePath">The package file path.</param>
+        /// <param name="settings">The settings.</param>
+        public void Push(FilePath packageFilePath, ChocolateyPushSettings settings)
+        {
+            if (packageFilePath == null)
+            {
+                throw new ArgumentNullException("packageFilePath");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            Run(settings, GetArguments(packageFilePath, settings), settings.ToolPath);
+        }
+
+        private ProcessArgumentBuilder GetArguments(FilePath packageFilePath, ChocolateyPushSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+            builder.Append("push");
+
+            builder.AppendQuoted(packageFilePath.MakeAbsolute(_environment).FullPath);
+
+            if (settings.Source != null)
+            {
+                builder.Append("-s");
+                builder.AppendQuoted(settings.Source);
+            }
+
+            if (settings.Timeout != null)
+            {
+                builder.Append("-t");
+                builder.Append(Convert.ToInt32(settings.Timeout.Value.TotalSeconds).ToString(CultureInfo.InvariantCulture));
+            }
+
+            if (settings.ApiKey != null)
+            {
+                builder.Append("-k");
+                builder.AppendSecret(settings.ApiKey);
+            }
+
+            // Debug
+            if (settings.Debug)
+            {
+                builder.Append("-d");
+            }
+
+            // Verbose
+            if (settings.Verbose)
+            {
+                builder.Append("-v");
+            }
+
+            // Always say yes, so as to not show interactive prompt
+            builder.Append("-y");
+
+            // Force
+            if (settings.Force)
+            {
+                builder.Append("-f");
+            }
+
+            // Noop
+            if (settings.Noop)
+            {
+                builder.Append("--noop");
+            }
+
+            // Limit Output
+            if (settings.LimitOutput)
+            {
+                builder.Append("-r");
+            }
+
+            // Execution Timeout
+            if (settings.ExecutionTimeout != 0)
+            {
+                builder.Append("--execution-timeout");
+                builder.AppendQuoted(settings.ExecutionTimeout.ToString(CultureInfo.InvariantCulture));
+            }
+
+            // Cache Location
+            if (!string.IsNullOrWhiteSpace(settings.CacheLocation))
+            {
+                builder.Append("-c");
+                builder.AppendQuoted(settings.CacheLocation);
+            }
+
+            // Allow Unoffical
+            if (settings.AllowUnoffical)
+            {
+                builder.Append("--allowunofficial");
+            }
+
+            return builder;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/Sources/ChocolateySources.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Sources/ChocolateySources.cs
@@ -1,0 +1,261 @@
+﻿using System;
+using System.Globalization;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Chocolatey.Sources
+{
+    /// <summary>
+    /// The Chocolatey sources is used to work with user config feeds &amp; credentials
+    /// </summary>
+    public sealed class ChocolateySources : ChocolateyTool<ChocolateySourcesSettings>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChocolateySources"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
+        /// <param name="resolver">The Chocolatey tool resolver.</param>
+        public ChocolateySources(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IGlobber globber,
+            IChocolateyToolResolver resolver)
+            : base(fileSystem, environment, processRunner, globber, resolver)
+        {
+        }
+
+        /// <summary>
+        /// Adds Chocolatey package source using the specified settings to global user config
+        /// </summary>
+        /// <param name="name">Name of the source.</param>
+        /// <param name="source">Path to the package(s) source.</param>
+        /// <param name="settings">The settings.</param>
+        public void AddSource(string name, string source, ChocolateySourcesSettings settings)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException("name");
+            }
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("Source name cannot be empty.", "name");
+            }
+            if (source == null)
+            {
+                throw new ArgumentNullException("source");
+            }
+            if (string.IsNullOrWhiteSpace(source))
+            {
+                throw new ArgumentException("Source cannot be empty.", "source");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            Run(settings, GetAddArguments(name, source, settings), settings.ToolPath);
+        }
+
+        /// <summary>
+        /// Remove specified Chocolatey package source
+        /// </summary>
+        /// <param name="name">Name of the source.</param>
+        /// <param name="settings">The settings.</param>
+        public void RemoveSource(string name, ChocolateySourcesSettings settings)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException("name");
+            }
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("Source name cannot be empty.", "name");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            Run(settings, GetRemoveArguments(name, settings), settings.ToolPath);
+        }
+
+        /// <summary>
+        /// Enable specified Chocolatey package source
+        /// </summary>
+        /// <param name="name">Name of the source.</param>
+        /// <param name="settings">The settings.</param>
+        public void EnableSource(string name, ChocolateySourcesSettings settings)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException("name");
+            }
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("Source name cannot be empty.", "name");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            Run(settings, GetEnableArguments(name, settings), settings.ToolPath);
+        }
+
+        /// <summary>
+        /// Disable specified Chocolatey package source
+        /// </summary>
+        /// <param name="name">Name of the source.</param>
+        /// <param name="settings">The settings.</param>
+        public void DisableSource(string name, ChocolateySourcesSettings settings)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException("name");
+            }
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("Source name cannot be empty.", "name");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            Run(settings, GetDisableArguments(name, settings), settings.ToolPath);
+        }
+
+        private static ProcessArgumentBuilder GetAddArguments(string name, string source, ChocolateySourcesSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("source add");
+
+            AddCommonParameters(name, source, settings, builder);
+
+            // User name specified?
+            if (!string.IsNullOrWhiteSpace(settings.UserName))
+            {
+                builder.Append("-u");
+                builder.AppendQuoted(settings.UserName);
+            }
+
+            // Password specified?
+            if (!string.IsNullOrWhiteSpace(settings.Password))
+            {
+                builder.Append("-p");
+                builder.AppendQuotedSecret(settings.Password);
+            }
+
+            return builder;
+        }
+
+        private static ProcessArgumentBuilder GetRemoveArguments(string name, ChocolateySourcesSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("source remove");
+
+            AddCommonParameters(name, string.Empty, settings, builder);
+
+            return builder;
+        }
+
+        private static ProcessArgumentBuilder GetEnableArguments(string name, ChocolateySourcesSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("source enable");
+
+            AddCommonParameters(name, string.Empty, settings, builder);
+
+            return builder;
+        }
+
+        private static ProcessArgumentBuilder GetDisableArguments(string name, ChocolateySourcesSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("source disable");
+
+            AddCommonParameters(name, string.Empty, settings, builder);
+
+            return builder;
+        }
+
+        private static void AddCommonParameters(string name, string source, ChocolateySourcesSettings settings, ProcessArgumentBuilder builder)
+        {
+            builder.Append("-n");
+            builder.AppendQuoted(name);
+
+            if (!string.IsNullOrWhiteSpace(source))
+            {
+                builder.Append("-s");
+                builder.AppendQuoted(source);
+            }
+
+            // Debug
+            if (settings.Debug)
+            {
+                builder.Append("-d");
+            }
+
+            // Verbose
+            if (settings.Verbose)
+            {
+                builder.Append("-v");
+            }
+
+            // Always say yes, so as to not show interactive prompt
+            builder.Append("-y");
+
+            // Force
+            if (settings.Force)
+            {
+                builder.Append("-f");
+            }
+
+            // Noop
+            if (settings.Noop)
+            {
+                builder.Append("--noop");
+            }
+
+            // Limit Output
+            if (settings.LimitOutput)
+            {
+                builder.Append("-r");
+            }
+
+            // Execution Timeout
+            if (settings.ExecutionTimeout != 0)
+            {
+                builder.Append("--execution-timeout");
+                builder.AppendQuoted(settings.ExecutionTimeout.ToString(CultureInfo.InvariantCulture));
+            }
+
+            // Cache Location
+            if (!string.IsNullOrWhiteSpace(settings.CacheLocation))
+            {
+                builder.Append("-c");
+                builder.AppendQuoted(settings.CacheLocation);
+            }
+
+            // Allow Unoffical
+            if (settings.AllowUnoffical)
+            {
+                builder.Append("--allowunofficial");
+            }
+
+            if (settings.Priority > 0)
+            {
+                builder.Append("--priority");
+                builder.AppendQuoted(settings.Priority.ToString(CultureInfo.InvariantCulture));
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/Sources/ChocolateySourcesSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Sources/ChocolateySourcesSettings.cs
@@ -1,0 +1,83 @@
+﻿using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Chocolatey.Sources
+{
+    /// <summary>
+    /// Contains settings used by <see cref="ChocolateySources"/>.
+    /// </summary>
+    public sealed class ChocolateySourcesSettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in debug mode.
+        /// </summary>
+        /// <value>The debug flag</value>
+        public bool Debug { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in verbose mode.
+        /// </summary>
+        /// <value>The verbose flag.</value>
+        public bool Verbose { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in forced mode.
+        /// </summary>
+        /// <value>The force flag</value>
+        public bool Force { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in noop mode.
+        /// </summary>
+        /// <value>The noop flag.</value>
+        public bool Noop { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in limited output mode.
+        /// </summary>
+        /// <value>The limit output flag</value>
+        public bool LimitOutput { get; set; }
+
+        /// <summary>
+        /// Gets or sets the execution timeout value.
+        /// </summary>
+        /// <value>The execution timeout</value>
+        /// <remarks>Default is 2700 seconds</remarks>
+        public int ExecutionTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the location of the download cache.
+        /// </summary>
+        /// <value>The download cache location</value>
+        public string CacheLocation { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in allow unofficial mode.
+        /// </summary>
+        /// <value>The allow unofficial flag</value>
+        public bool AllowUnoffical { get; set; }
+
+        /// <summary>
+        /// Gets or sets the (optional) user name.
+        /// </summary>
+        /// <value>Optional user name to be used when connecting to an authenticated source.</value>
+        public string UserName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the (optional) password.
+        /// </summary>
+        /// <value>Optional password to be used when connecting to an authenticated source.</value>
+        public string Password { get; set; }
+
+        /// <summary>
+        /// Gets or sets the (optional) priority.
+        /// </summary>
+        /// <value>Optional priority to be used when creating source.</value>
+        public int Priority { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tool path.
+        /// </summary>
+        /// <value>The tool path.</value>
+        public FilePath ToolPath { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/Upgrade/ChocolateyUpgradeSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Upgrade/ChocolateyUpgradeSettings.cs
@@ -1,0 +1,171 @@
+﻿using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Chocolatey.Upgrade
+{
+    /// <summary>
+    /// Contains settings used by <see cref="ChocolateyUpgrader"/>.
+    /// </summary>
+    public sealed class ChocolateyUpgradeSettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in debug mode.
+        /// </summary>
+        /// <value>The debug flag</value>
+        public bool Debug { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in verbose mode.
+        /// </summary>
+        /// <value>The verbose flag.</value>
+        public bool Verbose { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to accept license for package.
+        /// </summary>
+        /// <value>The accept license flag</value>
+        public bool AcceptLicense { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in forced mode.
+        /// </summary>
+        /// <value>The force flag</value>
+        public bool Force { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in noop mode.
+        /// </summary>
+        /// <value>The noop flag.</value>
+        public bool Noop { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in limited output mode.
+        /// </summary>
+        /// <value>The limit output flag</value>
+        public bool LimitOutput { get; set; }
+
+        /// <summary>
+        /// Gets or sets the execution timeout value.
+        /// </summary>
+        /// <value>The execution timeout</value>
+        /// <remarks>Default is 2700 seconds</remarks>
+        public int ExecutionTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the location of the download cache.
+        /// </summary>
+        /// <value>The download cache location</value>
+        public string CacheLocation { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in allow unofficial mode.
+        /// </summary>
+        /// <value>The allow unofficial flag</value>
+        public bool AllowUnoffical { get; set; }
+
+        /// <summary>
+        /// Gets or sets the source to use for this command.
+        /// </summary>
+        public string Source { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Nuspec version.
+        /// </summary>
+        /// <value>The Nuspec version.</value>
+        public string Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow upgrading to prerelease versions.
+        /// This flag is not required when updating prerelease packages that are already installed.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> to allow updating to prerelease versions; otherwise, <c>false</c>.
+        /// </value>
+        public bool Prerelease { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to force installation of the x86 version of package.
+        /// </summary>
+        /// <value>The force x86 flag</value>
+        public bool Forcex86 { get; set; }
+
+        /// <summary>
+        /// Gets or sets the install arguments to pass to native installer.
+        /// </summary>
+        public string InstallArguments { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to override the passed arguments.
+        /// </summary>
+        /// <value>The override arguments flag</value>
+        public bool OverrideArguments { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not to install silently.
+        /// </summary>
+        /// <value>The not silent flag</value>
+        public bool NotSilent { get; set; }
+
+        /// <summary>
+        /// Gets or sets the parameters to pass to the package.
+        /// </summary>
+        public string PackageParameters { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow downgrade of package.
+        /// </summary>
+        /// <value>The downgrade package flag</value>
+        public bool AllowDowngrade { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow side by side installation.
+        /// </summary>
+        /// <value>The side by side installation flag</value>
+        public bool SideBySide { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to ignore dependencies.
+        /// </summary>
+        /// <value>The ignore dependencies flag</value>
+        public bool IgnoreDependencies { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to skip the PowerShell installation of package.
+        /// </summary>
+        /// <value>The skip powershell flag</value>
+        public bool SkipPowerShell { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to fail on unfound packages.
+        /// </summary>
+        /// <value>The skip powershell flag</value>
+        public bool FailOnUnfound { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to fail on not installed packages.
+        /// </summary>
+        /// <value>The skip powershell flag</value>
+        public bool FailOnNotInstalled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user for authenticated feeds.
+        /// </summary>
+        public string User { get; set; }
+
+        /// <summary>
+        /// Gets or sets the password for authenticated feeds.
+        /// </summary>
+        public string Password { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to ignore checksums.
+        /// </summary>
+        /// <value>The ignore checksums flag</value>
+        public bool IgnoreChecksums { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tool path.
+        /// </summary>
+        /// <value>The tool path.</value>
+        public FilePath ToolPath { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/Upgrade/ChocolateyUpgrader.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Upgrade/ChocolateyUpgrader.cs
@@ -1,0 +1,227 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Chocolatey.Upgrade
+{
+    using System.Globalization;
+
+    /// <summary>
+    /// The Chocolatey package upgrader.
+    /// </summary>
+    public sealed class ChocolateyUpgrader : ChocolateyTool<ChocolateyUpgradeSettings>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChocolateyUpgrader"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
+        /// <param name="resolver">The Chocolatey tool resolver.</param>
+        public ChocolateyUpgrader(IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IGlobber globber,
+            IChocolateyToolResolver resolver)
+            : base(fileSystem, environment, processRunner, globber, resolver)
+        {
+        }
+
+        /// <summary>
+        /// Upgrades Chocolatey packages using the specified settings.
+        /// </summary>
+        /// <param name="packageId">The source package id.</param>
+        /// <param name="settings">The settings.</param>
+        public void Upgrade(string packageId, ChocolateyUpgradeSettings settings)
+        {
+            if (string.IsNullOrWhiteSpace(packageId))
+            {
+                throw new ArgumentNullException("packageId");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            Run(settings, GetArguments(packageId, settings), settings.ToolPath);
+        }
+
+        private ProcessArgumentBuilder GetArguments(string packageId, ChocolateyUpgradeSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("upgrade");
+            builder.AppendQuoted(packageId);
+
+            // Debug
+            if (settings.Debug)
+            {
+                builder.Append("-d");
+            }
+
+            // Verbose
+            if (settings.Verbose)
+            {
+                builder.Append("-v");
+            }
+
+            // Accept License
+            if (settings.AcceptLicense)
+            {
+                builder.Append("--acceptLicense");
+            }
+
+            // Always say yes, so as to not show interactive prompt
+            builder.Append("-y");
+
+            // Force
+            if (settings.Force)
+            {
+                builder.Append("-f");
+            }
+
+            // Noop
+            if (settings.Noop)
+            {
+                builder.Append("--noop");
+            }
+
+            // Limit Output
+            if (settings.LimitOutput)
+            {
+                builder.Append("-r");
+            }
+
+            // Execution Timeout
+            if (settings.ExecutionTimeout != 0)
+            {
+                builder.Append("--execution-timeout");
+                builder.AppendQuoted(settings.ExecutionTimeout.ToString(CultureInfo.InvariantCulture));
+            }
+
+            // Cache Location
+            if (!string.IsNullOrWhiteSpace(settings.CacheLocation))
+            {
+                builder.Append("-c");
+                builder.AppendQuoted(settings.CacheLocation);
+            }
+
+            // Allow Unoffical
+            if (settings.AllowUnoffical)
+            {
+                builder.Append("--allowunofficial");
+            }
+
+            // Package source
+            if (!string.IsNullOrWhiteSpace(settings.Source))
+            {
+                builder.Append("-s");
+                builder.AppendQuoted(settings.Source);
+            }
+
+            // Version
+            if (settings.Version != null)
+            {
+                builder.Append("--version");
+                builder.AppendQuoted(settings.Version);
+            }
+
+            // Prerelease
+            if (settings.Prerelease)
+            {
+                builder.Append("--pre");
+            }
+
+            // Forcex86
+            if (settings.Forcex86)
+            {
+                builder.Append("--x86");
+            }
+
+            // Install Arguments
+            if (!string.IsNullOrWhiteSpace(settings.InstallArguments))
+            {
+                builder.Append("--ia");
+                builder.AppendQuoted(settings.InstallArguments);
+            }
+
+            // OverrideArguments
+            if (settings.OverrideArguments)
+            {
+                builder.Append("-o");
+            }
+
+            // NotSilent
+            if (settings.NotSilent)
+            {
+                builder.Append("--notSilent");
+            }
+
+            // Package Parameters
+            if (!string.IsNullOrWhiteSpace(settings.PackageParameters))
+            {
+                builder.Append("--params");
+                builder.AppendQuoted(settings.PackageParameters);
+            }
+
+            // Allow Downgrade
+            if (settings.AllowDowngrade)
+            {
+                builder.Append("--allowdowngrade");
+            }
+
+            // Side by side installation
+            if (settings.SideBySide)
+            {
+                builder.Append("-m");
+            }
+
+            // Ignore Dependencies
+            if (settings.IgnoreDependencies)
+            {
+                builder.Append("-i");
+            }
+
+            // Skip PowerShell
+            if (settings.SkipPowerShell)
+            {
+                builder.Append("-n");
+            }
+
+            // Fail on Unfound
+            if (settings.FailOnUnfound)
+            {
+                builder.Append("--failonunfound");
+            }
+
+            // Fail on Not Installed
+            if (settings.FailOnNotInstalled)
+            {
+                builder.Append("--failonnotinstalled");
+            }
+
+            // User
+            if (!string.IsNullOrWhiteSpace(settings.User))
+            {
+                builder.Append("-u");
+                builder.AppendQuoted(settings.User);
+            }
+
+            // Password
+            if (!string.IsNullOrWhiteSpace(settings.Password))
+            {
+                builder.Append("-p");
+                builder.AppendQuoted(settings.Password);
+            }
+
+            // Ignore Checksums
+            if (settings.IgnoreChecksums)
+            {
+                builder.Append("--ignorechecksums");
+            }
+
+            return builder;
+        }
+    }
+}


### PR DESCRIPTION
Choco commands that will be included in this first release of Chocolatey support

- [x] Install
- [x] Pack
- [x] Pin
- [x] Push
- [x] ApiKey/SetApiKey
- [x] Source/Sources
- [x] Update/Upgrade
- [x] Feature/Features
- [x] Config
- [x] Documentation

*NOTE:* Only the commands that apply can action will be included in this release, as these are the most likely commands that are needed within a build script.  For example, only `choco config set` will be implemented, where as `choco config get` will not.

Choco commands which are unlikely to be implemented in this PR:

* Search/List
* Outdated
* Unpackself
* New
* Uninstall
* Version
