### PR TITLE
[WIP] Adding XmlPeek for reading XML values.

### DIFF
--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -254,6 +254,8 @@
     <Compile Include="Unit\XML\XmlPokeTests.cs" />
     <Compile Include="Unit\XML\XmlTransformationTests.cs" />
     <Compile Include="Unit\Build\Bamboo\Data\BambooPlanInfoTests.cs" />
+    <Compile Include="Unit\XML\XmlPeekAliasesTests.cs" />
+    <Compile Include="Fixtures\XmlPeekAliasesFixture.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cake.Common\Cake.Common.csproj">

--- a/src/Cake.Common.Tests/Fixtures/XmlPeekAliasesFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/XmlPeekAliasesFixture.cs
@@ -1,0 +1,46 @@
+﻿using System.IO;
+using System.Linq;
+using System.Xml;
+using Cake.Common.Tests.Properties;
+using Cake.Common.Xml;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Testing;
+using NSubstitute;
+
+namespace Cake.Common.Tests.Fixtures
+{
+    internal sealed class XmlPeekAliasesFixture
+    {
+       public IFileSystem FileSystem { get; set; }
+       public ICakeContext Context { get; set; }
+       public FilePath XmlPath { get; set; }
+       public XmlPeekSettings Settings { get; set; }
+
+       public XmlPeekAliasesFixture(bool xmlExists = true)
+       {
+           Settings = new XmlPeekSettings();
+
+           var environment = FakeEnvironment.CreateUnixEnvironment();
+           var fileSystem = new FakeFileSystem(environment);
+           fileSystem.CreateDirectory("/Working");
+
+           if (xmlExists)
+           {
+               var xmlFile = fileSystem.CreateFile("/Working/web.config").SetContent(Resources.XmlPeek_Xml);
+               XmlPath = xmlFile.Path;
+           }
+
+           FileSystem = fileSystem;
+
+           Context = Substitute.For<ICakeContext>();
+           Context.FileSystem.Returns(FileSystem);
+           Context.Environment.Returns(environment);
+       }
+
+       public string Peek(string xpath)
+       {
+           return XmlPeekAliases.XmlPeek(Context, XmlPath, xpath, Settings);
+       }
+    }
+}

--- a/src/Cake.Common.Tests/Properties/Resources.Designer.cs
+++ b/src/Cake.Common.Tests/Properties/Resources.Designer.cs
@@ -360,6 +360,21 @@ namespace Cake.Common.Tests.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; ?&gt;
+        ///&lt;configuration&gt;
+        ///    &lt;appSettings&gt;
+        ///        &lt;add key=&quot;server&quot; value=&quot;testhost.somecompany.com&quot; /&gt;
+        ///        &lt;add key=&quot;test&quot; value=&quot;true&quot; /&gt;
+        ///    &lt;/appSettings&gt;
+        ///&lt;/configuration&gt;.
+        /// </summary>
+        internal static string XmlPeek_Xml {
+            get {
+                return ResourceManager.GetString("XmlPeek_Xml", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&lt;html&gt;&lt;body style=&quot;font-family:Arial;font-size:12pt;background-color:#EEEEEE&quot;&gt;&lt;div style=&quot;background-color:teal;color:white;padding:4px&quot;&gt;&lt;span style=&quot;font-weight:bold&quot;&gt;Belgian Waffles
         ///                    -
         ///                &lt;/span&gt;$5.95&lt;/div&gt;&lt;div style=&quot;margin-left:20px;margin-bottom:1em;font-size:10pt&quot;&gt;&lt;p&gt;Two of our famous Belgian Waffles with plenty of real maple syrup&lt;span style=&quot;font-style:italic&quot;&gt;

--- a/src/Cake.Common.Tests/Properties/Resources.resx
+++ b/src/Cake.Common.Tests/Properties/Resources.resx
@@ -454,6 +454,17 @@ Line #3]]&gt;&lt;/releaseNotes&gt;
     &lt;/appSettings&gt;
 &lt;/configuration&gt;</value>
   </data>
+  <data name="XmlPeek_Xml" xml:space="preserve">
+    <value>&lt;?xml version="1.0" encoding="utf-8" ?&gt;
+&lt;configuration&gt;
+    &lt;appSettings&gt;
+        &lt;add key="server" value="testhost.somecompany.com" /&gt;
+        &lt;add key="test" value="true" /&gt;
+    &lt;/appSettings&gt;
+    &lt;test&gt;test value&lt;/test&gt;
+&lt;/configuration&gt;
+</value>
+  </data>
   <data name="XmlTransformation_Htm" xml:space="preserve">
     <value>&lt;?xml version="1.0" encoding="utf-8"?&gt;&lt;html&gt;&lt;body style="font-family:Arial;font-size:12pt;background-color:#EEEEEE"&gt;&lt;div style="background-color:teal;color:white;padding:4px"&gt;&lt;span style="font-weight:bold"&gt;Belgian Waffles
                     -

--- a/src/Cake.Common.Tests/Unit/XML/XmlPeekAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/XML/XmlPeekAliasesTests.cs
@@ -1,0 +1,78 @@
+﻿using System.IO;
+using Cake.Common.Tests.Fixtures;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.XML
+{
+    public sealed class XmlPeekAliasesTests
+    {
+        public sealed class TheXmlPeekMethod
+        {
+            [Fact]
+            public void Should_Throw_If_FilePath_Is_Null()
+            {
+                // Given
+                var fixture = new XmlPeekAliasesFixture(false);
+
+                // When
+                var result = Record.Exception(() => fixture.Peek("gibblygook"));
+
+                // Then
+                Assert.IsArgumentNullException(result, "filePath");
+            }
+
+            [Fact]
+            public void Should_Throw_If_File_Does_Not_Exists()
+            {
+                // Given
+                var fixture = new XmlPeekAliasesFixture(false);
+                fixture.XmlPath = "/Working/web.config";
+
+                // When
+                var result = Record.Exception(() => fixture.Peek("gibblygook"));
+
+                // Then
+                Assert.IsType<FileNotFoundException>(result);
+            }
+
+            [Fact]
+            public void Should_Throw_If_No_Xpath()
+            {
+                // Given
+                var fixture = new XmlPeekAliasesFixture();
+
+                // When
+                var result = Record.Exception(() => fixture.Peek(null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "xpath");
+            }
+            
+            [Fact]
+            public void Should_Get_Attribute_Value()
+            {
+                // Given
+                var fixture = new XmlPeekAliasesFixture();
+
+                // When
+                var result = fixture.Peek("/configuration/appSettings/add[@key = 'server']/@value");
+
+                // Then
+                Assert.Equal("testhost.somecompany.com", result);
+            }
+
+            [Fact]
+            public void Should_Get_Node_Value()
+            {
+                // Given
+                var fixture = new XmlPeekAliasesFixture();
+
+                // When
+                var result = fixture.Peek("/configuration/test/text()");
+
+                // Then
+                Assert.Equal("test value", result);
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -318,6 +318,8 @@
     <Compile Include="Tools\ILRepack\ILRepackRunner.cs" />
     <Compile Include="Tools\ILRepack\ILRepackAliases.cs" />
     <Compile Include="Build\Bamboo\Data\BambooPlanInfo.cs" />
+    <Compile Include="Xml\XmlPeekAliases.cs" />
+    <Compile Include="Xml\XmlPeekSettings.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cake.Core\Cake.Core.csproj">

--- a/src/Cake.Common/Xml/XmlPeekAliases.cs
+++ b/src/Cake.Common/Xml/XmlPeekAliases.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Xml;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+
+namespace Cake.Common.Xml
+{
+    /// <summary>
+    /// Contains functionality related to XML XPath queries.
+    /// </summary>
+    [CakeAliasCategory("XML")]
+    public static class XmlPeekAliases
+    {
+        /// <summary>
+        /// Gets the value of a target node.
+        /// </summary>
+        /// <returns>The value found at the given XPath query.</returns>
+        /// <param name="context">The context.</param>
+        /// <param name="filePath">The target file.</param>
+        /// <param name="xpath">The xpath of the node to get.</param>
+        [CakeMethodAlias]
+        public static string XmlPeek(this ICakeContext context, FilePath filePath, string xpath)
+        {
+            return context.XmlPeek(filePath, xpath, new XmlPeekSettings());
+        }
+        
+        /// <summary>
+        /// Get the value of a target node.
+        /// </summary>
+        /// <returns>The value found at the given XPath query.</returns>
+        /// <param name="context">The context.</param>
+        /// <param name="filePath">The target file.</param>
+        /// <param name="xpath">The xpath of the nodes to set.</param>
+        /// <param name="settings">Additional settings to tweak Xml Peek behavior.</param>
+        [CakeMethodAlias]
+        public static string XmlPeek(this ICakeContext context, FilePath filePath, string xpath, XmlPeekSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            
+            if (filePath == null)
+            {
+                throw new ArgumentNullException("filePath");
+            }
+            
+            var file = context.FileSystem.GetFile(filePath);
+            if (!file.Exists)
+            {
+                throw new FileNotFoundException("Source File not found.", file.Path.FullPath);
+            }
+            
+            using (var memoryStream = new MemoryStream())
+            {
+                using (var fileStream = file.Open(FileMode.Open, FileAccess.Read, FileShare.None))
+                using (var xmlReader = XmlReader.Create(fileStream))
+                using (var xmlWriter = XmlWriter.Create(memoryStream))
+                {
+                    var xmlValue = XmlPeek(xmlReader, xpath, settings);
+                    if (xmlValue == null)
+                    {
+                        context.Log.Warning("Warning: Failed to find node matching the XPath '{0}'", xpath);
+                    }
+                    return xmlValue;
+                }
+            }
+        }
+        
+        /// <summary>
+        /// Gets the value of a target node.
+        /// </summary>
+        /// <returns>The value found at the given XPath query (or the first, if multiple eligible nodes are found).</returns>
+        /// <param name="source">The source xml to transform.</param>
+        /// <param name="xpath">The xpath of the nodes to set.</param>
+        /// <param name="settings">Additional settings to tweak Xml Peek behavior.</param>
+        private static string XmlPeek(XmlReader source, string xpath, XmlPeekSettings settings)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException("source");
+            }
+            
+            if (string.IsNullOrWhiteSpace(xpath))
+            {
+                throw new ArgumentNullException("xpath");
+            }
+            
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+            
+            var document = new XmlDocument();
+            document.PreserveWhitespace = settings.PreserveWhitespace;
+            document.Load(source);
+            
+            var namespaceManager = new XmlNamespaceManager(document.NameTable);
+            foreach (var xmlNamespace in settings.Namespaces)
+            {
+                namespaceManager.AddNamespace(xmlNamespace.Key /* Prefix */, xmlNamespace.Value /* URI */);
+            }
+            
+            var node = document.SelectSingleNode(xpath, namespaceManager);
+            
+            return node != null ? node.Value : null;
+        }
+    }
+}

--- a/src/Cake.Common/Xml/XmlPeekSettings.cs
+++ b/src/Cake.Common/Xml/XmlPeekSettings.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+
+namespace Cake.Common.Xml
+{
+    /// <summary>
+    /// Contains settings for <see cref="XmlPeekAliases"/>
+    /// </summary>
+    public sealed class XmlPeekSettings
+    {
+        /// <summary>
+        /// Gets or sets namespaces to include for xpath recognition.
+        /// </summary>
+        public IDictionary<string, string> Namespaces { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to preserve white space.
+        /// </summary>
+        public bool PreserveWhitespace { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XmlPeekSettings"/> class.
+        /// </summary>
+        public XmlPeekSettings()
+        {
+            PreserveWhitespace = true;
+            Namespaces = new Dictionary<string, string>();
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Allow a build script to extract values from XML files.

Example

```
Task("PrintServerValue")
    .Does(() =>
{
    var file = File("test.xml");
    var serverValue = XmlPeek("/configuration/appSettings/add[@key = 'server']/@value");
    Information(serverValue);
});
```

## Current State

I copied over XmlPoke code and its testing code as well. From there, I removed the writing logic, and set it to return a `Value` string.

## Work Needed

I am terrible with XPath stuff, and I haven't been able to confirm what I've written will actually work. Unfortunately, I am working on a Mac using Xamarin Studio for these changes. I ran into a number of issues building and testing. I feel bad even putting this in a pull request, but I've been changing so many things trying to test it locally with NUnit, I wouldn't be sure I was even testing the same thing if I get it to work. Here are the issues I ran into that may or may not be easy to fix.

* The current develop branch doesn't build at all, even before I made changes. Every instance of `using Cake.Common.Tests.Properties;` is a build error. I have these removed locally, but not committed.
* Running xUnit tests on Xamarin Studio is problematic. I haven't figured out how to get it to happen at all.
* Running `./build.sh` from the command line built it fine, but failed on every non-skipped unit tests with the following error.

> System.Resources.MissingManifestResourceException : Could not find any resources appropriate for the specified culture or the neutral culture.  Make sure "Cake.Common.Tests.Resources.resources" was correctly embedded or linked into assembly "Cake.Common.Tests" at compile time, or that all the satellite assemblies required are loadable and fully signed.

I don't know if these problems are all specific to my machine or to my environment in general (OS X, XS, etc.). The first item above could even be a preexisting issue with current develop branch.