### PR TITLE
Improve argument parser to use unix-arguments

### DIFF
--- a/src/Cake.Tests/Cake.Tests.csproj
+++ b/src/Cake.Tests/Cake.Tests.csproj
@@ -76,6 +76,8 @@
     </Compile>
     <Compile Include="Unit\Arguments\ArgumentParserTests.cs" />
     <Compile Include="Unit\Arguments\ArgumentTokenizerTests.cs" />
+    <Compile Include="Unit\Arguments\UnixCommandArgumentParserTests.cs" />
+    <Compile Include="Unit\Arguments\UnixArgumentParserTests.cs" />
     <Compile Include="Unit\CakeApplicationTests.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/Cake.Tests/Unit/Arguments/ArgumentParserTests.cs
+++ b/src/Cake.Tests/Unit/Arguments/ArgumentParserTests.cs
@@ -85,7 +85,7 @@ namespace Cake.Tests.Unit.Arguments
 
                 // Then
                 Assert.Null(result);
-                Assert.True(fixture.Log.Entries.Any(x => x.Message == "Multiple arguments with the same name (unknown)."));
+                Assert.True(fixture.Log.Entries.Any(x => x.Message == "Using a argument-name more than once is not allowed: -unknown"));
             }
 
             [Theory]
@@ -152,7 +152,7 @@ namespace Cake.Tests.Unit.Arguments
                 parser.Parse(arguments);
 
                 // Then
-                Assert.Equal("More than one build script specified.", fixture.Log.Entries[0].Message);
+                Assert.Equal("An \"--key\" should preceed the value.", fixture.Log.Entries[0].Message);
             }
 
             [Theory]

--- a/src/Cake.Tests/Unit/Arguments/UnixArgumentParserTests.cs
+++ b/src/Cake.Tests/Unit/Arguments/UnixArgumentParserTests.cs
@@ -1,0 +1,94 @@
+﻿using Cake.Arguments;
+using Xunit;
+
+namespace Cake.Tests.Unit.Arguments
+{
+    public class UnixCommandArgumentNameTests
+    {
+        [Theory]
+        [InlineData("--test")]
+        [InlineData("-t")]
+        public void Constructor_Should_Store_Valid_Value(string name)
+        {
+            var arg = new CommandArgumentNameAttribute(name);
+            Assert.Equal(name, arg.Name);
+        }
+
+        [Fact]
+        public void Should_Throw_If_Name_Is_Null()
+        {
+            var result = Record.Exception(() => new CommandArgumentNameAttribute(null));
+
+            Assert.IsArgumentException(result, "name", "CommandArgumentName can not be empty or null");
+        }
+
+        [Fact]
+        public void Should_Throw_If_Name_Has_No_Dashes()
+        {
+            var result = Record.Exception(() => new CommandArgumentNameAttribute("no-dash"));
+
+            Assert.IsArgumentException(result, "name", "CommandArgumentName must start with either one or two dashes");
+        }
+
+        [Theory]
+        [InlineData("---three-dashes")]
+        [InlineData("----four-dashes")]
+        public void Should_Throw_If_Name_Has_Too_Many_Dashes(string name)
+        {
+            var result = Record.Exception(() => new CommandArgumentNameAttribute(name));
+
+            Assert.IsArgumentException(result, "name", "CommandArgumentName must start with either one or two dashes");
+        }
+
+        [Theory]
+        [InlineData("--in the_middle")]
+        [InlineData("-- AtStart")]
+        [InlineData("--AtEnd ")]
+        public void Should_Throw_If_Name_Contains_WhiteSpace(string name)
+        {
+            var result = Record.Exception(() => new CommandArgumentNameAttribute(name));
+
+            Assert.IsArgumentException(result, "name", "CommandArgumentName can not contain a space");
+        }
+
+        [Theory]
+        [InlineData("-")]
+        [InlineData("--")]
+        public void Should_Throw_If_Name_Is_Missing(string name)
+        {
+            var result = Record.Exception(() => new CommandArgumentNameAttribute(name));
+            Assert.IsArgumentException(result, "name",
+                "CommandArgumentName must have a name, only dashes is not allowed");
+        }
+
+        [Fact]
+        public void Should_Throw_If_ShortName_Has_More_Than_One_Character()
+        {
+            var result = Record.Exception(() => new CommandArgumentNameAttribute("-too_long"));
+            Assert.IsArgumentException(result, "name",
+                "CommandArgumentName with a single dash can only have one character following it");
+        }
+
+        [Fact]
+        public void Should_Not_Throw_If_ShortName_Has_More_Than_One_Character_And_Old_Style()
+        {
+            var arg = new CommandArgumentNameAttribute("-too_long", true);
+            Assert.Equal("-too_long", arg.Name);
+        }
+
+        [Fact]
+        public void Should_Throw_If_LongName_Has_Only_One_Character()
+        {
+            var result = Record.Exception(() => new CommandArgumentNameAttribute("--s"));
+            Assert.IsArgumentException(result, "name",
+                "CommandArgumentName with a double dash must use more than one character");
+        }
+
+        [Fact]
+        public void Should_Not_Throw_If_LongName_Has_Only_One_Character_And_Old_Style()
+        {
+            var arg = new CommandArgumentNameAttribute("--s", true);
+            Assert.Equal("--s", arg.Name);
+        }
+    }
+}

--- a/src/Cake.Tests/Unit/Arguments/UnixCommandArgumentParserTests.cs
+++ b/src/Cake.Tests/Unit/Arguments/UnixCommandArgumentParserTests.cs
@@ -1,0 +1,271 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Cake.Arguments;
+using Xunit;
+
+namespace Cake.Tests.Unit.Arguments
+{
+    public class UnixCommandArgumentParserTests
+    {
+        [Fact]
+        public void Should_Have_Nothing_When_No_Arguments()
+        {
+            // Arrange
+            var empty_argument = "";
+            var command_parser = new UnixCommandParser();
+
+            // Act
+            var range = command_parser.Parse(empty_argument);
+
+            // Assert
+            Assert.Empty(range);
+        }
+
+        [Fact]
+        public void Should_Have_An_Empty_Argument()
+        {
+            // Arrange
+            var argument = "--no-argument";
+            var command_parser = new UnixCommandParser();
+
+            // Act
+            var range = command_parser.Parse(argument);
+
+            // Assert
+            Assert.Equal(1, range.Count);
+            Assert.Equal(argument, range.Single().Key);
+            Assert.Null(range.Single().Value);
+        }
+
+        [Fact]
+        public void Should_Have_Multiple_Empty_Arguments()
+        {
+            // Arrange
+            var argument = "--first --second";
+            var command_parser = new UnixCommandParser();
+
+            // Act
+            var range = command_parser.Parse(argument);
+
+            // Assert
+            Assert.Equal(2, range.Count);
+            Assert.True(range.All(x => x.Value == null));
+        }
+
+        [Fact]
+        public void Should_Not_Have_Arguments_With_No_Key()
+        {
+            // Arrange
+            // Introduced extra spaces.
+            var argument = "--first     --second";
+            var command_parser = new UnixCommandParser();
+
+            // Act
+            var range = command_parser.Parse(argument);
+
+            // Assert
+            Assert.Equal(2, range.Count);
+            Assert.True(range.All(x => x.Value == null));
+        }
+
+        [Fact]
+        public void Should_Support_Duplicate_Keys_With_No_Value()
+        {
+            // Arrange
+            // Introduced extra spaces.
+            var argument = "--k1 --k1";
+            var command_parser = new UnixCommandParser();
+
+            // Act
+            var range = command_parser.Parse(argument);
+
+            // Assert
+            Assert.Equal(2, range.Count);
+            Assert.True(range.All(x => x.Key == "--k1"));
+        }
+
+        [Fact]
+        public void Should_Support_Duplicate_Keys_With_Different_Values()
+        {
+            // Arrange
+            // Introduced extra spaces.
+            var argument = "--k1 a --k1 b";
+            var command_parser = new UnixCommandParser();
+
+            // Act
+            var range = command_parser.Parse(argument);
+
+            // Assert
+            Assert.Equal(2, range.Count);
+            Assert.True(range.All(x => x.Key == "--k1"));
+            Assert.Equal("a", range.First().Value);
+            Assert.Equal("b", range.Last().Value);
+        }
+
+        [Fact]
+        public void Should_Have_Argument_With_No_Quoted_Value()
+        {
+            // Arrange
+            var argument = "--key value";
+            var command_parser = new UnixCommandParser();
+
+            // Act
+            var range = command_parser.Parse(argument);
+
+            // Assert
+            Assert.Equal(1, range.Count);
+            Assert.Equal("--key", range.Single().Key);
+            Assert.Equal("value", range.Single().Value);
+        }
+
+        [Fact]
+        public void Should_Have_Argument_With_NoQuoted_Value_Even_With_Extra_Spaces()
+        {
+            // Arrange
+            var argument = "--key   value";
+            var command_parser = new UnixCommandParser();
+
+            // Act
+            var range = command_parser.Parse(argument);
+
+            // Assert
+            Assert.Equal(1, range.Count);
+            Assert.Equal("--key", range.Single().Key);
+            Assert.Equal("value", range.Single().Value);
+        }
+
+        [Fact]
+        public void Should_Support_Argument_Value_With_Space_Single_Quote()
+        {
+            // Arrange
+            var argument = "--key 'abc def'";
+            var command_parser = new UnixCommandParser();
+
+            // Act
+            var range = command_parser.Parse(argument);
+
+            // Assert
+            Assert.Equal(1, range.Count);
+            Assert.Equal("--key", range.Single().Key);
+            Assert.Equal("abc def", range.Single().Value);
+        }
+
+        [Fact]
+        public void Should_Support_Argument_Value_With_Space_Double_Quote()
+        {
+            // Arrange
+            var argument = "--key \"abc def\"";
+            var command_parser = new UnixCommandParser();
+
+            // Act
+            var range = command_parser.Parse(argument);
+
+            // Assert
+            Assert.Equal(1, range.Count);
+            Assert.Equal("--key", range.Single().Key);
+            Assert.Equal("abc def", range.Single().Value);
+        }
+
+        [Fact]
+        public void Should_Support_Argument_Value_With_Double_Quote_And_Single_Quote()
+        {
+            // Arrange
+            var argument = "--k1 \"abc def\" --k2 'ghi jkl'";
+            var command_parser = new UnixCommandParser();
+
+            // Act
+            var range = command_parser.Parse(argument);
+
+            // Assert
+            Assert.Equal(2, range.Count);
+            Assert.Equal("--k1", range.First().Key);
+            Assert.Equal("abc def", range.First().Value);
+
+            Assert.Equal("--k2", range.Last().Key);
+            Assert.Equal("ghi jkl", range.Last().Value);
+        }
+
+        [Fact]
+        public void Should_Support_Escaped_Arguments()
+        {
+            // Arrange
+            var argument = "--k1 'contains another \\'quoted value\\''";
+            var command_parser = new UnixCommandParser();
+
+            // Act
+            var range = command_parser.Parse(argument);
+
+            // Assert
+            Assert.Equal(1, range.Count);
+            Assert.Equal("--k1", range.Single().Key);
+            Assert.Equal("contains another 'quoted value'", range.Single().Value);
+        }
+
+        [Fact]
+        public void Should_Support_Double_Escaped_Arguments()
+        {
+            // Arrange
+            var argument = "--k1 'contains another \\'quoted value\\''";
+            var command_parser = new UnixCommandParser();
+
+            // Act
+            var range = command_parser.Parse(argument);
+
+            // Assert
+            Assert.Equal(1, range.Count);
+            Assert.Equal("--k1", range.Single().Key);
+            Assert.Equal("contains another 'quoted value'", range.Single().Value);
+        }
+
+        [Theory]
+        [InlineData("'no terminator")]
+        [InlineData("\"no terminator")]
+        public void Should_Throw_On_Unbalanced_Quotes(string arg_value)
+        {
+            // Arrange
+            var argument = "--k1 " + arg_value;
+            var command_parser = new UnixCommandParser();
+
+            // Act
+            var result = Record.Exception(() => command_parser.Parse(argument));
+
+            // Assert
+            Assert.IsExceptionWithMessage<Exception>(result, "Unbalanced quoted argument: Missing quote terminator");
+        }
+
+        [Theory]
+        [InlineData("'no terminator\\")]
+        [InlineData("\"no terminator\\")]
+        public void Should_Throw_On_Escaping_EOF(string arg_value)
+        {
+            // Arrange
+            var argument = "--k1 " + arg_value;
+            var command_parser = new UnixCommandParser();
+
+            // Act
+            var result = Record.Exception(() => command_parser.Parse(argument));
+
+            // Assert
+            Assert.IsExceptionWithMessage<Exception>(result, "Unbalanced quoted argument: EOF can't be escaped");
+        }
+
+        [Theory]
+        [InlineData("this_value_has_no_key")]
+        [InlineData("--valid value second_value_has_no_key")]
+        public void Should_Throw_On_Missing_Key(string argument)
+        {
+            // Arrange
+            var command_parser = new UnixCommandParser();
+
+            // Act
+            var result = Record.Exception(() => command_parser.Parse(argument));
+
+            // Assert
+            Assert.IsExceptionWithMessage<Exception>(result, "An \"--key\" should preceed the value.");
+        }
+    }
+}

--- a/src/Cake/Arguments/ArgumentParser.cs
+++ b/src/Cake/Arguments/ArgumentParser.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
-using Cake.Core;
+using System.Reflection;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 
@@ -12,6 +12,14 @@ namespace Cake.Arguments
     {
         private readonly ICakeLog _log;
         private readonly IFileSystem _fileSystem;
+
+        private readonly string[] _defaultScriptNameConventions =
+        {
+            "build.cake",
+            "default.cake",
+            "bake.cake",
+            ".cakefile"
+        };
 
         public ArgumentParser(ICakeLog log, IFileSystem fileSystem)
         {
@@ -26,159 +34,207 @@ namespace Cake.Arguments
                 throw new ArgumentNullException("args");
             }
 
-            var options = new CakeOptions();
-            var isParsingOptions = false;
-
-            var arguments = args.ToList();
-
-            // If we don't have any arguments, search for a default script.
-            if (arguments.Count == 0)
+            string joinedCommandLine;
+            var result = new CakeOptions();
+            var firstArgument = args.FirstOrDefault() ?? string.Empty;
+            if (firstArgument.StartsWith("-"))
             {
-                options.Script = GetDefaultScript();
-            }
-
-            foreach (var arg in arguments)
-            {
-                var value = arg.UnQuote();
-
-                if (isParsingOptions)
-                {
-                    if (IsOption(value))
-                    {
-                        if (!ParseOption(value, options))
-                        {
-                            return null;
-                        }
-                    }
-                    else
-                    {
-                        _log.Error("More than one build script specified.");
-                        return null;
-                    }
-                }
-                else
-                {
-                    try
-                    {
-                        // If they didn't provide a specific build script, search for a defualt.
-                        if (IsOption(arg))
-                        {
-                            // Make sure we parse the option
-                            if (!ParseOption(value, options))
-                            {
-                                return null;
-                            }
-
-                            options.Script = GetDefaultScript();
-                            continue;
-                        }
-
-                        // Quoted?
-                        options.Script = new FilePath(value);
-                    }
-                    finally
-                    {
-                        // Start parsing options.
-                        isParsingOptions = true;
-                    }
-                }
-            }
-
-            return options;
-        }
-
-        private static bool IsOption(string arg)
-        {
-            if (string.IsNullOrWhiteSpace(arg))
-            {
-                return false;
-            }
-            return arg[0] == '-';
-        }
-
-        private bool ParseOption(string arg, CakeOptions options)
-        {
-            string name, value;
-
-            var separatorIndex = arg.IndexOfAny(new[] { '=' });
-            if (separatorIndex < 0)
-            {
-                name = arg.Substring(1);
-                value = string.Empty;
+                joinedCommandLine = string.Join(" ", args);
             }
             else
             {
-                name = arg.Substring(1, separatorIndex - 1);
-                value = arg.Substring(separatorIndex + 1);
-            }
-
-            if (value.Length > 2)
-            {
-                if (value[0] == '\"' && value[value.Length - 1] == '\"')
+                if (string.IsNullOrEmpty(firstArgument))
                 {
-                    value = value.Substring(1, value.Length - 2);
+                    result.Script = GetDefaultScript();
                 }
+                else
+                {
+                    var cakeFileArgument = firstArgument;
+                    if (cakeFileArgument.StartsWith("\""))
+                    {
+                        cakeFileArgument = cakeFileArgument.Trim('\"');
+                    }
+                    result.Script = new FilePath(cakeFileArgument);
+                }
+                joinedCommandLine = string.Join(" ", args.Skip(1));
             }
 
-            return ParseOption(name, value, options);
+            var parser = new UnixCommandParser();
+            List<KeyValuePair<string, string>> parsedResult;
+            try
+            {
+                parsedResult = parser.Parse(joinedCommandLine);
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex.Message);
+                return null;
+            }
+
+            var duplicateKeynames = parsedResult
+                .GroupBy(x => x.Key)
+                .Where(x => x.Count() > 1)
+                .Select(x => x.Key)
+                .Distinct()
+                .ToList();
+
+            if (duplicateKeynames.Any())
+            {
+                _log.Error("Using a argument-name more than once is not allowed: " +
+                           string.Join(", ", duplicateKeynames));
+                return null;
+            }
+
+            // Store all the options in the dictionary.
+            foreach (var kv in parsedResult)
+            {
+                var key = kv.Key;
+                result.Arguments.Add(string.Join(string.Empty, key.SkipWhile(x => x == '-')), kv.Value);
+            }
+
+            // Reflect the options and assign values. Keep track of which properties are assigned
+            // so to prevent double assiging using alternative.
+            var propertyOptions = result.GetType()
+                .GetProperties()
+                .Where(x => x.CanWrite)
+                .Select(x => new
+                {
+                    Property = x,
+                    Aliases = x.GetCustomAttributes<CommandArgumentNameAttribute>()
+                })
+                .Where(x => x.Aliases.Count() != 0)
+                .ToList();
+
+            var doublePropertyNames = propertyOptions.SelectMany(x => x.Aliases)
+                .GroupBy(x => x.Name.ToLower())
+                .Where(x => x.Count() > 1)
+                .Select(x => x.Key)
+                .Distinct()
+                .ToList();
+
+            if (doublePropertyNames.Any())
+            {
+                // Since this checks the data-class we throw an exception instead of an error.
+                // This will result in most of the unit tests to fail.
+                const string format = "Double command argument names are found in {0}: {1}";
+                var typeName = result.GetType().Name;
+                var propertyNames = string.Join(", ", doublePropertyNames);
+                throw new Exception(string.Format(CultureInfo.InvariantCulture, format, typeName, propertyNames));
+            }
+
+            foreach (var item in propertyOptions)
+            {
+                // 1. Find the arguments that can be applied
+                // 2. Check if there is only one argument (we don't support multiple arguments).
+                //    We already did a similar check but we didn't take in account the aliases.
+                // 3. If property-type is boolean and no argument set it to true
+                //    If property-type is boolean and a string is used then convert the string (use english!)
+                // 4. If property-type is an enum then try and convert to value-name to enum-value
+                // 5. If property-type is an integer then try and convert the string to a number (use english)
+                // 6. If property-type is a string then just store the string
+                // 7. If property-type is unknown the use an error.
+
+                // 1. Find the arguments that can be applied
+                var applicableArguments = parsedResult
+                    .Where(x => item.Aliases.Any(y => CompareKey(x.Key, y.Name)))
+                    .ToList();
+
+                if (applicableArguments.Count == 0)
+                {
+                    // Skip this property since no values are provided.
+                    continue;
+                }
+
+                // 2. Check if there is only one argument (we don't support multiple arguments).
+                //    We already did a similar check but we didn't take in account the aliases.
+                if (applicableArguments.Count() > 1)
+                {
+                    var keyNames = applicableArguments.Select(x => x.Key);
+                    _log.Error("Multiple arguments found that use an alias to double assign on {0} using {1}",
+                        item.Property.Name, string.Join(", ", keyNames));
+                    return null;
+                }
+
+                var singleValue = applicableArguments.Single().Value;
+
+                // 3. If property-type is boolean and no argument set it to true
+                //    If property-type is boolean and a string is used then convert the string (use english!)
+                if (item.Property.PropertyType == typeof(bool))
+                {
+                    if (singleValue != null)
+                    {
+                        var value = Convert.ToBoolean(singleValue, CultureInfo.InvariantCulture.NumberFormat);
+                        item.Property.SetValue(result, value);
+                    }
+                    else
+                    {
+                        item.Property.SetValue(result, true);
+                    }
+                    continue;
+                }
+
+                // 4. If property-type is an enum then try and convert to value-name to enum-value
+                if (item.Property.PropertyType.IsEnum)
+                {
+                    if (singleValue == null)
+                    {
+                        _log.Error("Argument-value required for {0}", item.Property.Name);
+                        return null;
+                    }
+
+                    if (singleValue.Length == 1)
+                    {
+                        // This is a short value.
+                        var groupedNames = Enum.GetNames(item.Property.PropertyType).ToDictionary(x => x[0], x => x);
+                        var filteredGroup = groupedNames.Where(x => CompareKey(x.Key.ToString(), singleValue)).ToList();
+                        if (filteredGroup.Any())
+                        {
+                            singleValue = filteredGroup.Single().Value;
+                        }
+                    }
+
+                    try
+                    {
+                        var convertedEnum = Enum.Parse(item.Property.PropertyType, singleValue, true);
+                        item.Property.SetValue(result, convertedEnum);
+                    }
+                    catch (Exception ex)
+                    {
+                        _log.Error(ex.Message);
+                        return null;
+                    }
+
+                    continue;
+                }
+
+                // 5. If property-type is an integer then try and convert the string to a number (use english)
+                if (item.Property.PropertyType == typeof(int))
+                {
+                    var convertedValue = Convert.ToInt32(singleValue, CultureInfo.InvariantCulture.NumberFormat);
+                    item.Property.SetValue(result, convertedValue);
+                    continue;
+                }
+
+                // 6. If property-type is a string then just store the string
+                if (item.Property.PropertyType == typeof(string))
+                {
+                    item.Property.SetValue(result, singleValue);
+                    continue;
+                }
+
+                // 7. If property-type is unknown the use an error.
+                _log.Error("The property \"{0}\" is of unsupported type {1}", item.Property.Name,
+                    item.Property.PropertyType.Name);
+                return null;
+            }
+
+            return result;
         }
 
-        private bool ParseOption(string name, string value, CakeOptions options)
+        private static bool CompareKey(string key_a, string key_b)
         {
-            if (name.Equals("verbosity", StringComparison.OrdinalIgnoreCase)
-                || name.Equals("v", StringComparison.OrdinalIgnoreCase))
-            {
-                // Parse verbosity.
-                var converter = TypeDescriptor.GetConverter(typeof(Verbosity));
-                var verbosity = converter.ConvertFromInvariantString(value);
-                if (verbosity != null)
-                {
-                    options.Verbosity = (Verbosity)verbosity;
-                }
-            }
-
-            if (name.Equals("showdescription", StringComparison.OrdinalIgnoreCase) ||
-                name.Equals("s", StringComparison.OrdinalIgnoreCase))
-            {
-                options.ShowDescription = true;
-            }
-
-            if (name.Equals("dryrun", StringComparison.OrdinalIgnoreCase) ||
-                name.Equals("noop", StringComparison.OrdinalIgnoreCase) ||
-                name.Equals("whatif", StringComparison.OrdinalIgnoreCase))
-            {
-                options.PerformDryRun = true;
-            }
-
-            if (name.Equals("help", StringComparison.OrdinalIgnoreCase) ||
-                name.Equals("?", StringComparison.OrdinalIgnoreCase))
-            {
-                options.ShowHelp = true;
-            }
-
-            if (name.Equals("version", StringComparison.OrdinalIgnoreCase) ||
-                name.Equals("ver", StringComparison.OrdinalIgnoreCase))
-            {
-                options.ShowVersion = true;
-            }
-
-            if (options.Arguments.ContainsKey(name))
-            {
-                _log.Error("Multiple arguments with the same name ({0}).", name);
-                return false;
-            }
-
-            options.Arguments.Add(name, value);
-            return true;
+            return string.Compare(key_a, key_b, StringComparison.InvariantCultureIgnoreCase) == 0;
         }
-
-        private readonly string[] _defaultScriptNameConventions =
-        {
-            "build.cake",
-            "default.cake",
-            "bake.cake",
-            ".cakefile"
-        };
 
         private FilePath GetDefaultScript()
         {

--- a/src/Cake/Arguments/CommandArgumentNameAttribute.cs
+++ b/src/Cake/Arguments/CommandArgumentNameAttribute.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Linq;
+
+namespace Cake.Arguments
+{
+    /// <summary>
+    ///     The command argument name can be used to mark properties in the option class which
+    ///     can then be dynamically looked up and assigned.
+    /// </summary>
+    /// <example>
+    ///     <code>
+    /// public class CommandOptions {
+    ///     [CommandArgumentName("--title")]
+    ///     [CommandArgumentName("-t")]
+    ///     [CommandArgumentName("--page-header")]
+    ///     public string Title { get; set;}
+    /// }
+    /// </code>
+    /// </example>
+    [AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+    internal sealed class CommandArgumentNameAttribute : Attribute
+    {
+        /// <summary>
+        ///     Gets the name of the command argument.
+        /// </summary>
+        public string Name { get; private set; }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="CommandArgumentNameAttribute" /> class.
+        /// </summary>
+        /// <param name="name">
+        ///     The identifier of the command argument name.
+        ///     It must start with either one or two dashes
+        /// </param>
+        /// <param name="oldStyle">
+        ///     When set true a single char can use double dash and a long string can use a
+        ///     single dash
+        /// </param>
+        public CommandArgumentNameAttribute(string name, bool oldStyle = false)
+        {
+            Name = name;
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("CommandArgumentName can not be empty or null", "name");
+            }
+
+            if (name.Any(char.IsWhiteSpace))
+            {
+                throw new ArgumentException("CommandArgumentName can not contain a space", "name");
+            }
+
+            var dashes = name.TakeWhile(x => x == '-').Count();
+            if (dashes != 1 && dashes != 2)
+            {
+                throw new ArgumentException("CommandArgumentName must start with either one or two dashes", "name");
+            }
+
+            if (!(name.Length > dashes))
+            {
+                throw new ArgumentException("CommandArgumentName must have a name, only dashes is not allowed", "name");
+            }
+
+            // When using the old style the dash limitation doesn't apply.
+            if (oldStyle)
+            {
+                return;
+            }
+
+            if (dashes == 1 && name.Length != 2)
+            {
+                throw new ArgumentException(
+                    "CommandArgumentName with a single dash can only have one character following it", "name");
+            }
+
+            if (dashes == 2 && name.Length == 3)
+            {
+                throw new ArgumentException("CommandArgumentName with a double dash must use more than one character",
+                    "name");
+            }
+        }
+    }
+}

--- a/src/Cake/Arguments/UnixCommandParser.cs
+++ b/src/Cake/Arguments/UnixCommandParser.cs
@@ -1,0 +1,263 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Cake.Arguments
+{
+    /// <summary>
+    ///     Parses the command line in unix style.
+    /// </summary>
+    public class UnixCommandParser
+    {
+        /// <summary>
+        ///     Parses the specified commandline.
+        /// </summary>
+        /// <param name="commandline">The arguments of the command line.</param>
+        /// <returns>A List of all key-values found.</returns>
+        /// <remarks>
+        /// Symbol language
+        /// arg_char               ::= [a-zA-Z0-9_-]
+        /// arg_single_key         ::=  -&lt;arg_char&gt;
+        /// arg_multi_key          ::= --&lt;arg_char&gt;&lt;arg_char&gt;+
+        /// arg_key                ::= (&lt;arg_single_key&gt;|&lt;arg_multi_key&gt;)
+        /// arg_value_no_quote     ::= [a-zA-Z0-9_][a-zA-Z0-9_-]*
+        /// arg_value_single_quote ::= '&lt;escaped_single_quote_string&gt;'
+        /// arg_value_multi_quote  ::= "&lt;escaped_multi_quote_string&gt;"
+        /// arg_value              ::= (&lt;arg_value_single_quote&gt;|&lt;arg_value_multi_quote&gt;|&lt;arg_value_no_quote&gt;)
+        /// argument               ::= (&lt;arg_key&gt;=&lt;arg_value&gt;|&lt;arg_key&gt;)
+        /// argument_string        ::= (&lt;argument&gt; )*&lt;argument&gt;
+        /// </remarks>
+        public List<KeyValuePair<string, string>> Parse(string commandline)
+        {
+            // If there is no information on the command line then we can safely skip it.
+            if (string.IsNullOrWhiteSpace(commandline))
+            {
+                return new List<KeyValuePair<string, string>>();
+            }
+
+            var result = new List<KeyValuePair<string, string>>();
+            TokenType mode = TokenType.Nothing;
+            int pos = 0;
+
+            var stack = new Stack<Tuple<TokenType, string>>();
+
+            while (pos < commandline.Length)
+            {
+                var current_char = commandline[pos];
+                switch (mode)
+                {
+                    case TokenType.Nothing:
+                    {
+                        mode = HandleNothing(current_char, ref mode, ref pos);
+                    }
+                        break;
+                    case TokenType.ArgumentKey:
+                    {
+                        ProcessStack(stack, result);
+                        mode = ParseKey(commandline, stack, ref pos);
+                    }
+                        break;
+                    case TokenType.ArgumentValue:
+                    {
+                        bool is_single_quoted = current_char == '\'';
+                        bool is_double_quoted = current_char == '"';
+
+                        if (is_single_quoted || is_double_quoted)
+                        {
+                            string argument = ParseArgumentValue(current_char, commandline, ref pos);
+                            stack.Push(new Tuple<TokenType, string>(TokenType.ArgumentValue, argument));
+                        }
+                        else
+                        {
+                            string argument = ParseArgumentValue(null, commandline, ref pos);
+                            stack.Push(new Tuple<TokenType, string>(TokenType.ArgumentValue, argument));
+                        }
+
+                        mode = TokenType.Nothing;
+                    }
+                        break;
+                    case TokenType.ArgumentKeyTerminator:
+                    case TokenType.WhiteSpace:
+                    case TokenType.EOF:
+                    {
+                        // Unhandeled whitespace is considered nothing.
+                        mode = TokenType.Nothing;
+                    }
+                        break;
+                    default:
+                    {
+                        throw new NotImplementedException("We don't support mode " + mode + " yet");
+                    }
+                }
+            }
+
+            ProcessStack(stack, result);
+
+            return result;
+        }
+
+        private static TokenType ParseKey(string commandline, Stack<Tuple<TokenType, string>> stack, ref int pos)
+        {
+            TokenType currentType = TokenType.ArgumentKey;
+            string argument = string.Empty;
+            while (currentType == TokenType.ArgumentKey)
+            {
+                if (pos >= commandline.Length)
+                {
+                    currentType = TokenType.EOF;
+                    break;
+                }
+                var currentChar = commandline[pos];
+                currentType = GetTokenType(currentChar, TokenType.ArgumentKey);
+                if (currentType == TokenType.ArgumentKey)
+                {
+                    argument += currentChar;
+                    pos++;
+                }
+                else if (currentType == TokenType.ArgumentKeyTerminator)
+                {
+                    pos++;
+                    break;
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(argument))
+            {
+                stack.Push(new Tuple<TokenType, string>(TokenType.ArgumentKey, argument));
+            }
+
+            return currentType;
+        }
+
+        private static string ParseArgumentValue(char? quoteCharacter, string commandline, ref int pos)
+        {
+            string argument = string.Empty;
+
+            // Skip the first character as it is part of the quote.
+            if (quoteCharacter != null)
+            {
+                pos += 1;
+            }
+            while (true)
+            {
+                if (quoteCharacter.HasValue)
+                {
+                    if (pos == commandline.Length)
+                    {
+                        throw new Exception("Unbalanced quoted argument: Missing quote terminator");
+                    }
+                }
+                else
+                {
+                    if (pos == commandline.Length || char.IsWhiteSpace(commandline[pos]))
+                    {
+                        return argument;
+                    }
+                }
+
+                var currentChar = commandline[pos];
+                if (currentChar == '\\')
+                {
+                    var nextPos = pos + 1;
+
+                    if (nextPos == commandline.Length)
+                    {
+                        throw new Exception("Unbalanced quoted argument: EOF can't be escaped");
+                    }
+
+                    var nextChar = commandline[nextPos];
+                    argument += nextChar;
+                    pos = nextPos + 1;
+                    continue;
+                }
+
+                if (quoteCharacter.HasValue && currentChar == quoteCharacter.Value)
+                {
+                    pos += 1;
+                    return argument;
+                }
+
+                argument += currentChar;
+                pos += 1;
+            }
+        }
+
+        private static void ProcessStack(Stack<Tuple<TokenType, string>> stack,
+            List<KeyValuePair<string, string>> result)
+        {
+            while (stack.Count != 0)
+            {
+                var current = stack.Pop();
+                switch (current.Item1)
+                {
+                    case TokenType.ArgumentKey:
+                        // Add it directly.
+                        result.Add(new KeyValuePair<string, string>(current.Item2, null));
+                        break;
+                    case TokenType.ArgumentValue:
+                        if (stack.Count == 0)
+                        {
+                            throw new Exception("An \"--key\" should preceed the value.");
+                        }
+
+                        var expectedKey = stack.Pop();
+                        if (expectedKey.Item1 != TokenType.ArgumentKey)
+                        {
+                            // In the event another value is precedeeing this value.
+                            throw new Exception("An \"--key\" should preceed the value.");
+                        }
+
+                        result.Add(new KeyValuePair<string, string>(expectedKey.Item2, current.Item2));
+                        break;
+                    default:
+                        throw new NotImplementedException("Unable to handle the stack");
+                }
+            }
+        }
+
+        private static TokenType HandleNothing(char currentChar, ref TokenType mode, ref int pos)
+        {
+            var currentType = GetTokenType(currentChar, mode);
+            switch (currentType)
+            {
+                case TokenType.WhiteSpace:
+                    pos++;
+                    return mode;
+                case TokenType.ArgumentKey:
+                    mode = TokenType.ArgumentKey;
+                    break;
+            }
+
+            return currentType;
+        }
+
+        private static TokenType GetTokenType(char currentChar, TokenType mode)
+        {
+            if (char.IsWhiteSpace(currentChar))
+            {
+                return TokenType.WhiteSpace;
+            }
+
+            if (currentChar == '=' && mode == TokenType.ArgumentKey)
+            {
+                return TokenType.ArgumentKeyTerminator;
+            }
+
+            if (currentChar == '-' || mode == TokenType.ArgumentKey)
+            {
+                return TokenType.ArgumentKey;
+            }
+
+            return TokenType.ArgumentValue;
+        }
+
+        private enum TokenType
+        {
+            Nothing,
+            WhiteSpace,
+            ArgumentKey,
+            ArgumentKeyTerminator,
+            ArgumentValue,
+            EOF,
+        }
+    }
+}

--- a/src/Cake/Cake.csproj
+++ b/src/Cake/Cake.csproj
@@ -119,6 +119,8 @@
   <ItemGroup>
     <Compile Include="Arguments\ArgumentParser.cs" />
     <Compile Include="Arguments\ArgumentTokenizer.cs" />
+    <Compile Include="Arguments\UnixCommandParser.cs" />
+    <Compile Include="Arguments\CommandArgumentNameAttribute.cs" />
     <Compile Include="Arguments\IArgumentParser.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/Cake/CakeOptions.cs
+++ b/src/Cake/CakeOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Cake.Arguments;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 
@@ -16,6 +17,9 @@ namespace Cake
         /// Gets or sets the output verbosity.
         /// </summary>
         /// <value>The output verbosity.</value>
+        [CommandArgumentName("-v")]
+        [CommandArgumentName("--verbosity")]
+        [CommandArgumentName("-verbosity", true)]
         public Verbosity Verbosity { get; set; }
 
         /// <summary>
@@ -39,6 +43,9 @@ namespace Cake
         /// <value>
         ///   <c>true</c> to show task description; otherwise, <c>false</c>.
         /// </value>
+        [CommandArgumentName("-s")]
+        [CommandArgumentName("--showdescription")]
+        [CommandArgumentName("-showdescription", true)]
         public bool ShowDescription { get; set; }
 
         /// <summary>
@@ -47,6 +54,12 @@ namespace Cake
         /// <value>
         ///   <c>true</c> if a dry run should be performed; otherwise, <c>false</c>.
         /// </value>
+        [CommandArgumentName("--noop")]
+        [CommandArgumentName("--dryrun")]
+        [CommandArgumentName("--whatif")]
+        [CommandArgumentName("-noop", true)]
+        [CommandArgumentName("-dryrun", true)]
+        [CommandArgumentName("-whatif", true)]
         public bool PerformDryRun { get; set; }
 
         /// <summary>
@@ -55,6 +68,9 @@ namespace Cake
         /// <value>
         ///   <c>true</c> to show help; otherwise, <c>false</c>.
         /// </value>
+        [CommandArgumentName("-?")]
+        [CommandArgumentName("--help")]
+        [CommandArgumentName("-help", true)]
         public bool ShowHelp { get; set; }
 
         /// <summary>
@@ -63,6 +79,10 @@ namespace Cake
         /// <value>
         ///   <c>true</c> to show version information; otherwise, <c>false</c>.
         /// </value>
+        [CommandArgumentName("--version")]
+        [CommandArgumentName("--ver")]
+        [CommandArgumentName("-version", true)]
+        [CommandArgumentName("-ver", true)]
         public bool ShowVersion { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Related to #474 

The original version used a non-conventional single-dash argument as a way
of passing arguments. This has been changed to double-dash arguments for
long options and single-dash argument for single character options.

To prevent this commit from becoming a breaking change the old behaviour
is also supported. It might be removed in the future in favor of the new
style, however until documentation and features have been updated this
should have no effect for everyone.

In the new approach we have also introduced a new way to create additional
options in `CakeOptions`. The command line key name is now decided by an
attribute. In the future we might wanna expend that with documentation
attribute so that we can generate the help on the fly. (Also it would be
really cool if we could let cake parse the build file for additional
options).

All the newly introduced code has been written using TDD behaviour and
exception for two error messages (so that it would support the new
behaviour) none of the original UnitTests have been changed.