### PR TITLE
Create Chocolatey Package for Cake

### DIFF
--- a/nuspec/Cake.Portable.nuspec
+++ b/nuspec/Cake.Portable.nuspec
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>cake.portable</id>
+    <title>Cake.Portable (Install)</title>
+    <version>0.0.0</version>
+    <authors>Patrik Svensson</authors>
+    <owners>Patrik Svensson</owners>
+    <summary>Cake (C# Make) is a build automation system with a C# DSL to do things like compiling code, copy files/folders, running unit tests, compress files and build NuGet packages.</summary>
+    <description>The Cake script runner.</description>
+    <projectUrl>http://cakebuild.net/</projectUrl>
+    <packageSourceUrl>https://github.com/cake-build/cake</packageSourceUrl>
+    <projectSourceUrl>https://github.com/cake-build/cake</projectSourceUrl>
+    <docsUrl>http://cakebuild.net/docs</docsUrl>
+    <!--<mailingListUrl></mailingListUrl>-->
+    <bugTrackerUrl>https://github.com/cake-build/cake/issues</bugTrackerUrl>
+    <tags>Cake Script Build</tags>
+    <copyright>Copyright (c) Patrik Svensson, Mattias Karlsson and contributors</copyright>
+    <licenseUrl>https://github.com/cake-build/cake/blob/develop/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <iconUrl>https://raw.githubusercontent.com/cake-build/graphics/master/png/cake-medium.png</iconUrl>
+    <!--<dependencies>
+      <dependency id="" version="__VERSION__" />
+      <dependency id="" />
+    </dependencies>-->
+    <!--<provides></provides>-->
+  </metadata>
+  <files></files>
+</package>

--- a/src/Cake.sln
+++ b/src/Cake.sln
@@ -33,6 +33,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "nuspec", "nuspec", "{B38B35
 		..\nuspec\Cake.Common.nuspec = ..\nuspec\Cake.Common.nuspec
 		..\nuspec\Cake.Core.nuspec = ..\nuspec\Cake.Core.nuspec
 		..\nuspec\Cake.nuspec = ..\nuspec\Cake.nuspec
+		..\nuspec\Cake.Portable.nuspec = ..\nuspec\Cake.Portable.nuspec
 		..\nuspec\Cake.Testing.nuspec = ..\nuspec\Cake.Testing.nuspec
 	EndProjectSection
 EndProject

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.5.5" />
+    <package id="Cake" version="0.6.0" />
     <package id="xunit.runner.console" version="2.0.0" />
 </packages>


### PR DESCRIPTION
This is a first pass at creating the Chocolatey Package for Cake.

It isn't quite as simple to create a Chocolatey Package, as it is for a Nuget package, as there is no concept of BasePath and OutputDirectory for Chocolatey, so there is a little bit more work to do, but the end result is the same.

Fixes GH-505