### PR TITLE
[HOLD] Forward all arguments to the cake.exe

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,27 +10,6 @@ TOOLS_DIR=$SCRIPT_DIR/tools
 NUGET_EXE=$TOOLS_DIR/nuget.exe
 CAKE_EXE=$TOOLS_DIR/Cake/Cake.exe
 
-# Define default arguments.
-SCRIPT="build.cake"
-TARGET="Travis"
-CONFIGURATION="Release"
-VERBOSITY="verbose"
-DRYRUN=false
-SHOW_VERSION=false
-
-# Parse arguments.
-for i in "$@"; do
-    case $1 in
-        -s|--script) SCRIPT="$2"; shift ;;
-        -t|--target) TARGET="$2"; shift ;;
-        -c|--configuration) CONFIGURATION="$2"; shift ;;
-        -v|--verbosity) VERBOSITY="$2"; shift ;;
-        -d|--dryrun) DRYRUN=true ;;
-        --version) SHOW_VERSION=true ;;
-    esac
-    shift
-done
-
 # Make sure the tools folder exist.
 if [ ! -d $TOOLS_DIR ]; then
   mkdir $TOOLS_DIR
@@ -72,12 +51,6 @@ if [ ! -f $CAKE_EXE ]; then
 fi
 
 # Start Cake
-if $SHOW_VERSION; then
-    mono $CAKE_EXE -version
-elif $DRYRUN; then
-    mono $CAKE_EXE $SCRIPT -verbosity=$VERBOSITY -configuration=$CONFIGURATION -target=$TARGET -dryrun
-else
-    mono $CAKE_EXE $SCRIPT -verbosity=$VERBOSITY -configuration=$CONFIGURATION -target=$TARGET
-fi
+mono $CAKE_EXE $@
 
 exit $?


### PR DESCRIPTION
The way the build.sh works now does not allow arguments to be passed to your cake script. This is a simple fix for this problem. If the argument parsing in the script is important then this fix won't work :)