### PR TITLE
Add methods to get relative paths (#621)

### DIFF
--- a/src/Cake.Core.Tests/Unit/IO/DirectoryPathTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/DirectoryPathTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Cake.Core.IO;
+using Cake.Testing.Xunit;
 using NSubstitute;
 using Xunit;
 
@@ -274,6 +275,335 @@ namespace Cake.Core.Tests.Unit.IO
 
                     // Then
                     Assert.Equal("/assets", result.FullPath);
+                }
+            }
+        }
+
+        public sealed class TheGetRelativePathMethod
+        {
+            public sealed class WithDirectoryPath
+            {
+                public sealed class InWindowsFormat
+                {
+                    [WindowsTheory]
+                    [InlineData("C:/A/B/C", "C:/A/B/C", ".")]
+                    [InlineData("C:/", "C:/", ".")]
+                    [InlineData("C:/A/B/C", "C:/A/D/E", "../../D/E")]
+                    [InlineData("C:/A/B/C", "C:/", "../../..")]
+                    [InlineData("C:/A/B/C/D/E/F", "C:/A/B/C", "../../..")]
+                    [InlineData("C:/A/B/C", "C:/A/B/C/D/E/F", "D/E/F")]
+                    public void Should_Returns_Relative_Path_Between_Paths(string from, string to, string expected)
+                    {
+                        // Given
+                        var path = new DirectoryPath(from);
+
+                        // When
+                        var relativePath = path.GetRelativePath(new DirectoryPath(to));
+
+                        // Then
+                        Assert.Equal(expected, relativePath.FullPath);
+                    }
+
+                    [WindowsTheory]
+                    [InlineData("C:/A/B/C", "D:/A/B/C")]
+                    [InlineData("C:/A/B", "D:/E/")]
+                    [InlineData("C:/", "B:/")]
+                    public void Should_Throw_If_No_Relative_Path_Can_Be_Found(string from, string to)
+                    {
+                        // Given
+                        var path = new DirectoryPath(from);
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath(new DirectoryPath(to)));
+
+                        // Then
+                        Assert.IsType<InvalidOperationException>(result);
+                        Assert.Equal("Paths must share a common prefix.", result.Message);
+                    }
+
+                    [WindowsFact]
+                    public void Should_Throw_If_Target_DirectoryPath_Is_Null()
+                    {
+                        // Given
+                        var path = new DirectoryPath("C:/A/B/C");
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath((DirectoryPath)null));
+
+                        // Then
+                        Assert.IsArgumentNullException(result, "to");
+                    }
+
+                    [WindowsFact]
+                    public void Should_Throw_If_Source_DirectoryPath_Is_Relative()
+                    {
+                        // Given
+                        var path = new DirectoryPath("A");
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath(new DirectoryPath("C:/D/E/F")));
+
+                        // Then
+                        Assert.IsType<InvalidOperationException>(result);
+                        Assert.Equal("Source path must be an absolute path.", result.Message);
+                    }
+
+                    [WindowsFact]
+                    public void Should_Throw_If_Target_DirectoryPath_Is_Relative()
+                    {
+                        // Given
+                        var path = new DirectoryPath("C:/A/B/C");
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath(new DirectoryPath("D")));
+
+                        // Then
+                        Assert.IsType<InvalidOperationException>(result);
+                        Assert.Equal("Target path must be an absolute path.", result.Message);
+                    }
+                }
+
+                public sealed class InUnixFormat
+                {
+                    [Theory]
+                    [InlineData("/C/A/B/C", "/C/A/B/C", ".")]
+                    [InlineData("/C/", "/C/", ".")]
+                    [InlineData("/C/A/B/C", "/C/A/D/E", "../../D/E")]
+                    [InlineData("/C/A/B/C", "/C/", "../../..")]
+                    [InlineData("/C/A/B/C/D/E/F", "/C/A/B/C", "../../..")]
+                    [InlineData("/C/A/B/C", "/C/A/B/C/D/E/F", "D/E/F")]
+                    public void Should_Returns_Relative_Path_Between_Paths(string from, string to, string expected)
+                    {
+                        // Given
+                        var path = new DirectoryPath(from);
+
+                        // When
+                        var relativePath = path.GetRelativePath(new DirectoryPath(to));
+
+                        // Then
+                        Assert.Equal(expected, relativePath.FullPath);
+                    }
+
+                    [Theory]
+                    [InlineData("/C/A/B/C", "/D/A/B/C")]
+                    [InlineData("/C/A/B", "/D/E/")]
+                    [InlineData("/C/", "/B/")]
+                    public void Should_Throw_If_No_Relative_Path_Can_Be_Found(string from, string to)
+                    {
+                        // Given
+                        var path = new DirectoryPath(from);
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath(new DirectoryPath(to)));
+
+                        // Then
+                        Assert.IsType<InvalidOperationException>(result);
+                        Assert.Equal("Paths must share a common prefix.", result.Message);
+                    }
+
+                    [Fact]
+                    public void Should_Throw_If_Target_DirectoryPath_Is_Null()
+                    {
+                        // Given
+                        var path = new DirectoryPath("/C/A/B/C");
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath((DirectoryPath)null));
+
+                        // Then
+                        Assert.IsArgumentNullException(result, "to");
+                    }
+
+                    [Fact]
+                    public void Should_Throw_If_Source_DirectoryPath_Is_Relative()
+                    {
+                        // Given
+                        var path = new DirectoryPath("A");
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath(new DirectoryPath("/C/D/E/F")));
+
+                        // Then
+                        Assert.IsType<InvalidOperationException>(result);
+                        Assert.Equal("Source path must be an absolute path.", result.Message);
+                    }
+
+                    [Fact]
+                    public void Should_Throw_If_Target_DirectoryPath_Is_Relative()
+                    {
+                        // Given
+                        var path = new DirectoryPath("/C/A/B/C");
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath(new DirectoryPath("D")));
+
+                        // Then
+                        Assert.IsType<InvalidOperationException>(result);
+                        Assert.Equal("Target path must be an absolute path.", result.Message);
+                    }
+                }
+            }
+
+            public sealed class WithFilePath
+            {
+                public sealed class InWindowsFormat
+                {
+                    [WindowsTheory]
+                    [InlineData("C:/A/B/C", "C:/A/B/C/hello.txt", "hello.txt")]
+                    [InlineData("C:/", "C:/hello.txt", "hello.txt")]
+                    [InlineData("C:/A/B/C", "C:/A/D/E/hello.txt", "../../D/E/hello.txt")]
+                    [InlineData("C:/A/B/C", "C:/hello.txt", "../../../hello.txt")]
+                    [InlineData("C:/A/B/C/D/E/F", "C:/A/B/C/hello.txt", "../../../hello.txt")]
+                    [InlineData("C:/A/B/C", "C:/A/B/C/D/E/F/hello.txt", "D/E/F/hello.txt")]
+                    public void Should_Returns_Relative_Path_Between_Paths(string from, string to, string expected)
+                    {
+                        // Given
+                        var path = new DirectoryPath(from);
+
+                        // When
+                        var relativePath = path.GetRelativePath(new FilePath(to));
+
+                        // Then
+                        Assert.Equal(expected, relativePath.FullPath);
+                    }
+
+                    [WindowsTheory]
+                    [InlineData("C:/A/B/C", "D:/A/B/C/hello.txt")]
+                    [InlineData("C:/A/B", "D:/E/hello.txt")]
+                    [InlineData("C:/", "B:/hello.txt")]
+                    public void Should_Throw_If_No_Relative_Path_Can_Be_Found(string from, string to)
+                    {
+                        // Given
+                        var path = new DirectoryPath(from);
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath(new FilePath(to)));
+
+                        // Then
+                        Assert.IsType<InvalidOperationException>(result);
+                        Assert.Equal("Paths must share a common prefix.", result.Message);
+                    }
+
+                    [WindowsFact]
+                    public void Should_Throw_If_Target_FilePath_Is_Null()
+                    {
+                        // Given
+                        var path = new DirectoryPath("C:/A/B/C");
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath((FilePath)null));
+
+                        // Then
+                        Assert.IsArgumentNullException(result, "to");
+                    }
+
+                    [WindowsFact]
+                    public void Should_Throw_If_Source_DirectoryPath_Is_Relative()
+                    {
+                        // Given
+                        var path = new DirectoryPath("A");
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath(new FilePath("C:/D/E/F/hello.txt")));
+
+                        // Then
+                        Assert.IsType<InvalidOperationException>(result);
+                        Assert.Equal("Source path must be an absolute path.", result.Message);
+                    }
+
+                    [WindowsFact]
+                    public void Should_Throw_If_Target_FilePath_Is_Relative()
+                    {
+                        // Given
+                        var path = new DirectoryPath("C:/A/B/C");
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath(new FilePath("D/hello.txt")));
+
+                        // Then
+                        Assert.IsType<InvalidOperationException>(result);
+                        Assert.Equal("Target path must be an absolute path.", result.Message);
+                    }
+                }
+
+                public sealed class InUnixFormat
+                {
+                    [Theory]
+                    [InlineData("/C/A/B/C", "/C/A/B/C/hello.txt", "hello.txt")]
+                    [InlineData("/C/", "/C/hello.txt", "hello.txt")]
+                    [InlineData("/C/A/B/C", "/C/A/D/E/hello.txt", "../../D/E/hello.txt")]
+                    [InlineData("/C/A/B/C", "/C/hello.txt", "../../../hello.txt")]
+                    [InlineData("/C/A/B/C/D/E/F", "/C/A/B/C/hello.txt", "../../../hello.txt")]
+                    [InlineData("/C/A/B/C", "/C/A/B/C/D/E/F/hello.txt", "D/E/F/hello.txt")]
+                    public void Should_Returns_Relative_Path_Between_Paths(string from, string to, string expected)
+                    {
+                        // Given
+                        var path = new DirectoryPath(from);
+
+                        // When
+                        var relativePath = path.GetRelativePath(new FilePath(to));
+
+                        // Then
+                        Assert.Equal(expected, relativePath.FullPath);
+                    }
+
+                    [Theory]
+                    [InlineData("/C/A/B/C", "/D/A/B/C/hello.txt")]
+                    [InlineData("/C/A/B", "/D/E/hello.txt")]
+                    [InlineData("/C/", "/B/hello.txt")]
+                    public void Should_Throw_If_No_Relative_Path_Can_Be_Found(string from, string to)
+                    {
+                        // Given
+                        var path = new DirectoryPath(from);
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath(new FilePath(to)));
+
+                        // Then
+                        Assert.IsType<InvalidOperationException>(result);
+                        Assert.Equal("Paths must share a common prefix.", result.Message);
+                    }
+
+                    [Fact]
+                    public void Should_Throw_If_Target_FilePath_Is_Null()
+                    {
+                        // Given
+                        var path = new DirectoryPath("/C/A/B/C");
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath((FilePath)null));
+
+                        // Then
+                        Assert.IsArgumentNullException(result, "to");
+                    }
+
+                    [Fact]
+                    public void Should_Throw_If_Source_DirectoryPath_Is_Relative()
+                    {
+                        // Given
+                        var path = new DirectoryPath("A");
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath(new FilePath("/C/D/E/F/hello.txt")));
+
+                        // Then
+                        Assert.IsType<InvalidOperationException>(result);
+                        Assert.Equal("Source path must be an absolute path.", result.Message);
+                    }
+
+                    [Fact]
+                    public void Should_Throw_If_Target_FilePath_Is_Relative()
+                    {
+                        // Given
+                        var path = new DirectoryPath("/C/A/B/C");
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath(new FilePath("D/hello.txt")));
+
+                        // Then
+                        Assert.IsType<InvalidOperationException>(result);
+                        Assert.Equal("Target path must be an absolute path.", result.Message);
+                    }
                 }
             }
         }

--- a/src/Cake.Core.Tests/Unit/IO/FilePathTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/FilePathTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Cake.Core.IO;
+using Cake.Testing.Xunit;
 using NSubstitute;
 using Xunit;
 
@@ -158,7 +159,7 @@ namespace Cake.Core.Tests.Unit.IO
                     var path = new FilePath("temp/hello.txt");
 
                     // When
-                    var result = Record.Exception(() => path.MakeAbsolute((ICakeEnvironment)null));
+                    var result = Record.Exception(() => path.MakeAbsolute((ICakeEnvironment) null));
 
                     // Then
                     Assert.IsArgumentNullException(result, "environment");
@@ -204,7 +205,7 @@ namespace Cake.Core.Tests.Unit.IO
                     var path = new FilePath("./test.txt");
 
                     // When
-                    var result = Record.Exception(() => path.MakeAbsolute((DirectoryPath)null));
+                    var result = Record.Exception(() => path.MakeAbsolute((DirectoryPath) null));
 
                     // Then
                     Assert.IsArgumentNullException(result, "path");
@@ -251,6 +252,337 @@ namespace Cake.Core.Tests.Unit.IO
 
                     // Then
                     Assert.Equal("/test.txt", result.FullPath);
+                }
+            }
+        }
+
+        public sealed class TheGetRelativePathMethod
+        {
+            public sealed class WithDirectoryPath
+            {
+                public sealed class InWindowsFormat
+                {
+                    [WindowsTheory]
+                    [InlineData("C:/A/B/C/hello.txt", "C:/A/B/C", ".")]
+                    [InlineData("C:/hello.txt", "C:/", ".")]
+                    [InlineData("C:/A/B/C/hello.txt", "C:/A/D/E", "../../D/E")]
+                    [InlineData("C:/A/B/C/hello.txt", "C:/", "../../..")]
+                    [InlineData("C:/A/B/C/D/E/F/hello.txt", "C:/A/B/C", "../../..")]
+                    [InlineData("C:/A/B/C/hello.txt", "C:/A/B/C/D/E/F", "D/E/F")]
+                    public void Should_Returns_Relative_Path_Between_Paths(string from, string to, string expected)
+                    {
+                        // Given
+                        var path = new FilePath(from);
+
+                        // When
+                        var relativePath = path.GetRelativePath(new DirectoryPath(to));
+
+                        // Then
+                        Assert.Equal(expected, relativePath.FullPath);
+                    }
+
+                    [WindowsTheory]
+                    [InlineData("C:/A/B/C/hello.txt", "D:/A/B/C")]
+                    [InlineData("C:/A/B/hello.txt", "D:/E/")]
+                    [InlineData("C:/hello.txt", "B:/")]
+                    public void Should_Throw_If_No_Relative_Path_Can_Be_Found(string from, string to)
+                    {
+                        // Given
+                        var path = new FilePath(from);
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath(new DirectoryPath(to)));
+
+                        // Then
+                        Assert.IsType<InvalidOperationException>(result);
+                        Assert.Equal("Paths must share a common prefix.", result.Message);
+                    }
+
+                    [WindowsFact]
+                    public void Should_Throw_If_Target_DirectoryPath_Is_Null()
+                    {
+                        // Given
+                        var path = new FilePath("C:/A/B/C/hello.txt");
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath((DirectoryPath)null));
+
+                        // Then
+                        Assert.IsArgumentNullException(result, "to");
+                    }
+
+                    [WindowsFact]
+                    public void Should_Throw_If_Source_DirectoryPath_Is_Relative()
+                    {
+                        // Given
+                        var path = new FilePath("A/hello.txt");
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath(new DirectoryPath("C:/D/E/F")));
+
+                        // Then
+                        Assert.IsType<InvalidOperationException>(result);
+                        Assert.Equal("Source path must be an absolute path.", result.Message);
+                    }
+
+                    [WindowsFact]
+                    public void Should_Throw_If_Target_DirectoryPath_Is_Relative()
+                    {
+                        // Given
+                        var path = new FilePath("C:/A/B/C/hello.txt");
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath(new DirectoryPath("D")));
+
+                        // Then
+                        Assert.IsType<InvalidOperationException>(result);
+                        Assert.Equal("Target path must be an absolute path.", result.Message);
+                    }
+                }
+
+                public sealed class InUnixFormat
+                {
+                    [Theory]
+                    [InlineData("/C/A/B/C/hello.txt", "/C/A/B/C", ".")]
+                    [InlineData("/C/hello.txt", "/C/", ".")]
+                    [InlineData("/C/A/B/C/hello.txt", "/C/A/D/E", "../../D/E")]
+                    [InlineData("/C/A/B/C/hello.txt", "/C/", "../../..")]
+                    [InlineData("/C/A/B/C/D/E/F/hello.txt", "/C/A/B/C", "../../..")]
+                    [InlineData("/C/A/B/C/hello.txt", "/C/A/B/C/D/E/F", "D/E/F")]
+                    public void Should_Returns_Relative_Path_Between_Paths(string from, string to, string expected)
+                    {
+                        // Given
+                        var path = new FilePath(from);
+
+                        // When
+                        var relativePath = path.GetRelativePath(new DirectoryPath(to));
+
+                        // Then
+                        Assert.Equal(expected, relativePath.FullPath);
+                    }
+
+                    [Theory]
+                    [InlineData("/C/A/B/C/hello.txt", "/D/A/B/C")]
+                    [InlineData("/C/A/B/hello.txt", "/D/E/")]
+                    [InlineData("/C/hello.txt", "/B/")]
+                    public void Should_Throw_If_No_Relative_Path_Can_Be_Found(string from, string to)
+                    {
+                        // Given
+                        var path = new FilePath(from);
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath(new DirectoryPath(to)));
+
+                        // Then
+                        Assert.IsType<InvalidOperationException>(result);
+                        Assert.Equal("Paths must share a common prefix.", result.Message);
+                    }
+
+                    [Fact]
+                    public void Should_Throw_If_Target_DirectoryPath_Is_Null()
+                    {
+                        // Given
+                        var path = new FilePath("/C/A/B/C/hello.txt");
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath((DirectoryPath)null));
+
+                        // Then
+                        Assert.IsArgumentNullException(result, "to");
+                    }
+
+                    [Fact]
+                    public void Should_Throw_If_Source_DirectoryPath_Is_Relative()
+                    {
+                        // Given
+                        var path = new FilePath("A/hello.txt");
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath(new DirectoryPath("/C/D/E/F")));
+
+                        // Then
+                        Assert.IsType<InvalidOperationException>(result);
+                        Assert.Equal("Source path must be an absolute path.", result.Message);
+                    }
+
+                    [Fact]
+                    public void Should_Throw_If_Target_DirectoryPath_Is_Relative()
+                    {
+                        // Given
+                        var path = new FilePath("/C/A/B/C/hello.txt");
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath(new DirectoryPath("D")));
+
+                        // Then
+                        Assert.IsType<InvalidOperationException>(result);
+                        Assert.Equal("Target path must be an absolute path.", result.Message);
+                    }
+                }
+            }
+
+            public sealed class WithFilePath
+            {
+                public sealed class InWindowsFormat
+                {
+                    [WindowsTheory]
+                    [InlineData("C:/A/B/C/hello.txt", "C:/A/B/C/hello.txt", "hello.txt")]
+                    [InlineData("C:/hello.txt", "C:/hello.txt", "hello.txt")]
+                    [InlineData("C:/hello.txt", "C:/world.txt", "world.txt")]
+                    [InlineData("C:/A/B/C/hello.txt", "C:/A/D/E/hello.txt", "../../D/E/hello.txt")]
+                    [InlineData("C:/A/B/C/hello.txt", "C:/hello.txt", "../../../hello.txt")]
+                    [InlineData("C:/A/B/C/D/E/F/hello.txt", "C:/A/B/C/hello.txt", "../../../hello.txt")]
+                    [InlineData("C:/A/B/C/hello.txt", "C:/A/B/C/D/E/F/hello.txt", "D/E/F/hello.txt")]
+                    public void Should_Returns_Relative_Path_Between_Paths(string from, string to, string expected)
+                    {
+                        // Given
+                        var path = new FilePath(from);
+
+                        // When
+                        var relativePath = path.GetRelativePath(new FilePath(to));
+
+                        // Then
+                        Assert.Equal(expected, relativePath.FullPath);
+                    }
+
+                    [WindowsTheory]
+                    [InlineData("C:/A/B/C/hello.txt", "D:/A/B/C/hello.txt")]
+                    [InlineData("C:/A/B/hello.txt", "D:/E/hello.txt")]
+                    [InlineData("C:/hello.txt", "B:/hello.txt")]
+                    public void Should_Throw_If_No_Relative_Path_Can_Be_Found(string from, string to)
+                    {
+                        // Given
+                        var path = new FilePath(from);
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath(new FilePath(to)));
+
+                        // Then
+                        Assert.IsType<InvalidOperationException>(result);
+                        Assert.Equal("Paths must share a common prefix.", result.Message);
+                    }
+
+                    [WindowsFact]
+                    public void Should_Throw_If_Target_FilePath_Is_Null()
+                    {
+                        // Given
+                        var path = new FilePath("C:/A/B/C/hello.txt");
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath((FilePath)null));
+
+                        // Then
+                        Assert.IsArgumentNullException(result, "to");
+                    }
+
+                    [WindowsFact]
+                    public void Should_Throw_If_Source_DirectoryPath_Is_Relative()
+                    {
+                        // Given
+                        var path = new FilePath("A/hello.txt");
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath(new FilePath("C:/D/E/F/hello.txt")));
+
+                        // Then
+                        Assert.IsType<InvalidOperationException>(result);
+                        Assert.Equal("Source path must be an absolute path.", result.Message);
+                    }
+
+                    [WindowsFact]
+                    public void Should_Throw_If_Target_FilePath_Is_Relative()
+                    {
+                        // Given
+                        var path = new FilePath("C:/A/B/C/hello.txt");
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath(new FilePath("D/hello.txt")));
+
+                        // Then
+                        Assert.IsType<InvalidOperationException>(result);
+                        Assert.Equal("Target path must be an absolute path.", result.Message);
+                    }
+                }
+
+                public sealed class InUnixFormat
+                {
+                    [Theory]
+                    [InlineData("/C/A/B/C/hello.txt", "/C/A/B/C/hello.txt", "hello.txt")]
+                    [InlineData("/C/hello.txt", "/C/hello.txt", "hello.txt")]
+                    [InlineData("/C/hello.txt", "/C/world.txt", "world.txt")]
+                    [InlineData("/C/A/B/C/hello.txt", "/C/A/D/E/hello.txt", "../../D/E/hello.txt")]
+                    [InlineData("/C/A/B/C/hello.txt", "/C/hello.txt", "../../../hello.txt")]
+                    [InlineData("/C/A/B/C/D/E/F/hello.txt", "/C/A/B/C/hello.txt", "../../../hello.txt")]
+                    [InlineData("/C/A/B/C/hello.txt", "/C/A/B/C/D/E/F/hello.txt", "D/E/F/hello.txt")]
+                    public void Should_Returns_Relative_Path_Between_Paths(string from, string to, string expected)
+                    {
+                        // Given
+                        var path = new FilePath(from);
+
+                        // When
+                        var relativePath = path.GetRelativePath(new FilePath(to));
+
+                        // Then
+                        Assert.Equal(expected, relativePath.FullPath);
+                    }
+
+                    [Theory]
+                    [InlineData("/C/A/B/C/hello.txt", "/D/A/B/C/hello.txt")]
+                    [InlineData("/C/A/B/hello.txt", "/D/E/hello.txt")]
+                    [InlineData("/C/hello.txt", "/B/hello.txt")]
+                    public void Should_Throw_If_No_Relative_Path_Can_Be_Found(string from, string to)
+                    {
+                        // Given
+                        var path = new FilePath(from);
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath(new FilePath(to)));
+
+                        // Then
+                        Assert.IsType<InvalidOperationException>(result);
+                        Assert.Equal("Paths must share a common prefix.", result.Message);
+                    }
+
+                    [Fact]
+                    public void Should_Throw_If_Target_FilePath_Is_Null()
+                    {
+                        // Given
+                        var path = new FilePath("/C/A/B/C/hello.txt");
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath((FilePath)null));
+
+                        // Then
+                        Assert.IsArgumentNullException(result, "to");
+                    }
+
+                    [Fact]
+                    public void Should_Throw_If_Source_DirectoryPath_Is_Relative()
+                    {
+                        // Given
+                        var path = new FilePath("A/hello.txt");
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath(new FilePath("/C/D/E/F/hello.txt")));
+
+                        // Then
+                        Assert.IsType<InvalidOperationException>(result);
+                        Assert.Equal("Source path must be an absolute path.", result.Message);
+                    }
+
+                    [Fact]
+                    public void Should_Throw_If_Target_FilePath_Is_Relative()
+                    {
+                        // Given
+                        var path = new FilePath("/C/A/B/C/hello.txt");
+
+                        // When
+                        var result = Record.Exception(() => path.GetRelativePath(new FilePath("D/hello.txt")));
+
+                        // Then
+                        Assert.IsType<InvalidOperationException>(result);
+                        Assert.Equal("Target path must be an absolute path.", result.Message);
+                    }
                 }
             }
         }

--- a/src/Cake.Core/Cake.Core.csproj
+++ b/src/Cake.Core/Cake.Core.csproj
@@ -142,6 +142,7 @@
     <Compile Include="IO\ProcessSettings.cs" />
     <Compile Include="IO\ProcessWrapper.cs" />
     <Compile Include="IO\Arguments\QuotedArgument.cs" />
+    <Compile Include="IO\RelativePathResolver.cs" />
     <Compile Include="IO\SearchScope.cs" />
     <Compile Include="IO\Arguments\SecretArgument.cs" />
     <Compile Include="IO\SpecialPath.cs" />

--- a/src/Cake.Core/IO/DirectoryPath.cs
+++ b/src/Cake.Core/IO/DirectoryPath.cs
@@ -151,5 +151,30 @@ namespace Cake.Core.IO
         {
             return new DirectoryPath(path);
         }
+
+        /// <summary>
+        /// Get the relative path to another directory.
+        /// </summary>
+        /// <param name="to">The target directory path.</param>
+        /// <returns>A <see cref="DirectoryPath"/>.</returns>
+        public DirectoryPath GetRelativePath(DirectoryPath to)
+        {
+            return RelativePathResolver.Resolve(this, to);
+        }
+
+        /// <summary>
+        /// Get the relative path to another file.
+        /// </summary>
+        /// <param name="to">The target file path.</param>
+        /// <returns>A <see cref="FilePath"/>.</returns>
+        public FilePath GetRelativePath(FilePath to)
+        {
+            if (to == null)
+            {
+                throw new ArgumentNullException("to");
+            }
+
+            return GetRelativePath(to.GetDirectory()).GetFilePath(to.GetFilename());
+        }
     }
 }

--- a/src/Cake.Core/IO/FilePath.cs
+++ b/src/Cake.Core/IO/FilePath.cs
@@ -164,5 +164,25 @@ namespace Cake.Core.IO
         {
             return new FilePath(path);
         }
+
+        /// <summary>
+        /// Get the relative path to another directory.
+        /// </summary>
+        /// <param name="to">The target directory path.</param>
+        /// <returns>A <see cref="DirectoryPath"/>.</returns>
+        public DirectoryPath GetRelativePath(DirectoryPath to)
+        {
+            return GetDirectory().GetRelativePath(to);
+        }
+
+        /// <summary>
+        /// Get the relative path to another file.
+        /// </summary>
+        /// <param name="to">The target file path.</param>
+        /// <returns>A <see cref="FilePath"/>.</returns>
+        public FilePath GetRelativePath(FilePath to)
+        {
+            return GetDirectory().GetRelativePath(to);
+        }
     }
 }

--- a/src/Cake.Core/IO/RelativePathResolver.cs
+++ b/src/Cake.Core/IO/RelativePathResolver.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Linq;
+
+namespace Cake.Core.IO
+{
+    internal static class RelativePathResolver
+    {
+        public static DirectoryPath Resolve(DirectoryPath from, DirectoryPath to)
+        {
+            if (from == null)
+            {
+                throw new ArgumentNullException("from");
+            }
+            if (to == null)
+            {
+                throw new ArgumentNullException("to");
+            }
+            if (to.IsRelative)
+            {
+                throw new InvalidOperationException("Target path must be an absolute path.");
+            }
+            if (from.IsRelative)
+            {
+                throw new InvalidOperationException("Source path must be an absolute path.");
+            }
+            if (from.Segments[0] != to.Segments[0])
+            {
+                throw new InvalidOperationException("Paths must share a common prefix.");
+            }
+
+            if (string.CompareOrdinal(from.FullPath, to.FullPath) == 0)
+            {
+                return new DirectoryPath(".");
+            }
+
+            var minimumSegmentsLength = Math.Min(from.Segments.Length, to.Segments.Length);
+            var numberOfSharedSegments = 1;
+
+            for (var i = 1; i < minimumSegmentsLength; i++)
+            {
+                if (string.CompareOrdinal(from.Segments[i], to.Segments[i]) != 0)
+                {
+                    break;
+                }
+
+                numberOfSharedSegments++;
+            }
+
+            var fromSegments = Enumerable.Repeat("..", from.Segments.Length - numberOfSharedSegments);
+            var toSegments = to.Segments.Skip(numberOfSharedSegments);
+
+            var relativePath = System.IO.Path.Combine(fromSegments.Concat(toSegments).ToArray());
+
+            return new DirectoryPath(relativePath);
+        }
+    }
+}


### PR DESCRIPTION
This PR implements #621 and adds methods to get relative paths for both the `FilePath` and `DirectoryPath` classes.

This is a WIP as I was wondering how you'd want me to do the refactoring. At the moment, there is a lot of duplication, but I was not sure what would be the best way to refactor things. I could move the methods to the abstract base class and add some extract abstract methods, but I'm not sure you'd want to go that way. Any ideas?