### PR TITLE
Add ability to parse entire AssemblyInfo

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/AssemblyInfoParserFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/AssemblyInfoParserFixture.cs
@@ -1,4 +1,5 @@
-﻿using Cake.Common.Solution.Project.Properties;
+﻿using System.Collections.Generic;
+using Cake.Common.Solution.Project.Properties;
 using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
@@ -12,9 +13,20 @@ namespace Cake.Common.Tests.Fixtures
         public FakeFileSystem FileSystem { get; set; }
         public ICakeEnvironment Environment { get; set; }
 
-        public AssemblyInfoParserFixture(string version = "1.2.3.4",
+        public AssemblyInfoParserFixture(bool clsCompliant = false,
+            string company = "Company",
+            bool comVisible = false,
+            string configuration = "Debug",
+            string copyright = "Copyright 2015",
+            string description = "Description",
             string fileVersion = "4.3.2.1",
+            string guid = "ABCEDF",
             string informationalVersion = "4.2.3.1",
+            string internalsVisibleTo = "Cake.Common.Test",
+            string product = "Cake",
+            string title = "Cake",
+            string trademark = "Trademark",
+            string version = "1.2.3.4",
             bool createAssemblyInfo = true)
         {
             Environment = Substitute.For<ICakeEnvironment>();
@@ -27,17 +39,58 @@ namespace Cake.Common.Tests.Fixtures
             {
                 // Set the versions.
                 var settings = new AssemblyInfoSettings();
-                if (version != null)
+                settings.CLSCompliant = clsCompliant;
+
+                if (company != null)
                 {
-                    settings.Version = version;
+                    settings.Company = company;
+                }
+
+                settings.ComVisible = comVisible;
+
+                if (configuration != null)
+                {
+                    settings.Configuration = configuration;
+                }
+                if (copyright != null)
+                {
+                    settings.Copyright = copyright;
+                }
+                if (description != null)
+                {
+                    settings.Description = description;
                 }
                 if (fileVersion != null)
                 {
                     settings.FileVersion = fileVersion;
                 }
+                if (guid != null)
+                {
+                    settings.Guid = guid;
+                }
                 if (informationalVersion != null)
                 {
                     settings.InformationalVersion = informationalVersion;
+                }
+                if (internalsVisibleTo != null)
+                {
+                    settings.InternalsVisibleTo = new List<string>() { internalsVisibleTo };
+                }
+                if (product != null)
+                {
+                    settings.Product = product;
+                }
+                if (title != null)
+                {
+                    settings.Title = title;
+                }
+                if (trademark != null)
+                {
+                    settings.Trademark = trademark;
+                }
+                if (version != null)
+                {
+                    settings.Version = version;
                 }
 
                 // Create the assembly info.

--- a/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoParserTests.cs
+++ b/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoParserTests.cs
@@ -64,23 +64,100 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
 
                 // Then
                 Assert.IsType<CakeException>(result);
-                Assert.Equal("Assembly info file '/Working/output.cs' do not exist.", result.Message);
+                Assert.Equal("Assembly info file '/Working/output.cs' does not exist.", result.Message);
             }
 
             [Theory]
-            [InlineData("1.2.3.4", "1.2.3.4")]
-            [InlineData("1.2.*.*", "1.2.*.*")]
-            [InlineData(null, "1.0.0.0")]
-            public void Should_Read_AssemblyVersion(string value, string expected)
+            [InlineData(true, true)]
+            [InlineData(false, false)]
+            [InlineData(null, false)]
+            public void Should_Read_ClsCompliance(bool value, bool expected)
             {
                 // Given
-                var fixture = new AssemblyInfoParserFixture(value);
+                var fixture = new AssemblyInfoParserFixture(clsCompliant: value);
 
                 // When
                 var result = fixture.Parse();
 
                 // Then
-                Assert.Equal(expected, result.AssemblyVersion);
+                Assert.Equal(expected, result.ClsCompliant);
+            }
+
+            [Theory]
+            [InlineData("CompanyA", "CompanyA")]
+            [InlineData(null, "")]
+            public void Should_Read_Company(string value, string expected)
+            {
+                // Given
+                var fixture = new AssemblyInfoParserFixture(company: value);
+
+                // When
+                var result = fixture.Parse();
+
+                // Then
+                Assert.Equal(expected, result.Company);
+            }
+
+            [Theory]
+            [InlineData(true, true)]
+            [InlineData(false, false)]
+            [InlineData(null, false)]
+            public void Should_Read_ComVisible(bool value, bool expected)
+            {
+                // Given
+                var fixture = new AssemblyInfoParserFixture(comVisible: value);
+
+                // When
+                var result = fixture.Parse();
+
+                // Then
+                Assert.Equal(expected, result.ComVisible);
+            }
+
+            [Theory]
+            [InlineData("Debug", "Debug")]
+            [InlineData("Release", "Release")]
+            [InlineData(null, "")]
+            public void Should_Read_Configuration(string value, string expected)
+            {
+                // Given
+                var fixture = new AssemblyInfoParserFixture(configuration: value);
+
+                // When
+                var result = fixture.Parse();
+
+                // Then
+                Assert.Equal(expected, result.Configuration);
+            }
+
+            [Theory]
+            [InlineData("Copyright (c) Patrik Svensson, Mattias Karlsson and contributors", "Copyright (c) Patrik Svensson, Mattias Karlsson and contributors")]
+            [InlineData(null, "")]
+            public void Should_Read_Copyright(string value, string expected)
+            {
+                // Given
+                var fixture = new AssemblyInfoParserFixture(copyright: value);
+
+                // When
+                var result = fixture.Parse();
+
+                // Then
+                Assert.Equal(expected, result.Copyright);
+            }
+
+            [Theory]
+            [InlineData("Assembly Description", "Assembly Description")]
+            [InlineData(null, "")]
+            public void Should_Read_Description(string value, string expected)
+            {
+                // Given
+                var fixture = new AssemblyInfoParserFixture(description: value);
+
+                // When
+                var result = fixture.Parse();
+
+                // Then
+                Assert.Equal(expected, result.Description);
             }
 
             [Theory]
@@ -100,6 +177,21 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
             }
 
             [Theory]
+            [InlineData("D394B7DB-0DDC-4D11-AD69-C408212E1E80", "D394B7DB-0DDC-4D11-AD69-C408212E1E80")]
+            [InlineData(null, "")]
+            public void Should_Read_Guid(string value, string expected)
+            {
+                // Given
+                var fixture = new AssemblyInfoParserFixture(guid: value);
+
+                // When
+                var result = fixture.Parse();
+
+                // Then
+                Assert.Equal(expected, result.Guid);
+            }
+
+            [Theory]
             [InlineData("1.2.3.4", "1.2.3.4")]
             [InlineData("1.2.*.*", "1.2.*.*")]
             [InlineData(null, "1.0.0.0")]
@@ -113,6 +205,82 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
 
                 // Then
                 Assert.Equal(expected, result.AssemblyInformationalVersion);
+            }
+
+            [Theory]
+            [InlineData("Cake.Common.Tests", "Cake.Common.Tests")]
+            [InlineData(null, "")]
+            public void Should_Read_InternalsVisibleTo(string value, string expected)
+            {
+                // Given
+                var fixture = new AssemblyInfoParserFixture(internalsVisibleTo: value);
+
+                // When
+                var result = fixture.Parse();
+
+                // Then
+                Assert.Equal(expected, result.InternalsVisibileTo);
+            }
+
+            [Theory]
+            [InlineData("Cake", "Cake")]
+            [InlineData(null, "")]
+            public void Should_Read_Product(string value, string expected)
+            {
+                // Given
+                var fixture = new AssemblyInfoParserFixture(product: value);
+
+                // When
+                var result = fixture.Parse();
+
+                // Then
+                Assert.Equal(expected, result.Product);
+            }
+
+            [Theory]
+            [InlineData("Cake.Common", "Cake.Common")]
+            [InlineData(null, "")]
+            public void Should_Read_Title(string value, string expected)
+            {
+                // Given
+                var fixture = new AssemblyInfoParserFixture(title: value);
+
+                // When
+                var result = fixture.Parse();
+
+                // Then
+                Assert.Equal(expected, result.Title);
+            }
+
+            [Theory]
+            [InlineData("Trademark Cake", "Trademark Cake")]
+            [InlineData(null, "")]
+            public void Should_Read_Trademark(string value, string expected)
+            {
+                // Given
+                var fixture = new AssemblyInfoParserFixture(trademark: value);
+
+                // When
+                var result = fixture.Parse();
+
+                // Then
+                Assert.Equal(expected, result.Trademark);
+            }
+
+            [Theory]
+            [InlineData("1.2.3.4", "1.2.3.4")]
+            [InlineData("1.2.*.*", "1.2.*.*")]
+            [InlineData(null, "1.0.0.0")]
+            public void Should_Read_AssemblyVersion(string value, string expected)
+            {
+                // Given
+                var fixture = new AssemblyInfoParserFixture(version: value);
+
+                // When
+                var result = fixture.Parse();
+
+                // Then
+                Assert.Equal(expected, result.AssemblyVersion);
             }
         }
     }

--- a/src/Cake.Common/Solution/Project/Properties/AssemblyInfoParseResult.cs
+++ b/src/Cake.Common/Solution/Project/Properties/AssemblyInfoParseResult.cs
@@ -5,17 +5,73 @@
     /// </summary>
     public sealed class AssemblyInfoParseResult
     {
-        private readonly string _assemblyVersion;
+        private readonly bool _clsCompliant;
+        private readonly string _company;
+        private readonly bool _comVisible;
+        private readonly string _configuration;
+        private readonly string _copyright;
+        private readonly string _description;
         private readonly string _assemblyFileVersion;
+        private readonly string _guid;
         private readonly string _assemblyInformationalVersion;
+        private readonly string _internalsVisibileTo;
+        private readonly string _product;
+        private readonly string _title;
+        private readonly string _trademark;
+        private readonly string _assemblyVersion;
 
         /// <summary>
-        /// Gets the assembly version.
+        /// Gets a value indicating whether the assembly is CLSCompliant.
         /// </summary>
-        /// <value>The assembly version.</value>
-        public string AssemblyVersion
+        /// <value>The assembly CLSCompliant attribute.</value>
+        public bool ClsCompliant
         {
-            get { return _assemblyVersion; }
+            get { return _clsCompliant; }
+        }
+
+        /// <summary>
+        /// Gets the assembly Company Attribute.
+        /// </summary>
+        /// <value>The assembly Company attribute.</value>
+        public string Company
+        {
+            get { return _company; }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the assembly is ComVisible
+        /// </summary>
+        /// <value>The assembly ComVisible attribute.</value>
+        public bool ComVisible
+        {
+            get { return _comVisible; }
+        }
+
+        /// <summary>
+        /// Gets the assembly Configuration Attribute.
+        /// </summary>
+        /// <value>The assembly Configuration attribute.</value>
+        public string Configuration
+        {
+            get { return _configuration; }
+        }
+
+        /// <summary>
+        /// Gets the assembly Copyright Attribute.
+        /// </summary>
+        /// <value>The assembly Copyright attribute.</value>
+        public string Copyright
+        {
+            get { return _copyright; }
+        }
+
+        /// <summary>
+        /// Gets the assembly Description Attribute.
+        /// </summary>
+        /// <value>The assembly Description attribute.</value>
+        public string Description
+        {
+            get { return _description; }
         }
 
         /// <summary>
@@ -28,6 +84,15 @@
         }
 
         /// <summary>
+        /// Gets the assembly Guid Attribute.
+        /// </summary>
+        /// <value>The assembly Guid attribute.</value>
+        public string Guid
+        {
+            get { return _guid; }
+        }
+
+        /// <summary>
         /// Gets the assembly informational version.
         /// </summary>
         /// <value>The assembly informational version.</value>
@@ -37,16 +102,96 @@
         }
 
         /// <summary>
+        /// Gets the assembly InternalsVisibileTo Attribute.
+        /// </summary>
+        /// <value>The assembly InternalsVisibileTo attribute.</value>
+        public string InternalsVisibileTo
+        {
+            get { return _internalsVisibileTo; }
+        }
+
+        /// <summary>
+        /// Gets the assembly Product Attribute.
+        /// </summary>
+        /// <value>The assembly Product attribute.</value>
+        public string Product
+        {
+            get { return _product; }
+        }
+
+        /// <summary>
+        /// Gets the assembly Title Attribute.
+        /// </summary>
+        /// <value>The assembly Title attribute.</value>
+        public string Title
+        {
+            get { return _title; }
+        }
+
+        /// <summary>
+        /// Gets the assembly Trademark Attribute.
+        /// </summary>
+        /// <value>The assembly Trademark attribute.</value>
+        public string Trademark
+        {
+            get { return _trademark; }
+        }
+
+        /// <summary>
+        /// Gets the assembly version.
+        /// </summary>
+        /// <value>The assembly version.</value>
+        public string AssemblyVersion
+        {
+            get { return _assemblyVersion; }
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="AssemblyInfoParseResult"/> class.
         /// </summary>
-        /// <param name="assemblyVersion">The assembly version.</param>
+        /// <param name="clsCompliant">The assembly CLSCompliant Attribute.</param>
+        /// <param name="company">The assembly Company Attribute.</param>
+        /// <param name="comVisible">The assembly ComVisible Attribute.</param>
+        /// <param name="configuration">The assembly Configuration Attribute.</param>
+        /// <param name="copyright">The assembly Copyright Attribute.</param>
+        /// <param name="description">The assembly Description Attribute.</param>
         /// <param name="assemblyFileVersion">The assembly file version.</param>
+        /// <param name="guid">The assembly Guid Attribute.</param>
         /// <param name="assemblyInformationalVersion">The assembly informational version.</param>
-        public AssemblyInfoParseResult(string assemblyVersion, string assemblyFileVersion, string assemblyInformationalVersion)
+        /// <param name="internalsVisibleTo">The assembly InternalsVisibleTo Attribute.</param>
+        /// <param name="product">The assembly Product Attribute.</param>
+        /// <param name="title">The assembly Title Attribute.</param>
+        /// <param name="trademark">The assembly Trademark Attribute.</param>
+        /// <param name="assemblyVersion">The assembly version.</param>
+        public AssemblyInfoParseResult(string clsCompliant,
+            string company,
+            string comVisible,
+            string configuration,
+            string copyright,
+            string description,
+            string assemblyFileVersion,
+            string guid,
+            string assemblyInformationalVersion,
+            string internalsVisibleTo,
+            string product,
+            string title,
+            string trademark,
+            string assemblyVersion)
         {
-            _assemblyVersion = assemblyVersion;
+            _clsCompliant = !string.IsNullOrWhiteSpace(clsCompliant) && bool.Parse(clsCompliant);
+            _company = company;
+            _comVisible = !string.IsNullOrWhiteSpace(clsCompliant) && bool.Parse(comVisible);
+            _configuration = configuration;
+            _copyright = copyright;
+            _description = description;
             _assemblyFileVersion = assemblyFileVersion;
+            _guid = guid;
             _assemblyInformationalVersion = assemblyInformationalVersion;
+            _internalsVisibileTo = internalsVisibleTo;
+            _product = product;
+            _title = title;
+            _trademark = trademark;
+            _assemblyVersion = assemblyVersion;
         }
     }
 }

--- a/src/Cake.Common/Solution/Project/Properties/AssemblyInfoParser.cs
+++ b/src/Cake.Common/Solution/Project/Properties/AssemblyInfoParser.cs
@@ -12,7 +12,9 @@ namespace Cake.Common.Solution.Project.Properties
     /// </summary>
     public sealed class AssemblyInfoParser
     {
-        private const string Pattern = @"{0}\(""([.]*(\d*|\*?)[.]*(\d*|\*?)[.]*(\d*|\*?)[.]*(\d*|\*?))""\)";
+        private const string VersionPattern = @"{0}\(""([.]*(\d*|\*?)[.]*(\d*|\*?)[.]*(\d*|\*?)[.]*(\d*|\*?))""\)";
+        private const string GeneralNonQuotedAttributePattern = @"{0}\((?<attributeValue>.*)\)";
+        private const string GeneralQuotedAttributePattern = @"{0}\(""(?<attributeValue>.*)""\)";
         private const string DefaultVersion = "1.0.0.0";
 
         private readonly IFileSystem _fileSystem;
@@ -58,7 +60,7 @@ namespace Cake.Common.Solution.Project.Properties
             var file = _fileSystem.GetFile(assemblyInfoPath);
             if (!file.Exists)
             {
-                const string format = "Assembly info file '{0}' do not exist.";
+                const string format = "Assembly info file '{0}' does not exist.";
                 var message = string.Format(CultureInfo.InvariantCulture, format, assemblyInfoPath.FullPath);
                 throw new CakeException(message);
             }
@@ -67,15 +69,26 @@ namespace Cake.Common.Solution.Project.Properties
             {
                 var content = reader.ReadToEnd();
                 return new AssemblyInfoParseResult(
-                    ParseVersion("AssemblyVersion", content),
+                    ParseGeneralNonQuotedAttribute("CLSCompliant", content),
+                    ParseGeneralQuotedAttribute("AssemblyCompany", content),
+                    ParseGeneralNonQuotedAttribute("ComVisible", content),
+                    ParseGeneralQuotedAttribute("AssemblyConfiguration", content),
+                    ParseGeneralQuotedAttribute("AssemblyCopyright", content),
+                    ParseGeneralQuotedAttribute("AssemblyDescription", content),
                     ParseVersion("AssemblyFileVersion", content),
-                    ParseVersion("AssemblyInformationalVersion", content));
+                    ParseGeneralQuotedAttribute("Guid", content),
+                    ParseVersion("AssemblyInformationalVersion", content),
+                    ParseGeneralQuotedAttribute("InternalsVisibleTo", content),
+                    ParseGeneralQuotedAttribute("AssemblyProduct", content),
+                    ParseGeneralQuotedAttribute("AssemblyTitle", content),
+                    ParseGeneralQuotedAttribute("AssemblyTrademark", content),
+                    ParseVersion("AssemblyVersion", content));
             }
         }
 
         private static string ParseVersion(string attributeName, string content)
         {
-            var regex = new Regex(string.Format(CultureInfo.InvariantCulture, Pattern, attributeName));
+            var regex = new Regex(string.Format(CultureInfo.InvariantCulture, VersionPattern, attributeName));
             var match = regex.Match(content);
             if (match.Groups.Count > 0)
             {
@@ -86,6 +99,36 @@ namespace Cake.Common.Solution.Project.Properties
                 }
             }
             return DefaultVersion;
+        }
+
+        private static string ParseGeneralQuotedAttribute(string attributeName, string content)
+        {
+            var regex = new Regex(string.Format(CultureInfo.InvariantCulture, GeneralQuotedAttributePattern, attributeName));
+            var match = regex.Match(content);
+            if (match.Groups.Count > 0)
+            {
+                var value = match.Groups["attributeValue"].Value;
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    return value;
+                }
+            }
+            return string.Empty;
+        }
+
+        private static string ParseGeneralNonQuotedAttribute(string attributeName, string content)
+        {
+            var regex = new Regex(string.Format(CultureInfo.InvariantCulture, GeneralNonQuotedAttributePattern, attributeName));
+            var match = regex.Match(content);
+            if (match.Groups.Count > 0)
+            {
+                var value = match.Groups["attributeValue"].Value;
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    return value;
+                }
+            }
+            return string.Empty;
         }
     }
 }


### PR DESCRIPTION
As requested in GH-372, in addition to being able to create an
AssemblyInfo file with all required parameters, it should also be
possible to parse all of these properties for later
inspection/retrieval.

Fixes #372 