### PR TITLE
Add ability to set TeamCity Build Number

### DIFF
--- a/src/Cake.Common/Build/TeamCity/ITeamCityProvider.cs
+++ b/src/Cake.Common/Build/TeamCity/ITeamCityProvider.cs
@@ -36,6 +36,12 @@ namespace Cake.Common.Build.TeamCity
         void PublishArtifacts(string path);
 
         /// <summary>
+        /// Tells TeamCity to change the current build number.
+        /// </summary>
+        /// <param name="buildNumber">The required build number.</param>
+        void SetBuildNumber(string buildNumber);
+
+        /// <summary>
         /// Write the end of a message block to the TeamCity build log.
         /// </summary>
         /// <param name="blockName">Block name.</param>

--- a/src/Cake.Common/Build/TeamCity/TeamCityProvider.cs
+++ b/src/Cake.Common/Build/TeamCity/TeamCityProvider.cs
@@ -187,6 +187,15 @@ namespace Cake.Common.Build.TeamCity
             WriteServiceMessage("publishArtifacts", " ", path);
         }
 
+        /// <summary>
+        /// Tells TeamCity to change the current build number.
+        /// </summary>
+        /// <param name="buildNumber">The required build number.</param>
+        public void SetBuildNumber(string buildNumber)
+        {
+            WriteServiceMessage("buildNumber", buildNumber);
+        }
+
         private static void WriteServiceMessage(string messageName, string attributeValue)
         {
             WriteServiceMessage(messageName, new Dictionary<string, string> { { " ", attributeValue } });


### PR DESCRIPTION
I believe that this completes the TeamCity support [issue](https://github.com/cake-build/cake/issues/56).

Added the ability to use the TeamCity Service Message for setting the
build number, as described here:

https://confluence.jetbrains.com/display/TCD7/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ReportingBuildNumber