### PR TITLE
Move from WebClient to HttpClient

### DIFF
--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -43,6 +43,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -50,7 +51,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="System.IO.Compression.FileSystem" />
-    <Reference Include="System.Net" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Build\AppVeyor\Data\AppVeyorEnvironmentInfo.cs" />
@@ -81,6 +81,7 @@
     <Compile Include="Build\Bamboo\Data\BambooCustomBuildInfo.cs" />
     <Compile Include="IO\Paths\ConvertableDirectoryPath.cs" />
     <Compile Include="IO\Paths\ConvertableFilePath.cs" />
+    <Compile Include="Net\HttpClientExtensions.cs" />
     <Compile Include="Properties\Namespaces.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/Cake.Common/Net/HttpClientExtensions.cs
+++ b/src/Cake.Common/Net/HttpClientExtensions.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Cake.Common.Net
+{
+    internal static class HttpClientExtensions
+    {
+        private const int DefaultBufferSize = 4096;
+
+        public static async Task DownloadFileAsync(this HttpClient client, Uri requestUri, string path, IProgress<int> progress = null)
+        {
+            var response = await client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+
+            response.EnsureSuccessStatusCode();
+
+            long? contentLength = null;
+
+            if (progress != null && response.Content.Headers.ContentLength.HasValue)
+            {
+                contentLength = response.Content.Headers.ContentLength.Value;
+            }
+
+            using (var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+            using (var fileStream = File.Create(path, DefaultBufferSize))
+            {
+                var bytesRead = 0;
+                var totalBytesRead = 0L;
+                var buffer = new byte[DefaultBufferSize];
+
+                while ((bytesRead = await responseStream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false)) > 0)
+                {
+                    await fileStream.WriteAsync(buffer, 0, bytesRead).ConfigureAwait(false);
+
+                    totalBytesRead += bytesRead;
+
+                    if (contentLength.HasValue)
+                    {
+                        var progressPercentage = totalBytesRead * 1d / (contentLength.Value * 1d);
+
+                        progress.Report((int)(progressPercentage * 100));
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I noticed in https://github.com/dotnet/cli/issues/270#issuecomment-167539366 that `WebClient` is used and that it's not part of the .NET Core surface area.

This moves Cake.Common from 96.39% to 97.50% :stuck_out_tongue_closed_eyes: