### PR TITLE
#689: enable dnu on osx/linux if dnu in path

### DIFF
--- a/src/Cake.Common/Tools/DNU/DNUTool.cs
+++ b/src/Cake.Common/Tools/DNU/DNUTool.cs
@@ -43,7 +43,7 @@ namespace Cake.Common.Tools.DNU
         /// <returns>The tool executable name.</returns>
         protected override IEnumerable<string> GetToolExecutableNames()
         {
-            return new[] { "dnu.cmd" };
+            return new[] { "dnu.cmd", "dnu" };
         }
     }
 }


### PR DESCRIPTION
# Summary

This is a trivial change that enables DNU tools in OSX/Linux environments.

## Issue

see #689 for issue.

## changes

- add `dnu` to `DNUTool`'s executable names.

## Testing

* tested Cake project on windows (doesn't build on mono even with change)
* tested example project on windows/osx
* tested my dnx project on windows/osx
* ran both `DNURestore` and `DNUBuild` tools.