### PR TITLE
GitReleaseManager Addin for Cake

### DIFF
--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Fixtures\Tools\GitReleaseManagerFixture.cs" />
     <Compile Include="Fixtures\Tools\GitReleaseManager\GitReleaseManagerAssetsAdderFixture.cs" />
     <Compile Include="Fixtures\Tools\GitReleaseManager\GitReleaseManagerCreatorFixture.cs" />
+    <Compile Include="Fixtures\Tools\GitReleaseManager\GitReleaseManagerMilestoneCloserFixture.cs" />
     <Compile Include="Fixtures\Tools\ILMergeRunnerFixture.cs" />
     <Compile Include="Fixtures\Diagnostics\LogActionFixture.cs" />
     <Compile Include="Fixtures\Tools\InspectCodeRunnerFixture.cs" />
@@ -159,6 +160,7 @@
     <Compile Include="Unit\Tools\DupFinder\DupFinderRunnerTests.cs" />
     <Compile Include="Unit\Tools\Fixie\FixieRunnerTests.cs" />
     <Compile Include="Unit\Tools\GitReleaseManager\AddAssets\GitReleaseManagerAssetsAdderTests.cs" />
+    <Compile Include="Unit\Tools\GitReleaseManager\Close\GitReleaseManagerMilestoneCloserTests.cs" />
     <Compile Include="Unit\Tools\GitReleaseManager\Create\GitReleaseManagerCreatorTests.cs" />
     <Compile Include="Unit\Tools\ILMerge\ILMergeRunnerTests.cs" />
     <Compile Include="Unit\Tools\ILMerge\ILMergeSettingsTests.cs" />
@@ -240,7 +242,6 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Unit\Tools\GitReleaseManager\Close\" />
     <Folder Include="Unit\Tools\GitReleaseManager\Export\" />
     <Folder Include="Unit\Tools\GitReleaseManager\Publish\" />
   </ItemGroup>

--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Fixtures\Tools\GitReleaseManagerFixture.cs" />
     <Compile Include="Fixtures\Tools\GitReleaseManager\GitReleaseManagerAssetsAdderFixture.cs" />
     <Compile Include="Fixtures\Tools\GitReleaseManager\GitReleaseManagerCreatorFixture.cs" />
+    <Compile Include="Fixtures\Tools\GitReleaseManager\GitReleaseManagerExporterFixture.cs" />
     <Compile Include="Fixtures\Tools\GitReleaseManager\GitReleaseManagerMilestoneCloserFixture.cs" />
     <Compile Include="Fixtures\Tools\GitReleaseManager\GitReleaseManagerPublisherFixture.cs" />
     <Compile Include="Fixtures\Tools\ILMergeRunnerFixture.cs" />
@@ -163,6 +164,7 @@
     <Compile Include="Unit\Tools\GitReleaseManager\AddAssets\GitReleaseManagerAssetsAdderTests.cs" />
     <Compile Include="Unit\Tools\GitReleaseManager\Close\GitReleaseManagerMilestoneCloserTests.cs" />
     <Compile Include="Unit\Tools\GitReleaseManager\Create\GitReleaseManagerCreatorTests.cs" />
+    <Compile Include="Unit\Tools\GitReleaseManager\Export\GitReleaseManagerExporterTests.cs" />
     <Compile Include="Unit\Tools\GitReleaseManager\Publish\GitReleaseManagerPublisherTests.cs" />
     <Compile Include="Unit\Tools\ILMerge\ILMergeRunnerTests.cs" />
     <Compile Include="Unit\Tools\ILMerge\ILMergeSettingsTests.cs" />
@@ -243,9 +245,7 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Unit\Tools\GitReleaseManager\Export\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -76,6 +76,8 @@
     <Compile Include="Fixtures\Tools\Chocolatey\ChocolateyUpgraderFixture.cs" />
     <Compile Include="Fixtures\Tools\DupFinderRunnerFixture.cs" />
     <Compile Include="Fixtures\Tools\FixieRunnerFixture.cs" />
+    <Compile Include="Fixtures\Tools\GitReleaseManagerFixture.cs" />
+    <Compile Include="Fixtures\Tools\GitReleaseManager\GitReleaseManagerCreatorFixture.cs" />
     <Compile Include="Fixtures\Tools\ILMergeRunnerFixture.cs" />
     <Compile Include="Fixtures\Diagnostics\LogActionFixture.cs" />
     <Compile Include="Fixtures\Tools\InspectCodeRunnerFixture.cs" />
@@ -155,6 +157,7 @@
     <Compile Include="Unit\Tools\Chocolatey\Upgrade\ChocolateyUpgradeSettingsTests.cs" />
     <Compile Include="Unit\Tools\DupFinder\DupFinderRunnerTests.cs" />
     <Compile Include="Unit\Tools\Fixie\FixieRunnerTests.cs" />
+    <Compile Include="Unit\Tools\GitReleaseManager\Create\GitReleaseManagerCreatorTests.cs" />
     <Compile Include="Unit\Tools\ILMerge\ILMergeRunnerTests.cs" />
     <Compile Include="Unit\Tools\ILMerge\ILMergeSettingsTests.cs" />
     <Compile Include="Unit\IO\ZipperTests.cs" />
@@ -233,6 +236,12 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Unit\Tools\GitReleaseManager\AddAsset\" />
+    <Folder Include="Unit\Tools\GitReleaseManager\Close\" />
+    <Folder Include="Unit\Tools\GitReleaseManager\Export\" />
+    <Folder Include="Unit\Tools\GitReleaseManager\Publish\" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Fixtures\Tools\DupFinderRunnerFixture.cs" />
     <Compile Include="Fixtures\Tools\FixieRunnerFixture.cs" />
     <Compile Include="Fixtures\Tools\GitReleaseManagerFixture.cs" />
+    <Compile Include="Fixtures\Tools\GitReleaseManager\GitReleaseManagerAssetsAdderFixture.cs" />
     <Compile Include="Fixtures\Tools\GitReleaseManager\GitReleaseManagerCreatorFixture.cs" />
     <Compile Include="Fixtures\Tools\ILMergeRunnerFixture.cs" />
     <Compile Include="Fixtures\Diagnostics\LogActionFixture.cs" />
@@ -157,6 +158,7 @@
     <Compile Include="Unit\Tools\Chocolatey\Upgrade\ChocolateyUpgradeSettingsTests.cs" />
     <Compile Include="Unit\Tools\DupFinder\DupFinderRunnerTests.cs" />
     <Compile Include="Unit\Tools\Fixie\FixieRunnerTests.cs" />
+    <Compile Include="Unit\Tools\GitReleaseManager\AddAssets\GitReleaseManagerAssetsAdderTests.cs" />
     <Compile Include="Unit\Tools\GitReleaseManager\Create\GitReleaseManagerCreatorTests.cs" />
     <Compile Include="Unit\Tools\ILMerge\ILMergeRunnerTests.cs" />
     <Compile Include="Unit\Tools\ILMerge\ILMergeSettingsTests.cs" />
@@ -238,7 +240,6 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Unit\Tools\GitReleaseManager\AddAsset\" />
     <Folder Include="Unit\Tools\GitReleaseManager\Close\" />
     <Folder Include="Unit\Tools\GitReleaseManager\Export\" />
     <Folder Include="Unit\Tools\GitReleaseManager\Publish\" />

--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Fixtures\Tools\GitReleaseManager\GitReleaseManagerAssetsAdderFixture.cs" />
     <Compile Include="Fixtures\Tools\GitReleaseManager\GitReleaseManagerCreatorFixture.cs" />
     <Compile Include="Fixtures\Tools\GitReleaseManager\GitReleaseManagerMilestoneCloserFixture.cs" />
+    <Compile Include="Fixtures\Tools\GitReleaseManager\GitReleaseManagerPublisherFixture.cs" />
     <Compile Include="Fixtures\Tools\ILMergeRunnerFixture.cs" />
     <Compile Include="Fixtures\Diagnostics\LogActionFixture.cs" />
     <Compile Include="Fixtures\Tools\InspectCodeRunnerFixture.cs" />
@@ -162,6 +163,7 @@
     <Compile Include="Unit\Tools\GitReleaseManager\AddAssets\GitReleaseManagerAssetsAdderTests.cs" />
     <Compile Include="Unit\Tools\GitReleaseManager\Close\GitReleaseManagerMilestoneCloserTests.cs" />
     <Compile Include="Unit\Tools\GitReleaseManager\Create\GitReleaseManagerCreatorTests.cs" />
+    <Compile Include="Unit\Tools\GitReleaseManager\Publish\GitReleaseManagerPublisherTests.cs" />
     <Compile Include="Unit\Tools\ILMerge\ILMergeRunnerTests.cs" />
     <Compile Include="Unit\Tools\ILMerge\ILMergeSettingsTests.cs" />
     <Compile Include="Unit\IO\ZipperTests.cs" />
@@ -243,7 +245,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Unit\Tools\GitReleaseManager\Export\" />
-    <Folder Include="Unit\Tools\GitReleaseManager\Publish\" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Cake.Common.Tests/Fixtures/Tools/GitReleaseManager/GitReleaseManagerAssetsAdderFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/GitReleaseManager/GitReleaseManagerAssetsAdderFixture.cs
@@ -1,0 +1,32 @@
+﻿using Cake.Common.Tools.GitReleaseManager.AddAssets;
+
+namespace Cake.Common.Tests.Fixtures.Tools.GitReleaseManager
+{
+    public sealed class GitReleaseManagerAssetsAdderFixture : GitReleaseManagerFixture
+    {
+        public string UserName { get; set; }
+        public string Password { get; set; }
+        public string Owner { get; set; }
+        public string Repository { get; set; }
+        public string TagName { get; set; }
+        public string Assets { get; set; }
+        public GitReleaseManagerAddAssetsSettings Settings { get; set; }
+
+        public GitReleaseManagerAssetsAdderFixture()
+        {
+            UserName = "bob";
+            Password = "password";
+            Owner = "repoOwner";
+            Repository = "repo";
+            TagName = "0.1.0";
+            Assets = @"c:/temp/asset1.txt";
+            Settings = new GitReleaseManagerAddAssetsSettings();
+        }
+
+        public void AddAssets()
+        {
+            var tool = new GitReleaseManagerAssetsAdder(FileSystem, Environment, ProcessRunner, Globber, GitReleaseManagerToolResolver);
+            tool.AddAssets(UserName, Password, Owner, Repository, TagName, Assets, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Fixtures/Tools/GitReleaseManager/GitReleaseManagerCreatorFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/GitReleaseManager/GitReleaseManagerCreatorFixture.cs
@@ -1,0 +1,28 @@
+﻿using Cake.Common.Tools.GitReleaseManager.Create;
+
+namespace Cake.Common.Tests.Fixtures.Tools.GitReleaseManager
+{
+    public sealed class GitReleaseManagerCreatorFixture : GitReleaseManagerFixture
+    {
+        public string UserName { get; set; }
+        public string Password { get; set; }
+        public string Owner { get; set; }
+        public string Repository { get; set; }
+        public GitReleaseManagerCreateSettings Settings { get; set; }
+
+        public GitReleaseManagerCreatorFixture()
+        {
+            UserName = "bob";
+            Password = "password";
+            Owner = "repoOwner";
+            Repository = "repo";
+            Settings = new GitReleaseManagerCreateSettings();
+        }
+
+        public void Create()
+        {
+            var tool = new GitReleaseManagerCreator(FileSystem, Environment, ProcessRunner, Globber, GitReleaseManagerToolResolver);
+            tool.Create(UserName, Password, Owner, Repository, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Fixtures/Tools/GitReleaseManager/GitReleaseManagerExporterFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/GitReleaseManager/GitReleaseManagerExporterFixture.cs
@@ -1,0 +1,31 @@
+﻿using Cake.Common.Tools.GitReleaseManager.Export;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tests.Fixtures.Tools.GitReleaseManager
+{
+    public sealed class GitReleaseManagerExporterFixture : GitReleaseManagerFixture
+    {
+        public string UserName { get; set; }
+        public string Password { get; set; }
+        public string Owner { get; set; }
+        public string Repository { get; set; }
+        public FilePath FileOutputPath { get; set; }
+        public GitReleaseManagerExportSettings Settings { get; set; }
+
+        public GitReleaseManagerExporterFixture()
+        {
+            UserName = "bob";
+            Password = "password";
+            Owner = "repoOwner";
+            Repository = "repo";
+            FileOutputPath = "c:/temp";
+            Settings = new GitReleaseManagerExportSettings();
+        }
+
+        public void Export()
+        {
+            var tool = new GitReleaseManagerExporter(FileSystem, Environment, ProcessRunner, Globber, GitReleaseManagerToolResolver);
+            tool.Export(UserName, Password, Owner, Repository, FileOutputPath, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Fixtures/Tools/GitReleaseManager/GitReleaseManagerMilestoneCloserFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/GitReleaseManager/GitReleaseManagerMilestoneCloserFixture.cs
@@ -1,0 +1,30 @@
+﻿using Cake.Common.Tools.GitReleaseManager.Close;
+
+namespace Cake.Common.Tests.Fixtures.Tools.GitReleaseManager
+{
+    public sealed class GitReleaseManagerMilestoneCloserFixture : GitReleaseManagerFixture
+    {
+        public string UserName { get; set; }
+        public string Password { get; set; }
+        public string Owner { get; set; }
+        public string Repository { get; set; }
+        public string Milestone { get; set; }
+        public GitReleaseManagerCloseMilestoneSettings Settings { get; set; }
+
+        public GitReleaseManagerMilestoneCloserFixture()
+        {
+            UserName = "bob";
+            Password = "password";
+            Owner = "repoOwner";
+            Repository = "repo";
+            Milestone = "0.1.0";
+            Settings = new GitReleaseManagerCloseMilestoneSettings();
+        }
+
+        public void Close()
+        {
+            var tool = new GitReleaseManagerMilestoneCloser(FileSystem, Environment, ProcessRunner, Globber, GitReleaseManagerToolResolver);
+            tool.Close(UserName, Password, Owner, Repository, Milestone, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Fixtures/Tools/GitReleaseManager/GitReleaseManagerPublisherFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/GitReleaseManager/GitReleaseManagerPublisherFixture.cs
@@ -1,0 +1,30 @@
+﻿using Cake.Common.Tools.GitReleaseManager.Publish;
+
+namespace Cake.Common.Tests.Fixtures.Tools.GitReleaseManager
+{
+    public sealed class GitReleaseManagerPublisherFixture : GitReleaseManagerFixture
+    {
+        public string UserName { get; set; }
+        public string Password { get; set; }
+        public string Owner { get; set; }
+        public string Repository { get; set; }
+        public string TagName { get; set; }
+        public GitReleaseManagerPublishSettings Settings { get; set; }
+
+        public GitReleaseManagerPublisherFixture()
+        {
+            UserName = "bob";
+            Password = "password";
+            Owner = "repoOwner";
+            Repository = "repo";
+            TagName = "0.1.0";
+            Settings = new GitReleaseManagerPublishSettings();
+        }
+
+        public void Publish()
+        {
+            var tool = new GitReleaseManagerPublisher(FileSystem, Environment, ProcessRunner, Globber, GitReleaseManagerToolResolver);
+            tool.Publish(UserName, Password, Owner, Repository, TagName, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Fixtures/Tools/GitReleaseManagerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/GitReleaseManagerFixture.cs
@@ -1,0 +1,68 @@
+﻿using Cake.Common.Tools.GitReleaseManager;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using Cake.Testing;
+using NSubstitute;
+
+namespace Cake.Common.Tests.Fixtures.Tools
+{
+    public abstract class GitReleaseManagerFixture
+    {
+        public FakeFileSystem FileSystem { get; set; }
+        public ICakeEnvironment Environment { get; set; }
+        public IProcessRunner ProcessRunner { get; set; }
+        public IProcess Process { get; set; }
+        public ICakeLog Log { get; set; }
+        public IGitReleaseManagerToolResolver GitReleaseManagerToolResolver { get; set; }
+        public IGlobber Globber { get; set; }
+
+        protected GitReleaseManagerFixture()
+        {
+            Environment = FakeEnvironment.CreateUnixEnvironment();
+
+            Process = Substitute.For<IProcess>();
+            Process.GetExitCode().Returns(0);
+            ProcessRunner = Substitute.For<IProcessRunner>();
+            ProcessRunner.Start(Arg.Any<FilePath>(), Arg.Any<ProcessSettings>()).Returns(Process);
+
+            Globber = Substitute.For<IGlobber>();
+            Globber.Match("./tools/**/gitreleasemanager.exe").Returns(new[] { (FilePath)"/Working/tools/GitReleaseManager.exe" });
+            Globber.Match("./tools/**/GitReleaseManager.exe").Returns(new[] { (FilePath)"/Working/tools/GitReleaseManager.exe" });
+
+            GitReleaseManagerToolResolver = Substitute.For<IGitReleaseManagerToolResolver>();
+
+            Log = Substitute.For<ICakeLog>();
+            FileSystem = new FakeFileSystem(Environment);
+
+            // By default, there is a default tool.
+            GitReleaseManagerToolResolver.ResolvePath().Returns("/Working/tools/GitReleaseManager.exe");
+            FileSystem.CreateFile("/Working/tools/GitReleaseManager.exe");
+
+            // Set standard output.
+            Process.GetStandardOutput().Returns(new string[0]);
+        }
+
+        public void GivenCustomToolPathExist(FilePath toolPath)
+        {
+            FileSystem.CreateFile(toolPath);
+        }
+
+        public void GivenDefaultToolDoNotExist()
+        {
+            var toolPath = new FilePath("/Working/tools/GitReleaseManager.exe");
+            FileSystem.EnsureFileDoNotExist(toolPath);
+            GitReleaseManagerToolResolver.ResolvePath().Returns("/NonWorking/tools/GitReleaseManager.exe");
+        }
+
+        public void GivenProcessCannotStart()
+        {
+            ProcessRunner.Start(Arg.Any<FilePath>(), Arg.Any<ProcessSettings>()).Returns((IProcess)null);
+        }
+
+        public void GivenProcessReturnError()
+        {
+            Process.GetExitCode().Returns(1);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/AddAssets/GitReleaseManagerAssetsAdderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/AddAssets/GitReleaseManagerAssetsAdderTests.cs
@@ -1,0 +1,234 @@
+﻿using Cake.Common.Tests.Fixtures.Tools.GitReleaseManager;
+using Cake.Core.IO;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.GitReleaseManager.AddAssets
+{
+    public sealed class GitReleaseManagerAssetsAdderTests
+    {
+        public sealed class TheAddAssetsMethod
+        {
+            [Fact]
+            public void Should_Throw_If_UserName_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerAssetsAdderFixture();
+                fixture.UserName = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.AddAssets());
+
+                // Then
+                Assert.IsArgumentNullException(result, "userName");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Password_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerAssetsAdderFixture();
+                fixture.Password = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.AddAssets());
+
+                // Then
+                Assert.IsArgumentNullException(result, "password");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Owner_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerAssetsAdderFixture();
+                fixture.Owner = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.AddAssets());
+
+                // Then
+                Assert.IsArgumentNullException(result, "owner");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Repository_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerAssetsAdderFixture();
+                fixture.Repository = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.AddAssets());
+
+                // Then
+                Assert.IsArgumentNullException(result, "repository");
+            }
+
+            [Fact]
+            public void Should_Throw_If_TagName_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerAssetsAdderFixture();
+                fixture.TagName = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.AddAssets());
+
+                // Then
+                Assert.IsArgumentNullException(result, "tagName");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Assets_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerAssetsAdderFixture();
+                fixture.Assets = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.AddAssets());
+
+                // Then
+                Assert.IsArgumentNullException(result, "assets");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerAssetsAdderFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.AddAssets());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_GitReleaseManager_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new GitReleaseManagerAssetsAdderFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.AddAssets());
+
+                // Then
+                Assert.IsCakeException(result, "GitReleaseManager: Could not locate executable.");
+            }
+
+            [Theory]
+            [InlineData("C:/GitReleaseManager/GitReleaseManager.exe", "C:/GitReleaseManager/GitReleaseManager.exe")]
+            [InlineData("./tools/GitReleaseManager/GitReleaseManager.exe", "/Working/tools/GitReleaseManager/GitReleaseManager.exe")]
+            public void Should_Use_NuGet_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new GitReleaseManagerAssetsAdderFixture();
+                fixture.GivenCustomToolPathExist(expected);
+                fixture.Settings.ToolPath = toolPath;
+
+                // When
+                fixture.AddAssets();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == expected),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new GitReleaseManagerAssetsAdderFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.AddAssets());
+
+                // Then
+                Assert.IsCakeException(result, "GitReleaseManager: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new GitReleaseManagerAssetsAdderFixture();
+                fixture.GivenProcessReturnError();
+
+                // When
+                var result = Record.Exception(() => fixture.AddAssets());
+
+                // Then
+                Assert.IsCakeException(result, "GitReleaseManager: Process returned an error.");
+            }
+
+            [Fact]
+            public void Should_Find_GitReleaseManager_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new GitReleaseManagerAssetsAdderFixture();
+
+                // When
+                fixture.AddAssets();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == "/Working/tools/GitReleaseManager.exe"),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new GitReleaseManagerAssetsAdderFixture();
+
+                // When
+                fixture.AddAssets();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "addasset -u \"bob\" -p \"password\" -o \"repoOwner\" -r \"repo\" -t \"0.1.0\" -a \"c:/temp/asset1.txt\""));
+            }
+
+            [Fact]
+            public void Should_Add_TargetDirectory_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerAssetsAdderFixture();
+                fixture.Settings.TargetDirectory = @"c:/temp";
+
+                // When
+                fixture.AddAssets();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "addasset -u \"bob\" -p \"password\" -o \"repoOwner\" -r \"repo\" -t \"0.1.0\" -a \"c:/temp/asset1.txt\" -d \"c:/temp\""));
+            }
+
+            [Fact]
+            public void Should_Add_LogFilePath_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerAssetsAdderFixture();
+                fixture.Settings.LogFilePath = @"c:/temp/log.txt";
+
+                // When
+                fixture.AddAssets();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "addasset -u \"bob\" -p \"password\" -o \"repoOwner\" -r \"repo\" -t \"0.1.0\" -a \"c:/temp/asset1.txt\" -l \"c:/temp/log.txt\""));
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/Close/GitReleaseManagerMilestoneCloserTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/Close/GitReleaseManagerMilestoneCloserTests.cs
@@ -1,0 +1,220 @@
+﻿using Cake.Common.Tests.Fixtures.Tools.GitReleaseManager;
+using Cake.Core.IO;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.GitReleaseManager.Close
+{
+    public sealed class GitReleaseManagerMilestoneCloserTests
+    {
+        public sealed class TheCloseMethod
+        {
+            [Fact]
+            public void Should_Throw_If_UserName_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneCloserFixture();
+                fixture.UserName = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Close());
+
+                // Then
+                Assert.IsArgumentNullException(result, "userName");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Password_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneCloserFixture();
+                fixture.Password = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Close());
+
+                // Then
+                Assert.IsArgumentNullException(result, "password");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Owner_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneCloserFixture();
+                fixture.Owner = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Close());
+
+                // Then
+                Assert.IsArgumentNullException(result, "owner");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Repository_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneCloserFixture();
+                fixture.Repository = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Close());
+
+                // Then
+                Assert.IsArgumentNullException(result, "repository");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Milestone_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneCloserFixture();
+                fixture.Milestone = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Close());
+
+                // Then
+                Assert.IsArgumentNullException(result, "milestone");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneCloserFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Close());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_GitReleaseManager_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneCloserFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Close());
+
+                // Then
+                Assert.IsCakeException(result, "GitReleaseManager: Could not locate executable.");
+            }
+
+            [Theory]
+            [InlineData("C:/GitReleaseManager/GitReleaseManager.exe", "C:/GitReleaseManager/GitReleaseManager.exe")]
+            [InlineData("./tools/GitReleaseManager/GitReleaseManager.exe", "/Working/tools/GitReleaseManager/GitReleaseManager.exe")]
+            public void Should_Use_NuGet_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneCloserFixture();
+                fixture.GivenCustomToolPathExist(expected);
+                fixture.Settings.ToolPath = toolPath;
+
+                // When
+                fixture.Close();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == expected),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneCloserFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Close());
+
+                // Then
+                Assert.IsCakeException(result, "GitReleaseManager: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneCloserFixture();
+                fixture.GivenProcessReturnError();
+
+                // When
+                var result = Record.Exception(() => fixture.Close());
+
+                // Then
+                Assert.IsCakeException(result, "GitReleaseManager: Process returned an error.");
+            }
+
+            [Fact]
+            public void Should_Find_GitReleaseManager_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneCloserFixture();
+
+                // When
+                fixture.Close();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == "/Working/tools/GitReleaseManager.exe"),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneCloserFixture();
+
+                // When
+                fixture.Close();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "close -u \"bob\" -p \"password\" -o \"repoOwner\" -r \"repo\" -m \"0.1.0\""));
+            }
+
+            [Fact]
+            public void Should_Add_TargetDirectory_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneCloserFixture();
+                fixture.Settings.TargetDirectory = @"c:/temp";
+
+                // When
+                fixture.Close();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "close -u \"bob\" -p \"password\" -o \"repoOwner\" -r \"repo\" -m \"0.1.0\" -d \"c:/temp\""));
+            }
+
+            [Fact]
+            public void Should_Add_LogFilePath_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneCloserFixture();
+                fixture.Settings.LogFilePath = @"c:/temp/log.txt";
+
+                // When
+                fixture.Close();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "close -u \"bob\" -p \"password\" -o \"repoOwner\" -r \"repo\" -m \"0.1.0\" -l \"c:/temp/log.txt\""));
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/Create/GitReleaseManagerCreatorTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/Create/GitReleaseManagerCreatorTests.cs
@@ -1,0 +1,302 @@
+﻿using Cake.Common.Tests.Fixtures.Tools.GitReleaseManager;
+using Cake.Core.IO;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.GitReleaseManager.Create
+{
+    public sealed class GitReleaseManagerCreatorTests
+    {
+        public sealed class TheCreateMethod
+        {
+            [Fact]
+            public void Should_Throw_If_UserName_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+                fixture.UserName = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Create());
+
+                // Then
+                Assert.IsArgumentNullException(result, "userName");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Password_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+                fixture.Password = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Create());
+
+                // Then
+                Assert.IsArgumentNullException(result, "password");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Owner_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+                fixture.Owner = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Create());
+
+                // Then
+                Assert.IsArgumentNullException(result, "owner");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Repository_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+                fixture.Repository = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Create());
+
+                // Then
+                Assert.IsArgumentNullException(result, "repository");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Create());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_GitReleaseManager_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Create());
+
+                // Then
+                Assert.IsCakeException(result, "GitReleaseManager: Could not locate executable.");
+            }
+
+            [Theory]
+            [InlineData("C:/GitReleaseManager/GitReleaseManager.exe", "C:/GitReleaseManager/GitReleaseManager.exe")]
+            [InlineData("./tools/GitReleaseManager/GitReleaseManager.exe", "/Working/tools/GitReleaseManager/GitReleaseManager.exe")]
+            public void Should_Use_NuGet_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+                fixture.GivenCustomToolPathExist(expected);
+                fixture.Settings.ToolPath = toolPath;
+
+                // When
+                fixture.Create();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == expected),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Create());
+
+                // Then
+                Assert.IsCakeException(result, "GitReleaseManager: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+                fixture.GivenProcessReturnError();
+
+                // When
+                var result = Record.Exception(() => fixture.Create());
+
+                // Then
+                Assert.IsCakeException(result, "GitReleaseManager: Process returned an error.");
+            }
+
+            [Fact]
+            public void Should_Find_GitReleaseManager_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+
+                // When
+                fixture.Create();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == "/Working/tools/GitReleaseManager.exe"),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+
+                // When
+                fixture.Create();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "create -u \"bob\" -p \"password\" -o \"repoOwner\" -r \"repo\""));
+            }
+
+            [Fact]
+            public void Should_Add_Milestone_To_Arguments_If_True()
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+                fixture.Settings.Milestone = "1.0.0";
+
+                // When
+                fixture.Create();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "create -u \"bob\" -p \"password\" -o \"repoOwner\" -r \"repo\" -m \"1.0.0\""));
+            }
+
+            [Fact]
+            public void Should_Add_Name_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+                fixture.Settings.Name = "1.0.0";
+
+                // When
+                fixture.Create();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "create -u \"bob\" -p \"password\" -o \"repoOwner\" -r \"repo\" -n \"1.0.0\""));
+            }
+
+            [Fact]
+            public void Should_Add_InputFilePath_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+                fixture.Settings.InputFilePath = @"c:/temp";
+
+                // When
+                fixture.Create();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "create -u \"bob\" -p \"password\" -o \"repoOwner\" -r \"repo\" -i \"c:/temp\""));
+            }
+
+            [Fact]
+            public void Should_Add_Prerelease_To_Arguments_If_True()
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+                fixture.Settings.Prerelease = true;
+
+                // When
+                fixture.Create();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "create -u \"bob\" -p \"password\" -o \"repoOwner\" -r \"repo\" -pre"));
+            }
+
+            [Fact]
+            public void Should_Add_Assets_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+                fixture.Settings.Assets = "asset1,asset2";
+
+                // When
+                fixture.Create();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "create -u \"bob\" -p \"password\" -o \"repoOwner\" -r \"repo\" -a \"asset1,asset2\""));
+            }
+
+            [Fact]
+            public void Should_Add_TargetCommitish_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+                fixture.Settings.TargetCommitish = "master";
+
+                // When
+                fixture.Create();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "create -u \"bob\" -p \"password\" -o \"repoOwner\" -r \"repo\" -c \"master\""));
+            }
+
+            [Fact]
+            public void Should_Add_TargetDirectory_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+                fixture.Settings.TargetDirectory = @"c:/temp";
+
+                // When
+                fixture.Create();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "create -u \"bob\" -p \"password\" -o \"repoOwner\" -r \"repo\" -d \"c:/temp\""));
+            }
+
+            [Fact]
+            public void Should_Add_LogFilePath_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+                fixture.Settings.LogFilePath = @"c:/temp/log.txt";
+
+                // When
+                fixture.Create();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "create -u \"bob\" -p \"password\" -o \"repoOwner\" -r \"repo\" -l \"c:/temp/log.txt\""));
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/Export/GitReleaseManagerExporterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/Export/GitReleaseManagerExporterTests.cs
@@ -1,0 +1,236 @@
+﻿using Cake.Common.Tests.Fixtures.Tools.GitReleaseManager;
+using Cake.Core.IO;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.GitReleaseManager.Export
+{
+    public sealed class GitReleaseManagerExporterTests
+    {
+        public sealed class TheExportMethod
+        {
+            [Fact]
+            public void Should_Throw_If_UserName_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerExporterFixture();
+                fixture.UserName = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Export());
+
+                // Then
+                Assert.IsArgumentNullException(result, "userName");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Password_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerExporterFixture();
+                fixture.Password = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Export());
+
+                // Then
+                Assert.IsArgumentNullException(result, "password");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Owner_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerExporterFixture();
+                fixture.Owner = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Export());
+
+                // Then
+                Assert.IsArgumentNullException(result, "owner");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Repository_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerExporterFixture();
+                fixture.Repository = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Export());
+
+                // Then
+                Assert.IsArgumentNullException(result, "repository");
+            }
+
+            [Fact]
+            public void Should_Throw_If_FileOutputPath_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerExporterFixture();
+                fixture.FileOutputPath = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Export());
+
+                // Then
+                Assert.IsArgumentNullException(result, "fileOutputPath");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerExporterFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Export());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_GitReleaseManager_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new GitReleaseManagerExporterFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Export());
+
+                // Then
+                Assert.IsCakeException(result, "GitReleaseManager: Could not locate executable.");
+            }
+
+            [Theory]
+            [InlineData("C:/GitReleaseManager/GitReleaseManager.exe", "C:/GitReleaseManager/GitReleaseManager.exe")]
+            [InlineData("./tools/GitReleaseManager/GitReleaseManager.exe", "/Working/tools/GitReleaseManager/GitReleaseManager.exe")]
+            public void Should_Use_NuGet_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new GitReleaseManagerExporterFixture();
+                fixture.GivenCustomToolPathExist(expected);
+                fixture.Settings.ToolPath = toolPath;
+
+                // When
+                fixture.Export();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == expected),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new GitReleaseManagerExporterFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Export());
+
+                // Then
+                Assert.IsCakeException(result, "GitReleaseManager: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new GitReleaseManagerExporterFixture();
+                fixture.GivenProcessReturnError();
+
+                // When
+                var result = Record.Exception(() => fixture.Export());
+
+                // Then
+                Assert.IsCakeException(result, "GitReleaseManager: Process returned an error.");
+            }
+
+            [Fact]
+            public void Should_Find_GitReleaseManager_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new GitReleaseManagerExporterFixture();
+
+                // When
+                fixture.Export();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == "/Working/tools/GitReleaseManager.exe"),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new GitReleaseManagerExporterFixture();
+
+                // When
+                fixture.Export();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "export -u \"bob\" -p \"password\" -o \"repoOwner\" -r \"repo\" -f \"c:/temp\""));
+            }
+
+            [Fact]
+            public void Should_Add_TagName_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerExporterFixture();
+                fixture.Settings.TagName = "0.1.0";
+
+                // When
+                fixture.Export();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "export -u \"bob\" -p \"password\" -o \"repoOwner\" -r \"repo\" -f \"c:/temp\" -t \"0.1.0\""));
+            }
+
+            [Fact]
+            public void Should_Add_TargetDirectory_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerExporterFixture();
+                fixture.Settings.TargetDirectory = @"c:/temp";
+
+                // When
+                fixture.Export();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "export -u \"bob\" -p \"password\" -o \"repoOwner\" -r \"repo\" -f \"c:/temp\" -d \"c:/temp\""));
+            }
+
+            [Fact]
+            public void Should_Add_LogFilePath_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerExporterFixture();
+                fixture.Settings.LogFilePath = @"c:/temp/log.txt";
+
+                // When
+                fixture.Export();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "export -u \"bob\" -p \"password\" -o \"repoOwner\" -r \"repo\" -f \"c:/temp\" -l \"c:/temp/log.txt\""));
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/Publish/GitReleaseManagerPublisherTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/Publish/GitReleaseManagerPublisherTests.cs
@@ -1,0 +1,220 @@
+﻿using Cake.Common.Tests.Fixtures.Tools.GitReleaseManager;
+using Cake.Core.IO;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.GitReleaseManager.Publish
+{
+    public sealed class GitReleaseManagerPublisherTests
+    {
+        public sealed class ThePublishMethod
+        {
+            [Fact]
+            public void Should_Throw_If_UserName_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerPublisherFixture();
+                fixture.UserName = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Publish());
+
+                // Then
+                Assert.IsArgumentNullException(result, "userName");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Password_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerPublisherFixture();
+                fixture.Password = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Publish());
+
+                // Then
+                Assert.IsArgumentNullException(result, "password");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Owner_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerPublisherFixture();
+                fixture.Owner = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Publish());
+
+                // Then
+                Assert.IsArgumentNullException(result, "owner");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Repository_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerPublisherFixture();
+                fixture.Repository = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Publish());
+
+                // Then
+                Assert.IsArgumentNullException(result, "repository");
+            }
+
+            [Fact]
+            public void Should_Throw_If_TagName_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerPublisherFixture();
+                fixture.TagName = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Publish());
+
+                // Then
+                Assert.IsArgumentNullException(result, "tagName");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerPublisherFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Publish());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_GitReleaseManager_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new GitReleaseManagerPublisherFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Publish());
+
+                // Then
+                Assert.IsCakeException(result, "GitReleaseManager: Could not locate executable.");
+            }
+
+            [Theory]
+            [InlineData("C:/GitReleaseManager/GitReleaseManager.exe", "C:/GitReleaseManager/GitReleaseManager.exe")]
+            [InlineData("./tools/GitReleaseManager/GitReleaseManager.exe", "/Working/tools/GitReleaseManager/GitReleaseManager.exe")]
+            public void Should_Use_NuGet_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new GitReleaseManagerPublisherFixture();
+                fixture.GivenCustomToolPathExist(expected);
+                fixture.Settings.ToolPath = toolPath;
+
+                // When
+                fixture.Publish();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == expected),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new GitReleaseManagerPublisherFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Publish());
+
+                // Then
+                Assert.IsCakeException(result, "GitReleaseManager: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new GitReleaseManagerPublisherFixture();
+                fixture.GivenProcessReturnError();
+
+                // When
+                var result = Record.Exception(() => fixture.Publish());
+
+                // Then
+                Assert.IsCakeException(result, "GitReleaseManager: Process returned an error.");
+            }
+
+            [Fact]
+            public void Should_Find_GitReleaseManager_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new GitReleaseManagerPublisherFixture();
+
+                // When
+                fixture.Publish();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(p => p.FullPath == "/Working/tools/GitReleaseManager.exe"),
+                    Arg.Any<ProcessSettings>());
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new GitReleaseManagerPublisherFixture();
+
+                // When
+                fixture.Publish();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "publish -u \"bob\" -p \"password\" -o \"repoOwner\" -r \"repo\" -t \"0.1.0\""));
+            }
+
+            [Fact]
+            public void Should_Add_TargetDirectory_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerPublisherFixture();
+                fixture.Settings.TargetDirectory = @"c:/temp";
+
+                // When
+                fixture.Publish();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "publish -u \"bob\" -p \"password\" -o \"repoOwner\" -r \"repo\" -t \"0.1.0\" -d \"c:/temp\""));
+            }
+
+            [Fact]
+            public void Should_Add_LogFilePath_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerPublisherFixture();
+                fixture.Settings.LogFilePath = @"c:/temp/log.txt";
+
+                // When
+                fixture.Publish();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(), Arg.Is<ProcessSettings>(p =>
+                        p.Arguments.Render() == "publish -u \"bob\" -p \"password\" -o \"repoOwner\" -r \"repo\" -t \"0.1.0\" -l \"c:/temp/log.txt\""));
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -142,6 +142,12 @@
     <Compile Include="Tools\Fixie\FixieRunner.cs" />
     <Compile Include="Tools\Fixie\FixieSettings.cs" />
     <Compile Include="Tools\Fixie\FixieSettingsExtensions.cs" />
+    <Compile Include="Tools\GitReleaseManager\Create\GitReleaseManagerCreateSettings.cs" />
+    <Compile Include="Tools\GitReleaseManager\Create\GitReleaseManagerCreator.cs" />
+    <Compile Include="Tools\GitReleaseManager\GitReleaseManagerAliases.cs" />
+    <Compile Include="Tools\GitReleaseManager\GitReleaseManagerTool.cs" />
+    <Compile Include="Tools\GitReleaseManager\GitReleaseManagerToolResolver.cs" />
+    <Compile Include="Tools\GitReleaseManager\IGitReleaseManagerToolResolver.cs" />
     <Compile Include="Tools\ILMerge\ILMergeAliases.cs" />
     <Compile Include="Tools\ILMerge\ILMergeRunner.cs" />
     <Compile Include="Tools\ILMerge\ILMergeSettings.cs" />
@@ -261,6 +267,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Tools\GitReleaseManager\AddAsset\" />
+    <Folder Include="Tools\GitReleaseManager\Close\" />
+    <Folder Include="Tools\GitReleaseManager\Export\" />
+    <Folder Include="Tools\GitReleaseManager\Publish\" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -148,6 +148,8 @@
     <Compile Include="Tools\GitReleaseManager\Close\GitReleaseManagerMilestoneCloser.cs" />
     <Compile Include="Tools\GitReleaseManager\Create\GitReleaseManagerCreateSettings.cs" />
     <Compile Include="Tools\GitReleaseManager\Create\GitReleaseManagerCreator.cs" />
+    <Compile Include="Tools\GitReleaseManager\Export\GitReleaseManagerExporter.cs" />
+    <Compile Include="Tools\GitReleaseManager\Export\GitReleaseManagerExportSettings.cs" />
     <Compile Include="Tools\GitReleaseManager\GitReleaseManagerAliases.cs" />
     <Compile Include="Tools\GitReleaseManager\GitReleaseManagerTool.cs" />
     <Compile Include="Tools\GitReleaseManager\GitReleaseManagerToolResolver.cs" />
@@ -274,9 +276,7 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Tools\GitReleaseManager\Export\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets" Condition="Exists('..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets') and $(Configuration)=='Release'" />

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -152,6 +152,8 @@
     <Compile Include="Tools\GitReleaseManager\GitReleaseManagerTool.cs" />
     <Compile Include="Tools\GitReleaseManager\GitReleaseManagerToolResolver.cs" />
     <Compile Include="Tools\GitReleaseManager\IGitReleaseManagerToolResolver.cs" />
+    <Compile Include="Tools\GitReleaseManager\Publish\GitReleaseManagerPublisher.cs" />
+    <Compile Include="Tools\GitReleaseManager\Publish\GitReleaseManagerPublishSettings.cs" />
     <Compile Include="Tools\ILMerge\ILMergeAliases.cs" />
     <Compile Include="Tools\ILMerge\ILMergeRunner.cs" />
     <Compile Include="Tools\ILMerge\ILMergeSettings.cs" />
@@ -274,7 +276,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Tools\GitReleaseManager\Export\" />
-    <Folder Include="Tools\GitReleaseManager\Publish\" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -142,6 +142,8 @@
     <Compile Include="Tools\Fixie\FixieRunner.cs" />
     <Compile Include="Tools\Fixie\FixieSettings.cs" />
     <Compile Include="Tools\Fixie\FixieSettingsExtensions.cs" />
+    <Compile Include="Tools\GitReleaseManager\AddAssets\GitReleaseManagerAddAssetsSettings.cs" />
+    <Compile Include="Tools\GitReleaseManager\AddAssets\GitReleaseManagerAssetsAdder.cs" />
     <Compile Include="Tools\GitReleaseManager\Create\GitReleaseManagerCreateSettings.cs" />
     <Compile Include="Tools\GitReleaseManager\Create\GitReleaseManagerCreator.cs" />
     <Compile Include="Tools\GitReleaseManager\GitReleaseManagerAliases.cs" />
@@ -269,7 +271,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Tools\GitReleaseManager\AddAsset\" />
     <Folder Include="Tools\GitReleaseManager\Close\" />
     <Folder Include="Tools\GitReleaseManager\Export\" />
     <Folder Include="Tools\GitReleaseManager\Publish\" />

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -144,6 +144,8 @@
     <Compile Include="Tools\Fixie\FixieSettingsExtensions.cs" />
     <Compile Include="Tools\GitReleaseManager\AddAssets\GitReleaseManagerAddAssetsSettings.cs" />
     <Compile Include="Tools\GitReleaseManager\AddAssets\GitReleaseManagerAssetsAdder.cs" />
+    <Compile Include="Tools\GitReleaseManager\Close\GitReleaseManagerCloseMilestoneSettings.cs" />
+    <Compile Include="Tools\GitReleaseManager\Close\GitReleaseManagerMilestoneCloser.cs" />
     <Compile Include="Tools\GitReleaseManager\Create\GitReleaseManagerCreateSettings.cs" />
     <Compile Include="Tools\GitReleaseManager\Create\GitReleaseManagerCreator.cs" />
     <Compile Include="Tools\GitReleaseManager\GitReleaseManagerAliases.cs" />
@@ -271,7 +273,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Tools\GitReleaseManager\Close\" />
     <Folder Include="Tools\GitReleaseManager\Export\" />
     <Folder Include="Tools\GitReleaseManager\Publish\" />
   </ItemGroup>

--- a/src/Cake.Common/Tools/GitReleaseManager/AddAssets/GitReleaseManagerAddAssetsSettings.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/AddAssets/GitReleaseManagerAddAssetsSettings.cs
@@ -1,0 +1,25 @@
+﻿namespace Cake.Common.Tools.GitReleaseManager.AddAssets
+{
+    using global::Cake.Core.IO;
+
+    /// <summary>
+    /// Contains settings used by <see cref="GitReleaseManagerAssetsAdder"/>.
+    /// </summary>
+    public sealed class GitReleaseManagerAddAssetsSettings
+    {
+        /// <summary>
+        /// Gets or sets the path on which GitReleaseManager should be executed.
+        /// </summary>
+        public DirectoryPath TargetDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the GitReleaseManager log file.
+        /// </summary>
+        public FilePath LogFilePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to <c>GitReleaseManager.exe</c>.
+        /// </summary>
+        public FilePath ToolPath { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/GitReleaseManager/AddAssets/GitReleaseManagerAssetsAdder.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/AddAssets/GitReleaseManagerAssetsAdder.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.GitReleaseManager.AddAssets
+{
+    /// <summary>
+    /// The GitReleaseManager Asset Adder used to add assets to a release.
+    /// </summary>
+    public sealed class GitReleaseManagerAssetsAdder : GitReleaseManagerTool<GitReleaseManagerAddAssetsSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GitReleaseManagerAssetsAdder"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
+        /// <param name="resolver">The GitReleaseManager tool resolver.</param>
+        public GitReleaseManagerAssetsAdder(IFileSystem fileSystem, ICakeEnvironment environment,
+            IProcessRunner processRunner, IGlobber globber, IGitReleaseManagerToolResolver resolver)
+            : base(fileSystem, environment, processRunner, globber, resolver)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Creates a Release using the specified and settings.
+        /// </summary>
+        /// <param name="userName">The user name.</param>
+        /// <param name="password">The password.</param>
+        /// <param name="owner">The owner.</param>
+        /// <param name="repository">The repository.</param>
+        /// <param name="tagName">The tag name.</param>
+        /// <param name="assets">The assets to upload.</param>
+        /// <param name="settings">The settings.</param>
+        public void AddAssets(string userName, string password, string owner, string repository, string tagName, string assets, GitReleaseManagerAddAssetsSettings settings)
+        {
+            if (string.IsNullOrWhiteSpace(userName))
+            {
+                throw new ArgumentNullException("userName");
+            }
+
+            if (string.IsNullOrWhiteSpace(password))
+            {
+                throw new ArgumentNullException("password");
+            }
+
+            if (string.IsNullOrWhiteSpace(owner))
+            {
+                throw new ArgumentNullException("owner");
+            }
+
+            if (string.IsNullOrWhiteSpace(repository))
+            {
+                throw new ArgumentNullException("repository");
+            }
+
+            if (string.IsNullOrWhiteSpace(tagName))
+            {
+                throw new ArgumentNullException("tagName");
+            }
+
+            if (string.IsNullOrWhiteSpace(assets))
+            {
+                throw new ArgumentNullException("assets");
+            }
+
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            Run(settings, GetArguments(userName, password, owner, repository, tagName, assets, settings), settings.ToolPath);
+        }
+
+        private ProcessArgumentBuilder GetArguments(string userName, string password, string owner, string repository, string tagName, string assets, GitReleaseManagerAddAssetsSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("addasset");
+
+            builder.Append("-u");
+            builder.AppendQuoted(userName);
+
+            builder.Append("-p");
+            builder.AppendQuotedSecret(password);
+
+            builder.Append("-o");
+            builder.AppendQuoted(owner);
+
+            builder.Append("-r");
+            builder.AppendQuoted(repository);
+
+            builder.Append("-t");
+            builder.AppendQuoted(tagName);
+
+            builder.Append("-a");
+            builder.AppendQuoted(assets);
+
+            // Target Directory
+            if (settings.TargetDirectory != null)
+            {
+                builder.Append("-d");
+                builder.AppendQuoted(settings.TargetDirectory.MakeAbsolute(_environment).FullPath);
+            }
+
+            // Log File Path
+            if (settings.LogFilePath != null)
+            {
+                builder.Append("-l");
+                builder.AppendQuoted(settings.LogFilePath.MakeAbsolute(_environment).FullPath);
+            }
+
+            return builder;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/GitReleaseManager/Close/GitReleaseManagerCloseMilestoneSettings.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Close/GitReleaseManagerCloseMilestoneSettings.cs
@@ -1,0 +1,25 @@
+﻿using Cake.Core.IO;
+
+namespace Cake.Common.Tools.GitReleaseManager.Close
+{
+    /// <summary>
+    /// Contains settings used by <see cref="GitReleaseManagerMilestoneCloser"/>.
+    /// </summary>
+    public sealed class GitReleaseManagerCloseMilestoneSettings
+    {
+        /// <summary>
+        /// Gets or sets the path on which GitReleaseManager should be executed.
+        /// </summary>
+        public DirectoryPath TargetDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the GitReleaseManager log file.
+        /// </summary>
+        public FilePath LogFilePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to <c>GitReleaseManager.exe</c>.
+        /// </summary>
+        public FilePath ToolPath { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/GitReleaseManager/Close/GitReleaseManagerMilestoneCloser.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Close/GitReleaseManagerMilestoneCloser.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.GitReleaseManager.Close
+{
+    /// <summary>
+    /// The GitReleaseManager Milestone Closer used to close milestones.
+    /// </summary>
+    public sealed class GitReleaseManagerMilestoneCloser : GitReleaseManagerTool<GitReleaseManagerCloseMilestoneSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GitReleaseManagerMilestoneCloser"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
+        /// <param name="resolver">The GitReleaseManager tool resolver.</param>
+        public GitReleaseManagerMilestoneCloser(IFileSystem fileSystem, ICakeEnvironment environment,
+            IProcessRunner processRunner, IGlobber globber, IGitReleaseManagerToolResolver resolver)
+            : base(fileSystem, environment, processRunner, globber, resolver)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Creates a Release using the specified and settings.
+        /// </summary>
+        /// <param name="userName">The user name.</param>
+        /// <param name="password">The password.</param>
+        /// <param name="owner">The owner.</param>
+        /// <param name="repository">The repository.</param>
+        /// <param name="milestone">The milestone.</param>
+        /// <param name="settings">The settings.</param>
+        public void Close(string userName, string password, string owner, string repository, string milestone, GitReleaseManagerCloseMilestoneSettings settings)
+        {
+            if (string.IsNullOrWhiteSpace(userName))
+            {
+                throw new ArgumentNullException("userName");
+            }
+
+            if (string.IsNullOrWhiteSpace(password))
+            {
+                throw new ArgumentNullException("password");
+            }
+
+            if (string.IsNullOrWhiteSpace(owner))
+            {
+                throw new ArgumentNullException("owner");
+            }
+
+            if (string.IsNullOrWhiteSpace(repository))
+            {
+                throw new ArgumentNullException("repository");
+            }
+
+            if (string.IsNullOrWhiteSpace(milestone))
+            {
+                throw new ArgumentNullException("milestone");
+            }
+
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            Run(settings, GetArguments(userName, password, owner, repository, milestone, settings), settings.ToolPath);
+        }
+
+        private ProcessArgumentBuilder GetArguments(string userName, string password, string owner, string repository, string milestone, GitReleaseManagerCloseMilestoneSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("close");
+
+            builder.Append("-u");
+            builder.AppendQuoted(userName);
+
+            builder.Append("-p");
+            builder.AppendQuotedSecret(password);
+
+            builder.Append("-o");
+            builder.AppendQuoted(owner);
+
+            builder.Append("-r");
+            builder.AppendQuoted(repository);
+
+            builder.Append("-m");
+            builder.AppendQuoted(milestone);
+
+            // Target Directory
+            if (settings.TargetDirectory != null)
+            {
+                builder.Append("-d");
+                builder.AppendQuoted(settings.TargetDirectory.MakeAbsolute(_environment).FullPath);
+            }
+
+            // Log File Path
+            if (settings.LogFilePath != null)
+            {
+                builder.Append("-l");
+                builder.AppendQuoted(settings.LogFilePath.MakeAbsolute(_environment).FullPath);
+            }
+
+            return builder;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/GitReleaseManager/Create/GitReleaseManagerCreateSettings.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Create/GitReleaseManagerCreateSettings.cs
@@ -1,0 +1,55 @@
+﻿using Cake.Core.IO;
+
+namespace Cake.Common.Tools.GitReleaseManager.Create
+{
+    /// <summary>
+    /// Contains settings used by <see cref="GitReleaseManagerCreator"/>.
+    /// </summary>
+    public sealed class GitReleaseManagerCreateSettings
+    {
+        /// <summary>
+        /// Gets or sets the milestone to be used when creating the release.
+        /// </summary>
+        public string Milestone { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name to be used when creating the release.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the location of a set of Release Notes to be used when creating the release.
+        /// </summary>
+        public FilePath InputFilePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not to create the release as a pre-release.
+        /// </summary>
+        public bool Prerelease { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Path(s) to the file(s) to include in the release.
+        /// </summary>
+        public string Assets { get; set; }
+
+        /// <summary>
+        /// Gets or sets the commit to tag. Can be a branch or SHA. Defaults to repository's default branch..
+        /// </summary>
+        public string TargetCommitish { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path on which GitReleaseManager should be executed.
+        /// </summary>
+        public DirectoryPath TargetDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the GitReleaseManager log file.
+        /// </summary>
+        public FilePath LogFilePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to <c>GitReleaseManager.exe</c>.
+        /// </summary>
+        public FilePath ToolPath { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/GitReleaseManager/Create/GitReleaseManagerCreator.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Create/GitReleaseManagerCreator.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.GitReleaseManager.Create
+{
+    /// <summary>
+    /// The GitReleaseManager Release Creator used to create releases.
+    /// </summary>
+    public sealed class GitReleaseManagerCreator : GitReleaseManagerTool<GitReleaseManagerCreateSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GitReleaseManagerCreator"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
+        /// <param name="resolver">The GitReleaseManager tool resolver.</param>
+        public GitReleaseManagerCreator(IFileSystem fileSystem, ICakeEnvironment environment,
+            IProcessRunner processRunner, IGlobber globber, IGitReleaseManagerToolResolver resolver)
+            : base(fileSystem, environment, processRunner, globber, resolver)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Creates a Release using the specified and settings.
+        /// </summary>
+        /// <param name="userName">The user name.</param>
+        /// <param name="password">The password.</param>
+        /// <param name="owner">The owner.</param>
+        /// <param name="repository">The repository.</param>
+        /// <param name="settings">The settings.</param>
+        public void Create(string userName, string password, string owner, string repository, GitReleaseManagerCreateSettings settings)
+        {
+            if (string.IsNullOrWhiteSpace(userName))
+            {
+                throw new ArgumentNullException("userName");
+            }
+
+            if (string.IsNullOrWhiteSpace(password))
+            {
+                throw new ArgumentNullException("password");
+            }
+
+            if (string.IsNullOrWhiteSpace(owner))
+            {
+                throw new ArgumentNullException("owner");
+            }
+
+            if (string.IsNullOrWhiteSpace(repository))
+            {
+                throw new ArgumentNullException("repository");
+            }
+
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            Run(settings, GetArguments(userName, password, owner, repository, settings), settings.ToolPath);
+        }
+
+        private ProcessArgumentBuilder GetArguments(string userName, string password, string owner, string repository, GitReleaseManagerCreateSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("create");
+
+            builder.Append("-u");
+            builder.AppendQuoted(userName);
+
+            builder.Append("-p");
+            builder.AppendQuotedSecret(password);
+
+            builder.Append("-o");
+            builder.AppendQuoted(owner);
+
+            builder.Append("-r");
+            builder.AppendQuoted(repository);
+
+            // Milestone
+            if (!string.IsNullOrWhiteSpace(settings.Milestone))
+            {
+                builder.Append("-m");
+                builder.AppendQuoted(settings.Milestone);
+            }
+
+            // Name
+            if (!string.IsNullOrWhiteSpace(settings.Name))
+            {
+                builder.Append("-n");
+                builder.AppendQuoted(settings.Name);
+            }
+
+            // Input File Path
+            if (settings.InputFilePath != null)
+            {
+                builder.Append("-i");
+                builder.AppendQuoted(settings.InputFilePath.MakeAbsolute(_environment).FullPath);
+            }
+
+            // Prerelease?
+            if (settings.Prerelease)
+            {
+                builder.Append("-pre");
+            }
+
+            // Assets
+            if (!string.IsNullOrWhiteSpace(settings.Assets))
+            {
+                builder.Append("-a");
+                builder.AppendQuoted(settings.Assets);
+            }
+
+            // Target Commitish
+            if (!string.IsNullOrWhiteSpace(settings.TargetCommitish))
+            {
+                builder.Append("-c");
+                builder.AppendQuoted(settings.TargetCommitish);
+            }
+
+            // Target Directory
+            if (settings.TargetDirectory != null)
+            {
+                builder.Append("-d");
+                builder.AppendQuoted(settings.TargetDirectory.MakeAbsolute(_environment).FullPath);
+            }
+
+            // Log File Path
+            if (settings.LogFilePath != null)
+            {
+                builder.Append("-l");
+                builder.AppendQuoted(settings.LogFilePath.MakeAbsolute(_environment).FullPath);
+            }
+
+            return builder;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/GitReleaseManager/Export/GitReleaseManagerExportSettings.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Export/GitReleaseManagerExportSettings.cs
@@ -1,0 +1,30 @@
+﻿using Cake.Core.IO;
+
+namespace Cake.Common.Tools.GitReleaseManager.Export
+{
+    /// <summary>
+    /// Contains settings used by <see cref="GitReleaseManagerExporter"/>.
+    /// </summary>
+    public sealed class GitReleaseManagerExportSettings
+    {
+        /// <summary>
+        /// Gets or sets the tag name to be used when exporting the release notes.
+        /// </summary>
+        public string TagName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path on which GitReleaseManager should be executed.
+        /// </summary>
+        public DirectoryPath TargetDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the GitReleaseManager log file.
+        /// </summary>
+        public FilePath LogFilePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to <c>GitReleaseManager.exe</c>.
+        /// </summary>
+        public FilePath ToolPath { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/GitReleaseManager/Export/GitReleaseManagerExporter.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Export/GitReleaseManagerExporter.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.GitReleaseManager.Export
+{
+    /// <summary>
+    /// The GitReleaseManager Reelase Publisher used to publish releases.
+    /// </summary>
+    public sealed class GitReleaseManagerExporter : GitReleaseManagerTool<GitReleaseManagerExportSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GitReleaseManagerExporter"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
+        /// <param name="resolver">The GitReleaseManager tool resolver.</param>
+        public GitReleaseManagerExporter(IFileSystem fileSystem, ICakeEnvironment environment,
+            IProcessRunner processRunner, IGlobber globber, IGitReleaseManagerToolResolver resolver)
+            : base(fileSystem, environment, processRunner, globber, resolver)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Creates a Release using the specified and settings.
+        /// </summary>
+        /// <param name="userName">The user name.</param>
+        /// <param name="password">The password.</param>
+        /// <param name="owner">The owner.</param>
+        /// <param name="repository">The repository.</param>
+        /// <param name="fileOutputPath">The output path.</param>
+        /// <param name="settings">The settings.</param>
+        public void Export(string userName, string password, string owner, string repository, FilePath fileOutputPath, GitReleaseManagerExportSettings settings)
+        {
+            if (string.IsNullOrWhiteSpace(userName))
+            {
+                throw new ArgumentNullException("userName");
+            }
+
+            if (string.IsNullOrWhiteSpace(password))
+            {
+                throw new ArgumentNullException("password");
+            }
+
+            if (string.IsNullOrWhiteSpace(owner))
+            {
+                throw new ArgumentNullException("owner");
+            }
+
+            if (string.IsNullOrWhiteSpace(repository))
+            {
+                throw new ArgumentNullException("repository");
+            }
+
+            if (fileOutputPath == null)
+            {
+                throw new ArgumentNullException("fileOutputPath");
+            }
+
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            Run(settings, GetArguments(userName, password, owner, repository, fileOutputPath, settings), settings.ToolPath);
+        }
+
+        private ProcessArgumentBuilder GetArguments(string userName, string password, string owner, string repository, FilePath fileOutputPath, GitReleaseManagerExportSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("export");
+
+            builder.Append("-u");
+            builder.AppendQuoted(userName);
+
+            builder.Append("-p");
+            builder.AppendQuotedSecret(password);
+
+            builder.Append("-o");
+            builder.AppendQuoted(owner);
+
+            builder.Append("-r");
+            builder.AppendQuoted(repository);
+
+            builder.Append("-f");
+            builder.AppendQuoted(fileOutputPath.MakeAbsolute(_environment).FullPath);
+
+            if (!string.IsNullOrWhiteSpace(settings.TagName))
+            {
+                builder.Append("-t");
+                builder.AppendQuoted(settings.TagName);
+            }
+
+            // Target Directory
+            if (settings.TargetDirectory != null)
+            {
+                builder.Append("-d");
+                builder.AppendQuoted(settings.TargetDirectory.MakeAbsolute(_environment).FullPath);
+            }
+
+            // Log File Path
+            if (settings.LogFilePath != null)
+            {
+                builder.Append("-l");
+                builder.AppendQuoted(settings.LogFilePath.MakeAbsolute(_environment).FullPath);
+            }
+
+            return builder;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerAliases.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerAliases.cs
@@ -2,6 +2,7 @@
 using Cake.Common.Tools.GitReleaseManager.AddAssets;
 using Cake.Common.Tools.GitReleaseManager.Close;
 using Cake.Common.Tools.GitReleaseManager.Create;
+using Cake.Common.Tools.GitReleaseManager.Publish;
 using Cake.Core;
 using Cake.Core.Annotations;
 
@@ -86,6 +87,31 @@ namespace Cake.Common.Tools.GitReleaseManager
             var resolver = new GitReleaseManagerToolResolver(context.FileSystem, context.Environment, context.Globber);
             var milestoneCloser = new GitReleaseManagerMilestoneCloser(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
             milestoneCloser.Close(userName, password, owner, repository, milestone, settings);
+        }
+
+        /// <summary>
+        /// Closes the milestone associated with a release using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="userName">The user name.</param>
+        /// <param name="password">The password.</param>
+        /// <param name="owner">The owner.</param>
+        /// <param name="repository">The repository.</param>
+        /// <param name="tagName">The tag name.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Publish")]
+        [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.Publish")]
+        public static void GitReleaseManagerPublish(this ICakeContext context, string userName, string password, string owner, string repository, string tagName, GitReleaseManagerPublishSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var resolver = new GitReleaseManagerToolResolver(context.FileSystem, context.Environment, context.Globber);
+            var publisher = new GitReleaseManagerPublisher(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
+            publisher.Publish(userName, password, owner, repository, tagName, settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerAliases.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerAliases.cs
@@ -25,6 +25,31 @@ namespace Cake.Common.Tools.GitReleaseManager
         /// <param name="owner">The owner.</param>
         /// <param name="repository">The repository.</param>
         /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// GitReleaseManagerCreate("user", "password", "owner", "repo", new GitReleaseManagerCreateSettings {
+        ///     Milestone         = "0.1.0",
+        ///     Prerelease        = false,
+        ///     Assets            = "c:/temp/asset1.txt,c:/temp/asset2.txt",
+        ///     TargetCommitish   = "master",
+        ///     TargetDirectory   = "c:/repo",
+        ///     LogFilePath       = "c:/temp/grm.log"
+        /// });
+        /// </code>
+        /// </example>
+        /// <example>
+        /// <code>
+        /// GitReleaseManagerCreate("user", "password", "owner", "repo", new GitReleaseManagerCreateSettings {
+        ///     Name              = "0.1.0",
+        ///     InputFilePath     = "c:/repo/releasenotes.md",
+        ///     Prerelease        = false,
+        ///     Assets            = "c:/temp/asset1.txt,c:/temp/asset2.txt",
+        ///     TargetCommitish   = "master",
+        ///     TargetDirectory   = "c:/repo",
+        ///     LogFilePath       = "c:/temp/grm.log"
+        /// });
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Create")]
         [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.Create")]
@@ -51,6 +76,14 @@ namespace Cake.Common.Tools.GitReleaseManager
         /// <param name="tagName">The tag name.</param>
         /// <param name="assets">The assets.</param>
         /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// GitReleaseManagerAddAssets("user", "password", "owner", "repo", "0.1.0", "c:/temp/asset1.txt,c:/temp/asset2.txt" new GitReleaseManagerAddAssetsSettings {
+        ///     TargetDirectory   = "c:/repo",
+        ///     LogFilePath       = "c:/temp/grm.log"
+        /// });
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("AddAssets")]
         [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.AddAssets")]
@@ -76,6 +109,14 @@ namespace Cake.Common.Tools.GitReleaseManager
         /// <param name="repository">The repository.</param>
         /// <param name="milestone">The milestone.</param>
         /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// GitReleaseManagerClose("user", "password", "owner", "repo", "0.1.0", new GitReleaseManagerCloseMilestoneSettings {
+        ///     TargetDirectory   = "c:/repo",
+        ///     LogFilePath       = "c:/temp/grm.log"
+        /// });
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Close")]
         [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.Close")]
@@ -92,7 +133,7 @@ namespace Cake.Common.Tools.GitReleaseManager
         }
 
         /// <summary>
-        /// Closes the milestone associated with a release using the specified settings.
+        /// Publishes the release using the specified settings.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="userName">The user name.</param>
@@ -101,6 +142,14 @@ namespace Cake.Common.Tools.GitReleaseManager
         /// <param name="repository">The repository.</param>
         /// <param name="tagName">The tag name.</param>
         /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// GitReleaseManagerPublish("user", "password", "owner", "repo", "0.1.0", new GitReleaseManagerPublishSettings {
+        ///     TargetDirectory   = "c:/repo",
+        ///     LogFilePath       = "c:/temp/grm.log"
+        /// });
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Publish")]
         [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.Publish")]
@@ -126,6 +175,15 @@ namespace Cake.Common.Tools.GitReleaseManager
         /// <param name="repository">The repository.</param>
         /// <param name="fileOutputPath">The output file path.</param>
         /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// GitReleaseManagerExport("user", "password", "owner", "repo", "c:/temp/releasenotes.md", new GitReleaseManagerExportSettings {
+        ///     TagName           = "0.1.0",
+        ///     TargetDirectory   = "c:/repo",
+        ///     LogFilePath       = "c:/temp/grm.log"
+        /// });
+        /// </code>
+        /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Export")]
         [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.Export")]

--- a/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerAliases.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerAliases.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Cake.Common.Tools.GitReleaseManager.AddAssets;
 using Cake.Common.Tools.GitReleaseManager.Create;
 using Cake.Core;
 using Cake.Core.Annotations;
@@ -33,6 +34,32 @@ namespace Cake.Common.Tools.GitReleaseManager
             var resolver = new GitReleaseManagerToolResolver(context.FileSystem, context.Environment, context.Globber);
             var creator = new GitReleaseManagerCreator(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
             creator.Create(userName, password, owner, repository, settings);
+        }
+
+        /// <summary>
+        /// Add Assets to an existing release using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="userName">The user name.</param>
+        /// <param name="password">The password.</param>
+        /// <param name="owner">The owner.</param>
+        /// <param name="repository">The repository.</param>
+        /// <param name="tagName">The tag name.</param>
+        /// <param name="assets">The assets.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("AddAssets")]
+        [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.AddAssets")]
+        public static void GitReleaseManagerAddAssets(this ICakeContext context, string userName, string password, string owner, string repository, string tagName, string assets, GitReleaseManagerAddAssetsSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var resolver = new GitReleaseManagerToolResolver(context.FileSystem, context.Environment, context.Globber);
+            var assetsAdder = new GitReleaseManagerAssetsAdder(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
+            assetsAdder.AddAssets(userName, password, owner, repository, tagName, assets, settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerAliases.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerAliases.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Cake.Common.Tools.GitReleaseManager.Create;
+using Cake.Core;
+using Cake.Core.Annotations;
+
+namespace Cake.Common.Tools.GitReleaseManager
+{
+    /// <summary>
+    /// Contains functionality for working with GitReleaseManager.
+    /// </summary>
+    [CakeAliasCategory("GitReleaseManager")]
+    public static class GitReleaseManagerAliases
+    {
+        /// <summary>
+        /// Creates a Package Release using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="userName">The user name.</param>
+        /// <param name="password">The password.</param>
+        /// <param name="owner">The owner.</param>
+        /// <param name="repository">The repository.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Create")]
+        [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.Create")]
+        public static void GitReleaseManagerCreate(this ICakeContext context, string userName, string password, string owner, string repository, GitReleaseManagerCreateSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var resolver = new GitReleaseManagerToolResolver(context.FileSystem, context.Environment, context.Globber);
+            var creator = new GitReleaseManagerCreator(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
+            creator.Create(userName, password, owner, repository, settings);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerAliases.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerAliases.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Cake.Common.Tools.GitReleaseManager.AddAssets;
+using Cake.Common.Tools.GitReleaseManager.Close;
 using Cake.Common.Tools.GitReleaseManager.Create;
 using Cake.Core;
 using Cake.Core.Annotations;
@@ -60,6 +61,31 @@ namespace Cake.Common.Tools.GitReleaseManager
             var resolver = new GitReleaseManagerToolResolver(context.FileSystem, context.Environment, context.Globber);
             var assetsAdder = new GitReleaseManagerAssetsAdder(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
             assetsAdder.AddAssets(userName, password, owner, repository, tagName, assets, settings);
+        }
+
+        /// <summary>
+        /// Closes the milestone associated with a release using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="userName">The user name.</param>
+        /// <param name="password">The password.</param>
+        /// <param name="owner">The owner.</param>
+        /// <param name="repository">The repository.</param>
+        /// <param name="milestone">The milestone.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Close")]
+        [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.Close")]
+        public static void GitReleaseManagerClose(this ICakeContext context, string userName, string password, string owner, string repository, string milestone, GitReleaseManagerCloseMilestoneSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var resolver = new GitReleaseManagerToolResolver(context.FileSystem, context.Environment, context.Globber);
+            var milestoneCloser = new GitReleaseManagerMilestoneCloser(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
+            milestoneCloser.Close(userName, password, owner, repository, milestone, settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerAliases.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerAliases.cs
@@ -2,9 +2,11 @@
 using Cake.Common.Tools.GitReleaseManager.AddAssets;
 using Cake.Common.Tools.GitReleaseManager.Close;
 using Cake.Common.Tools.GitReleaseManager.Create;
+using Cake.Common.Tools.GitReleaseManager.Export;
 using Cake.Common.Tools.GitReleaseManager.Publish;
 using Cake.Core;
 using Cake.Core.Annotations;
+using Cake.Core.IO;
 
 namespace Cake.Common.Tools.GitReleaseManager
 {
@@ -112,6 +114,31 @@ namespace Cake.Common.Tools.GitReleaseManager
             var resolver = new GitReleaseManagerToolResolver(context.FileSystem, context.Environment, context.Globber);
             var publisher = new GitReleaseManagerPublisher(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
             publisher.Publish(userName, password, owner, repository, tagName, settings);
+        }
+
+        /// <summary>
+        /// Exports the release notes using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="userName">The user name.</param>
+        /// <param name="password">The password.</param>
+        /// <param name="owner">The owner.</param>
+        /// <param name="repository">The repository.</param>
+        /// <param name="fileOutputPath">The output file path.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Export")]
+        [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.Export")]
+        public static void GitReleaseManagerExport(this ICakeContext context, string userName, string password, string owner, string repository, FilePath fileOutputPath, GitReleaseManagerExportSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var resolver = new GitReleaseManagerToolResolver(context.FileSystem, context.Environment, context.Globber);
+            var publisher = new GitReleaseManagerExporter(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber, resolver);
+            publisher.Export(userName, password, owner, repository, fileOutputPath, settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerTool.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerTool.cs
@@ -1,0 +1,70 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Utilities;
+
+namespace Cake.Common.Tools.GitReleaseManager
+{
+    /// <summary>
+    /// Base class for all GitReleaseManager related tools.
+    /// </summary>
+    /// <typeparam name="TSettings">The settings type.</typeparam>
+    public abstract class GitReleaseManagerTool<TSettings> : Tool<TSettings>
+    {
+        private readonly IGitReleaseManagerToolResolver _resolver;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GitReleaseManagerTool{TSettings}"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
+        /// <param name="resolver">The GitReleaseManager tool resolver.</param>
+        protected GitReleaseManagerTool(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IGlobber globber,
+            IGitReleaseManagerToolResolver resolver)
+            : base(fileSystem, environment, processRunner, globber)
+        {
+            _resolver = resolver;
+        }
+
+        /// <summary>
+        /// Gets the name of the tool.
+        /// </summary>
+        /// <returns>The name of the tool.</returns>
+        protected sealed override string GetToolName()
+        {
+            return "GitReleaseManager";
+        }
+
+        /// <summary>
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected sealed override IEnumerable<string> GetToolExecutableNames()
+        {
+            return new[] { "GitReleaseManager.exe", "gitreleasemanager.exe", "grm.exe" };
+        }
+
+        /// <summary>
+        /// Gets alternative file paths which the tool may exist in
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The default tool path.</returns>
+        protected sealed override IEnumerable<FilePath> GetAlternativeToolPaths(TSettings settings)
+        {
+            var path = _resolver.ResolvePath();
+            if (path != null)
+            {
+                return new[] { path };
+            }
+
+            return Enumerable.Empty<FilePath>();
+        }
+    }
+}

--- a/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerToolResolver.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerToolResolver.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Linq;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.GitReleaseManager
+{
+    /// <summary>
+    /// Contains GitReleaseManager path resolver functionality
+    /// </summary>
+    public sealed class GitReleaseManagerToolResolver : IGitReleaseManagerToolResolver
+    {
+        private readonly IFileSystem _fileSystem;
+        private readonly ICakeEnvironment _environment;
+        private readonly IGlobber _globber;
+        private IFile _cachedPath;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GitReleaseManagerToolResolver" /> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="globber">The globber.</param>
+        public GitReleaseManagerToolResolver(IFileSystem fileSystem, ICakeEnvironment environment, IGlobber globber)
+        {
+            if (fileSystem == null)
+            {
+                throw new ArgumentNullException("fileSystem");
+            }
+
+            if (environment == null)
+            {
+                throw new ArgumentNullException("environment");
+            }
+
+            if (globber == null)
+            {
+                throw new ArgumentNullException("globber");
+            }
+
+            _fileSystem = fileSystem;
+            _environment = environment;
+            _globber = globber;
+        }
+
+        /// <summary>
+        /// Resolves the path to GitReleaseManager.exe.
+        /// </summary>
+        /// <returns>The path to GitReleaseManager.exe.</returns>
+        public FilePath ResolvePath()
+        {
+            // Check if path already resolved
+            if (_cachedPath != null && _cachedPath.Exists)
+            {
+                return _cachedPath.Path;
+            }
+
+            // Check if tool exists in tool folder
+            const string expression = "./tools/**/GitReleaseManager.exe";
+            var toolsExe = _globber.GetFiles(expression).FirstOrDefault();
+            if (toolsExe != null)
+            {
+                var toolsFile = _fileSystem.GetFile(toolsExe);
+                if (toolsFile.Exists)
+                {
+                    _cachedPath = toolsFile;
+                    return _cachedPath.Path;
+                }
+            }
+
+            // Last resort try path
+            var envPath = _environment.GetEnvironmentVariable("path");
+            if (!string.IsNullOrWhiteSpace(envPath))
+            {
+                var pathFile = envPath
+                    .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(path => _fileSystem.GetDirectory(path))
+                    .Where(path => path.Exists)
+                    .Select(path => path.Path.CombineWithFilePath("GitReleaseManager.exe"))
+                    .Select(_fileSystem.GetFile)
+                    .FirstOrDefault(file => file.Exists);
+
+                if (pathFile != null)
+                {
+                    _cachedPath = pathFile;
+                    return _cachedPath.Path;
+                }
+            }
+
+            throw new CakeException("Could not locate GitReleaseManager.exe.");
+        }
+    }
+}

--- a/src/Cake.Common/Tools/GitReleaseManager/IGitReleaseManagerToolResolver.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/IGitReleaseManagerToolResolver.cs
@@ -1,0 +1,16 @@
+﻿using Cake.Core.IO;
+
+namespace Cake.Common.Tools.GitReleaseManager
+{
+    /// <summary>
+    /// Represents a GitReleaseManager path resolver.
+    /// </summary>
+    public interface IGitReleaseManagerToolResolver
+    {
+        /// <summary>
+        /// Resolves the path to GitReleaseManager.exe.
+        /// </summary>
+        /// <returns>The path to nuget.exe.</returns>
+        FilePath ResolvePath();
+    }
+}

--- a/src/Cake.Common/Tools/GitReleaseManager/Publish/GitReleaseManagerPublishSettings.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Publish/GitReleaseManagerPublishSettings.cs
@@ -1,0 +1,25 @@
+﻿using Cake.Core.IO;
+
+namespace Cake.Common.Tools.GitReleaseManager.Publish
+{
+    /// <summary>
+    /// Contains settings used by <see cref="GitReleaseManagerPublisher"/>.
+    /// </summary>
+    public sealed class GitReleaseManagerPublishSettings
+    {
+        /// <summary>
+        /// Gets or sets the path on which GitReleaseManager should be executed.
+        /// </summary>
+        public DirectoryPath TargetDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the GitReleaseManager log file.
+        /// </summary>
+        public FilePath LogFilePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to <c>GitReleaseManager.exe</c>.
+        /// </summary>
+        public FilePath ToolPath { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/GitReleaseManager/Publish/GitReleaseManagerPublisher.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Publish/GitReleaseManagerPublisher.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.GitReleaseManager.Publish
+{
+    /// <summary>
+    /// The GitReleaseManager Reelase Publisher used to publish releases.
+    /// </summary>
+    public sealed class GitReleaseManagerPublisher : GitReleaseManagerTool<GitReleaseManagerPublishSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GitReleaseManagerPublisher"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
+        /// <param name="resolver">The GitReleaseManager tool resolver.</param>
+        public GitReleaseManagerPublisher(IFileSystem fileSystem, ICakeEnvironment environment,
+            IProcessRunner processRunner, IGlobber globber, IGitReleaseManagerToolResolver resolver)
+            : base(fileSystem, environment, processRunner, globber, resolver)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Creates a Release using the specified and settings.
+        /// </summary>
+        /// <param name="userName">The user name.</param>
+        /// <param name="password">The password.</param>
+        /// <param name="owner">The owner.</param>
+        /// <param name="repository">The repository.</param>
+        /// <param name="tagName">The tag name.</param>
+        /// <param name="settings">The settings.</param>
+        public void Publish(string userName, string password, string owner, string repository, string tagName, GitReleaseManagerPublishSettings settings)
+        {
+            if (string.IsNullOrWhiteSpace(userName))
+            {
+                throw new ArgumentNullException("userName");
+            }
+
+            if (string.IsNullOrWhiteSpace(password))
+            {
+                throw new ArgumentNullException("password");
+            }
+
+            if (string.IsNullOrWhiteSpace(owner))
+            {
+                throw new ArgumentNullException("owner");
+            }
+
+            if (string.IsNullOrWhiteSpace(repository))
+            {
+                throw new ArgumentNullException("repository");
+            }
+
+            if (string.IsNullOrWhiteSpace(tagName))
+            {
+                throw new ArgumentNullException("tagName");
+            }
+
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            Run(settings, GetArguments(userName, password, owner, repository, tagName, settings), settings.ToolPath);
+        }
+
+        private ProcessArgumentBuilder GetArguments(string userName, string password, string owner, string repository, string tagName, GitReleaseManagerPublishSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("publish");
+
+            builder.Append("-u");
+            builder.AppendQuoted(userName);
+
+            builder.Append("-p");
+            builder.AppendQuotedSecret(password);
+
+            builder.Append("-o");
+            builder.AppendQuoted(owner);
+
+            builder.Append("-r");
+            builder.AppendQuoted(repository);
+
+            builder.Append("-t");
+            builder.AppendQuoted(tagName);
+
+            // Target Directory
+            if (settings.TargetDirectory != null)
+            {
+                builder.Append("-d");
+                builder.AppendQuoted(settings.TargetDirectory.MakeAbsolute(_environment).FullPath);
+            }
+
+            // Log File Path
+            if (settings.LogFilePath != null)
+            {
+                builder.Append("-l");
+                builder.AppendQuoted(settings.LogFilePath.MakeAbsolute(_environment).FullPath);
+            }
+
+            return builder;
+        }
+    }
+}


### PR DESCRIPTION
GitReleaseManager commands that will be included in this first release of GitReleaseManager support

- [x] Create
- [x] AddAsset
- [x] Close
- [x] Publish
- [x] Export
- [x] Documentation

*NOTE:* Only the commands that apply an action will be included in this release, as these are the most likely commands that are needed within a build script.

GitReleaseManager commands which are unlikely to be implemented in this PR:

* Init
* Showconfig