### PR TITLE
Added OpenCover support.

### DIFF
--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Fixtures\Tools\NUnitRunnerFixture.cs" />
     <Compile Include="Fixtures\ProcessFixture.cs" />
     <Compile Include="Fixtures\Tools\OctopusDeployReleaseCreatorFixture.cs" />
+    <Compile Include="Fixtures\Tools\OpenCoverFixture.cs" />
     <Compile Include="Fixtures\Tools\ReportUnit\ReportUnitDirectoryFixture.cs" />
     <Compile Include="Fixtures\Tools\ReportUnit\ReportUnitFileFixture.cs" />
     <Compile Include="Fixtures\Tools\ReportGeneratorRunnerFixture.cs" />
@@ -219,6 +220,7 @@
     <Compile Include="Unit\Tools\NUnit\NUnitRunnerTests.cs" />
     <Compile Include="Unit\Tools\NUnit\NUnitSettingsTests.cs" />
     <Compile Include="Unit\Tools\OctopusDeploy\OctoCreateReleaseTests.cs" />
+    <Compile Include="Unit\Tools\OpenCover\OpenCoverTests.cs" />
     <Compile Include="Unit\Tools\ReportUnit\ReportUnitRunnerTests.cs" />
     <Compile Include="Unit\Tools\ReportGenerator\ReportGeneratorRunnerTests.cs" />
     <Compile Include="Unit\Tools\Roundhouse\RoundhouseRunnerTests.cs" />

--- a/src/Cake.Common.Tests/Fixtures/Tools/OpenCoverFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/OpenCoverFixture.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Cake.Common.Tools.OpenCover;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using NSubstitute;
+
+namespace Cake.Common.Tests.Fixtures.Tools
+{
+    internal sealed class OpenCoverFixture : ToolFixture<OpenCoverSettings>
+    {
+        public ICakeContext Context { get; set; }
+        public Action<ICakeContext> Action { get; set; }
+        public FilePath OutputPath { get; set; }
+
+        public OpenCoverFixture()
+            : base("OpenCover.Console.exe")
+        {
+            // Set the output file.
+            OutputPath = new FilePath("./result.xml");
+
+            // Setup the Cake Context.
+            Context = Substitute.For<ICakeContext>();
+            Context.FileSystem.Returns(FileSystem);
+            Context.Arguments.Returns(Substitute.For<ICakeArguments>());
+            Context.Environment.Returns(Environment);
+            Context.Globber.Returns(Globber);
+            Context.Log.Returns(Substitute.For<ICakeLog>());
+            Context.Registry.Returns(Substitute.For<IRegistry>());
+            Context.ProcessRunner.Returns((IProcessRunner)null);
+
+            // Set up the default action that intercepts.
+            Action = context =>
+            {
+                context.ProcessRunner.Start(
+                    new FilePath("/Working/tools/Test.exe"),
+                    new ProcessSettings()
+                    {
+                        Arguments = "-argument"
+                    });
+            };
+        }
+
+        protected override void RunTool()
+        {
+            var tool = new OpenCoverRunner(FileSystem, Environment, ProcessRunner, Globber);
+            tool.Run(Context, Action, OutputPath, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/OpenCover/OpenCoverTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/OpenCover/OpenCoverTests.cs
@@ -1,0 +1,224 @@
+﻿using Cake.Common.Tests.Fixtures.Tools;
+using Cake.Common.Tools.NUnit;
+using Cake.Common.Tools.XUnit;
+using Cake.Core.IO;
+using Cake.Testing;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.OpenCover
+{
+    public sealed class OpenCoverTests
+    {
+        public sealed class TheRunMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Context_Is_Null()
+            {
+                // Given
+                var fixture = new OpenCoverFixture();
+                fixture.Context = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "context");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Action_Is_Null()
+            {
+                // Given
+                var fixture = new OpenCoverFixture();
+                fixture.Action = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "action");
+
+            }
+
+            [Fact]
+            public void Should_Throw_If_Output_File_Is_Null()
+            {
+                // Given
+                var fixture = new OpenCoverFixture();
+                fixture.OutputPath = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "outputPath");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new OpenCoverFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_No_Tool_Was_Intercepted()
+            {
+                // Given
+                var fixture = new OpenCoverFixture();
+                fixture.Action = context => { };
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsCakeException(result, "No tool was started.");
+            }
+
+            [Fact]
+            public void Should_Capture_Tool_And_Arguments_From_Action()
+            {
+                // Given
+                var fixture = new OpenCoverFixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-target:\"/Working/tools/Test.exe\" "+
+                             "-targetargs:\"-argument\" " +
+                             "-register:user -output:\"/Working/result.xml\"", result.Args);
+            }
+
+            [Theory]
+            [InlineData("")]
+            [InlineData(null)]
+            public void Should_Not_Capture_Arguments_From_Action_If_Excluded(string arguments)
+            {
+                // Given
+                var fixture = new OpenCoverFixture();
+                fixture.Action = context =>
+                {
+                    context.ProcessRunner.Start(
+                        new FilePath("/Working/tools/Test.exe"),
+                        new ProcessSettings()
+                        {
+                            Arguments = arguments
+                        });
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-target:\"/Working/tools/Test.exe\" " +
+                             "-register:user -output:\"/Working/result.xml\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_Filters()
+            {
+                // Given
+                var fixture = new OpenCoverFixture();
+                fixture.Settings.Filters.Add("filter1");
+                fixture.Settings.Filters.Add("filter2");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-target:\"/Working/tools/Test.exe\" " +
+                             "-targetargs:\"-argument\" " +
+                             "-filter:\"filter1 filter2\" " +
+                             "-register:user -output:\"/Working/result.xml\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_Attribute_Filters()
+            {
+                // Given
+                var fixture = new OpenCoverFixture();
+                fixture.Settings.ExcludedAttributeFilters.Add("filter1");
+                fixture.Settings.ExcludedAttributeFilters.Add("filter2");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-target:\"/Working/tools/Test.exe\" " +
+                             "-targetargs:\"-argument\" " +
+                             "-excludebyattribute:\"filter1;filter2\" " +
+                             "-register:user -output:\"/Working/result.xml\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_File_Filters()
+            {
+                // Given
+                var fixture = new OpenCoverFixture();
+                fixture.Settings.ExcludedFileFilters.Add("filter1");
+                fixture.Settings.ExcludedFileFilters.Add("filter2");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-target:\"/Working/tools/Test.exe\" " +
+                             "-targetargs:\"-argument\" " +
+                             "-excludebyfile:\"filter1;filter2\" " +
+                             "-register:user -output:\"/Working/result.xml\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Capture_XUnit()
+            {
+                // Given
+                var fixture = new OpenCoverFixture();
+                fixture.FileSystem.CreateFile("/Working/tools/xunit.console.exe");
+                fixture.Action = context =>
+                {
+                    context.XUnit2(
+                        new FilePath[] { "./Test.dll" },
+                        new XUnit2Settings { ShadowCopy = false });
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-target:\"/Working/tools/xunit.console.exe\" " +
+                             "-targetargs:\"\\\"/Working/Test.dll\\\" -noshadow\" " +
+                             "-register:user -output:\"/Working/result.xml\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Capture_NUnit()
+            {
+                // Given
+                var fixture = new OpenCoverFixture();
+                fixture.FileSystem.CreateFile("/Working/tools/nunit-console.exe");
+                fixture.Action = context =>
+                {
+                    context.NUnit(
+                        new FilePath[] { "./Test.dll" },
+                        new NUnitSettings { ShadowCopy = false });
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-target:\"/Working/tools/nunit-console.exe\" " +
+                             "-targetargs:\"\\\"/Working/Test.dll\\\" -noshadow\" " +
+                             "-register:user -output:\"/Working/result.xml\"", result.Args);
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -234,6 +234,12 @@
     <Compile Include="Tools\OctopusDeploy\CreateReleaseSettings.cs" />
     <Compile Include="Tools\OctopusDeploy\OctopusDeployReleaseCreator.cs" />
     <Compile Include="Tools\OctopusDeploy\OctopusDeploySettings.cs" />
+    <Compile Include="Tools\OpenCover\OpenCoverAliases.cs" />
+    <Compile Include="Tools\OpenCover\OpenCoverContext.cs" />
+    <Compile Include="Tools\OpenCover\OpenCoverRunner.cs" />
+    <Compile Include="Tools\OpenCover\OpenCoverSettings.cs" />
+    <Compile Include="Tools\OpenCover\OpenCoverProcessRunner.cs" />
+    <Compile Include="Tools\OpenCover\OpenCoverSettingsExtensions.cs" />
     <Compile Include="Tools\ReportUnit\ReportUnitAliases.cs" />
     <Compile Include="Tools\ReportUnit\ReportUnitRunner.cs" />
     <Compile Include="Tools\ReportUnit\ReportUnitSettings.cs" />

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverAliases.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverAliases.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.OpenCover
+{
+    /// <summary>
+    /// Contains functionality related to OpenCover.
+    /// </summary>
+    [CakeAliasCategory("OpenCover")]
+    public static class OpenCoverAliases
+    {
+        /// <summary>
+        /// Runs <see href="https://github.com/OpenCover/opencover">OpenCover</see>
+        /// for the specified action and settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="action">The action to run OpenCover for.</param>
+        /// <param name="outputFile">The OpenCover output file.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// OpenCover(tool => {
+        ///   tool.XUnit2("./**/App.Tests.dll",
+        ///     new XUnit2Settings {
+        ///       ShadowCopy = false
+        ///     });
+        ///   },
+        ///   new OpenCoverSettings()
+        ///     .WithFilter("+[App]*")
+        ///     .WithFilter("-[App.Tests]*")
+        ///     .SetOutputFile("./result.xml"));
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static void OpenCover(
+            this ICakeContext context,
+            Action<ICakeContext> action,
+            FilePath outputFile,
+            OpenCoverSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            // Create the OpenCover runner.
+            var runner = new OpenCoverRunner(
+                context.FileSystem, context.Environment,
+                context.ProcessRunner, context.Globber);
+
+            // Run OpenCover.
+            runner.Run(context, action, outputFile, settings);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverContext.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverContext.cs
@@ -1,0 +1,65 @@
+﻿using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.OpenCover
+{
+    internal sealed class OpenCoverContext : ICakeContext
+    {
+        private readonly ICakeContext _context;
+        private readonly ICakeLog _log;
+        private readonly OpenCoverProcessRunner _runner;
+
+        public IFileSystem FileSystem
+        {
+            get { return _context.FileSystem; }
+        }
+
+        public ICakeEnvironment Environment
+        {
+            get { return _context.Environment; }
+        }
+
+        public IGlobber Globber
+        {
+            get { return _context.Globber; }
+        }
+
+        public ICakeLog Log
+        {
+            get { return _log; }
+        }
+
+        public ICakeArguments Arguments
+        {
+            get { return _context.Arguments; }
+        }
+
+        public IProcessRunner ProcessRunner
+        {
+            get { return _runner; }
+        }
+
+        public IRegistry Registry
+        {
+            get { return _context.Registry; }
+        }
+
+        public FilePath FilePath
+        {
+            get { return _runner.FilePath; }
+        }
+
+        public ProcessSettings Settings
+        {
+            get { return _runner.ProcessSettings; }
+        }
+
+        public OpenCoverContext(ICakeContext context)
+        {
+            _context = context;
+            _log = new NullLog();
+            _runner = new OpenCoverProcessRunner();
+        }
+    }
+}

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverProcessRunner.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverProcessRunner.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.OpenCover
+{
+    internal sealed class OpenCoverProcessRunner : IProcessRunner
+    {
+        public FilePath FilePath { get; set; }
+
+        public ProcessSettings ProcessSettings { get; set; }
+
+        private sealed class InterceptedProcess : IProcess
+        {
+            public void Dispose()
+            {
+            }
+
+            public void WaitForExit()
+            {
+            }
+
+            public bool WaitForExit(int milliseconds)
+            {
+                return true;
+            }
+
+            public int GetExitCode()
+            {
+                return 0;
+            }
+
+            public IEnumerable<string> GetStandardOutput()
+            {
+                return Enumerable.Empty<string>();
+            }
+
+            public void Kill()
+            {
+            }
+        }
+
+        public IProcess Start(FilePath filePath, ProcessSettings settings)
+        {
+            FilePath = filePath;
+            ProcessSettings = settings;
+            return new InterceptedProcess();
+        }
+    }
+}

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverRunner.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverRunner.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Collections.Generic;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.OpenCover
+{
+    /// <summary>
+    /// The OpenCover runner.
+    /// </summary>
+    public sealed class OpenCoverRunner : Tool<OpenCoverSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenCoverRunner"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
+        public OpenCoverRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IGlobber globber)
+            : base(fileSystem, environment, processRunner, globber)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Runs OpenCover with the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="action">The action.</param>
+        /// <param name="outputPath">The output file path.</param>
+        /// <param name="settings">The settings.</param>
+        public void Run(
+            ICakeContext context,
+            Action<ICakeContext> action,
+            FilePath outputPath,
+            OpenCoverSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            if (action == null)
+            {
+                throw new ArgumentNullException("action");
+            }
+            if (outputPath == null)
+            {
+                throw new ArgumentNullException("outputPath");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            // Run the tool using the interceptor.
+            var interceptor = InterceptAction(context, action);
+
+            // Run the tool.
+            Run(settings, GetArguments(interceptor, settings, outputPath));
+        }
+
+        private static OpenCoverContext InterceptAction(
+            ICakeContext context,
+            Action<ICakeContext> action)
+        {
+            var interceptor = new OpenCoverContext(context);
+            action(interceptor);
+
+            // Validate arguments.
+            if (interceptor.FilePath == null)
+            {
+                throw new CakeException("No tool was started.");
+            }
+
+            return interceptor;
+        }
+
+        private ProcessArgumentBuilder GetArguments(
+            OpenCoverContext context,
+            OpenCoverSettings settings,
+            FilePath outputPath)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            // The target application to call.
+            builder.AppendSwitch("-target", ":", context.FilePath.FullPath.Quote());
+
+            // The arguments to the target application.
+            if (context.Settings != null && context.Settings.Arguments != null)
+            {
+                var arguments = context.Settings.Arguments.Render();
+                if (!string.IsNullOrWhiteSpace(arguments))
+                {
+                    arguments = arguments.Replace("\"", "\\\"");
+                    builder.AppendSwitch("-targetargs", ":", arguments.Quote());
+                }
+            }
+
+            // Filters
+            if (settings.Filters.Count > 0)
+            {
+                var filters = string.Join(" ", settings.Filters);
+                builder.AppendSwitch("-filter", ":", filters.Quote());
+            }
+
+            // Exclude by attribute
+            if (settings.ExcludedAttributeFilters.Count > 0)
+            {
+                var filters = string.Join(";", settings.ExcludedAttributeFilters);
+                builder.AppendSwitch("-excludebyattribute", ":", filters.Quote());
+            }
+
+            // Exclude by file
+            if (settings.ExcludedFileFilters.Count > 0)
+            {
+                var filters = string.Join(";", settings.ExcludedFileFilters);
+                builder.AppendSwitch("-excludebyfile", ":", filters.Quote());
+            }
+
+            // Use per-user registration of code coverage profiler.
+            builder.AppendSwitch("-register", ":", "user");
+
+            // Set the output file.
+            outputPath = outputPath.MakeAbsolute(_environment);
+            builder.AppendSwitch("-output", ":", outputPath.FullPath.Quote());
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Gets the name of the tool.
+        /// </summary>
+        /// <returns>The name of the tool.</returns>
+        protected override string GetToolName()
+        {
+            return "OpenCover";
+        }
+
+        /// <summary>
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return new[] { "OpenCover.Console.exe" };
+        }
+    }
+}

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverSettings.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverSettings.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.OpenCover
+{
+    /// <summary>
+    /// Contains settings used by <see cref="OpenCoverRunner"/>.
+    /// </summary>
+    public sealed class OpenCoverSettings : ToolSettings
+    {
+        private readonly HashSet<string> _filters;
+        private readonly HashSet<string> _excludedAttributeFilters;
+        private readonly HashSet<string> _excludedFileFilters;
+
+        /// <summary>
+        /// Gets the filters.
+        /// This represents the <c>-filter</c> option.
+        /// </summary>
+        /// <value>The filters.</value>
+        public ISet<string> Filters
+        {
+            get { return _filters; }
+        }
+
+        /// <summary>
+        /// Gets attribute filters used to exclude classes or methods.
+        /// This represents the <c>-excludebyattribute</c> option.
+        /// </summary>
+        /// <value>The excluded attributes.</value>
+        public ISet<string> ExcludedAttributeFilters
+        {
+            get { return _excludedAttributeFilters; }
+        }
+
+        /// <summary>
+        /// Gets file filters used to excluded classes or methods.
+        /// This represents the <c>-excludebyfile</c> option.
+        /// </summary>
+        /// <value>The excluded file filters.</value>
+        public ISet<string> ExcludedFileFilters
+        {
+            get { return _excludedFileFilters; }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenCoverSettings"/> class.
+        /// </summary>
+        public OpenCoverSettings()
+        {
+            _filters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _excludedAttributeFilters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _excludedFileFilters = new HashSet<string>(StringComparer.Ordinal);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverSettingsExtensions.cs
@@ -1,0 +1,60 @@
+using System;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.OpenCover
+{
+    /// <summary>
+    /// Contains extensions for <see cref="OpenCoverSettings"/>.
+    /// </summary>
+    public static class OpenCoverSettingsExtensions
+    {
+        /// <summary>
+        /// Adds the filter.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="filter">The filter.</param>
+        /// <returns>The same <see cref="OpenCoverSettings"/> instance so that multiple calls can be chained.</returns>
+        public static OpenCoverSettings WithFilter(this OpenCoverSettings settings, string filter)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+            settings.Filters.Add(filter);
+            return settings;
+        }
+
+        /// <summary>
+        /// Exclude a class or method by filter
+        /// that match attributes that have been applied.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="filter">The filter.</param>
+        /// <returns>The same <see cref="OpenCoverSettings"/> instance so that multiple calls can be chained.</returns>
+        public static OpenCoverSettings ExcludeByAttribute(this OpenCoverSettings settings, string filter)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+            settings.ExcludedAttributeFilters.Add(filter);
+            return settings;
+        }
+
+        /// <summary>
+        /// Exclude a class (or methods) by filter that match the filenames.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="filter">The filter.</param>
+        /// <returns>The same <see cref="OpenCoverSettings"/> instance so that multiple calls can be chained.</returns>
+        public static OpenCoverSettings ExcludeByFile(this OpenCoverSettings settings, string filter)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+            settings.ExcludedFileFilters.Add(filter);
+            return settings;
+        }
+    }
+}


### PR DESCRIPTION
Not all options are included in this PR.
The options included are:

- filter
- target
- targetargs
- excludebyattribute
- excludebyfilter
- output

```csharp
Task("OpenCover-NUnit-Tests")
  .IsDependentOn("Build")
  .Does(() =>
{
  OpenCover(tool => {
      tool.NUnit("./**/bin/**/OpenCoverTest.NUnit.dll",
        new NUnitSettings {
          ShadowCopy = false
        });
    },
    new FilePath("./result.xml"),
    new OpenCoverSettings()
      .WithFilter("+[OpenCovertTest]*")
      .WithFilter("-[OpenCoverTest.XUnit]*")
      .WithFilter("-[OpenCoverTest.NUnit]*"));
});
```

Closes #340