### PR TITLE
Don't show delegating tasks (#639)

### DIFF
--- a/src/Cake.Core.Tests/Unit/CakeEngineTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeEngineTests.cs
@@ -904,39 +904,57 @@ namespace Cake.Core.Tests.Unit
             }
 
             [Fact]
-            public void Should_Return_Report_That_Marks_Executed_Tasks_As_Non_Skipped()
+            public void Should_Return_Report_That_Marks_Executed_Tasks_As_Executed()
             {
                 // Given
+                var result = new List<string>();
                 var fixture = new CakeEngineFixture();
                 var engine = fixture.CreateEngine();
-                engine.RegisterTask("A").IsDependentOn("B");
+                engine.RegisterTask("A").IsDependentOn("B").Does(() => result.Add("A"));
                 engine.RegisterTask("B").IsDependentOn("C");
-                engine.RegisterTask("C").WithCriteria(() => false);
+                engine.RegisterTask("C").WithCriteria(() => false).Does(() => result.Add("C"));
 
                 // When
                 var report = engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A");
 
                 // Then
-                Assert.False(report.First(e => e.TaskName == "A").Skipped);
-                Assert.False(report.First(e => e.TaskName == "B").Skipped);
+                Assert.Equal(CakeTaskExecutionStatus.Executed, report.First(e => e.TaskName == "A").ExecutionStatus);
             }
 
             [Fact]
             public void Should_Return_Report_That_Marks_Skipped_Tasks_As_Skipped()
             {
                 // Given
+                var result = new List<string>();
                 var fixture = new CakeEngineFixture();
                 var engine = fixture.CreateEngine();
-                engine.RegisterTask("A").IsDependentOn("B");
-                engine.RegisterTask("B").IsDependentOn("C").WithCriteria(() => false);
-                engine.RegisterTask("C").WithCriteria(() => false);
+                engine.RegisterTask("A").IsDependentOn("B").Does(() => result.Add("A"));
+                engine.RegisterTask("B").IsDependentOn("C");
+                engine.RegisterTask("C").WithCriteria(() => false).Does(() => result.Add("C"));
 
                 // When
                 var report = engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A");
 
                 // Then
-                Assert.True(report.First(e => e.TaskName == "B").Skipped);
-                Assert.True(report.First(e => e.TaskName == "C").Skipped);
+                Assert.Equal(CakeTaskExecutionStatus.Skipped, report.First(e => e.TaskName == "C").ExecutionStatus);
+            }
+
+            [Fact]
+            public void Should_Return_Report_That_Marks_Delegated_Tasks_As_Delegated()
+            {
+                // Given
+                var result = new List<string>();
+                var fixture = new CakeEngineFixture();
+                var engine = fixture.CreateEngine();
+                engine.RegisterTask("A").IsDependentOn("B").Does(() => result.Add("A"));
+                engine.RegisterTask("B").IsDependentOn("C");
+                engine.RegisterTask("C").WithCriteria(() => false).Does(() => result.Add("C"));
+
+                // When
+                var report = engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A");
+
+                // Then
+                Assert.Equal(CakeTaskExecutionStatus.Delegated, report.First(e => e.TaskName == "B").ExecutionStatus);
             }
         }
     }

--- a/src/Cake.Core.Tests/Unit/CakeReportTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeReportTests.cs
@@ -25,7 +25,7 @@ namespace Cake.Core.Tests.Unit
                 Assert.NotNull(firstTask);
                 Assert.Equal(taskName, firstTask.TaskName);
                 Assert.Equal(duration, firstTask.Duration);
-                Assert.False(firstTask.Skipped);
+                Assert.Equal(CakeTaskExecutionStatus.Executed, firstTask.ExecutionStatus);
             }
 
             [Fact]
@@ -47,7 +47,7 @@ namespace Cake.Core.Tests.Unit
                 Assert.NotNull(lastTask);
                 Assert.Equal(taskName, lastTask.TaskName);
                 Assert.Equal(duration, lastTask.Duration);
-                Assert.False(lastTask.Skipped);
+                Assert.Equal(CakeTaskExecutionStatus.Executed, lastTask.ExecutionStatus);
             }
         }
 
@@ -69,7 +69,7 @@ namespace Cake.Core.Tests.Unit
                 Assert.NotNull(firstTask);
                 Assert.Equal(taskName, firstTask.TaskName);
                 Assert.Equal(TimeSpan.Zero, firstTask.Duration);
-                Assert.True(firstTask.Skipped);
+                Assert.Equal(CakeTaskExecutionStatus.Skipped, firstTask.ExecutionStatus);
             }
 
             [Fact]
@@ -90,7 +90,52 @@ namespace Cake.Core.Tests.Unit
                 Assert.NotNull(lastTask);
                 Assert.Equal(taskName, lastTask.TaskName);
                 Assert.Equal(TimeSpan.Zero, lastTask.Duration);
-                Assert.True(lastTask.Skipped);
+                Assert.Equal(CakeTaskExecutionStatus.Skipped, lastTask.ExecutionStatus);
+            }
+        }
+
+        public sealed class TheAddDelegatedMethod
+        {
+            [Fact]
+            public void Should_Add_A_New_Task()
+            {
+                // Given
+                var report = new CakeReport();
+                var taskName = "task";
+                var duration = TimeSpan.FromMilliseconds(100);
+
+                // When
+                report.AddDelegated(taskName, duration);
+
+                // Then
+                var firstTask = report.FirstOrDefault();
+
+                Assert.NotNull(firstTask);
+                Assert.Equal(taskName, firstTask.TaskName);
+                Assert.Equal(duration, firstTask.Duration);
+                Assert.Equal(CakeTaskExecutionStatus.Delegated, firstTask.ExecutionStatus);
+            }
+
+            [Fact]
+            public void Should_Add_To_End_Of_Sequence()
+            {
+                // Given
+                var report = new CakeReport();
+                report.AddSkipped("task 1");
+
+                var taskName = "task 2";
+                var duration = TimeSpan.FromMilliseconds(100);
+
+                // When
+                report.AddDelegated(taskName, duration);
+
+                // Then
+                var lastTask = report.LastOrDefault();
+
+                Assert.NotNull(lastTask);
+                Assert.Equal(taskName, lastTask.TaskName);
+                Assert.Equal(duration, lastTask.Duration);
+                Assert.Equal(CakeTaskExecutionStatus.Delegated, lastTask.ExecutionStatus);
             }
         }
     }

--- a/src/Cake.Core/Cake.Core.csproj
+++ b/src/Cake.Core/Cake.Core.csproj
@@ -64,6 +64,7 @@
     <Compile Include="CakeTask.cs" />
     <Compile Include="CakeTaskBuilder.cs" />
     <Compile Include="CakeTaskBuilderExtensions.cs" />
+    <Compile Include="CakeTaskExecutionStatus.cs" />
     <Compile Include="DefaultExecutionStrategy.cs" />
     <Compile Include="Diagnostics\ICakeLog.cs" />
     <Compile Include="Diagnostics\LogAction.cs" />

--- a/src/Cake.Core/CakeEngine.cs
+++ b/src/Cake.Core/CakeEngine.cs
@@ -250,8 +250,15 @@ namespace Cake.Core
                 PerformTaskTeardown(context, strategy, task, stopWatch.Elapsed, false, exceptionWasThrown);
             }
 
-            // Add the task results to the report.
-            report.Add(task.Name, stopWatch.Elapsed);
+            // Add the task results to the report
+            if (IsDelegatedTask(task))
+            {
+                report.AddDelegated(task.Name, stopWatch.Elapsed);
+            }
+            else
+            {
+                report.Add(task.Name, stopWatch.Elapsed);
+            }
         }
 
         private void PerformTaskSetup(ICakeContext context, IExecutionStrategy strategy, ICakeTaskInfo task, bool skipped)
@@ -302,6 +309,13 @@ namespace Cake.Core
 
             // Add the skipped task to the report.
             report.AddSkipped(task.Name);
+        }
+
+        private static bool IsDelegatedTask(CakeTask task)
+        {
+            var actionTask = task as ActionTask;
+
+            return actionTask != null && !actionTask.Actions.Any();
         }
 
         private static void ReportErrors(IExecutionStrategy strategy, Action<Exception> errorReporter, Exception taskException)

--- a/src/Cake.Core/CakeReport.cs
+++ b/src/Cake.Core/CakeReport.cs
@@ -37,7 +37,7 @@ namespace Cake.Core
         /// <param name="span">The span.</param>
         public void Add(string task, TimeSpan span)
         {
-            _report.Add(new CakeReportEntry(task, span));
+            Add(task, span, CakeTaskExecutionStatus.Executed);
         }
 
         /// <summary>
@@ -46,7 +46,28 @@ namespace Cake.Core
         /// <param name="task">The task.</param>
         public void AddSkipped(string task)
         {
-            _report.Add(new CakeReportEntry(task, TimeSpan.Zero, true));
+            Add(task, TimeSpan.Zero, CakeTaskExecutionStatus.Skipped);
+        }
+
+        /// <summary>
+        /// Adds a delegated task result to the report.
+        /// </summary>
+        /// <param name="task">The task.</param>
+        /// <param name="span">The span.</param>
+        public void AddDelegated(string task, TimeSpan span)
+        {
+            Add(task, span, CakeTaskExecutionStatus.Delegated);
+        }
+
+        /// <summary>
+        /// Adds a task result to the report.
+        /// </summary>
+        /// <param name="task">The task.</param>
+        /// <param name="span">The span.</param>
+        /// <param name="executionStatus">The execution status.</param>
+        public void Add(string task, TimeSpan span, CakeTaskExecutionStatus executionStatus)
+        {
+            _report.Add(new CakeReportEntry(task, span, executionStatus));
         }
 
         /// <summary>

--- a/src/Cake.Core/CakeReportEntry.cs
+++ b/src/Cake.Core/CakeReportEntry.cs
@@ -9,7 +9,7 @@ namespace Cake.Core
     {
         private readonly string _taskName;
         private readonly TimeSpan _duration;
-        private readonly bool _skipped;
+        private readonly CakeTaskExecutionStatus _executionStatus;
 
         /// <summary>
         /// Gets the task name.
@@ -30,14 +30,12 @@ namespace Cake.Core
         }
 
         /// <summary>
-        /// Gets a value indicating whether the task was skipped.
+        /// Gets the task execution status.
         /// </summary>
-        /// <value>
-        ///   <c>true</c> if the task was skipped; otherwise, <c>false</c>.
-        /// </value>
-        public bool Skipped
+        /// <value>The execution status.</value>
+        public CakeTaskExecutionStatus ExecutionStatus
         {
-            get { return _skipped; }
+            get { return _executionStatus; }
         }
 
         /// <summary>
@@ -46,7 +44,7 @@ namespace Cake.Core
         /// <param name="taskName">The name of the task.</param>
         /// <param name="duration">The duration.</param>
         public CakeReportEntry(string taskName, TimeSpan duration) 
-            : this(taskName, duration, false)
+            : this(taskName, duration, CakeTaskExecutionStatus.Executed)
         {
         }
 
@@ -55,12 +53,12 @@ namespace Cake.Core
         /// </summary>
         /// <param name="taskName">The name of the task.</param>
         /// <param name="duration">The duration.</param>
-        /// <param name="skipped">Indicates if the task was skipped.</param>
-        public CakeReportEntry(string taskName, TimeSpan duration, bool skipped)
+        /// <param name="executionStatus">The execution status.</param>
+        public CakeReportEntry(string taskName, TimeSpan duration, CakeTaskExecutionStatus executionStatus)
         {
             _taskName = taskName;
             _duration = duration;
-            _skipped = skipped;
+            _executionStatus = executionStatus;
         }
     }
 }

--- a/src/Cake.Core/CakeTaskExecutionStatus.cs
+++ b/src/Cake.Core/CakeTaskExecutionStatus.cs
@@ -1,0 +1,23 @@
+﻿namespace Cake.Core
+{
+    /// <summary>
+    /// The execution status of a <see cref="CakeTask"/>.
+    /// </summary>
+    public enum CakeTaskExecutionStatus
+    {
+        /// <summary>
+        /// The task was executed.
+        /// </summary>
+        Executed,
+
+        /// <summary>
+        /// The task delegated execution.
+        /// </summary>
+        Delegated,
+
+        /// <summary>
+        /// The task was skipped.
+        /// </summary>
+        Skipped
+    }
+}

--- a/src/Cake.Tests/Unit/CakeReportPrinterTests.cs
+++ b/src/Cake.Tests/Unit/CakeReportPrinterTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Cake.Core;
+using Cake.Core.Diagnostics;
 using Cake.Testing;
 using NSubstitute;
 using Xunit;
@@ -14,8 +15,9 @@ namespace Cake.Tests.Unit
             public void Should_Throw_If_Report_Is_Null()
             {
                 // Given
+                var context = Substitute.For<ICakeContext>();
                 var console = Substitute.For<IConsole>();
-                var printer = new CakeReportPrinter(console);
+                var printer = new CakeReportPrinter(console, context);
 
                 // When
                 var result = Record.Exception(() => printer.Write(null));
@@ -28,13 +30,14 @@ namespace Cake.Tests.Unit
             public void Should_Default_To_30_Width()
             {
                 // Given
+                var context = Substitute.For<ICakeContext>();
                 var console = new FakeConsole();
                 var report = new CakeReport();
                 string taskName = "TaskName";
                 TimeSpan duration = TimeSpan.FromSeconds(10);
 
                 report.Add(taskName, duration);
-                var printer = new CakeReportPrinter(console);
+                var printer = new CakeReportPrinter(console, context);
 
                 // When
                 printer.Write(report);
@@ -48,6 +51,7 @@ namespace Cake.Tests.Unit
             public void Should_Increase_Width_For_Long_Task_Names()
             {
                 // Given
+                var context = Substitute.For<ICakeContext>();
                 var console = new FakeConsole();
                 var report = new CakeReport();
                 string taskName = "TaskName";
@@ -56,7 +60,7 @@ namespace Cake.Tests.Unit
 
                 report.Add(taskName, duration);
                 report.Add(taskName2, duration);
-                var printer = new CakeReportPrinter(console);
+                var printer = new CakeReportPrinter(console, context);
 
                 // When
                 printer.Write(report);
@@ -70,6 +74,7 @@ namespace Cake.Tests.Unit
             public void Should_Print_No_Duration_For_Skipped_Tasks()
             {
                 // Given
+                var context = Substitute.For<ICakeContext>();
                 var console = new FakeConsole();
                 var report = new CakeReport();
                 string taskName = "TaskName";
@@ -79,7 +84,7 @@ namespace Cake.Tests.Unit
                 report.Add(taskName, duration);
                 report.AddSkipped(taskNameThatWasSkipped);
 
-                var printer = new CakeReportPrinter(console);
+                var printer = new CakeReportPrinter(console, context);
 
                 // When
                 printer.Write(report);
@@ -87,6 +92,67 @@ namespace Cake.Tests.Unit
                 // Then
                 string expected = String.Format("{0,-30}{1,-20}", taskNameThatWasSkipped, "Skipped");
                 Assert.Contains(console.Messages, s => s == expected);
+            }
+
+            [Theory]
+            [InlineData(Verbosity.Verbose)]
+            [InlineData(Verbosity.Diagnostic)]
+            public void Should_Print_Delegated_Tasks_When_Verbosity_Suffices(Verbosity verbosity)
+            {
+                // Given
+                var log = Substitute.For<ICakeLog>();
+                log.Verbosity.Returns(verbosity);
+                var context = Substitute.For<ICakeContext>();
+                context.Log.Returns(log);
+                var console = new FakeConsole();
+                var report = new CakeReport();
+                string taskName = "TaskName";
+                string tasknameThatWasDelegated = "TaskName-That-Was-Delegated";
+                TimeSpan duration = TimeSpan.FromSeconds(10);
+                TimeSpan durationDelegatedTask = TimeSpan.FromSeconds(5);
+                
+                report.Add(taskName, duration);
+                report.AddDelegated(tasknameThatWasDelegated, durationDelegatedTask);
+
+                var printer = new CakeReportPrinter(console, context);
+
+                // When
+                printer.Write(report);
+
+                // Then
+                string expected = String.Format("{0,-30}{1,-20}", tasknameThatWasDelegated, durationDelegatedTask);
+                Assert.Contains(console.Messages, s => s == expected);
+            }
+
+            [Theory]
+            [InlineData(Verbosity.Quiet)]
+            [InlineData(Verbosity.Minimal)]
+            [InlineData(Verbosity.Normal)]
+            public void Should_Not_Print_Delegated_Tasks_When_Verbosity_Does_Not_Suffice(Verbosity verbosity)
+            {
+                // Given
+                var log = Substitute.For<ICakeLog>();
+                log.Verbosity.Returns(verbosity);
+                var context = Substitute.For<ICakeContext>();
+                context.Log.Returns(log);
+                var console = new FakeConsole();
+                var report = new CakeReport();
+                string taskName = "TaskName";
+                string tasknameThatWasDelegated = "TaskName-That-Was-Delegated";
+                TimeSpan duration = TimeSpan.FromSeconds(10);
+                TimeSpan durationDelegatedTask = TimeSpan.FromSeconds(5);
+
+                report.Add(taskName, duration);
+                report.AddDelegated(tasknameThatWasDelegated, durationDelegatedTask);
+
+                var printer = new CakeReportPrinter(console, context);
+
+                // When
+                printer.Write(report);
+
+                // Then
+                string expected = String.Format("{0,-30}{1,-20}", tasknameThatWasDelegated, durationDelegatedTask);
+                Assert.DoesNotContain(console.Messages, s => s == expected);
             }
         }
     }


### PR DESCRIPTION
This PR implements #639 to show delegating tasks based on verbosity level. At the moment, it only shows delegating tasks on the `Verbose` and `Diagnostic` levels. Furthermore, when a delegating task is displayed on the other levels, it is displayed in gray.

I've tagged it as a WIP due to the fact that I would like to discuss the design of the `CakeReport` class. At the moment, there are the following methods:

```csharp
public void Add(string task, TimeSpan span)
public void AddSkipped(string task)
public void AddDelegated(string task, TimeSpan span)
public void Add(string task, TimeSpan span, CakeTaskExecutionStatus executionStatus)
```

The first `Add` method actually calls the fourth method with the `CakeTaskExecutionStatus.Executed` value. I created the `AddSkipped` and `AddDelegated` methods to be more verbose, however they could also be removed and direct calls be made to the `Add` method that takes the `CakeTaskExecutionStatus`. Is that desirable? Or should I perhaps make the fourth `Add` method private?

If we decide to keep the `AddSkipped` and `AddDelegated` methods, the first `Add` task should be renamed to `AddExecuted`, right? However, that would break backwards-compatibility.

Secondly, the `CakeReportEntry` class has two constructors:

```csharp
public CakeReportEntry(string taskName, TimeSpan duration)
public CakeReportEntry(string taskName, TimeSpan duration, CakeTaskExecutionStatus executionStatus)
```

The first constructor just calls the second one. I've left it in there for backwards-compatibility. Should In leave it in or remove it?