### PR TITLE
Fixed line numbers in error messages.

### DIFF
--- a/src/Cake.Core/Scripting/Analysis/ScriptAnalyzer.cs
+++ b/src/Cake.Core/Scripting/Analysis/ScriptAnalyzer.cs
@@ -100,20 +100,16 @@ namespace Cake.Core.Scripting.Analysis
             var lines = ReadLines(path);
 
             // Iterate all lines in the script.
-            var firstLine = true;
             foreach (var line in lines)
             {
                 if (!_lineProcessors.Any(p => p.Process(context, line)))
                 {
-                    if (firstLine)
-                    {
-                        // Append the line directive for the script.
-                        var scriptFullPath = path.MakeAbsolute(_environment);
-                        context.AddScriptLine(string.Format(CultureInfo.InvariantCulture, "#line 1 \"{0}\"", scriptFullPath.FullPath));
-                        firstLine = false;
-                    }
-
                     context.AddScriptLine(line);
+                }
+                else
+                {
+                    // Comment out processed lines to keep line data.
+                    context.AddScriptLine(string.Concat("// ", line));
                 }
             }
         }

--- a/src/Cake.Core/Scripting/Analysis/ScriptAnalyzerContext.cs
+++ b/src/Cake.Core/Scripting/Analysis/ScriptAnalyzerContext.cs
@@ -16,7 +16,7 @@ namespace Cake.Core.Scripting.Analysis
         private readonly List<string> _lines;
         private readonly HashSet<FilePath> _processedScripts;
         private ScriptInformation _root;
-        private ScriptInformation _current; 
+        private ScriptInformation _current;
 
         public IScriptInformation Script
         {
@@ -99,6 +99,8 @@ namespace Cake.Core.Scripting.Analysis
 
             _current = script;
             _stack.Push(_current);
+
+            InsertLineDirective();
         }
 
         public void Pop()
@@ -107,6 +109,18 @@ namespace Cake.Core.Scripting.Analysis
             if (_stack.Count > 0)
             {
                 _current = _stack.Peek();
+
+                InsertLineDirective();
+            }
+        }
+
+        private void InsertLineDirective()
+        {
+            if (_current != null)
+            {
+                var position = Math.Max(1, _current.Lines.Count + 1);
+                _lines.Add(string.Format(CultureInfo.InvariantCulture, 
+                    "#line {0} \"{1}\"", position, _current.Path.FullPath));
             }
         }
     }


### PR DESCRIPTION
This PR will make sure that `#line` directives are inserted at the correct position when loading other script files. This way the line numbering will be correct if an error occurs in the script.

**a.cake**
```
int x=0;
#l b.cake
int y=2;
```

**b.cake**
```
int z=1;
#l c.cake
int p=4;
```

**c.cake**
```
int o=3;
#r d.dll
```

**Will result in the following aggregated script (when analyzing a.cake):**

```csharp
#line 1 "/Working/a.cake"
int x=0;
#line 1 "/Working/b.cake"
int z=1;
#line 1 "/Working/c.cake"
int o=3;
// #r d.dll
#line 2 "/Working/b.cake"
// #l c.cake
int p=4;
#line 2 "/Working/a.cake"
// #l b.cake
int y=2;
```

Closes #375