### PR TITLE
Tools and Addins environment variables

### DIFF
--- a/src/Cake.Core/Scripting/ScriptRunner.cs
+++ b/src/Cake.Core/Scripting/ScriptRunner.cs
@@ -110,13 +110,35 @@ namespace Cake.Core.Scripting
 
             // Install tools.
             _log.Verbose("Processing build script...");
-            var toolsPath = scriptPath.GetDirectory().Combine("tools");
+            var toolsEnv = _environment.GetEnvironmentVariable("CAKE_TOOLS");
+
+            DirectoryPath toolsPath;
+            if (!string.IsNullOrEmpty(toolsEnv))
+            {
+                toolsPath = new DirectoryPath(toolsEnv).MakeAbsolute(_environment);
+            }
+            else
+            {
+                toolsPath = scriptPath.GetDirectory().Combine("tools");
+            }
+
             _processor.InstallTools(result, toolsPath);
 
             // Install addins.
             var applicationRoot = _environment.GetApplicationRoot();
-            var addinRoot = applicationRoot.Combine("../Addins").Collapse();
-            var addinReferences = _processor.InstallAddins(result, addinRoot);
+            var addinsEnv = _environment.GetEnvironmentVariable("CAKE_ADDINS");
+
+            DirectoryPath addinPath;
+            if (!string.IsNullOrEmpty(addinsEnv))
+            {
+                addinPath = new DirectoryPath(addinsEnv).MakeAbsolute(_environment);
+            }
+            else
+            {
+                addinPath = applicationRoot.Combine("../Addins").Collapse();
+            }
+
+            var addinReferences = _processor.InstallAddins(result, addinPath);
             foreach (var addinReference in addinReferences)
             {
                 result.References.Add(addinReference.FullPath);

--- a/src/Cake.Core/Tooling/Tool.cs
+++ b/src/Cake.Core/Tooling/Tool.cs
@@ -230,6 +230,17 @@ namespace Cake.Core.Tooling
                     return toolPath.MakeAbsolute(_environment);
                 }
 
+                // Look in the tools enviroment variable
+                var toolsEnv = _environment.GetEnvironmentVariable("CAKE_TOOLS");
+                if (!string.IsNullOrEmpty(toolsEnv))
+                {
+                    toolPath = _globber.GetFiles(toolsEnv + "**/" + toolExeName).FirstOrDefault();
+                    if (toolPath != null)
+                    {
+                        return toolPath.MakeAbsolute(_environment);
+                    }
+                }
+
                 // Cache the PATH directory list if we didn't already.
                 if (pathDirs == null)
                 {


### PR DESCRIPTION
Allows you to define shared folders in your powershell scripts for Cake to use when resolving / installing tools and addins:

```powershell
# Find tools
if(($Tools.IsPresent) -and (Test-Path $Tools))
{
    # Parameter
    Write-Host "Using tools parameter"
    $TOOLS_DIR = $Tools
}
elseif (Test-Path "C:/Tools/Cake/Cake.exe") 
{
    # Shared location
    Write-Host "Using shared tools"
    $TOOLS_DIR = "C:/Tools/"
}
else
{
    # Local path
    Write-Host "Using local tools"
    $PSScriptRoot = split-path -parent $MyInvocation.MyCommand.Definition
    $TOOLS_DIR = Join-Path $PSScriptRoot "tools"

    if (!(Test-Path $TOOLS_DIR)) 
    {
        Write-Host "Creating tools directory"
        New-Item $TOOLS_DIR -itemtype directory
    }
}

# Save paths to environment for use in child processes
$ENV:CAKE_TOOLS = $TOOLS_DIR
$ENV:CAKE_ADDINS = $TOOLS_DIR + "Addins/"
```