### PR TITLE
Use gobbler to locate tools from PATH environment variable

### DIFF
--- a/src/Cake.Common/Tools/Chocolatey/ChocolateyToolResolver.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ChocolateyToolResolver.cs
@@ -59,7 +59,7 @@ namespace Cake.Common.Tools.Chocolatey
             }
 
             // Last resort try path
-            var envPath = _environment.GetEnvironmentVariable("path");
+            var envPath = _environment.GetEnvironmentVariable("PATH");
             if (!string.IsNullOrWhiteSpace(envPath))
             {
                 var pathFile = envPath

--- a/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerToolResolver.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerToolResolver.cs
@@ -69,7 +69,7 @@ namespace Cake.Common.Tools.GitReleaseManager
             }
 
             // Last resort try path
-            var envPath = _environment.GetEnvironmentVariable("path");
+            var envPath = _environment.GetEnvironmentVariable("PATH");
             if (!string.IsNullOrWhiteSpace(envPath))
             {
                 var pathFile = envPath

--- a/src/Cake.Core.Tests/Unit/IO/NuGet/NuGetToolResolverTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/NuGet/NuGetToolResolverTests.cs
@@ -63,7 +63,7 @@ namespace Cake.Core.Tests.Unit.IO.NuGet
                 environment.WorkingDirectory.Returns("/Working");
                 environment.IsUnix().Returns(false);
                 environment.GetEnvironmentVariable("NUGET_EXE").Returns(c => null);
-                environment.GetEnvironmentVariable("path").Returns(c => null);
+                environment.GetEnvironmentVariable("PATH").Returns(c => null);
                 var fileSystem = new FakeFileSystem(environment);
                 var globber = Substitute.For<IGlobber>();
                 globber.GetFiles("./tools/**/NuGet.exe").Returns(new FilePath[] { });
@@ -84,7 +84,7 @@ namespace Cake.Core.Tests.Unit.IO.NuGet
                 environment.WorkingDirectory.Returns("/Working");
                 environment.IsUnix().Returns(false);
                 environment.GetEnvironmentVariable("NUGET_EXE").Returns(c => null);
-                environment.GetEnvironmentVariable("path").Returns(c => null);
+                environment.GetEnvironmentVariable("PATH").Returns(c => null);
                 var fileSystem = new FakeFileSystem(environment);
                 var globber = Substitute.For<IGlobber>();
                 globber.GetFiles("./tools/**/NuGet.exe").Returns(new FilePath[] { });
@@ -101,7 +101,7 @@ namespace Cake.Core.Tests.Unit.IO.NuGet
                     // 2. Look for the environment variable NUGET_EXE.
                     environment.GetEnvironmentVariable("NUGET_EXE");
                     // 3. Panic and look in the path variable.
-                    environment.GetEnvironmentVariable("path");
+                    environment.GetEnvironmentVariable("PATH");
                 });
             }
 
@@ -151,7 +151,7 @@ namespace Cake.Core.Tests.Unit.IO.NuGet
                 var environment = Substitute.For<ICakeEnvironment>();
                 environment.WorkingDirectory.Returns("/Working");
                 environment.IsUnix().Returns(false);
-                environment.GetEnvironmentVariable("path").Returns("/temp;stuff/programs;/programs");
+                environment.GetEnvironmentVariable("PATH").Returns("/temp;stuff/programs;/programs");
                 var fileSystem = new FakeFileSystem(environment);
                 fileSystem.CreateDirectory("stuff/programs");
                 fileSystem.CreateFile("stuff/programs/nuget.exe");

--- a/src/Cake.Core/IO/NuGet/NuGetToolResolver.cs
+++ b/src/Cake.Core/IO/NuGet/NuGetToolResolver.cs
@@ -100,7 +100,7 @@ namespace Cake.Core.IO.NuGet
             }
 
             // Last resort try path
-            var envPath = _environment.GetEnvironmentVariable("path");
+            var envPath = _environment.GetEnvironmentVariable("PATH");
             if (!string.IsNullOrWhiteSpace(envPath))
             {
                 var pathFile = envPath

--- a/src/Cake.Core/Tooling/Tool.cs
+++ b/src/Cake.Core/Tooling/Tool.cs
@@ -247,11 +247,10 @@ namespace Cake.Core.Tooling
                 // Look in every PATH directory for the file.
                 foreach (var pathDir in pathDirs)
                 {
-                    var file = new DirectoryPath(pathDir).CombineWithFilePath(toolExeName);
-
-                    if (_fileSystem.Exist(file))
+                    toolPath = _globber.GetFiles(pathDir + "**/" + toolExeName).FirstOrDefault();
+                    if (toolPath != null)
                     {
-                        return file.MakeAbsolute(_environment);
+                        return toolPath.MakeAbsolute(_environment);
                     }
                 }
             }


### PR DESCRIPTION
Allows you to set the PATH environment variable to a shared tools folder and still locate tools with non-standard locations (eg: "tools/JetBrains.ReSharper.CommandLineTools/tools/inspectcode.exe").

```powershell
$ENV:PATH = "C:/Tools/"
```

Also upper-cased any instances of the PATH variable for consistency :smile: 