### PR TITLE
FileExists alias uses absolute paths (#649)

### DIFF
--- a/src/Cake.Common.Tests/Unit/IO/FileAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/FileAliasesTests.cs
@@ -1042,6 +1042,7 @@ namespace Cake.Common.Tests.Unit.IO
                 var environment = FakeEnvironment.CreateUnixEnvironment();
                 var fileSystem = new FakeFileSystem(environment);
                 context.FileSystem.Returns(fileSystem);
+                context.Environment.Returns(environment);
 
                 // When
                 var result = FileAliases.FileExists(context, "non-existent-file.txt");
@@ -1051,17 +1052,38 @@ namespace Cake.Common.Tests.Unit.IO
             }
 
             [Fact]
-            public void Should_Return_True_If_Directory_Exist()
+            public void Should_Return_True_If_Relative_Path_Exist()
             {
                 // Given
                 var context = Substitute.For<ICakeContext>();
                 var environment = FakeEnvironment.CreateUnixEnvironment();
+                environment.WorkingDirectory = "/Working";
                 var fileSystem = new FakeFileSystem(environment);
-                fileSystem.CreateFile("some file.txt");
+                fileSystem.CreateFile("/Working/some file.txt");
                 context.FileSystem.Returns(fileSystem);
+                context.Environment.Returns(environment);
 
                 // When
                 var result = FileAliases.FileExists(context, "some file.txt");
+
+                // Then
+                Assert.True(result);
+            }
+
+            [Fact]
+            public void Should_Return_True_If_Absolute_Path_Exist()
+            {
+                // Given
+                var context = Substitute.For<ICakeContext>();
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+                environment.WorkingDirectory = "/Working/target";
+                var fileSystem = new FakeFileSystem(environment);
+                fileSystem.CreateFile("/Working/target/some file.txt");
+                context.FileSystem.Returns(fileSystem);
+                context.Environment.Returns(environment);
+
+                // When
+                var result = FileAliases.FileExists(context, "/Working/target/some file.txt");
 
                 // Then
                 Assert.True(result);

--- a/src/Cake.Common/IO/FileAliases.cs
+++ b/src/Cake.Common/IO/FileAliases.cs
@@ -300,8 +300,8 @@ namespace Cake.Common.IO
             {
                 throw new ArgumentNullException("filePath");
             }
-
-            return context.FileSystem.GetFile(filePath).Exists;
+            
+            return context.FileSystem.GetFile(filePath.MakeAbsolute(context.Environment)).Exists;
         }
 
         /// <summary>


### PR DESCRIPTION
This PR modifies the `FileExists` method to use an absolute path to determine if a file exists. It implements #649 
