### PR TITLE
Added support for importing coverage to TeamCity

### DIFF
--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Fixtures\Build\BambooFixture.cs" />
     <Compile Include="Fixtures\Build\ContinuaCIInfoFixture.cs" />
     <Compile Include="Fixtures\Build\BambooInfoFixture.cs" />
+    <Compile Include="Fixtures\Build\TeamCityFixture.cs" />
     <Compile Include="Fixtures\AssemblyInfoFixture.cs" />
     <Compile Include="Fixtures\AssemblyInfoParserFixture.cs" />
     <Compile Include="Fixtures\Build\JenkinsFixture.cs" />

--- a/src/Cake.Common.Tests/Fixtures/Build/TeamCityFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/TeamCityFixture.cs
@@ -1,0 +1,28 @@
+using Cake.Common.Build.TeamCity;
+using Cake.Core;
+using NSubstitute;
+
+namespace Cake.Common.Tests.Fixtures.Build
+{
+    internal sealed class TeamCityFixture
+    {
+        public ICakeEnvironment Environment { get; set; }
+
+        public TeamCityFixture()
+        {
+            Environment = Substitute.For<ICakeEnvironment>();
+            Environment.WorkingDirectory.Returns("C:\\build\\CAKE-CAKE-JOB1");
+            Environment.GetEnvironmentVariable("TEAMCITY_VERSION").Returns((string)null);
+        }
+
+        public void IsRunningOnTeamCity()
+        {
+            Environment.GetEnvironmentVariable("TEAMCITY_VERSION").Returns("9.1.6");
+        }
+
+        public TeamCityProvider CreateTeamCityService()
+        {
+            return new TeamCityProvider(Environment);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Build/TeamCity/TeamCityProviderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TeamCity/TeamCityProviderTests.cs
@@ -1,5 +1,8 @@
-﻿using Cake.Common.Build.TeamCity;
-using NSubstitute;
+﻿using System;
+using System.IO;
+using Cake.Common.Build.TeamCity;
+using Cake.Common.Tests.Fixtures.Build;
+using Cake.Core.IO;
 using Xunit;
 
 namespace Cake.Common.Tests.Unit.Build.TeamCity
@@ -25,8 +28,9 @@ namespace Cake.Common.Tests.Unit.Build.TeamCity
             public void Should_Return_True_If_Running_On_TeamCity()
             {
                 // Given
-                var teamCity = Substitute.For<ITeamCityProvider>();
-                teamCity.IsRunningOnTeamCity.Returns(true);
+                var fixture = new TeamCityFixture();
+                fixture.IsRunningOnTeamCity();
+                var teamCity = fixture.CreateTeamCityService();
 
                 // When
                 var result = teamCity.IsRunningOnTeamCity;
@@ -39,13 +43,68 @@ namespace Cake.Common.Tests.Unit.Build.TeamCity
             public void Should_Return_False_If_Not_Running_On_TeamCity()
             {
                 // Given
-                var teamCity = Substitute.For<ITeamCityProvider>();
+                var fixture = new TeamCityFixture();
+                var teamCity = fixture.CreateTeamCityService();
 
                 // When
                 var result = teamCity.IsRunningOnTeamCity;
 
                 // Then
                 Assert.False(result);
+            }
+        }
+
+        public sealed class TheImportDotCoverCoverageMethod : IDisposable
+        {
+            private StringWriter _console;
+
+            public TheImportDotCoverCoverageMethod()
+            {
+                _console = new StringWriter();
+                Console.SetOut(_console);
+            }
+
+            public void Dispose()
+            {
+                Console.SetOut(new StreamWriter(Console.OpenStandardOutput()));
+                _console.Dispose();
+            }
+
+            [Fact]
+            public void Should_Use_Bundled_DotCover_If_ToolPath_Is_Null()
+            {
+                // Given
+                var fixture = new TeamCityFixture();
+                fixture.IsRunningOnTeamCity();
+                var teamCity = fixture.CreateTeamCityService();
+                var snapshot = new FilePath("/path/to/result.dcvr");
+
+                // When
+                teamCity.ImportDotCoverCoverage(snapshot);
+
+                // Then
+                Assert.Equal("##teamcity[dotNetCoverage ]" + Environment.NewLine +
+                    "##teamcity[importData type='dotNetCoverage' tool='dotcover' path='/path/to/result.dcvr']" + Environment.NewLine,
+                    _console.ToString());
+            }
+
+            [Fact]
+            public void Should_Use_Provided_DotCover_If_ToolPath_Is_Not_Null()
+            {
+                // Given
+                var fixture = new TeamCityFixture();
+                fixture.IsRunningOnTeamCity();
+                var teamCity = fixture.CreateTeamCityService();
+                var snapshot = new FilePath("/path/to/result.dcvr");
+                var dotCoverHome = new DirectoryPath("/path/to/dotcover_home");
+
+                // When
+                teamCity.ImportDotCoverCoverage(snapshot, dotCoverHome);
+
+                // Then
+                Assert.Equal("##teamcity[dotNetCoverage dotcover_home='/path/to/dotcover_home']" + Environment.NewLine +
+                    "##teamcity[importData type='dotNetCoverage' tool='dotcover' path='/path/to/result.dcvr']" + Environment.NewLine,
+                    _console.ToString());
             }
         }
     }

--- a/src/Cake.Common/Build/TeamCity/ITeamCityProvider.cs
+++ b/src/Cake.Common/Build/TeamCity/ITeamCityProvider.cs
@@ -22,6 +22,13 @@ namespace Cake.Common.Build.TeamCity
         void ImportData(string type, FilePath path);
 
         /// <summary>
+        /// Tell TeamCity to import coverage from dotCover snapshot file.
+        /// </summary>
+        /// <param name="snapshotFile">Snapshot file path.</param>
+        /// <param name="dotCoverHome">The full path to the dotCover home folder to override the bundled dotCover.</param>
+        void ImportDotCoverCoverage(FilePath snapshotFile, DirectoryPath dotCoverHome = null);
+
+        /// <summary>
         /// Gets a value indicating whether the current build is running on TeamCity.
         /// </summary>
         /// <value>

--- a/src/Cake.Common/Build/TeamCity/TeamCityProvider.cs
+++ b/src/Cake.Common/Build/TeamCity/TeamCityProvider.cs
@@ -165,6 +165,35 @@ namespace Cake.Common.Build.TeamCity
         }
 
         /// <summary>
+        /// Tell TeamCity to import coverage from dotCover snapshot file.
+        /// </summary>
+        /// <param name="snapshotFile">Snapshot file path.</param>
+        /// <param name="dotCoverHome">The full path to the dotCover home folder to override the bundled dotCover.</param>
+        public void ImportDotCoverCoverage(FilePath snapshotFile, DirectoryPath dotCoverHome = null)
+        {
+            if (snapshotFile == null)
+            {
+                throw new ArgumentNullException("snapshotFile");
+            }
+
+            var args = dotCoverHome == null ?
+                new Dictionary<string, string>() :
+                new Dictionary<string, string>
+                {
+                    { "dotcover_home", dotCoverHome.FullPath }
+                };
+
+            WriteServiceMessage("dotNetCoverage", args);
+
+            WriteServiceMessage("importData", new Dictionary<string, string>
+            {
+                { "type", "dotNetCoverage" },
+                { "tool", "dotcover" },
+                { "path", snapshotFile.FullPath }
+            });
+        }
+
+        /// <summary>
         /// Report a build problem to TeamCity.
         /// </summary>
         /// <param name="description">Description of build problem.</param>


### PR DESCRIPTION
This is needed to import to import Coverage to TeamCity. See https://confluence.jetbrains.com/display/TCD9/Manually+Configuring+Reporting+Coverage

Note, quick hack, I would like to test functionality on monday when I have access to TeamCity.

Also, unit tests are non-existent for TeamCity, wan't to add these also prior to merging this PR.

related to #713 

//cc @patriksvensson 