### PR TITLE
[WIP] Changing Copyright Information

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Make sure you've read the [contribution guidelines](http://cakebuild.net/contrib
 
 ## License
 
-Copyright © 2014 - 2015, Patrik Svensson, Mattias Karlsson and contributors.
+Copyright © 2014 - 2015, Patrik Svensson, Mattias Karlsson, Gary Ewan Park and contributors.
 Cake is provided as-is under the MIT license. For more information see [LICENSE](https://github.com/cake-build/cake/blob/develop/LICENSE).
 
 * For Roslyn, see https://github.com/dotnet/roslyn/blob/master/License.txt

--- a/nuspec/Cake.Common.nuspec
+++ b/nuspec/Cake.Common.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://github.com/cake-build/cake</projectUrl>
     <iconUrl>https://raw.githubusercontent.com/cake-build/graphics/master/png/cake-medium.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <copyright>Copyright (c) Patrik Svensson, Mattias Karlsson and contributors</copyright>
+    <copyright>Copyright (c) Patrik Svensson, Mattias Karlsson, Gary Ewan Park and contributors</copyright>
     <tags>Cake Script Build</tags>
     <dependencies>
       <dependency id="Cake.Core" version="$version$" />

--- a/nuspec/Cake.Core.nuspec
+++ b/nuspec/Cake.Core.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://github.com/cake-build/cake</projectUrl>
     <iconUrl>https://raw.githubusercontent.com/cake-build/graphics/master/png/cake-medium.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <copyright>Copyright (c) Patrik Svensson, Mattias Karlsson and contributors</copyright>
+    <copyright>Copyright (c) Patrik Svensson, Mattias Karlsson, Gary Ewan Park and contributors</copyright>
     <tags>Cake Script Build</tags>
   </metadata>
   <files>

--- a/nuspec/Cake.Testing.nuspec
+++ b/nuspec/Cake.Testing.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://github.com/cake-build/cake</projectUrl>
     <iconUrl>https://raw.githubusercontent.com/cake-build/graphics/master/png/cake-medium.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <copyright>Copyright (c) Patrik Svensson, Mattias Karlsson and contributors</copyright>
+    <copyright>Copyright (c) Patrik Svensson, Mattias Karlsson, Gary Ewan Park and contributors</copyright>
     <tags>Cake Script Build</tags>
     <dependencies>
       <dependency id="Cake.Core" version="$version$" />

--- a/nuspec/Cake.nuspec
+++ b/nuspec/Cake.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://github.com/cake-build/cake</projectUrl>
     <iconUrl>https://raw.githubusercontent.com/cake-build/graphics/master/png/cake-medium.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <copyright>Copyright (c) Patrik Svensson, Mattias Karlsson and contributors</copyright>
+    <copyright>Copyright (c) Patrik Svensson, Mattias Karlsson, Gary Ewan Park and contributors</copyright>
     <tags>Cake Script Build</tags>
   </metadata>
   <files>

--- a/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoParserTests.cs
+++ b/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoParserTests.cs
@@ -131,7 +131,7 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
             }
 
             [Theory]
-            [InlineData("Copyright (c) Patrik Svensson, Mattias Karlsson and contributors", "Copyright (c) Patrik Svensson, Mattias Karlsson and contributors")]
+            [InlineData("Copyright (c) Patrik Svensson, Mattias Karlsson, Gary Ewan Park and contributors", "Copyright (c) Patrik Svensson, Mattias Karlsson, Gary Ewan Park and contributors")]
             [InlineData(null, "")]
             public void Should_Read_Copyright(string value, string expected)
             {


### PR DESCRIPTION
So, although this was taken care of by @devlead here https://github.com/cake-build/cake/commit/e87b3159ebd8a3f636700fa547dee763b060f7d5 for any future packages, for the same reason that we keep the SolutionInfo.cs file in source, I think it makes sense to update the nuspec's to contain the full information as well.  This was after a conversation with @patriksvensson in Slack.