### PR TITLE
Add MSTest option for providing the tool (MSTest.exe) location

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSTest/MSTestRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSTest/MSTestRunnerTests.cs
@@ -106,6 +106,23 @@ namespace Cake.Common.Tests.Unit.Tools.MSTest
             Assert.Equal(existingToolPath, result.Path.FullPath);
         }
 
+        [Theory]
+        [InlineData("U:/ProgramFilesX86/Microsoft Visual Studio 14.0/Common7/IDE/mstest.exe")]
+        [InlineData("K:/Programs/Microsoft Visual Studio 12.0/Common7/IDE/mstest.exe")]
+        public void Should_Use_UserDefined_Tool_Path_If_Provided(string userDefinedPath)
+        {
+            //Given
+            var fixture = new MSTestRunnerFixture();
+            fixture.Settings.UserDefinedToolPath = userDefinedPath;
+            fixture.FileSystem.CreateFile(userDefinedPath);
+
+            //When
+            var result = fixture.Run();
+            
+            //Then
+            Assert.Equal(userDefinedPath, result.Path.FullPath);
+        }
+
         [Fact]
         public void Should_Set_Working_Directory()
         {

--- a/src/Cake.Common/Tools/MSTest/MSTestRunner.cs
+++ b/src/Cake.Common/Tools/MSTest/MSTestRunner.cs
@@ -91,6 +91,12 @@ namespace Cake.Common.Tools.MSTest
         /// <returns>The default tool path.</returns>
         protected override IEnumerable<FilePath> GetAlternativeToolPaths(MSTestSettings settings)
         {
+            if (settings.UserDefinedToolPath != null)
+            {
+                yield return FilePath.FromString(settings.UserDefinedToolPath);
+                yield break;
+            }
+
             foreach (var version in new[] { "14.0", "12.0", "11.0", "10.0" })
             {
                 var path = GetToolPath(version);

--- a/src/Cake.Common/Tools/MSTest/MSTestSettings.cs
+++ b/src/Cake.Common/Tools/MSTest/MSTestSettings.cs
@@ -1,4 +1,5 @@
-﻿using Cake.Core.Tooling;
+﻿using Cake.Core.IO;
+using Cake.Core.Tooling;
 
 namespace Cake.Common.Tools.MSTest
 {
@@ -16,6 +17,10 @@ namespace Cake.Common.Tools.MSTest
         ///   <c>true</c> if running without isolation; otherwise, <c>false</c>.
         /// </value>
         public bool NoIsolation { get; set; }
+        /// <summary>
+        /// Get or sets a value indicating the full path to MSBuild.exe
+        /// </summary>
+        public string UserDefinedToolPath { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MSTestSettings"/> class.
@@ -23,6 +28,16 @@ namespace Cake.Common.Tools.MSTest
         public MSTestSettings()
         {
             NoIsolation = true;
+        }
+
+        /// <summary>
+        ///  Initializes a new isntance of the <see cref="MSTestSettings"/> class
+        ///  with a user defined path to MSBuild.exe
+        /// </summary>
+        /// <param name="userDefinedToolPath"></param>
+        public MSTestSettings(string userDefinedToolPath) : this()
+        {
+            UserDefinedToolPath = userDefinedToolPath;
         }
     }
 }


### PR DESCRIPTION
I was trying to use Cake to setup a build process and ran into issues running the MSTest tool. The issue is my Visual Studio is installed in an alternate location so Cake wouldn't find my MSTest.exe. I've altered it to allow a user defined path to be passed to MSTestSettings.