### PR TITLE
Display skipped tasks in task summary. #638

### DIFF
--- a/src/Cake.Core.Tests/Cake.Core.Tests.csproj
+++ b/src/Cake.Core.Tests/Cake.Core.Tests.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Unit\Annotations\CakePropertyAliasAttributeTests.cs" />
     <Compile Include="Unit\CakeContextTests.cs" />
     <Compile Include="Unit\CakeEngineTests.cs" />
+    <Compile Include="Unit\CakeReportTests.cs" />
     <Compile Include="Unit\CakeTaskBuilderExtensionsTests.cs" />
     <Compile Include="Unit\CakeTaskBuilderTests.cs" />
     <Compile Include="Unit\CakeTaskTests.cs" />

--- a/src/Cake.Core.Tests/Unit/CakeReportTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeReportTests.cs
@@ -1,0 +1,97 @@
+namespace Cake.Core.Tests.Unit
+{
+    using System;
+    using System.Linq;
+    using Xunit;
+
+    public sealed class CakeReportTests
+    {
+        public sealed class TheAddMethod
+        {
+            [Fact]
+            public void Should_Add_A_New_Task()
+            {
+                // Given
+                var report = new CakeReport();
+                var taskName = "task";
+                var duration = TimeSpan.FromMilliseconds(100);
+
+                // When
+                report.Add("task", duration);
+
+                // Then
+                var firstTask = report.FirstOrDefault();
+                
+                Assert.NotNull(firstTask);
+                Assert.Equal(taskName, firstTask.TaskName);
+                Assert.Equal(duration, firstTask.Duration);
+                Assert.False(firstTask.Skipped);
+            }
+
+            [Fact]
+            public void Should_Add_To_End_Of_Sequence()
+            {
+                // Given
+                var report = new CakeReport();
+                report.Add("task 1", TimeSpan.FromMilliseconds(100));
+                
+                var taskName = "task";
+                var duration = TimeSpan.FromMilliseconds(200);
+
+                // When
+                report.Add(taskName, duration);
+
+                // Then
+                var lastTask = report.LastOrDefault();
+
+                Assert.NotNull(lastTask);
+                Assert.Equal(taskName, lastTask.TaskName);
+                Assert.Equal(duration, lastTask.Duration);
+                Assert.False(lastTask.Skipped);
+            }
+        }
+
+        public sealed class TheAddSkippedMethod
+        {
+            [Fact]
+            public void Should_Add_A_New_Task()
+            {
+                // Given
+                var report = new CakeReport();
+                var taskName = "task";
+
+                // When
+                report.AddSkipped(taskName);
+
+                // Then
+                var firstTask = report.FirstOrDefault();
+
+                Assert.NotNull(firstTask);
+                Assert.Equal(taskName, firstTask.TaskName);
+                Assert.Equal(TimeSpan.Zero, firstTask.Duration);
+                Assert.True(firstTask.Skipped);
+            }
+
+            [Fact]
+            public void Should_Add_To_End_Of_Sequence()
+            {
+                // Given
+                var report = new CakeReport();
+                report.AddSkipped("task 1");
+
+                var taskName = "task 2";
+
+                // When
+                report.AddSkipped(taskName);
+
+                // Then
+                var lastTask = report.LastOrDefault();
+
+                Assert.NotNull(lastTask);
+                Assert.Equal(taskName, lastTask.TaskName);
+                Assert.Equal(TimeSpan.Zero, lastTask.Duration);
+                Assert.True(lastTask.Skipped);
+            }
+        }
+    }
+}

--- a/src/Cake.Core/CakeEngine.cs
+++ b/src/Cake.Core/CakeEngine.cs
@@ -137,7 +137,7 @@ namespace Cake.Core
                     }
                     else
                     {
-                        SkipTask(context, strategy, task);
+                        SkipTask(context, strategy, task, report);
                     }
                 }
 
@@ -294,11 +294,14 @@ namespace Cake.Core
             }
         }
 
-        private void SkipTask(ICakeContext context, IExecutionStrategy strategy, CakeTask task)
+        private void SkipTask(ICakeContext context, IExecutionStrategy strategy, CakeTask task, CakeReport report)
         {
             PerformTaskSetup(context, strategy, task, true);
             strategy.Skip(task);
             PerformTaskTeardown(context, strategy, task, TimeSpan.Zero, true, false);
+
+            // Add the skipped task to the report.
+            report.AddSkipped(task.Name);
         }
 
         private static void ReportErrors(IExecutionStrategy strategy, Action<Exception> errorReporter, Exception taskException)

--- a/src/Cake.Core/CakeReport.cs
+++ b/src/Cake.Core/CakeReport.cs
@@ -41,6 +41,15 @@ namespace Cake.Core
         }
 
         /// <summary>
+        /// Adds a skipped task result to the report.
+        /// </summary>
+        /// <param name="task">The task.</param>
+        public void AddSkipped(string task)
+        {
+            _report.Add(new CakeReportEntry(task, TimeSpan.Zero, true));
+        }
+
+        /// <summary>
         /// Returns an enumerator that iterates through the collection.
         /// </summary>
         /// <returns>

--- a/src/Cake.Core/CakeReportEntry.cs
+++ b/src/Cake.Core/CakeReportEntry.cs
@@ -9,6 +9,7 @@ namespace Cake.Core
     {
         private readonly string _taskName;
         private readonly TimeSpan _duration;
+        private readonly bool _skipped;
 
         /// <summary>
         /// Gets the task name.
@@ -29,14 +30,37 @@ namespace Cake.Core
         }
 
         /// <summary>
+        /// Gets a value indicating whether the task was skipped.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if the task was skipped; otherwise, <c>false</c>.
+        /// </value>
+        public bool Skipped
+        {
+            get { return _skipped; }
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="CakeReportEntry"/> class.
         /// </summary>
         /// <param name="taskName">The name of the task.</param>
         /// <param name="duration">The duration.</param>
-        public CakeReportEntry(string taskName, TimeSpan duration)
+        public CakeReportEntry(string taskName, TimeSpan duration) 
+            : this(taskName, duration, false)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CakeReportEntry"/> class.
+        /// </summary>
+        /// <param name="taskName">The name of the task.</param>
+        /// <param name="duration">The duration.</param>
+        /// <param name="skipped">Indicates if the task was skipped.</param>
+        public CakeReportEntry(string taskName, TimeSpan duration, bool skipped)
         {
             _taskName = taskName;
             _duration = duration;
+            _skipped = skipped;
         }
     }
 }

--- a/src/Cake.Tests/Unit/CakeReportPrinterTests.cs
+++ b/src/Cake.Tests/Unit/CakeReportPrinterTests.cs
@@ -65,6 +65,29 @@ namespace Cake.Tests.Unit
                 string expected = String.Format("{0,-45}{1,-20}", taskName, duration);
                 Assert.Contains(console.Messages, s => s == expected);
             }
+
+            [Fact]
+            public void Should_Print_No_Duration_For_Skipped_Tasks()
+            {
+                // Given
+                var console = new FakeConsole();
+                var report = new CakeReport();
+                string taskName = "TaskName";
+                string taskNameThatWasSkipped = "TaskName-That-Was-Skipped";
+                TimeSpan duration = TimeSpan.FromSeconds(10);
+
+                report.Add(taskName, duration);
+                report.AddSkipped(taskNameThatWasSkipped);
+
+                var printer = new CakeReportPrinter(console);
+
+                // When
+                printer.Write(report);
+
+                // Then
+                string expected = String.Format("{0,-30}{1,-20}", taskNameThatWasSkipped, "Skipped");
+                Assert.Contains(console.Messages, s => s == expected);
+            }
         }
     }
 }

--- a/src/Cake/CakeReportPrinter.cs
+++ b/src/Cake/CakeReportPrinter.cs
@@ -45,10 +45,12 @@ namespace Cake
                 // Write task status.
                 foreach (var item in report)
                 {
-                    _console.WriteLine(lineFormat, item.TaskName, FormatTime(item.Duration));
+                    _console.ForegroundColor = GetItemForegroundColor(item);
+                    _console.WriteLine(lineFormat, item.TaskName, FormatDuration(item));
                 }
 
                 // Write footer.
+                _console.ForegroundColor = ConsoleColor.Green;
                 _console.WriteLine(new string('-', 20 + maxTaskNameLength));
                 _console.WriteLine(lineFormat, "Total:", FormatTime(GetTotalTime(report)));
             }
@@ -56,6 +58,16 @@ namespace Cake
             {
                 _console.ResetColor();
             }
+        }
+
+        private static string FormatDuration(CakeReportEntry item)
+        {
+            return item.Skipped ? "Skipped" : FormatTime(item.Duration);
+        }
+
+        private static ConsoleColor GetItemForegroundColor(CakeReportEntry item)
+        {
+            return item.Skipped ? ConsoleColor.Gray : ConsoleColor.Green;
         }
 
         private static string FormatTime(TimeSpan time)


### PR DESCRIPTION
This PR ensures that skipped tasks are displayed in the task summary (issue #638). It does this by adding a `Skipped` property to the `CakeReport` class. 

When you run the updated CAKE version on a script that has two skipped tasks, the new output looks as follows:

![image](https://cloud.githubusercontent.com/assets/135246/12421823/3910b2c6-bec4-11e5-8404-27dcef0d1a3d.png)

I'm not sure the "(skipped)" text is the best option, but I preferred it over "-" and "- (skipped)".

Everything has been unit tested (save for the changing of the foreground color, which I don't know how to test). In the process, I have also added tests that verify that the `CakeReport` returned by the `RunTarget` method is correct. 