### PR TITLE
Added DotCover Cover command

### DIFF
--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Fixtures\Tools\DNU\Pack\DNUPackerFixture.cs" />
     <Compile Include="Fixtures\Tools\DNU\Restorer\DNURestorerFixture.cs" />
     <Compile Include="Fixtures\Tools\DotCover\Analyse\DotCoverAnalyserFixture.cs" />
+    <Compile Include="Fixtures\Tools\DotCover\Cover\DotCoverCovererFixture.cs" />
     <Compile Include="Fixtures\Tools\DotCover\DotCoverFixture.cs" />
     <Compile Include="Fixtures\Tools\DupFinder\DupFinderRunnerConfigFixture.cs" />
     <Compile Include="Fixtures\Tools\DupFinder\DupFinderRunnerFixture.cs" />
@@ -209,6 +210,7 @@
     <Compile Include="Unit\Tools\DNU\Restore\DNURestorerTests.cs" />
     <Compile Include="Unit\Tools\DotCover\Analyse\DotCoverAnalyserTests.cs" />
     <Compile Include="Unit\Tools\DotCover\Analyse\DotCoverAnalyseSettingsTests.cs" />
+    <Compile Include="Unit\Tools\DotCover\Cover\DotCoverCovererTests.cs" />
     <Compile Include="Unit\Tools\DupFinder\DupFinderRunnerTests.cs" />
     <Compile Include="Unit\Tools\Fixie\FixieRunnerTests.cs" />
     <Compile Include="Unit\Tools\GitLink\GitlinkRunnerTests.cs" />

--- a/src/Cake.Common.Tests/Fixtures/Tools/DotCover/Cover/DotCoverCovererFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/DotCover/Cover/DotCoverCovererFixture.cs
@@ -3,24 +3,24 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Cake.Common.Tools.DotCover.Analyse;
+using Cake.Common.Tools.DotCover.Cover;
 using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using NSubstitute;
 
-namespace Cake.Common.Tests.Fixtures.Tools.DotCover.Analyse
+namespace Cake.Common.Tests.Fixtures.Tools.DotCover.Cover
 {
-    internal sealed class DotCoverAnalyserFixture : DotCoverFixture<DotCoverAnalyseSettings>
+    internal sealed class DotCoverCovererFixture : DotCoverFixture<DotCoverCoverSettings>
     {
         public ICakeContext Context { get; set; }
         public Action<ICakeContext> Action { get; set; }
         public FilePath OutputPath { get; set; }
 
-        public DotCoverAnalyserFixture()
+        public DotCoverCovererFixture()
         {
             // Set the output file.
-            OutputPath = new FilePath("./result.xml");
+            OutputPath = new FilePath("./result.dcvr");
 
             // Setup the Cake Context.
             Context = Substitute.For<ICakeContext>();
@@ -46,8 +46,8 @@ namespace Cake.Common.Tests.Fixtures.Tools.DotCover.Analyse
 
         protected override void RunTool()
         {
-            var tool = new DotCoverAnalyser(FileSystem, Environment, ProcessRunner, Globber);
-            tool.Analyse(Context, Action, OutputPath, Settings);
+            var tool = new DotCoverCoverer(FileSystem, Environment, ProcessRunner, Globber);
+            tool.Cover(Context, Action, OutputPath, Settings);
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/DotCover/Cover/DotCoverCovererTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotCover/Cover/DotCoverCovererTests.cs
@@ -1,0 +1,266 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Cake.Common.Tests.Fixtures.Tools.DotCover;
+using Cake.Common.Tests.Fixtures.Tools.DotCover.Cover;
+using Cake.Common.Tools.DotCover;
+using Cake.Common.Tools.DotCover.Cover;
+using Cake.Common.Tools.NUnit;
+using Cake.Common.Tools.XUnit;
+using Cake.Core.IO;
+using Cake.Testing;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
+{
+    public sealed class DotCoverCovererTests
+    {
+        public sealed class TheCoverMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Context_Is_Null()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Context = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "context");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Action_Is_Null()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Action = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "action");
+
+            }
+
+            [Fact]
+            public void Should_Throw_If_Output_File_Is_Null()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.OutputPath = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "outputPath");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_No_Tool_Was_Intercepted()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Action = context => { };
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsCakeException(result, "No tool was started.");
+            }
+
+            [Fact]
+            public void Should_Capture_Tool_And_Arguments_From_Action()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("Cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
+                             "/TargetArguments=\"-argument\" " +
+                             "/Output=\"/Working/result.dcvr\"", result.Args);
+            }
+
+            [Theory]
+            [InlineData("")]
+            [InlineData(null)]
+            public void Should_Not_Capture_Arguments_From_Action_If_Excluded(string arguments)
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Action = context =>
+                {
+                    context.ProcessRunner.Start(
+                        new FilePath("/Working/tools/Test.exe"),
+                        new ProcessSettings()
+                        {
+                            Arguments = arguments
+                        });
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("Cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
+                             "/Output=\"/Working/result.dcvr\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_TargetWorkingDir()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.TargetWorkingDir = new DirectoryPath("/Working");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("Cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
+                             "/TargetArguments=\"-argument\" " +
+                             "/Output=\"/Working/result.dcvr\" " +
+                             "/TargetWorkingDir=\"/Working\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_Scope()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.WithScope("/Working/*.dll")
+                    .WithScope("/Some/**/Other/*.dll");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("Cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
+                             "/TargetArguments=\"-argument\" " +
+                             "/Output=\"/Working/result.dcvr\" " +
+                             "/Scope=\"/Working/*.dll;/Some/**/Other/*.dll\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_Filters()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.WithFilter("+:module=Test.*")
+                    .WithFilter("-:myassembly");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("Cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
+                             "/TargetArguments=\"-argument\" " +
+                             "/Output=\"/Working/result.dcvr\" " +
+                             "/Filters=\"+:module=Test.*;-:myassembly\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_AttributeFilters()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.WithAttributeFilter("filter1")
+                    .WithAttributeFilter("filter2");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("Cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
+                             "/TargetArguments=\"-argument\" " +
+                             "/Output=\"/Working/result.dcvr\" " +
+                             "/AttributeFilters=\"filter1;filter2\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_DisableDefaultFilters()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.DisableDefaultFilters = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("Cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
+                             "/TargetArguments=\"-argument\" " +
+                             "/Output=\"/Working/result.dcvr\" " +
+                             "/DisableDefaultFilters", result.Args);
+            }
+
+            [Fact]
+            public void Should_Capture_XUnit()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.FileSystem.CreateFile("/Working/tools/xunit.console.exe");
+                fixture.Action = context =>
+                {
+                    context.XUnit2(
+                        new FilePath[] { "./Test.dll" },
+                        new XUnit2Settings { ShadowCopy = false });
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("Cover /TargetExecutable=\"/Working/tools/xunit.console.exe\" " +
+                             "/TargetArguments=\"\\\"/Working/Test.dll\\\" -noshadow\" " +
+                             "/Output=\"/Working/result.dcvr\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Capture_NUnit()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.FileSystem.CreateFile("/Working/tools/nunit-console.exe");
+                fixture.Action = context =>
+                {
+                    context.NUnit(
+                        new FilePath[] { "./Test.dll" },
+                        new NUnitSettings { ShadowCopy = false });
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("Cover /TargetExecutable=\"/Working/tools/nunit-console.exe\" " +
+                             "/TargetArguments=\"\\\"/Working/Test.dll\\\" -noshadow\" " +
+                             "/Output=\"/Working/result.dcvr\"", result.Args);
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -166,12 +166,15 @@
     <Compile Include="Tools\DNU\Restore\DNURestorer.cs" />
     <Compile Include="Tools\DNU\Restore\DNURestoreSettings.cs" />
     <Compile Include="Tools\DotCover\Analyse\DotCoverAnalyseSettings.cs" />
-    <Compile Include="Tools\DotCover\Analyse\DotCoverAnalyseSettingsExtensions.cs" />
     <Compile Include="Tools\DotCover\Analyse\DotCoverAnalyser.cs" />
+    <Compile Include="Tools\DotCover\Cover\DotCoverCoverSettings.cs" />
+    <Compile Include="Tools\DotCover\Cover\DotCoverCoverer.cs" />
     <Compile Include="Tools\DotCover\DotCoverReportType.cs" />
     <Compile Include="Tools\DotCover\DotCoverContext.cs" />
     <Compile Include="Tools\DotCover\DotCoverProcessRunner.cs" />
     <Compile Include="Tools\DotCover\DotCoverAliases.cs" />
+    <Compile Include="Tools\DotCover\DotCoverSettings.cs" />
+    <Compile Include="Tools\DotCover\DotCoverSettingsExtensions.cs" />
     <Compile Include="Tools\DotCover\DotCoverTool.cs" />
     <Compile Include="Tools\DupFinder\DupFinderAliases.cs" />
     <Compile Include="Tools\DupFinder\DupFinderRunner.cs" />

--- a/src/Cake.Common/Tools/DotCover/Analyse/DotCoverAnalyseSettings.cs
+++ b/src/Cake.Common/Tools/DotCover/Analyse/DotCoverAnalyseSettings.cs
@@ -9,12 +9,8 @@ namespace Cake.Common.Tools.DotCover.Analyse
     /// <summary>
     /// Contains settings used by <see cref="DotCoverAnalyser" />.
     /// </summary>
-    public sealed class DotCoverAnalyseSettings : ToolSettings
+    public sealed class DotCoverAnalyseSettings : DotCoverSettings
     {
-        private readonly HashSet<string> _scope;
-        private readonly HashSet<string> _filters;
-        private readonly HashSet<string> _attributeFilters;
-
         /// <summary>
         /// Gets or sets the type of the report.
         /// This represents the <c>/ReportType</c> option.
@@ -23,56 +19,10 @@ namespace Cake.Common.Tools.DotCover.Analyse
         public DotCoverReportType ReportType { get; set; }
 
         /// <summary>
-        /// Gets or sets program working directory
-        /// This represents the <c>/TargetWorkingDir</c> option.
-        /// </summary>
-        public DirectoryPath TargetWorkingDir { get; set; }
-
-        /// <summary>
-        /// Gets the assemblies loaded in the specified scope into coverage results.
-        /// Ant-style patterns are supported here (e.g.ProjectFolder/**/*.dll)
-        /// This represents the <c>/Scope</c> option.
-        /// </summary>
-        public ISet<string> Scope
-        {
-            get { return _scope; }
-        }
-
-        /// <summary>
-        /// Gets the coverage filters using the following syntax: +:module=*;class=*;function=*;
-        /// Use -:myassembly to exclude an assembly from code coverage. 
-        /// Asterisk wildcard (*) is supported here.
-        /// This represents the <c>/Filters</c> option.
-        /// </summary>
-        public ISet<string> Filters
-        {
-            get { return _filters; }
-        }
-
-        /// <summary>
-        /// Gets the attribute filters using the following syntax: filter1;filter2;...
-        /// Asterisk wildcard(*) is supported here
-        /// This represents the <c>/AttributeFilters</c> option.
-        /// </summary>
-        public ISet<string> AttributeFilters
-        {
-            get { return _attributeFilters; }
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the default (automatically added) filters should be disabled
-        /// This represents the <c>/DisableDefaultFilters</c> option.
-        /// </summary>
-        public bool DisableDefaultFilters { get; set; }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="DotCoverAnalyseSettings"/> class.
         /// </summary>
-        public DotCoverAnalyseSettings()
+        public DotCoverAnalyseSettings() : base()
         {
-            _scope = new HashSet<string>(StringComparer.Ordinal);
-            _filters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            _attributeFilters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Cake.Common/Tools/DotCover/Cover/DotCoverCoverSettings.cs
+++ b/src/Cake.Common/Tools/DotCover/Cover/DotCoverCoverSettings.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.DotCover.Cover
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotCoverCoverer" />.
+    /// </summary>
+    public sealed class DotCoverCoverSettings : DotCoverSettings
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotCoverCoverSettings"/> class.
+        /// </summary>
+        public DotCoverCoverSettings() : base()
+        {
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotCover/Cover/DotCoverCoverer.cs
+++ b/src/Cake.Common/Tools/DotCover/Cover/DotCoverCoverer.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotCover.Cover
+{
+    /// <summary>
+    /// DotCover Coverer builder.
+    /// </summary>
+    public sealed class DotCoverCoverer : DotCoverTool<DotCoverCoverSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotCoverCoverer" /> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
+        public DotCoverCoverer(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IGlobber globber)
+            : base(fileSystem, environment, processRunner, globber)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Runs DotCover Cover with the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="action">The action.</param>
+        /// <param name="outputPath">The output file path.</param>
+        /// <param name="settings">The settings.</param>
+        public void Cover(ICakeContext context,
+            Action<ICakeContext> action,
+            FilePath outputPath,
+            DotCoverCoverSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            if (action == null)
+            {
+                throw new ArgumentNullException("action");
+            }
+            if (outputPath == null)
+            {
+                throw new ArgumentNullException("outputPath");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            // Run the tool using the interceptor.
+            var interceptor = InterceptAction(context, action);
+
+            // Run the tool.
+            Run(settings, GetArguments(interceptor, settings, outputPath));
+        }
+
+        private static DotCoverContext InterceptAction(
+            ICakeContext context,
+            Action<ICakeContext> action)
+        {
+            var interceptor = new DotCoverContext(context);
+            action(interceptor);
+
+            // Validate arguments.
+            if (interceptor.FilePath == null)
+            {
+                throw new CakeException("No tool was started.");
+            }
+
+            return interceptor;
+        }
+
+        private ProcessArgumentBuilder GetArguments(
+            DotCoverContext context,
+            DotCoverCoverSettings settings,
+            FilePath outputPath)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("Cover");
+
+            // The target application to call.
+            builder.AppendSwitch("/TargetExecutable", "=", context.FilePath.FullPath.Quote());
+
+            // The arguments to the target application.
+            if (context.Settings != null && context.Settings.Arguments != null)
+            {
+                var arguments = context.Settings.Arguments.Render();
+                if (!string.IsNullOrWhiteSpace(arguments))
+                {
+                    arguments = arguments.Replace("\"", "\\\"");
+                    builder.AppendSwitch("/TargetArguments", "=", arguments.Quote());
+                }
+            }
+
+            // Set the output file.
+            outputPath = outputPath.MakeAbsolute(_environment);
+            builder.AppendSwitch("/Output", "=", outputPath.FullPath.Quote());
+
+            // TargetWorkingDir
+            if (settings.TargetWorkingDir != null)
+            {
+                builder.AppendSwitch("/TargetWorkingDir", "=", settings.TargetWorkingDir.MakeAbsolute(_environment).FullPath.Quote());
+            }
+
+            // Scope
+            if (settings.Scope.Count > 0)
+            {
+                var scope = string.Join(";", settings.Scope);
+                builder.AppendSwitch("/Scope", "=", scope.Quote());
+            }
+
+            // Filters
+            if (settings.Filters.Count > 0)
+            {
+                var filters = string.Join(";", settings.Filters);
+                builder.AppendSwitch("/Filters", "=", filters.Quote());
+            }
+
+            // Filters
+            if (settings.AttributeFilters.Count > 0)
+            {
+                var attributeFilters = string.Join(";", settings.AttributeFilters);
+                builder.AppendSwitch("/AttributeFilters", "=", attributeFilters.Quote());
+            }
+
+            // DisableDefaultFilters
+            if (settings.DisableDefaultFilters)
+            {
+                builder.Append("/DisableDefaultFilters");
+            }
+
+            return builder;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotCover/DotCoverAliases.cs
+++ b/src/Cake.Common/Tools/DotCover/DotCoverAliases.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Cake.Common.Tools.DotCover.Analyse;
+using Cake.Common.Tools.DotCover.Cover;
 using Cake.Core;
 using Cake.Core.Annotations;
 using Cake.Core.IO;
@@ -60,6 +61,56 @@ namespace Cake.Common.Tools.DotCover
 
             // Run DotCover analyse.
             analyser.Analyse(context, action, outputFile, settings);
+        }
+
+        /// <summary>
+        /// Runs <see href="https://www.jetbrains.com/dotcover/help/dotCover__Console_Runner_Commands.html#cover">DotCover Cover</see>
+        /// for the specified action and settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="action">The action to run DotCover for.</param>
+        /// <param name="outputFile">The DotCover output file.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// DotCoverCover(tool => {
+        ///   tool.XUnit2("./**/App.Tests.dll",
+        ///     new XUnit2Settings {
+        ///       ShadowCopy = false
+        ///     });
+        ///   },
+        ///   new FilePath("./result.dcvr"),
+        ///   new DotCoverCoverSettings()
+        ///     .WithFilter("+:App")
+        ///     .WithFilter("-:App.Tests"));
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Cover")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotCover.Cover")]
+        public static void DotCoverCover(
+            this ICakeContext context,
+            Action<ICakeContext> action,
+            FilePath outputFile,
+            DotCoverCoverSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            if (settings == null)
+            {
+                settings = new DotCoverCoverSettings();
+            }
+
+            // Create the DotCover coverer.
+            var coverer = new DotCoverCoverer(
+                context.FileSystem, context.Environment,
+                context.ProcessRunner, context.Globber);
+
+            // Run DotCover cover.
+            coverer.Cover(context, action, outputFile, settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/DotCover/DotCoverSettings.cs
+++ b/src/Cake.Common/Tools/DotCover/DotCoverSettings.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.DotCover
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotCoverTool{TSettings}" />.
+    /// </summary>
+    public abstract class DotCoverSettings : ToolSettings
+    {
+        private readonly HashSet<string> _scope;
+        private readonly HashSet<string> _filters;
+        private readonly HashSet<string> _attributeFilters;
+
+        /// <summary>
+        /// Gets or sets program working directory
+        /// This represents the <c>/TargetWorkingDir</c> option.
+        /// </summary>
+        public DirectoryPath TargetWorkingDir { get; set; }
+
+        /// <summary>
+        /// Gets the assemblies loaded in the specified scope into coverage results.
+        /// Ant-style patterns are supported here (e.g.ProjectFolder/**/*.dll)
+        /// This represents the <c>/Scope</c> option.
+        /// </summary>
+        public ISet<string> Scope
+        {
+            get { return _scope; }
+        }
+
+        /// <summary>
+        /// Gets the coverage filters using the following syntax: +:module=*;class=*;function=*;
+        /// Use -:myassembly to exclude an assembly from code coverage.
+        /// Asterisk wildcard (*) is supported here.
+        /// This represents the <c>/Filters</c> option.
+        /// </summary>
+        public ISet<string> Filters
+        {
+            get { return _filters; }
+        }
+
+        /// <summary>
+        /// Gets the attribute filters using the following syntax: filter1;filter2;...
+        /// Asterisk wildcard(*) is supported here
+        /// This represents the <c>/AttributeFilters</c> option.
+        /// </summary>
+        public ISet<string> AttributeFilters
+        {
+            get { return _attributeFilters; }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the default (automatically added) filters should be disabled
+        /// This represents the <c>/DisableDefaultFilters</c> option.
+        /// </summary>
+        public bool DisableDefaultFilters { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotCoverSettings"/> class.
+        /// </summary>
+        protected DotCoverSettings()
+        {
+            _scope = new HashSet<string>(StringComparer.Ordinal);
+            _filters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _attributeFilters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotCover/DotCoverSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/DotCover/DotCoverSettingsExtensions.cs
@@ -1,19 +1,20 @@
 using System;
 
-namespace Cake.Common.Tools.DotCover.Analyse
+namespace Cake.Common.Tools.DotCover
 {
     /// <summary>
-    /// Contains extensions for <see cref="DotCoverAnalyseSettings"/>.
+    /// Contains extensions for <see cref="DotCoverSettings"/>.
     /// </summary>
-    public static class DotCoverAnalyseSettingsExtensions
+    public static class DotCoverSettingsExtensions
     {
         /// <summary>
         /// Adds the scope.
         /// </summary>
         /// <param name="settings">The settings.</param>
         /// <param name="scope">The scope.</param>
-        /// <returns>The same <see cref="DotCoverAnalyseSettings"/> instance so that multiple calls can be chained.</returns>
-        public static DotCoverAnalyseSettings WithScope(this DotCoverAnalyseSettings settings, string scope)
+        /// <typeparam name="T">The settings type, derived from <see cref="DotCoverSettings"/></typeparam>
+        /// <returns>The same <see cref="DotCoverSettings"/> instance so that multiple calls can be chained.</returns>
+        public static T WithScope<T>(this T settings, string scope) where T : DotCoverSettings
         {
             if (settings == null)
             {
@@ -28,8 +29,9 @@ namespace Cake.Common.Tools.DotCover.Analyse
         /// </summary>
         /// <param name="settings">The settings.</param>
         /// <param name="filter">The filter.</param>
-        /// <returns>The same <see cref="DotCoverAnalyseSettings"/> instance so that multiple calls can be chained.</returns>
-        public static DotCoverAnalyseSettings WithFilter(this DotCoverAnalyseSettings settings, string filter)
+        /// <typeparam name="T">The settings type, derived from <see cref="DotCoverSettings"/></typeparam>
+        /// <returns>The same <see cref="DotCoverSettings"/> instance so that multiple calls can be chained.</returns>
+        public static T WithFilter<T>(this T settings, string filter) where T : DotCoverSettings
         {
             if (settings == null)
             {
@@ -44,8 +46,9 @@ namespace Cake.Common.Tools.DotCover.Analyse
         /// </summary>
         /// <param name="settings">The settings.</param>
         /// <param name="attributeFilter">The filter.</param>
-        /// <returns>The same <see cref="DotCoverAnalyseSettings"/> instance so that multiple calls can be chained.</returns>
-        public static DotCoverAnalyseSettings WithAttributeFilter(this DotCoverAnalyseSettings settings, string attributeFilter)
+        /// <typeparam name="T">The settings type, derived from <see cref="DotCoverSettings"/></typeparam>
+        /// <returns>The same <see cref="DotCoverSettings"/> instance so that multiple calls can be chained.</returns>
+        public static T WithAttributeFilter<T>(this T settings, string attributeFilter) where T : DotCoverSettings
         {
             if (settings == null)
             {


### PR DESCRIPTION
Added DotCover Cover command. Needed since TeamCity only want snapshots, not HTML/XML reports.

If possible, to remove duplicate code, I would like to reuse **DotCoverCoverSettings** in **DotCoverAnalyser** by having **DotCoverAnalyseSettings** to inherit from **DotCoverCoverSettings**.  Is this allowed since it will make documentation unclear?

NOTE: Quickly hacked using my Linux box, need to verify functionality on Windows (dotCover.exe doesn't run under Mono). But this have to wait until monday when I'm back at work.

//cc @patriksvensson 