### PR TITLE
Allow use of ICakeContext in WithCriteria (#512)

### DIFF
--- a/src/Cake.Core.Tests/Cake.Core.Tests.csproj
+++ b/src/Cake.Core.Tests/Cake.Core.Tests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Unit\CakeReportTests.cs" />
     <Compile Include="Unit\CakeTaskBuilderExtensionsTests.cs" />
     <Compile Include="Unit\CakeTaskBuilderTests.cs" />
+    <Compile Include="Unit\CakeTaskExtensionsTests.cs" />
     <Compile Include="Unit\CakeTaskTests.cs" />
     <Compile Include="Unit\Diagnostics\LogExtensionsTests.cs" />
     <Compile Include="Fixtures\CakeEngineFixture.cs" />

--- a/src/Cake.Core.Tests/Unit/CakeTaskBuilderExtensionsTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeTaskBuilderExtensionsTests.cs
@@ -41,7 +41,7 @@ namespace Cake.Core.Tests.Unit
                 }
             }
 
-            public sealed class ThatAcceptsLambda
+            public sealed class ThatAcceptsBooleanLambda
             {
                 [Fact]
                 public void Should_Add_Criteria_To_Task()
@@ -52,6 +52,23 @@ namespace Cake.Core.Tests.Unit
 
                     // When
                     builder.WithCriteria(() => true);
+
+                    // Then
+                    Assert.Equal(1, task.Criterias.Count);
+                }
+            }
+
+            public sealed class ThatAcceptsCakeContextToBooleanLambda
+            {
+                [Fact]
+                public void Should_Add_Criteria_To_Task()
+                {
+                    // Given
+                    var task = new ActionTask("task");
+                    var builder = new CakeTaskBuilder<ActionTask>(task);
+
+                    // When
+                    builder.WithCriteria(context => true);
 
                     // Then
                     Assert.Equal(1, task.Criterias.Count);

--- a/src/Cake.Core.Tests/Unit/CakeTaskExtensionsTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeTaskExtensionsTests.cs
@@ -1,0 +1,36 @@
+﻿using Xunit;
+
+namespace Cake.Core.Tests.Unit
+{
+    public sealed class CakeTaskExtensionsTests
+    {
+        public sealed class TheAddCriteriaMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Criteria_Is_Null()
+            {
+                // Given
+                var task = new ActionTask("task");
+
+                // When
+                var result = Record.Exception(() => task.AddCriteria(null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "criteria");
+            }
+
+            [Fact]
+            public void Should_Add_Criteria()
+            {
+                // Given
+                var task = new ActionTask("task");
+
+                // When
+                task.AddCriteria(() => true);
+
+                // Then
+                Assert.Equal(1, task.Criterias.Count);
+            }
+        }
+    }
+}

--- a/src/Cake.Core.Tests/Unit/CakeTaskTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeTaskTests.cs
@@ -89,7 +89,7 @@ namespace Cake.Core.Tests.Unit
                 var task = new ActionTask("task");
 
                 // When
-                task.AddCriteria(() => true);
+                task.AddCriteria(context => true);
 
                 // Then
                 Assert.Equal(1, task.Criterias.Count);

--- a/src/Cake.Core/Cake.Core.csproj
+++ b/src/Cake.Core/Cake.Core.csproj
@@ -65,6 +65,7 @@
     <Compile Include="CakeTaskBuilder.cs" />
     <Compile Include="CakeTaskBuilderExtensions.cs" />
     <Compile Include="CakeTaskExecutionStatus.cs" />
+    <Compile Include="CakeTaskExtensions.cs" />
     <Compile Include="DefaultExecutionStrategy.cs" />
     <Compile Include="Diagnostics\ICakeLog.cs" />
     <Compile Include="Diagnostics\LogAction.cs" />

--- a/src/Cake.Core/CakeEngine.cs
+++ b/src/Cake.Core/CakeEngine.cs
@@ -131,7 +131,7 @@ namespace Cake.Core
                     var isTarget = task.Name.Equals(target, StringComparison.OrdinalIgnoreCase);
 
                     // Should we execute the task?
-                    if (ShouldTaskExecute(task, isTarget))
+                    if (ShouldTaskExecute(context, task, isTarget))
                     {
                         ExecuteTask(context, strategy, stopWatch, task, report);
                     }
@@ -182,11 +182,11 @@ namespace Cake.Core
             }
         }
 
-        private static bool ShouldTaskExecute(CakeTask task, bool isTarget)
+        private static bool ShouldTaskExecute(ICakeContext context, CakeTask task, bool isTarget)
         {
             foreach (var criteria in task.Criterias)
             {
-                if (!criteria())
+                if (!criteria(context))
                 {
                     if (isTarget)
                     {

--- a/src/Cake.Core/CakeTask.cs
+++ b/src/Cake.Core/CakeTask.cs
@@ -12,7 +12,7 @@ namespace Cake.Core
     {
         private readonly string _name;
         private readonly List<string> _dependencies;
-        private readonly List<Func<bool>> _criterias;
+        private readonly List<Func<ICakeContext, bool>> _criterias;
 
         /// <summary>
         /// Gets the name of the task.
@@ -42,7 +42,7 @@ namespace Cake.Core
         /// Gets the task's criterias.
         /// </summary>
         /// <value>The task's criterias.</value>
-        public IReadOnlyList<Func<bool>> Criterias
+        public IReadOnlyList<Func<ICakeContext, bool>> Criterias
         {
             get { return _criterias; }
         }
@@ -79,7 +79,7 @@ namespace Cake.Core
             }
             _name = name;
             _dependencies = new List<string>();
-            _criterias = new List<Func<bool>>();
+            _criterias = new List<Func<ICakeContext, bool>>();
         }
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace Cake.Core
         /// Adds a criteria to the task that is invoked when the task is invoked.
         /// </summary>
         /// <param name="criteria">The criteria.</param>
-        public void AddCriteria(Func<bool> criteria)
+        public void AddCriteria(Func<ICakeContext, bool> criteria)
         {
             if (criteria == null)
             {

--- a/src/Cake.Core/CakeTaskBuilderExtensions.cs
+++ b/src/Cake.Core/CakeTaskBuilderExtensions.cs
@@ -41,7 +41,7 @@ namespace Cake.Core
                 throw new ArgumentNullException("builder");
             }
 
-            builder.Task.AddCriteria(() => criteria);
+            builder.Task.AddCriteria(_ => criteria);
             return builder;
         }
 
@@ -54,6 +54,26 @@ namespace Cake.Core
         /// <param name="criteria">The criteria.</param>
         /// <returns>The same <see cref="CakeTaskBuilder{T}"/> instance so that multiple calls can be chained.</returns>
         public static CakeTaskBuilder<T> WithCriteria<T>(this CakeTaskBuilder<T> builder, Func<bool> criteria)
+            where T : CakeTask
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException("builder");
+            }
+
+            builder.Task.AddCriteria(criteria);
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds a criteria that has to be fulfilled for the task to run.
+        /// The criteria is evaluated when traversal of the graph occurs.
+        /// </summary>
+        /// <typeparam name="T">The task type.</typeparam>
+        /// <param name="builder">The task builder.</param>
+        /// <param name="criteria">The criteria.</param>
+        /// <returns>The same <see cref="CakeTaskBuilder{T}"/> instance so that multiple calls can be chained.</returns>
+        public static CakeTaskBuilder<T> WithCriteria<T>(this CakeTaskBuilder<T> builder, Func<ICakeContext, bool> criteria)
             where T : CakeTask
         {
             if (builder == null)

--- a/src/Cake.Core/CakeTaskExtensions.cs
+++ b/src/Cake.Core/CakeTaskExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace Cake.Core
+{
+    /// <summary>
+    /// Contains extension methods for <see cref="CakeTask"/>.
+    /// </summary>
+    public static class CakeTaskExtensions
+    {
+        /// <summary>
+        /// Adds a criteria to the task that is invoked when the task is invoked.
+        /// </summary>
+        /// <param name="task">The task.</param>
+        /// <param name="criteria">The criteria.</param>
+        public static void AddCriteria(this CakeTask task, Func<bool> criteria)
+        {
+            if (task == null)
+            {
+                throw new ArgumentNullException("task");
+            }
+            if (criteria == null)
+            {
+                throw new ArgumentNullException("criteria");
+            }
+
+            task.AddCriteria(context => criteria());
+        }
+    }
+}


### PR DESCRIPTION
This PR allows use of the `ICakeContext` in the `WithCriteria` extension method. As discussed in #512, the existing `Func<bool>` criteria still work, albeit now via an extension method.