### PR TITLE
Add DotNetBuild settings extension methods and tests

### DIFF
--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -211,6 +211,8 @@
     <Compile Include="Unit\IO\DirectoryAliasesTests.cs" />
     <Compile Include="Unit\IO\FileAliasesTests.cs" />
     <Compile Include="Unit\Tools\InspectCode\InspectCodeRunnerTests.cs" />
+    <Compile Include="Unit\Tools\DotNetBuildSettingsExtensionsTests.cs" />
+    <Compile Include="Unit\Tools\DotNetBuildSettingsTests.cs" />
     <Compile Include="Unit\Tools\MSBuild\MSBuildRunnerTests.cs" />
     <Compile Include="Unit\Tools\MSBuild\MSBuildSettingsExtensionsTests.cs" />
     <Compile Include="Unit\Tools\MSBuild\MSBuildSettingsTests.cs" />

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetBuildSettingsExtensionsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetBuildSettingsExtensionsTests.cs
@@ -1,0 +1,131 @@
+﻿using Cake.Common.Tools;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools
+{
+    public sealed class DotNetBuildSettingsExtensionsTests
+    {
+        public sealed class TheWithTargetMethod
+        {
+            [Fact]
+            public void Should_Add_Target_To_Configuration()
+            {
+                // Given
+                var settings = new DotNetBuildSettings(new FilePath("./Test.sln"));
+
+                // When
+                settings.WithTarget("Target");
+
+                // Then
+                Assert.True(settings.Targets.Contains("Target"));
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetBuildSettings(new FilePath("./Test.sln"));
+
+                // When
+                var result = settings.WithTarget("Target");
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheWithPropertyMethod
+        {
+            [Fact]
+            public void Should_Add_Property_To_Configuration()
+            {
+                // Given
+                var settings = new DotNetBuildSettings(new FilePath("./Test.sln"));
+
+                // When
+                settings.WithProperty("PropertyName", "Value");
+
+                // Then
+                Assert.True(settings.Properties.ContainsKey("PropertyName"));
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetBuildSettings(new FilePath("./Test.sln"));
+
+                // When
+                var result = settings.WithProperty("PropertyName", "Value");
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheSetConfigurationMethod
+        {
+            [Fact]
+            public void Should_Set_Configuration()
+            {
+                // Given
+                var settings = new DotNetBuildSettings(new FilePath("./Test.sln"));
+
+                // When
+                settings.SetConfiguration("TheConfiguration");
+
+                // Then
+                Assert.Equal("TheConfiguration", settings.Configuration);
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetBuildSettings(new FilePath("./Test.sln"));
+
+                // When
+                var result = settings.SetConfiguration("TheConfiguration");
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheSetVerbosityMethod
+        {
+            [Theory]
+            [InlineData(Verbosity.Quiet)]
+            [InlineData(Verbosity.Minimal)]
+            [InlineData(Verbosity.Normal)]
+            [InlineData(Verbosity.Verbose)]
+            [InlineData(Verbosity.Diagnostic)]
+            public void Should_Set_Verbosity(Verbosity verbosity)
+            {
+                // Given
+                var settings = new DotNetBuildSettings(new FilePath("./Test.sln"));
+
+                // When
+                settings.SetVerbosity(verbosity);
+
+                // Then
+                Assert.Equal(verbosity, settings.Verbosity);
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetBuildSettings(new FilePath("./Test.sln"));
+
+                // When
+                var result = settings.SetVerbosity(Verbosity.Normal);
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetBuildSettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetBuildSettingsTests.cs
@@ -1,0 +1,94 @@
+﻿using Cake.Common.Tools;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools
+{
+    public sealed class DotNetBuildSettingsTests
+    {
+        public sealed class TheConstructor
+        {
+            [Fact]
+            public void Should_Set_Default_Verbosity_To_Normal()
+            {
+                // Given, When
+                var settings = new DotNetBuildSettings(new FilePath("./Test.sln"));
+
+                // Then
+                Assert.Equal(Verbosity.Normal, settings.Verbosity);
+            }
+            
+            [Fact]
+            public void Should_Throw_If_Solution_Is_Null()
+            {
+                // Given, When
+                var result = Record.Exception(() => new DotNetBuildSettings(null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "solution");
+            }
+        }
+
+        public sealed class TheTargetsProperty
+        {
+            [Fact]
+            public void Should_Return_A_Set_That_Is_Case_Insensitive()
+            {
+                // Given
+                var settings = new DotNetBuildSettings(new FilePath("./Test.sln"));
+
+                // When
+                settings.Targets.Add("TARGET");
+
+                // Then
+                Assert.True(settings.Targets.Contains("target"));
+            }
+        }
+
+        public sealed class ThePropertiesProperty
+        {
+            [Fact]
+            public void Should_Return_A_Dictionary_That_Is_Case_Insensitive()
+            {
+                // Given
+                var settings = new DotNetBuildSettings(new FilePath("./Test.sln"));
+
+                // When
+                settings.Properties.Add("THEKEY", new []{"THEVALUE"});
+
+                // Then
+                Assert.True(settings.Properties.ContainsKey("thekey"));
+            }
+        }
+
+        public sealed class TheConfigurationProperty
+        {
+            [Fact]
+            public void Should_Be_Empty_By_Default()
+            {
+                // Given, When
+                var settings = new DotNetBuildSettings(new FilePath("./Test.sln"));
+
+                // Then
+                Assert.Equal(string.Empty, settings.Configuration);
+            }
+        }
+
+        public sealed class TheSolutionProperty
+        {
+            [Fact]
+            public void Should_Return_Passed_Constructor_Argument()
+            {
+                // Given
+                var solution = new FilePath("./Test.sln");
+
+                // When
+                var settings = new DotNetBuildSettings(solution);
+
+                // Then
+                Assert.Equal(solution, settings.Solution);
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -208,6 +208,7 @@
     <Compile Include="Tools\InspectCode\InspectCodeRunner.cs" />
     <Compile Include="Tools\InspectCode\InspectCodeSettings.cs" />
     <Compile Include="Tools\InspectCode\SettingsLayer.cs" />
+    <Compile Include="Tools\DotNetBuildSettingsExtensions.cs" />
     <Compile Include="Tools\MSBuild\MSBuildAliases.cs" />
     <Compile Include="Tools\MSBuild\MSBuildResolver.cs" />
     <Compile Include="Tools\MSBuild\MSBuildRunner.cs" />

--- a/src/Cake.Common/Tools/DotNetBuildSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/DotNetBuildSettingsExtensions.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cake.Core.Diagnostics;
+
+namespace Cake.Common.Tools
+{
+    /// <summary>
+    /// Contains functionality related to .NET build settings.
+    /// </summary>
+    public static class DotNetBuildSettingsExtensions
+    {
+        /// <summary>
+        /// Adds a .NET build target to the configuration.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="target">The .NET build target.</param>
+        /// <returns>The same <see cref="DotNetBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetBuildSettings WithTarget(this DotNetBuildSettings settings, string target)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+            settings.Targets.Add(target);
+            return settings;
+        }
+        
+        /// <summary>
+        /// Adds a property to the configuration.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="name">The property name.</param>
+        /// <param name="values">The property values.</param>
+        /// <returns>The same <see cref="DotNetBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetBuildSettings WithProperty(this DotNetBuildSettings settings, string name, params string[] values)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            IList<string> currentValue;
+            currentValue = new List<string>(
+                settings.Properties.TryGetValue(name, out currentValue) && currentValue != null
+                    ? currentValue.Concat(values)
+                    : values);
+
+            settings.Properties[name] = currentValue;
+
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the configuration.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="configuration">The configuration.</param>
+        /// <returns>The same <see cref="DotNetBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetBuildSettings SetConfiguration(this DotNetBuildSettings settings, string configuration)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+            settings.Configuration = configuration;
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the build log verbosity.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="verbosity">The build log verbosity.</param>
+        /// <returns>The same <see cref="DotNetBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetBuildSettings SetVerbosity(this DotNetBuildSettings settings, Verbosity verbosity)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+            settings.Verbosity = verbosity;
+            return settings;
+        }
+    }
+}


### PR DESCRIPTION
The `MSBuildSettings` and `XBuildSettings` classes have some convenient extensions methods. These were not present for the `DotNetBuildSettings` class. This PR adds those extension methods. It also adds tests for the `DotNetBuildSettings` class itself, which was untested.