### PR TITLE
 Added CDATA attribute to releasenotes

### DIFF
--- a/src/Cake.Common.Tests/Properties/Resources.resx
+++ b/src/Cake.Common.Tests/Properties/Resources.resx
@@ -140,9 +140,9 @@
     &lt;licenseUrl&gt;https://license.com&lt;/licenseUrl&gt;
     &lt;requireLicenseAcceptance&gt;true&lt;/requireLicenseAcceptance&gt;
     &lt;iconUrl&gt;https://icon.com&lt;/iconUrl&gt;
-    &lt;releaseNotes&gt;Line #1
+    &lt;releaseNotes&gt;&lt;![CDATA[Line #1
 Line #2
-Line #3&lt;/releaseNotes&gt;
+Line #3]]&gt;&lt;/releaseNotes&gt;
   &lt;/metadata&gt;
   &lt;files&gt;
     &lt;file src="tools\**" target="tools" /&gt;
@@ -172,9 +172,9 @@ Line #3&lt;/releaseNotes&gt;
     &lt;licenseUrl&gt;https://license.com&lt;/licenseUrl&gt;
     &lt;requireLicenseAcceptance&gt;true&lt;/requireLicenseAcceptance&gt;
     &lt;iconUrl&gt;https://icon.com&lt;/iconUrl&gt;
-    &lt;releaseNotes&gt;Line #1
+    &lt;releaseNotes&gt;&lt;![CDATA[Line #1
 Line #2
-Line #3&lt;/releaseNotes&gt;
+Line #3]]&gt;&lt;/releaseNotes&gt;
   &lt;/metadata&gt;
   &lt;files&gt;
     &lt;file src="tools\**" target="tools" /&gt;
@@ -226,9 +226,9 @@ Line #3&lt;/releaseNotes&gt;
     &lt;iconUrl&gt;https://icon.com&lt;/iconUrl&gt;
     &lt;requireLicenseAcceptance&gt;true&lt;/requireLicenseAcceptance&gt;
     &lt;copyright&gt;The copyright&lt;/copyright&gt;
-    &lt;releaseNotes&gt;Line #1
+    &lt;releaseNotes&gt;&lt;![CDATA[Line #1
 Line #2
-Line #3&lt;/releaseNotes&gt;
+Line #3]]&gt;&lt;/releaseNotes&gt;
     &lt;tags&gt;Tag1 Tag2 Tag3&lt;/tags&gt;
   &lt;/metadata&gt;
   &lt;files&gt;
@@ -255,9 +255,9 @@ Line #3&lt;/releaseNotes&gt;
     &lt;iconUrl&gt;https://icon.com&lt;/iconUrl&gt;
     &lt;requireLicenseAcceptance&gt;true&lt;/requireLicenseAcceptance&gt;
     &lt;copyright&gt;The copyright&lt;/copyright&gt;
-    &lt;releaseNotes&gt;Line #1
+    &lt;releaseNotes&gt;&lt;![CDATA[Line #1
 Line #2
-Line #3&lt;/releaseNotes&gt;
+Line #3]]&gt;&lt;/releaseNotes&gt;
     &lt;tags&gt;Tag1 Tag2 Tag3&lt;/tags&gt;
   &lt;/metadata&gt;
   &lt;files&gt;

--- a/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyNuSpecTransformer.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyNuSpecTransformer.cs
@@ -10,6 +10,7 @@ namespace Cake.Common.Tools.Chocolatey.Pack
     internal static class ChocolateyNuSpecTransformer
     {
         private static readonly Dictionary<string, Func<ChocolateyPackSettings, string>> _mappings;
+        private static readonly List<string> cdataElements;
         private const string ChocolateyNuSpecXsd = "http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd";
 
         static ChocolateyNuSpecTransformer()
@@ -36,6 +37,11 @@ namespace Cake.Common.Tools.Chocolatey.Pack
                 { "iconUrl", settings => ToString(settings.IconUrl) },
                 { "releaseNotes", settings => ToMultiLineString(settings.ReleaseNotes) }
             };
+
+            cdataElements = new List<string>
+                                {
+                                    "releaseNotes"
+                                };
         }
 
         public static void Transform(XmlDocument document, ChocolateyPackSettings settings)
@@ -51,7 +57,15 @@ namespace Cake.Common.Tools.Chocolatey.Pack
                 {
                     // Replace the node content.
                     var node = FindOrCreateElement(document, namespaceManager, elementName);
-                    node.InnerText = content;
+
+                    if (cdataElements.Contains(elementName))
+                    {
+                        node.AppendChild(document.CreateCDataSection(content));
+                    }
+                    else
+                    {
+                        node.InnerText = content;
+                    }
                 }
             }
 

--- a/src/Cake.Common/Tools/NuGet/Pack/NuspecTransformer.cs
+++ b/src/Cake.Common/Tools/NuGet/Pack/NuspecTransformer.cs
@@ -10,6 +10,7 @@ namespace Cake.Common.Tools.NuGet.Pack
     internal static class NuspecTransformer
     {
         private static readonly Dictionary<string, Func<NuGetPackSettings, string>> _mappings;
+        private static readonly List<string> cdataElements;
         private const string NuSpecXsd = "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd";
 
         static NuspecTransformer()
@@ -31,6 +32,11 @@ namespace Cake.Common.Tools.NuGet.Pack
                 { "releaseNotes", settings => ToMultiLineString(settings.ReleaseNotes) },
                 { "tags", settings => ToSpaceSeparatedString(settings.Tags) }
             };
+
+            cdataElements = new List<string>
+                                {
+                                    "releaseNotes"
+                                };
         }
 
         public static void Transform(XmlDocument document, NuGetPackSettings settings)
@@ -46,7 +52,15 @@ namespace Cake.Common.Tools.NuGet.Pack
                 {
                     // Replace the node content.
                     var node = FindOrCreateElement(document, namespaceManager, elementName);
-                    node.InnerText = content;
+
+                    if (cdataElements.Contains(elementName))
+                    {
+                        node.AppendChild(document.CreateCDataSection(content));
+                    }
+                    else
+                    {
+                        node.InnerText = content;
+                    }
                 }
             }
 


### PR DESCRIPTION
@devlead this is quite crude, but also almost effective :smile_cat: 

The end result is the following:

![image](https://cloud.githubusercontent.com/assets/1271146/10606871/a7619efe-772d-11e5-8040-725c99786f38.png)

Are you doing some escaping of the strings that are added into the nuspec file?  Add initial glance, I couldn't see anything obvious.