### PR TITLE
Added missing CakeAliasCategory attribute

### DIFF
--- a/src/Cake.Common/Tools/Cake/CakeAliases.cs
+++ b/src/Cake.Common/Tools/Cake/CakeAliases.cs
@@ -8,6 +8,7 @@ namespace Cake.Common.Tools.Cake
     /// <summary>
     /// Contains functionality related to running Cake scripts out of process.
     /// </summary>
+    [CakeAliasCategory("Cake")]
     public static class CakeAliases
     {
         /// <summary>


### PR DESCRIPTION
The cake aliases didn't have and CakeAliasCategory attribute, which made them hard to find in docs.