### PR TITLE
Added NUnit 3 alias and unit tests

### DIFF
--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -123,6 +123,7 @@
     <Compile Include="Fixtures\Tools\NuGet\Sources\NuGetRemoveSourceFixture.cs" />
     <Compile Include="Fixtures\Tools\NuGet\Sources\NuGetSourcesFixture.cs" />
     <Compile Include="Fixtures\Tools\NuGet\Update\NuGetUpdateFixture.cs" />
+    <Compile Include="Fixtures\Tools\NUnit3RunnerFixture.cs" />
     <Compile Include="Fixtures\Tools\NUnitRunnerFixture.cs" />
     <Compile Include="Fixtures\ProcessFixture.cs" />
     <Compile Include="Fixtures\Tools\OctopusDeployReleaseCreatorFixture.cs" />
@@ -217,6 +218,8 @@
     <Compile Include="Unit\Tools\NuGet\Sources\NuGetSourcesTests.cs" />
     <Compile Include="Unit\Tools\NuGet\Update\NuGetUpdaterTests.cs" />
     <Compile Include="Unit\Tools\NuGet\Update\NuGetUpdateSettingsTests.cs" />
+    <Compile Include="Unit\Tools\NUnit\NUnit3RunnerTests.cs" />
+    <Compile Include="Unit\Tools\NUnit\NUnit3SettingsTests.cs" />
     <Compile Include="Unit\Tools\NUnit\NUnitRunnerTests.cs" />
     <Compile Include="Unit\Tools\NUnit\NUnitSettingsTests.cs" />
     <Compile Include="Unit\Tools\OctopusDeploy\OctoCreateReleaseTests.cs" />

--- a/src/Cake.Common.Tests/Fixtures/Tools/NUnit3RunnerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/NUnit3RunnerFixture.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using Cake.Common.Tools.NUnit;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tests.Fixtures.Tools
+{
+    internal sealed class NUnit3RunnerFixture : ToolFixture<NUnit3Settings>
+    {
+        public List<FilePath> Assemblies { get; set; }
+
+        public NUnit3RunnerFixture()
+            : base("nunit3-console.exe")
+        {
+            Assemblies = new List<FilePath>();
+            Assemblies.Add(new FilePath("./Test1.dll"));
+        }
+
+        protected override void RunTool()
+        {
+            var tool = new NUnit3Runner(FileSystem, Environment, Globber, ProcessRunner);
+            tool.Run(Assemblies, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/NUnit/NUnit3RunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NUnit/NUnit3RunnerTests.cs
@@ -1,0 +1,270 @@
+﻿using System;
+using System.Collections.Generic;
+using Cake.Common.Tests.Fixtures.Tools;
+using Cake.Common.Tools.NUnit;
+using Cake.Core;
+using Cake.Core.IO;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.NUnit
+{
+    public sealed class NUnit3RunnerTests
+    {
+        public sealed class TheRunMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Assembly_Path_Is_Null()
+            {
+                // Given
+                var fixture = new NUnit3RunnerFixture();
+                fixture.Assemblies = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "assemblyPaths");
+            }
+
+            [Fact]
+            public void Should_Throw_If_NUnit3_Runner_Was_Not_Found()
+            {
+                // Given
+                var fixture = new NUnit3RunnerFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("NUnit3: Could not locate executable.", result.Message);
+            }
+
+            [Theory]
+            [InlineData("C:/NUnit/nunit.exe", "C:/NUnit/nunit.exe")]
+            [InlineData("./tools/NUnit/nunit.exe", "/Working/tools/NUnit/nunit.exe")]
+            public void Should_Use_NUnit3_Runner_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new NUnit3RunnerFixture();
+                fixture.Settings.ToolPath = toolPath;
+                fixture.GivenSettingsToolPathExist();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.ToolPath.FullPath);
+            }
+
+            [Fact]
+            public void Should_Find_NUnit3_Runner_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new NUnit3RunnerFixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/Working/tools/nunit3-console.exe", result.ToolPath.FullPath);
+            }
+
+            [Fact]
+            public void Should_Use_Provided_Assembly_Path_In_Process_Arguments()
+            {
+                // Given
+                var fixture = new NUnit3RunnerFixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("\"/Working/Test1.dll\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Use_Provided_Assembly_Paths_In_Process_Arguments()
+            {
+                // Given
+                var fixture = new NUnit3RunnerFixture();
+                fixture.Assemblies.Clear();
+                fixture.Assemblies.Add(new FilePath("./Test1.dll"));
+                fixture.Assemblies.Add(new FilePath("./Test2.dll"));
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("\"/Working/Test1.dll\" \"/Working/Test2.dll\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Set_Working_Directory()
+            {
+                // Given
+                var fixture = new NUnit3RunnerFixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/Working", result.Process.WorkingDirectory.FullPath);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new NUnit3RunnerFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("NUnit3: Process was not started.", result.Message);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new NUnit3RunnerFixture();
+                fixture.GivenProcessExitsWithCode(1);
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("NUnit3: Process returned an error.", result.Message);
+            }
+
+            [Fact]
+            public void Should_Not_Allow_NoResults_And_ResultsFile()
+            {
+                // Given
+                var fixture = new NUnit3RunnerFixture();
+                fixture.Settings.Results = "NewResults.xml";
+                fixture.Settings.NoResults = true;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsType<ArgumentException>(result);
+                Assert.Equal("NUnit3: You can't specify both a results file and set NoResults to true.", result.Message);
+            }
+
+            [Fact]
+            public void Should_Set_Result_Switch()
+            {
+                // Given
+                var fixture = new NUnit3RunnerFixture();
+                fixture.Settings.Results = "NewTestResult.xml";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("\"/Working/Test1.dll\" " +
+                             "\"--result=/Working/NewTestResult.xml\"",
+                             result.Args);
+            }
+
+            [Fact]
+            public void Should_Set_Commandline_Switches()
+            {
+                // Given
+                var fixture = new NUnit3RunnerFixture();
+                fixture.Settings.Test = "Test1,Test2";
+                fixture.Settings.TestList = "Testlist.txt";
+                fixture.Settings.Where = "cat==Data";
+                fixture.Settings.Timeout = 5;
+                fixture.Settings.Seed = 6;
+                fixture.Settings.Workers = 7;
+                fixture.Settings.StopOnError = true;
+                fixture.Settings.Work = "out";
+                fixture.Settings.OutputFile = "stdout.txt";
+                fixture.Settings.ErrorOutputFile = "stderr.txt";
+                fixture.Settings.Full = true;
+                fixture.Settings.Results = "NewTestResult.xml";
+                fixture.Settings.ResultFormat = "nunit2";
+                fixture.Settings.ResultTransform = "nunit2.xslt";
+                fixture.Settings.Labels = NUnit3Labels.All;
+                fixture.Settings.TeamCity = true;
+                fixture.Settings.NoHeader = true;
+                fixture.Settings.NoColor = true;
+                fixture.Settings.Verbose = true;
+                fixture.Settings.Configuration = "Debug";
+                fixture.Settings.Process = NUnit3ProcessOption.InProcess;
+                fixture.Settings.AppDomainUsage = NUnit3AppDomainUsage.Single;
+                fixture.Settings.Framework = "net3.5";
+                fixture.Settings.X86 = true;
+                fixture.Settings.DisposeRunners = true;
+                fixture.Settings.ShadowCopy = true;
+                fixture.Settings.Agents = 3;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("\"/Working/Test1.dll\" --test=Test1,Test2 \"--testlist=/Working/Testlist.txt\" " +
+                        "--where \"cat==Data\" --timeout=5 --seed=6 --workers=7 " +
+                        "--stoponerror \"--work=/Working/out\" \"--out=/Working/stdout.txt\" " +
+                        "\"--err=/Working/stderr.txt\" --full " +
+                        "\"--result=/Working/NewTestResult.xml;format=nunit2;transform=/Working/nunit2.xslt\" " +
+                        "--labels=All --teamcity --noheader --nocolor --verbose " +
+                        "\"--config=Debug\" \"--framework=net3.5\" --x86 " +
+                        "--dispose-runners --shadowcopy --agents=3 " +
+                        "--process=InProcess --domain=Single", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Set_Switch_For_Default_Labels()
+            {
+                // Given
+                var fixture = new NUnit3RunnerFixture();
+                fixture.Settings.Labels = NUnit3Labels.Off;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("\"/Working/Test1.dll\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Set_Process_Switch_For_DefaultMultipleValue()
+            {
+                // Given
+                var fixture = new NUnit3RunnerFixture();
+                fixture.Settings.Process = NUnit3ProcessOption.Multiple;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("\"/Working/Test1.dll\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Set_Switch_For_Default_AppDomainUsage()
+            {
+                // Given
+                var fixture = new NUnit3RunnerFixture();
+                fixture.Settings.AppDomainUsage = NUnit3AppDomainUsage.Default;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("\"/Working/Test1.dll\"", result.Args);
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/NUnit/NUnit3SettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NUnit/NUnit3SettingsTests.cs
@@ -1,0 +1,51 @@
+﻿using Cake.Common.Tools.NUnit;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.NUnit
+{
+    public sealed class NUnit3SettingsTests
+    {
+        public sealed class TheConstructor
+        {
+            [Fact]
+            public void Should_Not_Enable_Shadow_Copying_By_Default()
+            {
+                // Given, When
+                var settings = new NUnit3Settings();
+
+                // Then
+                Assert.False(settings.ShadowCopy);
+            }
+
+            [Fact]
+            public void Should_Use_Multiple_Processes_By_Default()
+            {
+                // Given, When
+                var settings = new NUnit3Settings();
+
+                // Then
+                Assert.Equal(settings.Process, NUnit3ProcessOption.Multiple);
+            }
+
+            [Fact]
+            public void Should_Use_No_Labels_By_Default()
+            {
+                // Given, When
+                var settings = new NUnit3Settings();
+
+                // Then
+                Assert.Equal(settings.Labels, NUnit3Labels.Off);
+            }
+
+            [Fact]
+            public void Should_Use_Default_AppDomainUsage_By_Default()
+            {
+                // Given, When
+                var settings = new NUnit3Settings();
+
+                // Then
+                Assert.Equal(settings.AppDomainUsage, NUnit3AppDomainUsage.Default);
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -225,6 +225,12 @@
     <Compile Include="Tools\NuGet\Pack\NuspecTransformer.cs" />
     <Compile Include="Tools\NuGet\Update\NuGetUpdater.cs" />
     <Compile Include="Tools\NuGet\Update\NuGetUpdateSettings.cs" />
+    <Compile Include="Tools\NUnit\NUnit3Aliases.cs" />
+    <Compile Include="Tools\NUnit\NUnit3AppDomainUsage.cs" />
+    <Compile Include="Tools\NUnit\NUnit3Labels.cs" />
+    <Compile Include="Tools\NUnit\NUnit3ProcessOption.cs" />
+    <Compile Include="Tools\NUnit\NUnit3Runner.cs" />
+    <Compile Include="Tools\NUnit\NUnit3Settings.cs" />
     <Compile Include="Tools\NUnit\NUnitAliases.cs" />
     <Compile Include="Tools\NUnit\NUnitAppDomainUsage.cs" />
     <Compile Include="Tools\NUnit\NUnitProcessOption.cs" />

--- a/src/Cake.Common/Tools/NUnit/NUnit3Aliases.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnit3Aliases.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.NUnit
+{
+    /// <summary>
+    /// Contains functionality related to running NUnit v2 and v3 unit tests.
+    /// </summary>
+    [CakeAliasCategory("NUnit v3")]
+    public static class NUnit3Aliases
+    {
+        /// <summary>
+        /// Runs all NUnit unit tests in the assemblies matching the specified pattern.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="pattern">The pattern.</param>
+        [CakeMethodAlias]
+        public static void NUnit3(this ICakeContext context, string pattern)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var assemblies = context.Globber.GetFiles(pattern).ToArray();
+            if (assemblies.Length == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any files.");
+                return;
+            }
+
+            NUnit3(context, assemblies, new NUnit3Settings());
+        }
+
+        /// <summary>
+        /// Runs all NUnit unit tests in the assemblies matching the specified pattern,
+        /// using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="pattern">The pattern.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        public static void NUnit3(this ICakeContext context, string pattern, NUnit3Settings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var assemblies = context.Globber.GetFiles(pattern).ToArray();
+            if (assemblies.Length == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any files.");
+                return;
+            }
+
+            NUnit3(context, assemblies, settings);
+        }
+
+        /// <summary>
+        /// Runs all NUnit unit tests in the specified assemblies.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="assemblies">The assemblies.</param>
+        [CakeMethodAlias]
+        public static void NUnit3(this ICakeContext context, IEnumerable<string> assemblies)
+        {
+            if (assemblies == null)
+            {
+                throw new ArgumentNullException("assemblies");
+            }
+            var paths = assemblies.Select(p => new FilePath(p));
+            NUnit3(context, paths, new NUnit3Settings());
+        }
+
+        /// <summary>
+        /// Runs all NUnit unit tests in the specified assemblies.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="assemblies">The assemblies.</param>
+        [CakeMethodAlias]
+        public static void NUnit3(this ICakeContext context, IEnumerable<FilePath> assemblies)
+        {
+            NUnit3(context, assemblies, new NUnit3Settings());
+        }
+
+        /// <summary>
+        /// Runs all NUnit unit tests in the specified assemblies,
+        /// using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="assemblies">The assemblies.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        public static void NUnit3(this ICakeContext context, IEnumerable<string> assemblies, NUnit3Settings settings)
+        {
+            if (assemblies == null)
+            {
+                throw new ArgumentNullException("assemblies");
+            }
+            var paths = assemblies.Select(p => new FilePath(p));
+            NUnit3(context, paths, settings);
+        }
+
+        /// <summary>
+        /// Runs all NUnit unit tests in the specified assemblies,
+        /// using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="assemblies">The assemblies.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        public static void NUnit3(this ICakeContext context, IEnumerable<FilePath> assemblies, NUnit3Settings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            if (assemblies == null)
+            {
+                throw new ArgumentNullException("assemblies");
+            }
+
+            var runner = new NUnit3Runner(context.FileSystem, context.Environment, context.Globber, context.ProcessRunner);
+            runner.Run(assemblies, settings);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/NUnit/NUnit3AppDomainUsage.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnit3AppDomainUsage.cs
@@ -1,0 +1,31 @@
+namespace Cake.Common.Tools.NUnit
+{
+    /// <summary>
+    /// The /domain option controls of the creation of AppDomains for running tests.
+    /// </summary>
+    public enum NUnit3AppDomainUsage
+    {
+        /// <summary>
+        /// Create a separate AppDomain for each assembly if more than one is listed on the command
+        /// line, otherwise creates a single AppDomain.
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// No AppDomain is created - the tests are run in the primary domain.
+        /// This normally requires copying the NUnit assemblies into the same directory as your tests.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// A single test AppDomain is created for all test assemblies
+        /// This is how NUnit worked prior to version 2.4.
+        /// </summary>
+        Single,
+
+        /// <summary>
+        /// An AppDomain is created for each assembly specified on the command line.
+        /// </summary>
+        Multiple
+    }
+}

--- a/src/Cake.Common/Tools/NUnit/NUnit3Labels.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnit3Labels.cs
@@ -1,0 +1,23 @@
+﻿namespace Cake.Common.Tools.NUnit
+{
+    /// <summary>
+    /// Represents the possible values for the Labels option.
+    /// </summary>
+    public enum NUnit3Labels
+    {
+        /// <summary>
+        /// Does not output labels. This is the default.
+        /// </summary>
+        Off = 0,
+
+        /// <summary>
+        /// Outputs labels for tests that are run.
+        /// </summary>
+        On,
+
+        /// <summary>
+        /// Outputs labels for all tests.
+        /// </summary>
+        All
+    }
+}

--- a/src/Cake.Common/Tools/NUnit/NUnit3ProcessOption.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnit3ProcessOption.cs
@@ -1,0 +1,23 @@
+﻿namespace Cake.Common.Tools.NUnit
+{
+    /// <summary>
+    /// Represents the various ways NUnit loads tests in processes.
+    /// </summary>
+    public enum NUnit3ProcessOption
+    {
+        /// <summary>
+        /// A separate process is created for each test assembly. This is the default.
+        /// </summary>
+        Multiple = 0,
+
+        /// <summary>
+        /// One separate process is created to run all of the test assemblies.
+        /// </summary>
+        Separate,
+
+        /// <summary>
+        /// All the tests are run in the nunit-console process.
+        /// </summary>
+        InProcess
+    }
+}

--- a/src/Cake.Common/Tools/NUnit/NUnit3Runner.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnit3Runner.cs
@@ -1,0 +1,230 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.NUnit
+{
+    /// <summary>
+    /// The NUnit unit test runner.
+    /// </summary>
+    public sealed class NUnit3Runner : Tool<NUnit3Settings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NUnit3Runner"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="globber">The globber.</param>
+        /// <param name="processRunner">The process runner.</param>
+        public NUnit3Runner(IFileSystem fileSystem, ICakeEnvironment environment, IGlobber globber, IProcessRunner processRunner)
+            : base(fileSystem, environment, processRunner, globber)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Runs the tests in the specified assemblies, using the specified settings.
+        /// </summary>
+        /// <param name="assemblyPaths">The assembly paths.</param>
+        /// <param name="settings">The settings.</param>
+        public void Run(IEnumerable<FilePath> assemblyPaths, NUnit3Settings settings)
+        {
+            if (assemblyPaths == null)
+            {
+                throw new ArgumentNullException("assemblyPaths");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            Run(settings, GetArguments(assemblyPaths, settings));
+        }
+
+        private ProcessArgumentBuilder GetArguments(IEnumerable<FilePath> assemblyPaths, NUnit3Settings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            // Add the assemblies to build.
+            foreach (var assemblyPath in assemblyPaths)
+            {
+                builder.AppendQuoted(assemblyPath.MakeAbsolute(_environment).FullPath);
+            }
+
+            if (settings.Test != null)
+            {
+                builder.Append("--test=" + settings.Test);
+            }
+
+            if (settings.TestList != null)
+            {
+                builder.AppendQuoted(string.Format(CultureInfo.InvariantCulture, "--testlist={0}", settings.TestList.MakeAbsolute(_environment).FullPath));
+            }
+
+            if (settings.Where != null)
+            {
+                builder.Append("--where \"" + settings.Where + "\"");
+            }
+
+            if (settings.Timeout.HasValue)
+            {
+                builder.Append("--timeout=" + settings.Timeout.Value);
+            }
+
+            if (settings.Seed.HasValue)
+            {
+                builder.Append("--seed=" + settings.Seed.Value);
+            }
+
+            if (settings.Workers.HasValue)
+            {
+                builder.Append("--workers=" + settings.Workers.Value);
+            }
+
+            if (settings.StopOnError)
+            {
+                builder.Append("--stoponerror");
+            }
+
+            if (settings.Work != null)
+            {
+                builder.AppendQuoted(string.Format(CultureInfo.InvariantCulture, "--work={0}", settings.Work.MakeAbsolute(_environment).FullPath));
+            }
+
+            if (settings.OutputFile != null)
+            {
+                builder.AppendQuoted(string.Format(CultureInfo.InvariantCulture, "--out={0}", settings.OutputFile.MakeAbsolute(_environment).FullPath));
+            }
+
+            if (settings.ErrorOutputFile != null)
+            {
+                builder.AppendQuoted(string.Format(CultureInfo.InvariantCulture, "--err={0}", settings.ErrorOutputFile.MakeAbsolute(_environment).FullPath));
+            }
+
+            if (settings.Full)
+            {
+                builder.Append("--full");
+            }
+
+            if (settings.Results != null && settings.NoResults)
+            {
+                throw new ArgumentException(
+                    GetToolName() + ": You can't specify both a results file and set NoResults to true.");
+            }
+
+            if (settings.Results != null)
+            {
+                var results = new StringBuilder(settings.Results.MakeAbsolute(_environment).FullPath);
+                if (settings.ResultFormat != null)
+                {
+                    results.AppendFormat(";format={0}", settings.ResultFormat);
+                }
+                if (settings.ResultTransform != null)
+                {
+                    results.AppendFormat(";transform={0}", settings.ResultTransform.MakeAbsolute(_environment).FullPath);
+                }
+
+                builder.AppendQuoted(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "--result={0}", results.ToString()));
+            }
+            else if (settings.NoResults)
+            {
+                builder.AppendQuoted("--noresult");
+            }
+
+            if (settings.Labels != NUnit3Labels.Off)
+            {
+                builder.Append("--labels=" + settings.Labels);
+            }
+
+            if (settings.TeamCity)
+            {
+                builder.Append("--teamcity");
+            }
+
+            if (settings.NoHeader)
+            {
+                builder.Append("--noheader");
+            }
+
+            if (settings.NoColor)
+            {
+                builder.Append("--nocolor");
+            }
+
+            if (settings.Verbose)
+            {
+                builder.Append("--verbose");
+            }
+
+            if (settings.Configuration != null)
+            {
+                builder.AppendQuoted("--config=" + settings.Configuration);
+            }
+
+            if (settings.Framework != null)
+            {
+                builder.AppendQuoted("--framework=" + settings.Framework);
+            }
+
+            if (settings.X86)
+            {
+                builder.Append("--x86");
+            }
+
+            if (settings.DisposeRunners)
+            {
+                builder.Append("--dispose-runners");
+            }
+
+            if (settings.ShadowCopy)
+            {
+                builder.Append("--shadowcopy");
+            }
+
+            if (settings.Agents.HasValue)
+            {
+                builder.Append("--agents=" + settings.Agents.Value);
+            }
+
+            // don't include the default value
+            if (settings.Process != NUnit3ProcessOption.Multiple)
+            {
+                builder.Append("--process=" + settings.Process);
+            }
+
+            if (settings.AppDomainUsage != NUnit3AppDomainUsage.Default)
+            {
+                builder.Append("--domain=" + settings.AppDomainUsage);
+            }
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Gets the name of the tool.
+        /// </summary>
+        /// <returns>The name of the tool.</returns>
+        protected override string GetToolName()
+        {
+            return "NUnit3";
+        }
+
+        /// <summary>
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return new[] { "nunit3-console.exe" };
+        }
+    }
+}

--- a/src/Cake.Common/Tools/NUnit/NUnit3Settings.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnit3Settings.cs
@@ -1,0 +1,256 @@
+﻿using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.NUnit
+{
+    /// <summary>
+    /// Contains settings used by <see cref="NUnit3Runner" />.
+    /// </summary>
+    public sealed class NUnit3Settings : ToolSettings
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NUnit3Settings" /> class.
+        /// </summary>
+        public NUnit3Settings()
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the list of tests to run or explore.
+        /// </summary>
+        /// <value>
+        /// A comma-separated list of test names.
+        /// </value>
+        public string Test { get; set; }
+
+        /// <summary>
+        /// Gets or sets a file containing the tests to run.
+        /// </summary>
+        /// <value>
+        /// File path containing a list of tests to run, one per line.
+        /// </value>
+        public FilePath TestList { get; set; }
+
+        /// <summary>
+        /// Gets or sets the test selection expression indicating what tests will be run.
+        /// </summary>
+        /// <value>
+        /// The --where option is intended to extend or replace the earlier
+        /// --test, --include and --exclude options by use of a selection expression
+        /// describing exactly which tests to use. Examples of usage are:
+        ///    --where:cat==Data
+        ///    --where "method =~ /DataTest*/ &amp;&amp; cat = Slow"
+        /// </value>
+        public string Where { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default timeout to be used for test cases in this run.
+        /// If any test exceeds the timeout value, it is cancelled and reported as an error.
+        /// </summary>
+        /// <value>
+        /// The timeout in milliseconds.
+        /// </value>
+        public int? Timeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the random seed used to generate test cases.
+        /// </summary>
+        /// <value>
+        /// The random seed.
+        /// </value>
+        public int? Seed { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of worker threads to be used
+        /// in running tests.If not specified, defaults to
+        /// 2 or the number of processors, whichever is greater.
+        /// </summary>
+        /// <value>
+        /// The number of worker threads.
+        /// </value>
+        public int? Workers { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether execution of the test run should terminate
+        /// immediately on the first test failure or error.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if execution of the test run should terminate immediately on the first test failure or error;
+        /// otherwise, <c>false</c>.
+        /// </value>
+        public bool StopOnError { get; set; }
+
+        /// <summary>
+        /// Gets or sets the directory to use for output files. If
+        /// not specified, defaults to the current directory.
+        /// </summary>
+        /// <value>
+        /// PATH of the directory.
+        /// </value>
+        public DirectoryPath Work { get; set; }
+
+        /// <summary>
+        /// Gets or sets the location that NUnit should write test output.
+        /// </summary>
+        /// <value>The location that NUnit should write test output.</value>
+        public FilePath OutputFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the location that NUnit should write test error output.
+        /// </summary>
+        /// <value>The location that NUnit should write test error output.</value>
+        public FilePath ErrorOutputFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to print full report of all test results.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if a full report of test results should be printed;
+        /// otherwise, <c>false</c>.
+        /// </value>
+        public bool Full { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the XML result file.
+        /// </summary>
+        /// <value>
+        /// The name of the XML result file. Defaults to <c>TestResult.xml</c>.
+        /// </value>
+        public FilePath Results { get; set; }
+
+        /// <summary>
+        /// Gets or sets the format that the results should be in. Results must be set to
+        /// have any effect. Specify nunit2 to output the results in NUnit 2 xml format.
+        /// nunit3 may be specified for NUnit 3 format, however this is the default. Additional
+        /// formats may be supported in the future, check the NUnit documentation.
+        /// </summary>
+        /// <value>
+        /// The format of the result file. Defaults to <c>nunit3</c>.
+        /// </value>
+        public string ResultFormat { get; set; }
+
+        /// <summary>
+        /// Gets or sets the file name of an XSL transform that will be applied to the results.
+        /// </summary>
+        /// <value>
+        /// The name of an XSLT file that will be applied to the results.
+        /// </value>
+        public FilePath ResultTransform { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to generate the XML result file.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the XML result file should be generated; otherwise, <c>false</c>.
+        /// </value>
+        public bool NoResults { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying whether to write test case names to the output.
+        /// </summary>
+        /// <value>
+        /// <c>On</c> to write labels for tests that are run or <c>All</c> to write labels
+        /// for all tests.
+        /// </value>
+        public NUnit3Labels Labels { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to turn on TeamCity service messages.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> to turn on TeamCity service messages; otherwise, <c>false</c>.
+        /// </value>
+        public bool TeamCity { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to show copyright information at the start of the program.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if to show copyright information at the start of the program; otherwise, <c>false</c>.
+        /// </value>
+        public bool NoHeader { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to show the output in color.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> disable color output; otherwise, <c>false</c>.
+        /// </value>
+        public bool NoColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to show additional information as the tests run.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> shows additional information as the tests run; otherwise, <c>false</c>.
+        /// </value>
+        public bool Verbose { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of a project configuration to load (e.g.:Debug).
+        /// This selects the configuration within the NUnit project file.
+        /// </summary>
+        /// <value>
+        /// The name of the configuration to load.
+        /// </value>
+        public string Configuration { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run tests in an x86 process on 64 bit systems.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> to run tests in an x86 process on 64 bit systems; otherwise, <c>false</c>.
+        /// </value>
+        public bool X86 { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to Dispose each test runner after it has finished
+        /// running its tests.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> to Dispose each test runner after it has finished
+        /// running its tests; otherwise, <c>false</c>.
+        /// </value>
+        public bool DisposeRunners { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to shadow copy tests.
+        /// Default value is <c>false</c>.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if tests should be run as a shadow copy; otherwise, <c>false</c>.
+        /// </value>
+        public bool ShadowCopy { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version of the runtime to be used when executing tests.
+        /// </summary>
+        /// <value>
+        /// The version of the runtime to be used when executing tests.
+        /// </value>
+        public string Framework { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating how NUnit should load tests in processes.
+        /// The Default value is <see cref="NUnit3ProcessOption.Multiple"/>.
+        /// </summary>
+        public NUnit3ProcessOption Process { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value to control creation of AppDomains for running tests.
+        /// Corresponds to the /domain command line switch.
+        /// The default is to use multiple domains if multiple assemblies are listed on the command line,
+        /// otherwise a single domain is used.
+        /// </summary>
+        public NUnit3AppDomainUsage AppDomainUsage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of test assembly agents to run at one
+        /// time. If not specified, there is no limit.
+        /// </summary>
+        /// <value>
+        /// The maximum number of test assembly agents to run at one time.
+        /// </value>
+        public int? Agents { get; set; }
+    }
+}


### PR DESCRIPTION
Fixes #471

~~Not quite ready to merge~~, but putting it up to let you know it is pending. I think this is complete, I just want to do some 'real  world' testing with it in a test project. I have implemented all of the command line options that make sense in NUnit 3 and everything is unit tested.

If I get time today, I will add this into an NUnit testing project that I have created a Cake build script for. It has a mix of NUnit 2 and 3 test projects so will be a good exercise of this. I am a bit worried about #525. The NUnit runner NuGet package has been updated to be an empty meta package that pulls down the NUnit console package. The existing NUnit alias will no longer find nunit-console in the tools directory and even if it did, the command line is fairly different.

If a fix for #525 isn't in the pipeline, then the existing NUnit alias will be nearly useless unless NUnit 2.6.x is installed on the machine and in the path.

Also, a couple of quick questions about this PR,

- Should I update the release notes, or is that automated?
- Is the documentation for the website automatically generated, or does it need to be updated?