### PR TITLE
Support arbitrary text when parsing AssemblyInformationalVersion.

### DIFF
--- a/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoParserTests.cs
+++ b/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoParserTests.cs
@@ -194,6 +194,7 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
             [Theory]
             [InlineData("1.2.3.4", "1.2.3.4")]
             [InlineData("1.2.*.*", "1.2.*.*")]
+            [InlineData("1.2.3-rc1", "1.2.3-rc1")]
             [InlineData(null, "1.0.0.0")]
             public void Should_Read_AssemblyInformationalVersion(string value, string expected)
             {

--- a/src/Cake.Common/Solution/Project/Properties/AssemblyInfoParser.cs
+++ b/src/Cake.Common/Solution/Project/Properties/AssemblyInfoParser.cs
@@ -77,7 +77,7 @@ namespace Cake.Common.Solution.Project.Properties
                     ParseGeneralQuotedAttribute("AssemblyDescription", content),
                     ParseVersion("AssemblyFileVersion", content),
                     ParseGeneralQuotedAttribute("Guid", content),
-                    ParseVersion("AssemblyInformationalVersion", content),
+                    ParseGeneralQuotedAttribute("AssemblyInformationalVersion", content, DefaultVersion),
                     ParseGeneralQuotedAttribute("InternalsVisibleTo", content),
                     ParseGeneralQuotedAttribute("AssemblyProduct", content),
                     ParseGeneralQuotedAttribute("AssemblyTitle", content),
@@ -103,6 +103,11 @@ namespace Cake.Common.Solution.Project.Properties
 
         private static string ParseGeneralQuotedAttribute(string attributeName, string content)
         {
+            return ParseGeneralQuotedAttribute(attributeName, content, string.Empty);
+        }
+
+        private static string ParseGeneralQuotedAttribute(string attributeName, string content, string defaultValue)
+        {
             var regex = new Regex(string.Format(CultureInfo.InvariantCulture, GeneralQuotedAttributePattern, attributeName), RegexOptions.Multiline);
             var match = regex.Match(content);
             if (match.Groups.Count > 0)
@@ -113,7 +118,7 @@ namespace Cake.Common.Solution.Project.Properties
                     return value;
                 }
             }
-            return string.Empty;
+            return defaultValue;
         }
 
         private static string ParseGeneralNonQuotedAttribute(string attributeName, string content)


### PR DESCRIPTION
AssemblyInformationalVersionAttribute itself can accept arbitrary text strings, unlike AssemblyVersionAttribute / AssemblyFileVersionAttribute. However, the existing AssemblyInfoParser will only parse values from AssemblyInformationalVersionAttribute that conform to the same restrictions that AssemblyVersionAttribute / AssemblyFileVersionAttribute are subject to.

A real-world situation where this will cause issues is when using semantic versioning with pre-release or build metadata, such as "1.0.0-beta1" or "1.2.3-rc1". These values should be perfectly valid in AssemblyInformationalVersion, and should be accepted by AssemblyInfoParser.

This pull request adds support for arbitrary text strings when parsing AssemblyInformationalVersionAttribute using AssemblyInfoParser.