### PR TITLE
Support spaces in MSBuild configuration

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -587,19 +587,20 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                              "\"/Working/src/Solution.sln\"", result.Args);
             }
 
-            [Fact]
-            public void Should_Append_Configuration_As_Property_To_Process_Arguments()
+            [Theory]
+            [InlineData("Release", "/m /v:normal /p:Configuration=\"Release\" /target:Build \"/Working/src/Solution.sln\"")]
+            [InlineData("Custom Spaced", "/m /v:normal /p:Configuration=\"Custom Spaced\" /target:Build \"/Working/src/Solution.sln\"")]
+            public void Should_Append_Configuration_As_Property_To_Process_Arguments(string configuration, string expected)
             {
                 // Given
                 var fixture = new MSBuildRunnerFixture(false);
-                fixture.Settings.SetConfiguration("Release");
+                fixture.Settings.SetConfiguration(configuration);
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/m /v:normal /p:Configuration=Release /target:Build " +
-                             "\"/Working/src/Solution.sln\"", result.Args);
+                Assert.Equal(expected, result.Args);
             }
 
             [Theory]

--- a/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
@@ -61,8 +61,7 @@ namespace Cake.Common.Tools.MSBuild
             if (!string.IsNullOrWhiteSpace(settings.Configuration))
             {
                 // Add the configuration as a property.
-                var configuration = settings.Configuration;
-                builder.Append(string.Concat("/p:Configuration=", configuration));
+                builder.AppendSwitchQuoted("/p:Configuration", "=", settings.Configuration);
             }
 
             // Build for a specific platform?


### PR DESCRIPTION
Fixes an error I'm getting in a project that used to build correctly with Cake.


========================================
Build
========================================
Executing task: Build
Building Ex2007 SP3 from C:/Projects/Exchange.RemoveSection/src/RemoveSection.sln
Executing: C:/Program Files (x86)/MSBuild/14.0/Bin/amd64/MSBuild.exe /m /v:normal /p:Configuration=Ex2007 SP3 /p:Platform="Any CPU" /p:TreatWarningsAsErrors=true /target:Build "C:/Projects/Exchange.RemoveSection/src/RemoveSection.sln"
Microsoft (R) Build Engine version 14.0.23107.0
Copyright (C) Microsoft Corporation. All rights reserved.

MSBUILD : error MSB1008: Only one project can be specified.
Switch: C:/Projects/Exchange.RemoveSection/src/RemoveSection.sln

For switch syntax, type "MSBuild /help"
An error occured when executing task 'Build'.