### PR TITLE
Change Nuget.Core.dll to NuGet.Core.dll in build script

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -134,7 +134,7 @@ Task("Copy-Files")
     CopyFileToDirectory(buildDir + File("Cake.Common.xml"), binDir);
     CopyFileToDirectory(buildDir + File("Mono.CSharp.dll"), binDir);
     CopyFileToDirectory(buildDir + File("Autofac.dll"), binDir);
-    CopyFileToDirectory(buildDir + File("Nuget.Core.dll"), binDir);
+    CopyFileToDirectory(buildDir + File("NuGet.Core.dll"), binDir);
 
     // Copy testing assemblies.
     var testingDir = Directory("./src/Cake.Testing/bin") + Directory(configuration);


### PR DESCRIPTION
We were finding that NuGet.Core wasn't able to be resolved on our linux systems when using Cake because it was getting copied into the nuget package as Nu**g**et.Core.dll. It turns out that the resolution of this file is case sensitive on linux. I believe this issue may also have been encountered by @Silvenga in issue #623 