### PR TITLE
don't add BOM on text transformations (#709)

### DIFF
--- a/src/Cake.Common.Tests/Unit/Text/TextTransformationTests.cs
+++ b/src/Cake.Common.Tests/Unit/Text/TextTransformationTests.cs
@@ -44,15 +44,18 @@ namespace Cake.Common.Tests.Unit.Text
             public void Should_Render_Content_To_File()
             {
                 // Given
+                var expectedContent = "Hello World";
                 var fixture = new TextTransformationFixture();
-                fixture.TransformationTemplate.Render().Returns("Hello World");
+                fixture.TransformationTemplate.Render().Returns(expectedContent);
                 var transformation = fixture.CreateTextTransformation();
 
                 // When
                 transformation.Save("./output.txt");
 
                 // Then
-                Assert.Equal("Hello World", fixture.FileSystem.GetFile("/Working/output.txt").GetTextContent());
+                var outputFile = fixture.FileSystem.GetFile("/Working/output.txt");
+                Assert.Equal(expectedContent, outputFile.GetTextContent());
+                Assert.Equal(expectedContent.Length, outputFile.Length);
             }
         }
 

--- a/src/Cake.Common/Text/TextTransformation.cs
+++ b/src/Cake.Common/Text/TextTransformation.cs
@@ -64,7 +64,7 @@ namespace Cake.Common.Text
             // Render the content to the file.
             var file = _fileSystem.GetFile(path);
             using (var stream = file.OpenWrite())
-            using (var writer = new StreamWriter(stream, Encoding.UTF8, 1024, true))
+            using (var writer = new StreamWriter(stream, new UTF8Encoding(false), 1024, true))
             {
                 writer.Write(_template.Render());
             }


### PR DESCRIPTION
fix for https://github.com/cake-build/cake/issues/709

`TextTransform.Save` inadvertently adds a BOM to the resulting file.
would be nice to prevent this as it can result in unexpected modifications of the input template.

change TextTransformation.Save to omit the BOM, and add a unit test to verify that.
Unit tests failed before fix ("Hello world" file length was returned as 14 instead of 11), and passed after fix.
