### PR TITLE
Add missing command line switch for ILRepack's targetplatform

### DIFF
--- a/src/Cake.Common/Tools/ILRepack/ILRepackRunner.cs
+++ b/src/Cake.Common/Tools/ILRepack/ILRepackRunner.cs
@@ -127,7 +127,7 @@ namespace Cake.Common.Tools.ILRepack
 
             if (settings.TargetPlatform.HasValue)
             {
-                builder.Append(GetTargetPlatformString(settings.TargetPlatform.Value));
+                builder.AppendSwitch("/targetplatform", ":", GetTargetPlatformString(settings.TargetPlatform.Value));
             }
 
             if (settings.XmlDocs)


### PR DESCRIPTION
When building the command line arguments the `ILRepackRunner` was missing the `/targetplatform:` switch before the actual value, without it ILRepack thinks the value is an assembly it's trying to merge.