### PR TITLE
Add invariant IFormatterProvider to avoid issues based on user locale

### DIFF
--- a/src/Cake/Arguments/VerbosityParser.cs
+++ b/src/Cake/Arguments/VerbosityParser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Cake.Core.Diagnostics;
 
 namespace Cake.Arguments
@@ -44,7 +45,7 @@ namespace Cake.Arguments
                 return verbosity;
             }
             const string format = "The value '{0}' is not a valid verbosity.";
-            var message = string.Format(format, value ?? string.Empty);
+            var message = string.Format(CultureInfo.InvariantCulture, format, value);
             throw new InvalidOperationException(message);
         }
     }


### PR DESCRIPTION
Code analytics raised CA1305, this PR fixes the potential user locale issue by:
1. Adds CultureInfo.InvariantCulture for locale insensitive "ToString"
2. string.Format handles null so removed that assignment