### PR TITLE
One call to MSTest for multiple assemblies.

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/MSTestRunnerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/MSTestRunnerFixture.cs
@@ -1,17 +1,18 @@
 ﻿using Cake.Common.Tools.MSTest;
 using Cake.Core.IO;
 using Cake.Testing.Fixtures;
+using System.Collections.Generic;
 
 namespace Cake.Common.Tests.Fixtures.Tools
 {
     internal sealed class MSTestRunnerFixture : ToolFixture<MSTestSettings>
     {
-        public FilePath AssemblyPath { get; set; }
+        public IEnumerable<FilePath> AssemblyPaths { get; set; }
 
         public MSTestRunnerFixture()
             : base("mstest.exe")
         {
-            AssemblyPath = new FilePath("./Test1.dll");
+            AssemblyPaths = new FilePath[] { new FilePath("./Test1.dll") };
             Environment.SetSpecialPath(SpecialPath.ProgramFilesX86, "/ProgramFilesX86");
         }
 
@@ -23,7 +24,7 @@ namespace Cake.Common.Tests.Fixtures.Tools
         protected override void RunTool()
         {
             var tool = new MSTestRunner(FileSystem, Environment, ProcessRunner, Globber);
-            tool.Run(AssemblyPath, Settings);
+            tool.Run(AssemblyPaths, Settings);
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/MSTest/MSTestRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSTest/MSTestRunnerTests.cs
@@ -16,7 +16,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSTest
         {
             // Given
             var fixture = new MSTestRunnerFixture();
-            fixture.AssemblyPath = null;
+            fixture.AssemblyPaths = null;
 
             // When
             var result = Record.Exception(() => fixture.Run());
@@ -174,6 +174,20 @@ namespace Cake.Common.Tests.Unit.Tools.MSTest
 
             // Then
             Assert.Equal("\"/testcontainer:/Working/Test1.dll\"", result.Args);
+        }
+
+        [Fact]
+        public void Should_Add_Testcontainer_For_Each_Assembly()
+        {
+            // Given
+            var fixture = new MSTestRunnerFixture();
+            fixture.AssemblyPaths = new FilePath[] { new FilePath("./Test1.dll"), new FilePath("./Test2.dll") };
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            Assert.Equal("\"/testcontainer:/Working/Test1.dll\" \"/testcontainer:/Working/Test2.dll\" \"/noisolation\"", result.Args);
         }
     }
 }

--- a/src/Cake.Common/Tools/MSTest/MSTestAliases.cs
+++ b/src/Cake.Common/Tools/MSTest/MSTestAliases.cs
@@ -91,10 +91,7 @@ namespace Cake.Common.Tools.MSTest
             }
 
             var runner = new MSTestRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber);
-            foreach (var assembly in assemblyPaths)
-            {
-                runner.Run(assembly, settings);
-            }
+            runner.Run(assemblyPaths, settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/MSTest/MSTestRunner.cs
+++ b/src/Cake.Common/Tools/MSTest/MSTestRunner.cs
@@ -32,11 +32,11 @@ namespace Cake.Common.Tools.MSTest
         /// <summary>
         /// Runs the tests in the specified assembly.
         /// </summary>
-        /// <param name="assemblyPath">The assembly path.</param>
+        /// <param name="assemblyPaths">The assembly path.</param>
         /// <param name="settings">The settings.</param>
-        public void Run(FilePath assemblyPath, MSTestSettings settings)
+        public void Run(IEnumerable<FilePath> assemblyPaths, MSTestSettings settings)
         {
-            if (assemblyPath == null)
+            if (assemblyPaths == null)
             {
                 throw new ArgumentNullException("assemblyPath");
             }
@@ -45,15 +45,18 @@ namespace Cake.Common.Tools.MSTest
                 throw new ArgumentNullException("settings");
             }
 
-            Run(settings, GetArguments(assemblyPath, settings));
+            Run(settings, GetArguments(assemblyPaths, settings));
         }
 
-        private ProcessArgumentBuilder GetArguments(FilePath assemblyPath, MSTestSettings settings)
+        private ProcessArgumentBuilder GetArguments(IEnumerable<FilePath> assemblyPaths, MSTestSettings settings)
         {
             var builder = new ProcessArgumentBuilder();
 
             // Add the assembly to build.
-            builder.Append(string.Concat("/testcontainer:", assemblyPath.MakeAbsolute(_environment).FullPath).Quote());
+            foreach (var assemblyPath in assemblyPaths)
+            {
+                builder.Append(string.Concat("/testcontainer:", assemblyPath.MakeAbsolute(_environment).FullPath).Quote());
+            }
 
             if (settings.NoIsolation)
             {


### PR DESCRIPTION
This changes the behavior of the MSTest tool to execute the test runner only once even if there are multiple test assemblies. 

Previously MSTestAlias iterated over each assembly and called MSTestRunner for each iteration with only one assembly. Although it worked it's not the best solution and might cause some issues with additional tools that processes the result of MSTests.