### PR TITLE
Adds error log to stderr

### DIFF
--- a/src/Cake.Core/Extensions/ConsoleExtensions.cs
+++ b/src/Cake.Core/Extensions/ConsoleExtensions.cs
@@ -17,5 +17,17 @@ namespace Cake.Core
                 console.WriteLine(string.Empty);
             }
         }
+
+        /// <summary>
+        /// Writes an empty line to the console error output.
+        /// </summary>
+        /// <param name="console">The console to write to.</param>
+        public static void WriteErrorLine(this IConsole console)
+        {
+            if (console != null)
+            {
+                console.WriteErrorLine(string.Empty);
+            }
+        }
     }
 }

--- a/src/Cake.Core/IConsole.cs
+++ b/src/Cake.Core/IConsole.cs
@@ -37,6 +37,23 @@ namespace Cake.Core
         void WriteLine(string format, params object[] arg);
 
         /// <summary>
+        /// Writes the text representation of the specified array of objects to the
+        /// console error output using the specified format information.
+        /// </summary>
+        /// <param name="format">A composite format string</param>
+        /// <param name="arg">An array of objects to write using format.</param>
+        void WriteError(string format, params object[] arg);
+
+        /// <summary>
+        /// Writes the text representation of the specified array of objects, followed
+        /// by the current line terminator, to the console error output using the
+        /// specified format information.
+        /// </summary>
+        /// <param name="format">A composite format string</param>
+        /// <param name="arg">An array of objects to write using format.</param>
+        void WriteErrorLine(string format, params object[] arg);
+
+        /// <summary>
         /// Sets the foreground and background console colors to their defaults.
         /// </summary>
         void ResetColor();

--- a/src/Cake.Testing/FakeConsole.cs
+++ b/src/Cake.Testing/FakeConsole.cs
@@ -16,6 +16,12 @@ namespace Cake.Testing
         public List<string> Messages { get; set; }
 
         /// <summary>
+        /// Gets or sets the error messages.
+        /// </summary>
+        /// <value>The messages.</value>
+        public List<string> ErrorMessages { get; set; }
+
+        /// <summary>
         /// Gets or sets the foreground color.
         /// </summary>
         /// <value>The foreground color</value>
@@ -33,6 +39,7 @@ namespace Cake.Testing
         public FakeConsole()
         {
             Messages = new List<string>();
+            ErrorMessages = new List<string>();
             ForegroundColor = ConsoleColor.Gray;
             BackgroundColor = ConsoleColor.Black;
         }
@@ -60,6 +67,35 @@ namespace Cake.Testing
             if (!string.IsNullOrWhiteSpace(format))
             {
                 Messages.Add(string.Format(format, arg));
+            }
+        }
+
+        /// <summary>
+        /// Writes the text representation of the specified array of objects to the
+        /// console error output using the specified format information.
+        /// </summary>
+        /// <param name="format">A composite format string</param>
+        /// <param name="arg">An array of objects to write using format.</param>
+        public void WriteError(string format, params object[] arg)
+        {
+            if (!string.IsNullOrWhiteSpace(format))
+            {
+                ErrorMessages.Add(string.Format(format, arg));
+            }
+        }
+
+        /// <summary>
+        /// Writes the text representation of the specified array of objects, followed
+        /// by the current line terminator, to the console error output using the
+        /// specified format information.
+        /// </summary>
+        /// <param name="format">A composite format string</param>
+        /// <param name="arg">An array of objects to write using format.</param>
+        public void WriteErrorLine(string format, params object[] arg)
+        {
+            if (!string.IsNullOrWhiteSpace(format))
+            {
+                ErrorMessages.Add(string.Format(format, arg));
             }
         }
 

--- a/src/Cake.Tests/Unit/Diagnostics/CakeBuildLogTests.cs
+++ b/src/Cake.Tests/Unit/Diagnostics/CakeBuildLogTests.cs
@@ -44,6 +44,40 @@ namespace Cake.Tests.Unit.Diagnostics
                 // Then
                 Assert.Equal(1, console.Messages.Count);
             }
+
+            [Theory]
+            [InlineData(LogLevel.Warning)]
+            [InlineData(LogLevel.Information)]
+            [InlineData(LogLevel.Verbose)]
+            [InlineData(LogLevel.Debug)]
+            public void Should_Write_Standard_Log_Messages_Written_With_A_Higher_Log_Level_Than_Error(LogLevel logLevel)
+            {
+                // Given
+                var console = new FakeConsole();
+                var log = new CakeBuildLog(console, Verbosity.Diagnostic);
+
+                // When
+                log.Write(Verbosity.Diagnostic, logLevel, "Hello World");
+
+                // Then
+                Assert.Equal(1, console.Messages.Count);
+            }
+
+            [Theory]
+            [InlineData(LogLevel.Fatal)]
+            [InlineData(LogLevel.Error)]
+            public void Should_Write_Error_Log_Messages_Written_With_A_Lower_Log_Level_Than_Warning(LogLevel logLevel)
+            {
+                // Given
+                var console = new FakeConsole();
+                var log = new CakeBuildLog(console, Verbosity.Diagnostic);
+
+                // When
+                log.Write(Verbosity.Diagnostic, logLevel, "Hello World");
+
+                // Then
+                Assert.Equal(1, console.ErrorMessages.Count);
+            }
         }
     }
 }

--- a/src/Cake/CakeConsole.cs
+++ b/src/Cake/CakeConsole.cs
@@ -49,6 +49,29 @@ namespace Cake
         }
 
         /// <summary>
+        /// Writes the text representation of the specified array of objects to the
+        /// console error output using the specified format information.
+        /// </summary>
+        /// <param name="format">A composite format string</param>
+        /// <param name="arg">An array of objects to write using format.</param>
+        public void WriteError(string format, params object[] arg)
+        {
+            Console.Error.Write(format, arg);
+        }
+
+        /// <summary>
+        /// Writes the text representation of the specified array of objects, followed
+        /// by the current line terminator, to the console error output using the
+        /// specified format information.
+        /// </summary>
+        /// <param name="format">A composite format string</param>
+        /// <param name="arg">An array of objects to write using format.</param>
+        public void WriteErrorLine(string format, params object[] arg)
+        {
+            Console.Error.WriteLine(format, arg);
+        }
+
+        /// <summary>
         /// Sets the foreground and background console colors to their defaults.
         /// </summary>
         public void ResetColor()

--- a/src/Cake/Diagnostics/CakeBuildLog.cs
+++ b/src/Cake/Diagnostics/CakeBuildLog.cs
@@ -37,13 +37,27 @@ namespace Cake.Diagnostics
                     foreach (var token in tokens)
                     {
                         SetPalette(token, palette);
-                        _console.Write("{0}", token.Render(args));
+                        if (level > LogLevel.Error)
+                        {
+                            _console.Write("{0}", token.Render(args));
+                        }
+                        else
+                        {
+                            _console.WriteError("{0}", token.Render(args));
+                        }
                     }
                 }
                 finally
                 {
                     _console.ResetColor();
-                    _console.WriteLine();
+                    if (level > LogLevel.Error)
+                    {
+                        _console.WriteLine();
+                    }
+                    else
+                    {
+                        _console.WriteErrorLine();
+                    }
                 }
             }
         }
@@ -73,6 +87,7 @@ namespace Cake.Diagnostics
             var background = _console.BackgroundColor;
             var palette = new Dictionary<LogLevel, ConsolePalette>
             {
+                { LogLevel.Fatal, new ConsolePalette(ConsoleColor.Magenta, ConsoleColor.White, ConsoleColor.DarkMagenta, ConsoleColor.White) },
                 { LogLevel.Error, new ConsolePalette(ConsoleColor.DarkRed, ConsoleColor.White, ConsoleColor.Red, ConsoleColor.White) },
                 { LogLevel.Warning, new ConsolePalette(background, ConsoleColor.Yellow, background, ConsoleColor.Yellow) },
                 { LogLevel.Information, new ConsolePalette(background, ConsoleColor.White, ConsoleColor.DarkBlue, ConsoleColor.White) },


### PR DESCRIPTION
This PR relates to #592 and #593 .
1. Log level <= Error will be sent to standard error output stream. Fixes #593
2. Adds missing LogLevel.Fatal `ConsolePalette`. Fixes #592


Example this script:
```cake
for(var i = 0; i < 5; i++)
{
    Debug("Debug: {0}", i);
    Verbose("Verbose: {0}", i);
    Information("Information: {0}", i);
    Warning("Warning: {0}", i);
    Error("Error: {0}", i);
}
```

Will on i.e. Bamboo log output all but group errors last too and categorize them as error logs.
![image](https://cloud.githubusercontent.com/assets/1647294/11853909/f236c4e6-a440-11e5-9f82-67cf2491b5e2.png)


Besides other build servers supporting this, it will also let you use redirection to i.e. standard pipe to different logs, etc.