### PR TITLE
Nuget framework targeting for Addins

### DIFF
--- a/src/Cake.Core.Tests/Cake.Core.Tests.csproj
+++ b/src/Cake.Core.Tests/Cake.Core.Tests.csproj
@@ -89,7 +89,12 @@
     <Compile Include="Unit\IO\FilePathCollectionTests.cs" />
     <Compile Include="Unit\IO\FileSystemExtensionsTest.cs" />
     <Compile Include="Unit\IO\GlobberTests.cs" />
+    <Compile Include="Unit\IO\NuGet\Parsing\AssemblyFilePathFrameworkNameParserTests.cs" />
+    <Compile Include="Unit\IO\NuGet\NuGetAssemblyCompatibilityFilterTests.cs" />
+    <Compile Include="Unit\IO\NuGet\NuGetPackageAssembliesLocatorTests.cs" />
     <Compile Include="Unit\IO\NuGet\NuGetToolResolverTests.cs" />
+    <Compile Include="Unit\IO\NuGet\PackageReferenceBundlerTests.cs" />
+    <Compile Include="Unit\IO\NuGet\PackageReferenceSetTests.cs" />
     <Compile Include="Unit\IO\PathComparerTests.cs" />
     <Compile Include="Unit\IO\DirectoryPathTests.cs" />
     <Compile Include="Unit\IO\FilePathTests.cs" />

--- a/src/Cake.Core.Tests/Unit/IO/NuGet/NuGetAssemblyCompatibilityFilterTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/NuGet/NuGetAssemblyCompatibilityFilterTests.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Versioning;
+using Cake.Core.IO;
+using Cake.Core.IO.NuGet;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Core.Tests.Unit.IO.NuGet
+{
+    public class NuGetAssemblyCompatibilityFilterTests
+    {
+        public sealed class TheFilterCompatibleAssembliesMethod
+        {
+            private static readonly FrameworkName _dummyFrameworkName = new FrameworkName(".NETFramework,Version=v4.5.1");
+
+            [Fact]
+            public void Should_Throw_If_Target_Framework_Is_Null()
+            {
+                // Given
+
+                var filter = new NuGetAssemblyCompatibilityFilter(Substitute.For<INuGetFrameworkCompatibilityFilter>(),
+                    Substitute.For<IPackageReferenceBundler>());
+
+                // When
+                // ReSharper disable once ExpressionIsAlwaysNull
+                var result = Record.Exception(() => filter.FilterCompatibleAssemblies(null, new FilePath[0]));
+
+                // Then
+                Assert.IsArgumentNullException(result, "targetFramework");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Assembly_Paths_Is_Null()
+            {
+                // Given
+                var filter = new NuGetAssemblyCompatibilityFilter(Substitute.For<INuGetFrameworkCompatibilityFilter>(),
+                    Substitute.For<IPackageReferenceBundler>());
+
+                // When
+                var result = Record.Exception(() => filter.FilterCompatibleAssemblies(_dummyFrameworkName, null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "assemblyPaths");
+            }
+
+            [Fact]
+            public void Should_Return_Empty_When_No_References_Are_Compatible()
+            {
+                // Given
+                var targetFramework = _dummyFrameworkName;
+
+                var compatibilityFilter = Substitute.For<INuGetFrameworkCompatibilityFilter>();
+
+                compatibilityFilter.GetCompatibleItems(targetFramework, Arg.Any<IEnumerable<PackageReferenceSet>>())
+                    .Returns(Enumerable.Empty<PackageReferenceSet>());
+
+                var referenceSetFactory = Substitute.For<IPackageReferenceBundler>();
+
+                var assemblyFiles = new FilePath[] { "dummy.dll", "dummy2.dll" };
+                var filter = new NuGetAssemblyCompatibilityFilter(compatibilityFilter,
+                    referenceSetFactory);
+
+                // When
+                var result = filter.FilterCompatibleAssemblies(targetFramework, assemblyFiles);
+
+                // Then
+                Assert.Empty(result);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Any_Assembly_Path_Is_Not_Relative()
+            {
+                // Given
+                var compatibilityFilter = Substitute.For<INuGetFrameworkCompatibilityFilter>();
+                var referenceSetFactory = Substitute.For<IPackageReferenceBundler>();
+
+                var assemblyFiles = new FilePath[] { "c:/dir/dummy.dll", "dummy2.dll" };
+                var filter = new NuGetAssemblyCompatibilityFilter(compatibilityFilter,
+                    referenceSetFactory);
+
+                // When
+                var result = Record.Exception(() => filter.FilterCompatibleAssemblies(_dummyFrameworkName, assemblyFiles));
+                
+                // Then
+                Assert.IsCakeException(result, "All assemblyPaths must be relative to the package directory.");
+            }
+
+            [Fact]
+            public void Should_Return_Compatible_References()
+            {
+                // TODO: this is a pretty bad test -- some refactoring of the SUT implementation should simplify this
+
+                // Given
+                var targetFramework = new FrameworkName(".NETFramework,Version=v4.0");
+
+                var compatibleAssemblies = new FilePath[]
+                { "lib/net40/compatible1.dll", "lib/net40/compatible2.dll", "compatible3.dll" };
+                var allAssemblies =
+                    compatibleAssemblies.Concat(new FilePath[]
+                    { "lib/net452/incompatible1.dll", "lib/net452/incompatible2.dll" }).ToArray();
+
+                var compatibilityFilter = Substitute.For<INuGetFrameworkCompatibilityFilter>();
+                
+                compatibilityFilter.GetCompatibleItems(targetFramework, Arg.Any<IEnumerable<PackageReferenceSet>>())
+                    .Returns(args => new[]
+                    {
+                        new PackageReferenceSet(args.Arg<FrameworkName>(),
+                            compatibleAssemblies)
+                    });
+
+                var referenceSetFactory = Substitute.For<IPackageReferenceBundler>();
+
+                var filter = new NuGetAssemblyCompatibilityFilter(compatibilityFilter,
+                    referenceSetFactory);
+
+                // When
+                var result = filter.FilterCompatibleAssemblies(targetFramework, allAssemblies);
+
+                // Then
+                Assert.Equal(compatibleAssemblies.Select(ca => ca.FullPath).ToArray(),
+                    result.Select(ca => ca.FullPath).ToArray());
+            }
+        }
+    }
+}

--- a/src/Cake.Core.Tests/Unit/IO/NuGet/NuGetPackageAssembliesLocatorTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/NuGet/NuGetPackageAssembliesLocatorTests.cs
@@ -1,0 +1,139 @@
+using System.Collections.Generic;
+using System.Runtime.Versioning;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using Cake.Core.IO.NuGet;
+using Cake.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Core.Tests.Unit.IO.NuGet
+{
+    public sealed class NuGetPackageAssembliesLocatorTests
+    {
+        public sealed class TheFindAssembliesMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Package_Directory_Is_Null()
+            {
+                // Given
+                var fileSystem = Substitute.For<IFileSystem>();
+                var log = Substitute.For<ICakeLog>();
+                var assemblyCompatibilityFilter = Substitute.For<INuGetAssemblyCompatibilityFilter>();
+                var environment = Substitute.For<ICakeEnvironment>();
+                var locator = new NuGetPackageAssembliesLocator(fileSystem, log, assemblyCompatibilityFilter, environment);
+
+                // When
+                var result = Record.Exception(() => locator.FindAssemblies(null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "packageDirectory");
+            }
+
+            [Fact]
+            public void Should_Return_Empty_If_Package_Directory_Does_Not_Exist()
+            {
+                // Given
+                var environment = FakeEnvironment.CreateWindowsEnvironment();
+                var fileSystem = new FakeFileSystem(environment);
+                var log = Substitute.For<ICakeLog>();
+                var assemblyCompatibilityFilter = Substitute.For<INuGetAssemblyCompatibilityFilter>();
+
+                var locator = new NuGetPackageAssembliesLocator(fileSystem, log, assemblyCompatibilityFilter, environment);
+
+                var addinDirectory = DirectoryPath.FromString("c:/NonExistentDir");
+
+                // When
+                var result = locator.FindAssemblies(addinDirectory);
+
+                // Then
+                Assert.Empty(result);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Package_Directory_Is_Not_Absolute()
+            {
+                // Given
+                var environment = FakeEnvironment.CreateWindowsEnvironment();
+                var fileSystem = new FakeFileSystem(environment);
+                var log = Substitute.For<ICakeLog>();
+                var assemblyCompatibilityFilter = Substitute.For<INuGetAssemblyCompatibilityFilter>();
+
+                var locator = new NuGetPackageAssembliesLocator(fileSystem, log, assemblyCompatibilityFilter, environment);
+
+                var addinDirectory = DirectoryPath.FromString("RelativeDirPath");
+                Assert.True(addinDirectory.IsRelative);
+
+                // When
+                var result = Record.Exception(() => locator.FindAssemblies(addinDirectory)); 
+
+                // Then
+                Assert.IsCakeException(result, "Package directory (RelativeDirPath) must be an absolute path.");
+            }
+
+            [Fact]
+            public void Should_Return_Compatible_Packages_For_NuGet_Compliant_Package()
+            {
+                // Given
+                var targetFramework = new FrameworkName(".NETFramework,Version=v4.5");
+                var environment = FakeEnvironment.CreateWindowsEnvironment();
+                environment.SetTargetFramework(targetFramework);
+
+                var log = Substitute.For<ICakeLog>();
+
+                var fileSystem = new FakeFileSystem(environment);
+
+                var packageDirectory = fileSystem.CreateDirectory("c:/Working/addins/MyPackage");
+
+                fileSystem.CreateFile(packageDirectory.Path.CombineWithFilePath("lib/net40/myassembly1.dll"));
+                fileSystem.CreateFile(packageDirectory.Path.CombineWithFilePath("lib/net40/myassembly2.dll"));
+                var compatibleDll1 = fileSystem.CreateFile(packageDirectory.Path.CombineWithFilePath("lib/net45/myassembly1.dll"));
+                var compatibleDll2 = fileSystem.CreateFile(packageDirectory.Path.CombineWithFilePath("lib/net45/myassembly2.dll"));
+                fileSystem.CreateFile(packageDirectory.Path.CombineWithFilePath("lib/net452/myassembly1.dll"));
+                fileSystem.CreateFile(packageDirectory.Path.CombineWithFilePath("lib/net452/myassembly2.dll"));
+
+                var assemblyCompatibilityFilter = Substitute.For<INuGetAssemblyCompatibilityFilter>();
+                assemblyCompatibilityFilter.FilterCompatibleAssemblies(targetFramework, Arg.Any<IEnumerable<FilePath>>())
+                    .Returns(ci => new FilePath[] { "lib/net45/myassembly1.dll", "lib/net45/myassembly2.dll" });
+
+                var locator = new NuGetPackageAssembliesLocator(fileSystem, log, assemblyCompatibilityFilter, environment);
+
+                // When
+                var result = locator.FindAssemblies(packageDirectory.Path);
+
+                // Then
+                Assert.Equal(new List<IFile> { compatibleDll1, compatibleDll2 }.AsReadOnly(), result);
+            }
+
+            [Fact]
+            public void Should_Return_Empty_If_No_Package_Assemblies_Are_Found()
+            {
+                // Given
+                var targetFramework = new FrameworkName(".NETFramework,Version=v4.5");
+                var environment = FakeEnvironment.CreateWindowsEnvironment();
+                environment.SetTargetFramework(targetFramework);
+
+                var log = Substitute.For<ICakeLog>();
+
+                var fileSystem = new FakeFileSystem(environment);
+
+                var packageDirectory = fileSystem.CreateDirectory("c:/Working/addins/MyPackage");
+
+                var assemblyCompatibilityFilter = Substitute.For<INuGetAssemblyCompatibilityFilter>();
+                assemblyCompatibilityFilter.FilterCompatibleAssemblies(targetFramework, Arg.Any<IEnumerable<FilePath>>())
+                    .Returns(ci => ci[1]);
+
+                var locator = new NuGetPackageAssembliesLocator(fileSystem, log, assemblyCompatibilityFilter, environment);
+
+                // When
+                var result = locator.FindAssemblies(packageDirectory.Path);
+
+                // Then
+                Assert.Empty(result);
+                log.Received()
+                    .Write(Verbosity.Minimal, LogLevel.Warning, "Unable to locate any assemblies under {0}",
+                        packageDirectory.Path.FullPath);
+            }
+        }
+    }
+}

--- a/src/Cake.Core.Tests/Unit/IO/NuGet/PackageReferenceBundlerTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/NuGet/PackageReferenceBundlerTests.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Versioning;
+using Cake.Core.IO;
+using Cake.Core.IO.NuGet;
+using Cake.Core.IO.NuGet.Parsing;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Core.Tests.Unit.IO.NuGet
+{
+    public sealed class PackageReferenceBundlerTests
+    {
+        public sealed class TheParseMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Package_Assembly_Files_Is_Null()
+            {
+                // Given
+                IEnumerable<FilePath> packageAssemblyFiles = null;
+                var parser = new PackageReferenceBundler(Substitute.For<IAssemblyFilePathFrameworkNameParser>());
+
+                // When
+                var result = Record.Exception(() => parser.BundleByTargetFramework(packageAssemblyFiles));
+
+                // Then
+                Assert.IsArgumentNullException(result, "packageAssemblyFiles");
+            }
+
+            [Fact]
+            public void Should_Return_Empty_If_Package_Assembly_Files_Is_Empty()
+            {
+                // Given
+                var packageAssemblyFiles = Enumerable.Empty<FilePath>();
+
+                var parser = new PackageReferenceBundler(Substitute.For<IAssemblyFilePathFrameworkNameParser>());
+
+                // When
+                var result = parser.BundleByTargetFramework(packageAssemblyFiles);
+
+                // Then
+                Assert.Empty(result);
+            }
+
+            [Fact]
+            public void Should_Group_Assembly_Files_Into_Package_Reference_Sets_By_Target_Framework()
+            {
+                // Given
+                var packageAssemblyFiles = new FilePath[]
+                {
+                    "framework1/assemblyA.dll", "framework1/assemblyB.dll", "assemblyC.dll", "framework2/assemblyA.dll",
+                    "framework2/assemblyB.dll"
+                };
+
+                var pathParser = Substitute.For<IAssemblyFilePathFrameworkNameParser>();
+
+                pathParser.Parse(Arg.Any<FilePath>()).Returns(ci =>
+                {
+                    var directoryName = ci.Arg<FilePath>().GetDirectory().FullPath;
+
+                    if (string.IsNullOrEmpty(directoryName))
+                    {
+                        return null;
+                    }
+
+                    return new FrameworkName(directoryName, new Version());
+                });
+
+                var parser = new PackageReferenceBundler(pathParser);
+
+                // When
+                var result = parser.BundleByTargetFramework(packageAssemblyFiles).ToArray();
+
+                // Then
+                Assert.Equal(3, result.Length);
+
+                var framework1Set =
+                    result.Single(p => p.TargetFramework == new FrameworkName("framework1", new Version()));
+                Assert.Equal(2, framework1Set.References.Count);
+                Assert.ContainsFilePath(framework1Set.References, packageAssemblyFiles[0]);
+                Assert.ContainsFilePath(framework1Set.References, packageAssemblyFiles[1]);
+
+                var framework2Set =
+                    result.Single(p => p.TargetFramework == new FrameworkName("framework2", new Version()));
+                Assert.Equal(2, framework2Set.References.Count);
+                Assert.ContainsFilePath(framework2Set.References, packageAssemblyFiles[3]);
+                Assert.ContainsFilePath(framework2Set.References, packageAssemblyFiles[4]);
+
+                var noFrameworkSet =
+                    result.Single(p => p.TargetFramework == null);
+                Assert.Equal(1, noFrameworkSet.References.Count);
+                Assert.ContainsFilePath(noFrameworkSet.References, packageAssemblyFiles[2]);
+            }
+        }
+    }
+}

--- a/src/Cake.Core.Tests/Unit/IO/NuGet/PackageReferenceSetTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/NuGet/PackageReferenceSetTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Versioning;
+using Cake.Core.IO;
+using Cake.Core.IO.NuGet;
+using Xunit;
+
+namespace Cake.Core.Tests.Unit.IO.NuGet
+{
+    public sealed class PackageReferenceSetTests
+    {
+        private static readonly FrameworkName _dummyFrameworkName = new FrameworkName("DummyFx", new Version());
+
+        public sealed class TheConstructor
+        {
+            [Fact]
+            public void Should_Throw_If_References_Is_Null()
+            {
+                // Given
+                IEnumerable<FilePath> references = null;
+
+                // When
+                var result = Record.Exception(() => new PackageReferenceSet(_dummyFrameworkName, references));
+
+                // Then
+                Assert.IsArgumentNullException(result, "references");
+            }
+
+            [Fact]
+            public void Should_Allow_Null_Framework_Name()
+            {
+                // Given
+                var references = Enumerable.Empty<FilePath>();
+                FrameworkName frameworkName = null;
+
+                // When
+                var result = Record.Exception(() => new PackageReferenceSet(frameworkName, references));
+
+                // Then
+                Assert.Null(result);
+            }
+        }
+
+        public sealed class TheSupportedFrameworksProperty
+        {
+            [Fact]
+            public void Should_Be_Empty_When_Framework_Name_Is_Null()
+            {
+                // Given
+                var references = Enumerable.Empty<FilePath>();
+                FrameworkName frameworkName = null;
+                var referenceSet = new PackageReferenceSet(frameworkName, references);
+
+                // When
+                var result = referenceSet.SupportedFrameworks;
+
+                // Then
+                Assert.Empty(result);
+            }
+
+            [Fact]
+            public void Should_Be_Include_Framework_Name()
+            {
+                // Given
+                var referenceSet = new PackageReferenceSet(_dummyFrameworkName, Enumerable.Empty<FilePath>());
+
+                // When
+                var result = referenceSet.SupportedFrameworks;
+
+                // Then
+                Assert.Equal(new[] { _dummyFrameworkName }, result);
+            }
+        }
+    }
+}

--- a/src/Cake.Core.Tests/Unit/IO/NuGet/Parsing/AssemblyFilePathFrameworkNameParserTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/NuGet/Parsing/AssemblyFilePathFrameworkNameParserTests.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.Versioning;
+using Cake.Core.IO;
+using Cake.Core.IO.NuGet.Parsing;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Core.Tests.Unit.IO.NuGet.Parsing
+{
+    public sealed class AssemblyFilePathFrameworkNameParserTests
+    {
+        public sealed class TheParseMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Path_Is_Null()
+            {
+                // Given
+                FilePath path = null;
+                var parser = new AssemblyFilePathFrameworkNameParser(Substitute.For<IFrameworkNameParser>());
+
+                // When
+                var result = Record.Exception(() => parser.Parse(path));
+
+                // Then
+                Assert.IsArgumentNullException(result, "path");
+            }
+
+            [Theory]
+            [InlineData("lib/foo.dll", "Unsupported")]
+            [InlineData("lib/sub/foo.dll", "Unsupported")]
+            [InlineData("lib/fx1/foo.dll", "fx1")]
+            [InlineData("lib/sub/fx2/foo.dll", "fx2")]
+            [InlineData("fx2/foo.dll", "fx2")]
+            [InlineData("fx2/sub/foo.dll", "fx2")]
+            [InlineData("lib/fx1/sub/foo.dll", "fx1")]
+            [InlineData("foo.dll", null)]
+            public void Should_Parse_Framework_Name_Tokens_From_Path(string path, string expectedFrameworkNameIdentifier)
+            {
+                // Given
+                var dummyValidFrameworkTokens = new[] { "fx1", "fx2" };
+
+                var nameParser = Substitute.For<IFrameworkNameParser>();
+                nameParser.ParseFrameworkName(Arg.Any<string>()).Returns(ci =>
+                {
+                    var token = ci.Arg<string>();
+                    return new FrameworkName(dummyValidFrameworkTokens.Contains(token) ? token : "Unsupported",
+                        new Version());
+                });
+
+                var pathParser = new AssemblyFilePathFrameworkNameParser(nameParser);
+
+                // When
+                var result = pathParser.Parse(path);
+
+                // Then
+                Assert.Equal(expectedFrameworkNameIdentifier, result != null ? result.Identifier : null);
+            }
+        }
+    }
+}

--- a/src/Cake.Core.Tests/Unit/Scripting/ScriptProcessorTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/ScriptProcessorTests.cs
@@ -101,7 +101,7 @@ namespace Cake.Core.Tests.Unit.Scripting
             }
 
             [Fact]
-            public void Should_Not_Install_Addins_Present_On_Disc()
+            public void Should_Not_Install_Addins_Present_On_Disk()
             {
                 // Given
                 var fixture = new ScriptProcessorFixture();

--- a/src/Cake.Core/Cake.Core.csproj
+++ b/src/Cake.Core/Cake.Core.csproj
@@ -131,11 +131,21 @@
     <Compile Include="IO\IRegistry.cs" />
     <Compile Include="IO\IRegistryKey.cs" />
     <Compile Include="IO\Machine.cs" />
+    <Compile Include="IO\NuGet\Parsing\AssemblyFilePathFrameworkNameParser.cs" />
+    <Compile Include="IO\NuGet\Parsing\IAssemblyFilePathFrameworkNameParser.cs" />
+    <Compile Include="IO\NuGet\Parsing\IFrameworkNameParser.cs" />
+    <Compile Include="IO\NuGet\IFrameworkTargetable.cs" />
+    <Compile Include="IO\NuGet\INuGetAssemblyCompatibilityFilter.cs" />
     <Compile Include="IO\NuGet\INuGetPackageInstaller.cs" />
     <Compile Include="IO\NuGet\INuGetToolResolver.cs" />
+    <Compile Include="IO\NuGet\INuGetFrameworkCompatibilityFilter.cs" />
+    <Compile Include="IO\NuGet\IPackageReferenceBundler.cs" />
+    <Compile Include="IO\NuGet\NuGetAssemblyCompatibilityFilter.cs" />
     <Compile Include="IO\NuGet\NuGetPackage.cs" />
     <Compile Include="IO\NuGet\NuGetPackageInstaller.cs" />
     <Compile Include="IO\NuGet\NuGetToolResolver.cs" />
+    <Compile Include="IO\NuGet\PackageReferenceSet.cs" />
+    <Compile Include="IO\NuGet\PackageReferenceBundler.cs" />
     <Compile Include="IO\Path.cs" />
     <Compile Include="IO\DirectoryPath.cs" />
     <Compile Include="IO\FilePath.cs" />
@@ -160,6 +170,8 @@
     <Compile Include="..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="IO\NuGet\NuGetPackageAssembliesLocator.cs" />
+    <Compile Include="IO\NuGet\INuGetPackageAssembliesLocator.cs" />
     <Compile Include="Scripting\Analysis\IScriptAnalyzer.cs" />
     <Compile Include="Scripting\Analysis\IScriptAnalyzerContext.cs" />
     <Compile Include="Scripting\Analysis\IScriptInformation.cs" />

--- a/src/Cake.Core/CakeEnvironment.cs
+++ b/src/Cake.Core/CakeEnvironment.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Versioning;
 using Cake.Core.IO;
 
 namespace Cake.Core
@@ -118,6 +119,15 @@ namespace Cake.Core
                 key => (string)key.Key,
                 value => value.Value as string,
                 StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Gets the target .Net framework version that the current AppDomain is targeting.
+        /// </summary>
+        /// <returns>The target framework.</returns>
+        public FrameworkName GetTargetFramework()
+        {
+            return new FrameworkName(AppDomain.CurrentDomain.SetupInformation.TargetFrameworkName);
         }
 
         private static void SetWorkingDirectory(DirectoryPath path)

--- a/src/Cake.Core/ICakeEnvironment.cs
+++ b/src/Cake.Core/ICakeEnvironment.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.Versioning;
 using Cake.Core.IO;
 
 namespace Cake.Core
@@ -51,5 +52,11 @@ namespace Cake.Core
         /// </summary>
         /// <returns>The environment variables as IDictionary&lt;string, string&gt; </returns>
         IDictionary<string, string> GetEnvironmentVariables();
+
+        /// <summary>
+        /// Gets the target .Net framework version that the current AppDomain is targeting.
+        /// </summary>
+        /// <returns>The target framework.</returns>
+        FrameworkName GetTargetFramework();
     }
 }

--- a/src/Cake.Core/IO/NuGet/IFrameworkTargetable.cs
+++ b/src/Cake.Core/IO/NuGet/IFrameworkTargetable.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Runtime.Versioning;
+
+namespace Cake.Core.IO.NuGet
+{
+    /// <summary>
+    /// Represents an item that may support specific .Net framework versions
+    /// </summary>
+    public interface IFrameworkTargetable
+    {
+        /// <summary>
+        /// Gets the frameworks supported by this item.
+        /// </summary>
+        /// <value>
+        /// The supported frameworks.
+        /// </value>
+        IEnumerable<FrameworkName> SupportedFrameworks { get; }
+    }
+}

--- a/src/Cake.Core/IO/NuGet/INuGetAssemblyCompatibilityFilter.cs
+++ b/src/Cake.Core/IO/NuGet/INuGetAssemblyCompatibilityFilter.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Runtime.Versioning;
+
+namespace Cake.Core.IO.NuGet
+{
+    /// <summary>
+    /// Filters assemblies for .Net target framework compatibility
+    /// </summary>
+    public interface INuGetAssemblyCompatibilityFilter
+    {
+        /// <summary>
+        /// Filters a collection of assembly files for .Net target framework compatibility.
+        /// </summary>
+        /// <param name="targetFramework">The target framework.</param>
+        /// <param name="assemblyPaths">The assembly file paths, relative to their package folder.</param>
+        /// <returns>a subset of the provided assemblyFiles that match the provided targetFramework.</returns>
+        IEnumerable<FilePath> FilterCompatibleAssemblies(FrameworkName targetFramework,
+            IEnumerable<FilePath> assemblyPaths);
+    }
+}

--- a/src/Cake.Core/IO/NuGet/INuGetFrameworkCompatibilityFilter.cs
+++ b/src/Cake.Core/IO/NuGet/INuGetFrameworkCompatibilityFilter.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Runtime.Versioning;
+
+namespace Cake.Core.IO.NuGet
+{
+    /// <summary>
+    /// Wrapper interface for NuGet's Target Framework compatibility functionality. 
+    /// </summary>
+    public interface INuGetFrameworkCompatibilityFilter
+    {
+        /// <summary>
+        /// Filters the provided list of items, returning only those items compatible with the given project framework.
+        /// </summary>
+        /// <typeparam name="T">the type of items being filtered</typeparam>
+        /// <param name="projectFramework">The project framework.</param>
+        /// <param name="items">The items.</param>
+        /// <returns>The compatible items. Empty if try is unsuccessful.</returns>
+        /// <exception cref="System.ArgumentNullException">
+        /// projectFramework
+        /// or
+        /// items
+        /// </exception>
+        IEnumerable<T> GetCompatibleItems<T>(FrameworkName projectFramework, IEnumerable<T> items)
+            where T : IFrameworkTargetable;
+    }
+}

--- a/src/Cake.Core/IO/NuGet/INuGetPackageAssembliesLocator.cs
+++ b/src/Cake.Core/IO/NuGet/INuGetPackageAssembliesLocator.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Runtime.Versioning;
+
+namespace Cake.Core.IO.NuGet
+{
+    /// <summary>
+    /// Finds assemblies included in a nuget package.
+    /// </summary>
+    public interface INuGetPackageAssembliesLocator
+    {
+        /// <summary>
+        /// Finds assemblies (DLLs) included in a nuget package.
+        /// </summary>
+        /// <param name="packageDirectory">The package directory.</param>
+        /// <returns>
+        /// the DLLs.
+        /// </returns>
+        IReadOnlyList<IFile> FindAssemblies(DirectoryPath packageDirectory);
+    }
+}

--- a/src/Cake.Core/IO/NuGet/IPackageReferenceBundler.cs
+++ b/src/Cake.Core/IO/NuGet/IPackageReferenceBundler.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace Cake.Core.IO.NuGet
+{
+    /// <summary>
+    /// Bundles packageAssemblyFiles into package reference sets grouped by their target framework.
+    /// </summary>
+    public interface IPackageReferenceBundler
+    {
+        /// <summary>
+        /// Bundles the provided packageAssemblyFiles into package reference sets grouped by their target framework.
+        /// </summary>
+        /// <param name="packageAssemblyFiles">The package assembly files.</param>
+        /// <returns>The newly created PackageReferenceSets</returns>
+        IReadOnlyCollection<PackageReferenceSet> BundleByTargetFramework(IEnumerable<FilePath> packageAssemblyFiles);
+    }
+}

--- a/src/Cake.Core/IO/NuGet/NuGetAssemblyCompatibilityFilter.cs
+++ b/src/Cake.Core/IO/NuGet/NuGetAssemblyCompatibilityFilter.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Versioning;
+
+namespace Cake.Core.IO.NuGet
+{
+    /// <summary>
+    /// Filters assemblies for .Net target framework compatibility
+    /// </summary>
+    public sealed class NuGetAssemblyCompatibilityFilter : INuGetAssemblyCompatibilityFilter
+    {
+        private readonly INuGetFrameworkCompatibilityFilter _frameworkCompatibilityFilter;
+        private readonly IPackageReferenceBundler _referenceBundler;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NuGetAssemblyCompatibilityFilter" /> class.
+        /// </summary>
+        /// <param name="frameworkCompatibilityFilter">The framework compatibility filter.</param>
+        /// <param name="referenceBundler">The reference set factory.</param>
+        public NuGetAssemblyCompatibilityFilter(INuGetFrameworkCompatibilityFilter frameworkCompatibilityFilter,
+            IPackageReferenceBundler referenceBundler)
+        {
+            _frameworkCompatibilityFilter = frameworkCompatibilityFilter;
+            _referenceBundler = referenceBundler;
+        }
+
+        /// <summary>
+        /// Filters the assemblies for .Net target framework compatibility .
+        /// </summary>
+        /// <param name="targetFramework">The target framework.</param>
+        /// <param name="assemblyPaths">The assembly files.</param>
+        /// <returns>a subset of the provided assemblyFiles that match the provided targetFramework.</returns>
+        public IEnumerable<FilePath> FilterCompatibleAssemblies(FrameworkName targetFramework,
+            IEnumerable<FilePath> assemblyPaths)
+        {
+            if (targetFramework == null)
+            {
+                throw new ArgumentNullException("targetFramework");
+            }
+            if (assemblyPaths == null)
+            {
+                throw new ArgumentNullException("assemblyPaths");
+            }
+
+            assemblyPaths = assemblyPaths.ToArray();
+
+            if (assemblyPaths.Any(a => !a.IsRelative))
+            {
+                throw new CakeException("All assemblyPaths must be relative to the package directory.");
+            }
+
+            var referenceSets = _referenceBundler.BundleByTargetFramework(assemblyPaths);
+
+            return _frameworkCompatibilityFilter.GetCompatibleItems(targetFramework, referenceSets)
+                    .SelectMany(r => r.References);
+        }
+    }
+}

--- a/src/Cake.Core/IO/NuGet/NuGetPackageAssembliesLocator.cs
+++ b/src/Cake.Core/IO/NuGet/NuGetPackageAssembliesLocator.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Cake.Core.Diagnostics;
+
+namespace Cake.Core.IO.NuGet
+{
+    /// <summary>
+    /// Finds assemblies (DLLs) included in a nuget package.
+    /// </summary>
+    public sealed class NuGetPackageAssembliesLocator : INuGetPackageAssembliesLocator
+    {
+        private readonly INuGetAssemblyCompatibilityFilter _assemblyCompatibilityFilter;
+        private readonly ICakeEnvironment _environment;
+        private readonly IFileSystem _fileSystem;
+        private readonly ICakeLog _log;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NuGetPackageAssembliesLocator"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="log">The log.</param>
+        /// <param name="assemblyCompatibilityFilter">The assembly compatibility filter.</param>
+        /// <param name="environment">The environment.</param>
+        public NuGetPackageAssembliesLocator(IFileSystem fileSystem, ICakeLog log,
+            INuGetAssemblyCompatibilityFilter assemblyCompatibilityFilter, ICakeEnvironment environment)
+        {
+            _fileSystem = fileSystem;
+            _log = log;
+            _assemblyCompatibilityFilter = assemblyCompatibilityFilter;
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Finds assemblies (DLLs) included in a nuget package.
+        /// </summary>
+        /// <param name="packageDirectory">The package directory.</param>
+        /// <returns>
+        /// the DLLs.
+        /// </returns>
+        public IReadOnlyList<IFile> FindAssemblies(DirectoryPath packageDirectory)
+        {
+            if (packageDirectory == null)
+            {
+                throw new ArgumentNullException("packageDirectory");
+            }
+            if (packageDirectory.IsRelative)
+            {
+                throw new CakeException("Package directory (" + packageDirectory.FullPath +
+                                        ") must be an absolute path.");
+            }
+
+            if (!_fileSystem.Exist(packageDirectory))
+            {
+                return new List<IFile>().AsReadOnly();
+            }
+
+            var packageAssemblies = GetAllPackageAssemblies(packageDirectory);
+
+            if (!packageAssemblies.Any())
+            {
+                _log.Warning("Unable to locate any assemblies under {0}", packageDirectory.FullPath);
+            }
+
+            var compatibleAssemblyPaths = FilterCompatibleAssemblies(packageAssemblies, packageDirectory);
+
+            var resolvedAssemblyFiles = ResolveAssemblyFiles(compatibleAssemblyPaths);
+
+            return resolvedAssemblyFiles;
+        }
+
+        private ReadOnlyCollection<IFile> ResolveAssemblyFiles(IEnumerable<FilePath> compatibleAssemblyPaths)
+        {
+            return compatibleAssemblyPaths.Select(_fileSystem.GetFile).ToList().AsReadOnly();
+        }
+
+        private FilePath[] GetAllPackageAssemblies(DirectoryPath packageDirectory)
+        {
+            return _fileSystem.GetDirectory(packageDirectory).GetFiles("*.dll", SearchScope.Recursive)
+                .Where(
+                    file =>
+                        !"Cake.Core.dll".Equals(file.Path.GetFilename().FullPath, StringComparison.OrdinalIgnoreCase))
+                .Select(a => a.Path)
+                .ToArray();
+        }
+
+        private IEnumerable<FilePath> FilterCompatibleAssemblies(
+            IEnumerable<FilePath> assemblies, DirectoryPath packageDirectory)
+        {
+            var targetFramework = _environment.GetTargetFramework();
+
+            // standardize assembly paths as relative to package directory
+            var standardizedAssemblyPaths =
+                assemblies.Select(a => a.IsRelative ? a : a.FullPath.Substring(packageDirectory.FullPath.Length + 1))
+                    .ToArray();
+
+            var compatibleAssemblyPaths =
+                _assemblyCompatibilityFilter.FilterCompatibleAssemblies(targetFramework, standardizedAssemblyPaths);
+
+            // return as absolute paths
+            return compatibleAssemblyPaths
+                .Select(cp => cp.MakeAbsolute(packageDirectory));
+        }
+    }
+}

--- a/src/Cake.Core/IO/NuGet/PackageReferenceBundler.cs
+++ b/src/Cake.Core/IO/NuGet/PackageReferenceBundler.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cake.Core.IO.NuGet.Parsing;
+
+namespace Cake.Core.IO.NuGet
+{
+    /// <summary>
+    /// Bundles packageAssemblyFiles into package reference sets grouped by their target framework.
+    /// </summary>
+    public sealed class PackageReferenceBundler : IPackageReferenceBundler
+    {
+        private readonly IAssemblyFilePathFrameworkNameParser _frameworkNameParser;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PackageReferenceBundler"/> class.
+        /// </summary>
+        /// <param name="frameworkNameParser">The framework name parser.</param>
+        public PackageReferenceBundler(IAssemblyFilePathFrameworkNameParser frameworkNameParser)
+        {
+            _frameworkNameParser = frameworkNameParser;
+        }
+
+        /// <summary>
+        /// Bundles the provided packageAssemblyFiles into package reference sets grouped by their target framework.
+        /// </summary>
+        /// <param name="packageAssemblyFiles">The package assembly files.</param>
+        /// <returns>The newly created PackageReferenceSets</returns>
+        public IReadOnlyCollection<PackageReferenceSet> BundleByTargetFramework(IEnumerable<FilePath> packageAssemblyFiles)
+        {
+            if (packageAssemblyFiles == null)
+            {
+                throw new ArgumentNullException("packageAssemblyFiles");
+            }
+            
+            // create PackageReferenceSets from the given assemblies
+            var pathFrameworks = packageAssemblyFiles
+                .Select(
+                    d => new { FilePath = d, FrameworkName = _frameworkNameParser.Parse(d) }).ToArray();
+           var referenceSets = pathFrameworks
+                .GroupBy(d => d.FrameworkName)
+                .Select(grp => new PackageReferenceSet(grp.Key, grp.Select(d => d.FilePath))).ToList();
+
+            return referenceSets.AsReadOnly();
+        }
+    }
+}

--- a/src/Cake.Core/IO/NuGet/PackageReferenceSet.cs
+++ b/src/Cake.Core/IO/NuGet/PackageReferenceSet.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Versioning;
+
+namespace Cake.Core.IO.NuGet
+{
+    /// <summary>
+    /// Represents a targetFramework-specific set of assembly references belonging to a nuget package.
+    /// </summary>
+    public sealed class PackageReferenceSet : IFrameworkTargetable
+    {
+        private readonly IReadOnlyCollection<FilePath> _references;
+        private readonly FrameworkName _targetFramework;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PackageReferenceSet"/> class.
+        /// </summary>
+        /// <param name="targetFramework">The target framework. May be null.</param>
+        /// <param name="references">The references.</param>
+        /// <exception cref="System.ArgumentNullException"><paramref name="references"/> is null.</exception>
+        public PackageReferenceSet(FrameworkName targetFramework, IEnumerable<FilePath> references)
+        {
+            if (references == null)
+            {
+                throw new ArgumentNullException("references");
+            }
+
+            _targetFramework = targetFramework;
+            _references = references.ToList().AsReadOnly();
+        }
+
+        /// <summary>
+        /// Gets the references.
+        /// </summary>
+        /// <value>
+        /// The references.
+        /// </value>
+        public IReadOnlyCollection<FilePath> References
+        {
+            get { return _references; }
+        }
+
+        /// <summary>
+        /// Gets the target framework.
+        /// </summary>
+        /// <value>
+        /// The target framework.
+        /// </value>
+        public FrameworkName TargetFramework
+        {
+            get { return _targetFramework; }
+        }
+
+        /// <summary>
+        /// Gets the supported frameworks.
+        /// </summary>
+        /// <value>
+        /// The supported frameworks.
+        /// </value>
+        public IEnumerable<FrameworkName> SupportedFrameworks
+        {
+            get
+            {
+                if (TargetFramework == null)
+                {
+                    return Enumerable.Empty<FrameworkName>();
+                }
+                return new[] { TargetFramework };
+            }
+        }
+    }
+}

--- a/src/Cake.Core/IO/NuGet/Parsing/AssemblyFilePathFrameworkNameParser.cs
+++ b/src/Cake.Core/IO/NuGet/Parsing/AssemblyFilePathFrameworkNameParser.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Versioning;
+
+namespace Cake.Core.IO.NuGet.Parsing
+{
+    /// <summary>
+    /// Represents an object that parses the segments of a filepath for a .Net framework name
+    /// </summary>
+    public class AssemblyFilePathFrameworkNameParser : IAssemblyFilePathFrameworkNameParser
+    {
+        private static readonly FrameworkName _unsupportedFrameworkName = new FrameworkName("Unsupported", new Version());
+        private readonly IFrameworkNameParser _frameworkNameParser;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssemblyFilePathFrameworkNameParser"/> class.
+        /// </summary>
+        /// <param name="frameworkNameParser">The framework name parser.</param>
+        public AssemblyFilePathFrameworkNameParser(IFrameworkNameParser frameworkNameParser)
+        {
+            _frameworkNameParser = frameworkNameParser;
+        }
+
+        /// <summary>
+        /// Parses the framework name from assembly file path.
+        /// </summary>
+        /// <param name="path">The assembly file path.</param>
+        /// <returns>the parsed framework name, or <c>null</c> when path contains no folders.</returns>
+        public FrameworkName Parse(FilePath path)
+        {
+            if (path == null)
+            {
+                throw new ArgumentNullException("path");
+            }
+
+            // The path for a reference might look like this for assembly foo.dll:            
+            // foo.dll
+            // sub\foo.dll
+            // {FrameworkName}{Version}\foo.dll
+            // {FrameworkName}{Version}\sub1\foo.dll
+            // {FrameworkName}{Version}\sub1\sub2\foo.dll
+            return ParseFromDirectoryPath(path.GetDirectory());
+        }
+
+        private FrameworkName ParseFromDirectoryPath(DirectoryPath path)
+        {
+            var queue = new Queue<string>(path.Segments);
+            while (queue.Count > 0)
+            {
+                var current = queue.Dequeue();
+                var parsedFxName = _frameworkNameParser.ParseFrameworkName(current);
+                if (parsedFxName != _unsupportedFrameworkName || queue.Count == 0)
+                {
+                    return parsedFxName;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/src/Cake.Core/IO/NuGet/Parsing/IAssemblyFilePathFrameworkNameParser.cs
+++ b/src/Cake.Core/IO/NuGet/Parsing/IAssemblyFilePathFrameworkNameParser.cs
@@ -1,0 +1,17 @@
+using System.Runtime.Versioning;
+
+namespace Cake.Core.IO.NuGet.Parsing
+{
+    /// <summary>
+    /// Represents an object that parses the segments of a filepath for a .Net framework name
+    /// </summary>
+    public interface IAssemblyFilePathFrameworkNameParser
+    {
+        /// <summary>
+        /// Parses the framework name from assembly file path.
+        /// </summary>
+        /// <param name="path">The assembly file path.</param>
+        /// <returns>the parsed framework name, or <c>null</c> when path contains no folders.</returns>
+        FrameworkName Parse(FilePath path);
+    }
+}

--- a/src/Cake.Core/IO/NuGet/Parsing/IFrameworkNameParser.cs
+++ b/src/Cake.Core/IO/NuGet/Parsing/IFrameworkNameParser.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Runtime.Versioning;
+
+namespace Cake.Core.IO.NuGet.Parsing
+{
+    /// <summary>
+    /// Parses version-specific folder names into an instance of FrameworkName
+    /// </summary>
+    public interface IFrameworkNameParser
+    {
+        /// <summary>
+        /// This function tries to normalize a string that represents framework version names 
+        /// (the name of a framework version-specific folder in a nuget package, i.e., "net451" or "net35") into
+        /// something a framework name that the package manager understands.
+        /// </summary>
+        /// <param name="frameworkName">value to be parsed.</param>
+        /// <returns>A FrameworkName instance corresponding with the provided frameworkName token.  
+        /// When parsing is unsuccessful, returns a FrameworkName with an Identifier property of "Unsupported."</returns>
+        /// <exception cref="ArgumentNullException">when frameworkName is null.</exception>
+        FrameworkName ParseFrameworkName(string frameworkName);
+    }
+}

--- a/src/Cake.Testing/FakeEnvironment.cs
+++ b/src/Cake.Testing/FakeEnvironment.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
+using System.Runtime.Versioning;
 using Cake.Core;
 using Cake.Core.IO;
 
@@ -17,6 +17,7 @@ namespace Cake.Testing
         private readonly Dictionary<SpecialPath, DirectoryPath> _specialPaths;
         private DirectoryPath _applicationRoot;
         private bool _is64Bit;
+        private FrameworkName _targetFramework;
 
         /// <summary>
         /// Gets or sets the working directory.
@@ -165,6 +166,24 @@ namespace Cake.Testing
         public IDictionary<string, string> GetEnvironmentVariables()
         {
             return new Dictionary<string, string>(_environmentVariables, StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Gets the target .Net framework version that the current AppDomain is targeting.
+        /// </summary>
+        /// <returns>The target framework.</returns>
+        public FrameworkName GetTargetFramework()
+        {
+            return _targetFramework;
+        }
+
+        /// <summary>
+        /// Sets the target framework.
+        /// </summary>
+        /// <param name="targetFramework">The target framework.</param>
+        public void SetTargetFramework(FrameworkName targetFramework)
+        {
+            _targetFramework = targetFramework;
         }
     }
 }

--- a/src/Cake/Cake.csproj
+++ b/src/Cake/Cake.csproj
@@ -147,6 +147,7 @@
     <Compile Include="Diagnostics\Formatting\LiteralToken.cs" />
     <Compile Include="Diagnostics\Formatting\PropertyToken.cs" />
     <Compile Include="Diagnostics\IVerbosityAware.cs" />
+    <Compile Include="NuGet\NuGetVersionUtilityAdapter.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\SolutionInfo.cs">

--- a/src/Cake/NuGet/NuGetVersionUtilityAdapter.cs
+++ b/src/Cake/NuGet/NuGetVersionUtilityAdapter.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Versioning;
+using Cake.Core.IO.NuGet;
+using Cake.Core.IO.NuGet.Parsing;
+using NuGet;
+using IFrameworkTargetable = Cake.Core.IO.NuGet.IFrameworkTargetable;
+
+namespace Cake.NuGet
+{
+    /// <summary>
+    /// Adapts NuGet's <see cref="VersionUtility" /> to <see cref="INuGetFrameworkCompatibilityFilter" />,
+    /// <see cref="IFrameworkNameParser" />.
+    /// </summary>
+    internal sealed class NuGetVersionUtilityAdapter : INuGetFrameworkCompatibilityFilter, IFrameworkNameParser
+    {
+        /// <summary>
+        /// This function tries to normalize a string that represents framework version names
+        /// (the name of a framework version-specific folder in a nuget package, i.e., "net451" or "net35") into
+        /// something a framework name that the package manager understands.
+        /// </summary>
+        /// <param name="frameworkName">value to be parsed.</param>
+        /// <returns>
+        /// A FrameworkName instance corresponding with the provided frameworkName token.
+        /// When parsing is unsuccessful, returns a FrameworkName with an Identifier property of "Unsupported."
+        /// </returns>
+        /// <exception cref="ArgumentNullException">when frameworkName is null.</exception>
+        public FrameworkName ParseFrameworkName(string frameworkName)
+        {
+            if (frameworkName == null)
+            {
+                throw new ArgumentNullException("frameworkName");
+            }
+
+            return VersionUtility.ParseFrameworkName(frameworkName);
+        }
+
+        /// <summary>
+        /// Filters the provided list of items, returning only those items compatible with the given project framework.
+        /// </summary>
+        /// <typeparam name="T">the type of items being filtered</typeparam>
+        /// <param name="projectFramework">The project framework.</param>
+        /// <param name="items">The items.</param>
+        /// <returns>The compatible items. Empty if try is unsuccessful.</returns>
+        /// <exception cref="System.ArgumentNullException">
+        /// projectFramework or items
+        /// </exception>
+        public IEnumerable<T> GetCompatibleItems<T>(FrameworkName projectFramework, IEnumerable<T> items)
+            where T : IFrameworkTargetable
+        {
+            if (projectFramework == null)
+            {
+                throw new ArgumentNullException("projectFramework");
+            }
+            if (items == null)
+            {
+                throw new ArgumentNullException("items");
+            }
+
+            var nugetItems = items.Select(item => new FrameworkTargetableWrapper<T>(item)).ToArray();
+            IEnumerable<FrameworkTargetableWrapper<T>> compatibleNugetItems;
+            if (VersionUtility.TryGetCompatibleItems(projectFramework, nugetItems, out compatibleNugetItems))
+            {
+                return compatibleNugetItems.Select(item => item.WrappedItem);
+            }
+
+            return Enumerable.Empty<T>();
+        }
+
+        private class FrameworkTargetableWrapper<T> : global::NuGet.IFrameworkTargetable
+            where T : IFrameworkTargetable
+        {
+            private readonly T _inner;
+
+            public FrameworkTargetableWrapper(T inner)
+            {
+                _inner = inner;
+            }
+
+            public T WrappedItem
+            {
+                get { return _inner; }
+            }
+
+            public IEnumerable<FrameworkName> SupportedFrameworks
+            {
+                get { return _inner.SupportedFrameworks; }
+            }
+        }
+    }
+}

--- a/src/Cake/Program.cs
+++ b/src/Cake/Program.cs
@@ -7,9 +7,11 @@ using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.Core.IO.NuGet;
+using Cake.Core.IO.NuGet.Parsing;
 using Cake.Core.Scripting;
 using Cake.Core.Scripting.Analysis;
 using Cake.Diagnostics;
+using Cake.NuGet;
 using Cake.Scripting;
 using Cake.Scripting.Roslyn;
 using Cake.Scripting.Roslyn.Nightly;
@@ -74,6 +76,13 @@ namespace Cake
             builder.RegisterType<NuGetPackageInstaller>().As<INuGetPackageInstaller>().SingleInstance();
             builder.RegisterType<WindowsRegistry>().As<IRegistry>().SingleInstance();
             builder.RegisterType<CakeContext>().As<ICakeContext>().SingleInstance();
+
+            // NuGet addins support
+            builder.RegisterType<NuGetVersionUtilityAdapter>().As<INuGetFrameworkCompatibilityFilter>().As<IFrameworkNameParser>().SingleInstance();
+            builder.RegisterType<NuGetPackageAssembliesLocator>().As<INuGetPackageAssembliesLocator>().SingleInstance();
+            builder.RegisterType<PackageReferenceBundler>().As<IPackageReferenceBundler>().SingleInstance();
+            builder.RegisterType<NuGetAssemblyCompatibilityFilter>().As<INuGetAssemblyCompatibilityFilter>().SingleInstance();
+            builder.RegisterType<AssemblyFilePathFrameworkNameParser>().As<IAssemblyFilePathFrameworkNameParser>().SingleInstance();
 
             if (mono)
             {


### PR DESCRIPTION
Addresses #373 

This is currently just a proof of concept, not ready for production.
It "works," but lacks documentation and appropriate tests -- just looking to get design feedback.

The first commit is simply a refactoring of `AddInDirectiveProcessor`, to extract some of its responsibilities into other components, to help prepare for the additional functionality -- no new functionality should have been added.

The responsibility of locating assemblies to be referenced is extracted from `AddInDirectiveProcessor` into `AddInAssembliesLocator`

The next two commits, which should probably be squashed together, introduce a couple more components:
- `AddInPackageInstaller`: further extracted from  `AddInDirectiveProcessor`; uses NuGet tool to install the specified addin package
- `NuGetAssemblyCompatibilityFilter` is added to adapt Cake's model to NuGet's `VersionUtility.TryGetCompatibleItems`, while using that method figuring out which assemblies contained in a nuget package should be referenced when processing your cake script.
- `NuGetVersionUtilityWrapper` is a paper-thin wrapper around NuGet's `VersionUtility.TryGetCompatibleItems` and `VersionUtility.ParseFrameworkFolderName`, which are both used by `NuGetAssemblyCompatibilityFilter.`  It's only here to provide a testing/DI seam.
