### PR TITLE
Added SpecFlow support

### DIFF
--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -93,6 +93,9 @@
     <Compile Include="Fixtures\Tools\DNU\DNUFixture.cs" />
     <Compile Include="Fixtures\Tools\DNU\Pack\DNUPackerFixture.cs" />
     <Compile Include="Fixtures\Tools\DNU\Restorer\DNURestorerFixture.cs" />
+    <Compile Include="Fixtures\Tools\SpecFlow\StepDefinitionReport\SpecFlowStepDefinitionReporterFixture.cs" />
+    <Compile Include="Fixtures\Tools\SpecFlow\TestExecutionReport\SpecFlowTestExecutionReporterFixture.cs" />
+    <Compile Include="Fixtures\Tools\SpecFlow\SpecFlowFixture.cs" />
     <Compile Include="Fixtures\Tools\DotCover\Analyse\DotCoverAnalyserFixture.cs" />
     <Compile Include="Fixtures\Tools\DotCover\Cover\DotCoverCovererFixture.cs" />
     <Compile Include="Fixtures\Tools\DotCover\DotCoverFixture.cs" />
@@ -261,6 +264,8 @@
     <Compile Include="Unit\Tools\Roundhouse\RoundhouseRunnerTests.cs" />
     <Compile Include="Unit\Tools\SignTool\SignToolResolverTests.cs" />
     <Compile Include="Unit\Tools\SignTool\SignToolSignRunnerTests.cs" />
+    <Compile Include="Unit\Tools\SpecFlow\StepDefinitionReport\SpecFlowStepDefinitionReporterTests.cs" />
+    <Compile Include="Unit\Tools\SpecFlow\TestExecutionReport\SpecFlowTestExecutionReporterTests.cs" />
     <Compile Include="Unit\Tools\WiX\LightRunnerTests.cs" />
     <Compile Include="Unit\Tools\WiX\CandleRunnerTests.cs" />
     <Compile Include="Unit\Tools\XBuild\XBuildSettingsExtensionsTests.cs" />

--- a/src/Cake.Common.Tests/Fixtures/Tools/SpecFlow/SpecFlowFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/SpecFlow/SpecFlowFixture.cs
@@ -1,0 +1,26 @@
+﻿using Cake.Core.IO;
+using Cake.Core.Tooling;
+using Cake.Testing.Fixtures;
+
+namespace Cake.Common.Tests.Fixtures.Tools.SpecFlow
+{
+    internal abstract class SpecFlowFixture<TSettings> : SpecFlowFixture<TSettings, ToolFixtureResult>
+    where TSettings : ToolSettings, new()
+    {
+        protected override ToolFixtureResult CreateResult(FilePath path, ProcessSettings process)
+        {
+            return new ToolFixtureResult(path, process);
+        }
+    }
+
+    internal abstract class SpecFlowFixture<TSettings, TFixtureResult> : ToolFixture<TSettings, TFixtureResult>
+        where TSettings : ToolSettings, new()
+        where TFixtureResult : ToolFixtureResult
+    {
+        protected SpecFlowFixture()
+            : base("specflow.exe")
+        {
+            ProcessRunner.Process.SetStandardOutput(new string[] { });
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Fixtures/Tools/SpecFlow/StepDefinitionReport/SpecFlowStepDefinitionReporterFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/SpecFlow/StepDefinitionReport/SpecFlowStepDefinitionReporterFixture.cs
@@ -1,0 +1,22 @@
+﻿using Cake.Common.Tools.SpecFlow.StepDefinitionReport;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tests.Fixtures.Tools.SpecFlow.StepDefinitionReport
+{
+    internal sealed class SpecFlowStepDefinitionReporterFixture : SpecFlowFixture<SpecFlowStepDefinitionReportSettings>
+    {
+        public FilePath ProjectFile { get; set; }
+
+        public SpecFlowStepDefinitionReporterFixture()
+        {
+            // Set the project file.
+            ProjectFile = new FilePath("./Tests.csproj");
+        }
+
+        protected override void RunTool()
+        {
+            var tool = new SpecFlowStepDefinitionReporter(FileSystem, Environment, ProcessRunner, Globber);
+            tool.Run(ProjectFile, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Fixtures/Tools/SpecFlow/TestExecutionReport/SpecFlowTestExecutionReporterFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/SpecFlow/TestExecutionReport/SpecFlowTestExecutionReporterFixture.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Cake.Common.Tools.DotCover.Cover;
+using Cake.Common.Tools.SpecFlow.TestExecutionReport;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using NSubstitute;
+
+namespace Cake.Common.Tests.Fixtures.Tools.SpecFlow.TestExecutionReport
+{
+    internal sealed class SpecFlowTestExecutionReporterFixture : SpecFlowFixture<SpecFlowTestExecutionReportSettings>
+    {
+        public ICakeContext Context { get; set; }
+        public Action<ICakeContext> Action { get; set; }
+        public FilePath ProjectFile { get; set; }
+
+        public SpecFlowTestExecutionReporterFixture()
+        {
+            // Set the project file.
+            ProjectFile = new FilePath("./Tests.csproj");
+
+            // Setup the Cake Context.
+            Context = Substitute.For<ICakeContext>();
+            Context.FileSystem.Returns(FileSystem);
+            Context.Arguments.Returns(Substitute.For<ICakeArguments>());
+            Context.Environment.Returns(Environment);
+            Context.Globber.Returns(Globber);
+            Context.Log.Returns(Substitute.For<ICakeLog>());
+            Context.Registry.Returns(Substitute.For<IRegistry>());
+            Context.ProcessRunner.Returns(Substitute.For<IProcessRunner>());
+
+            // Set up the default action that intercepts.
+            Action = context =>
+            {
+                context.ProcessRunner.Start(
+                    new FilePath("/Working/tools/MSTest.exe"),
+                    new ProcessSettings()
+                    {
+                        Arguments = "/resultsfile:\"/Working/TestResult.trx\""
+                    });
+            };
+        }
+
+        protected override void RunTool()
+        {
+            var tool = new SpecFlowTestExecutionReporter(FileSystem, Environment, ProcessRunner, Globber);
+            tool.Run(Context, Action, ProjectFile, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/SpecFlow/StepDefinitionReport/SpecFlowStepDefinitionReporterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/SpecFlow/StepDefinitionReport/SpecFlowStepDefinitionReporterTests.cs
@@ -1,0 +1,90 @@
+﻿using Cake.Common.Tests.Fixtures.Tools.SpecFlow.StepDefinitionReport;
+using Cake.Common.Tools.NUnit;
+using Cake.Common.Tools.XUnit;
+using Cake.Common.Tools.MSTest;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Testing;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.SpecFlow.StepDefinitionReport
+{
+    public sealed class SpecFlowStepDefinitionReporterTests
+    {
+        public sealed class TheRunMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Project_File_Is_Null()
+            {
+                // Given
+                var fixture = new SpecFlowStepDefinitionReporterFixture();
+                fixture.ProjectFile = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "projectFile");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new SpecFlowStepDefinitionReporterFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Append_Out()
+            {
+                // Given
+                var fixture = new SpecFlowStepDefinitionReporterFixture();
+                fixture.Settings.Out = "/Working/out.html";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("stepdefinitionreport \"/Working/Tests.csproj\" " +
+                             "/out:\"/Working/out.html\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_XsltFile()
+            {
+                // Given
+                var fixture = new SpecFlowStepDefinitionReporterFixture();
+                fixture.Settings.XsltFile = "/Working/template.xslt";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("stepdefinitionreport \"/Working/Tests.csproj\" " +
+                             "/xsltFile:\"/Working/template.xslt\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_BinFolder()
+            {
+                // Given
+                var fixture = new SpecFlowStepDefinitionReporterFixture();
+                fixture.Settings.BinFolder = "/Working/some-folder";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("stepdefinitionreport \"/Working/Tests.csproj\" " +
+                             "/binFolder:\"/Working/some-folder\"", result.Args);
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/SpecFlow/TestExecutionReport/SpecFlowTestExecutionReporterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/SpecFlow/TestExecutionReport/SpecFlowTestExecutionReporterTests.cs
@@ -1,0 +1,383 @@
+﻿using Cake.Common.Tests.Fixtures.Tools.SpecFlow.TestExecutionReport;
+using Cake.Common.Tools.NUnit;
+using Cake.Common.Tools.XUnit;
+using Cake.Common.Tools.MSTest;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Testing;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.SpecFlow.TestExecutionReport
+{
+    public sealed class SpecFlowTestExecutionReporterTests
+    {
+        public sealed class TheRunMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Context_Is_Null()
+            {
+                // Given
+                var fixture = new SpecFlowTestExecutionReporterFixture();
+                fixture.Context = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "context");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Action_Is_Null()
+            {
+                // Given
+                var fixture = new SpecFlowTestExecutionReporterFixture();
+                fixture.Action = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "action");
+
+            }
+
+            [Fact]
+            public void Should_Throw_If_Project_File_Is_Null()
+            {
+                // Given
+                var fixture = new SpecFlowTestExecutionReporterFixture();
+                fixture.ProjectFile = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "projectFile");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new SpecFlowTestExecutionReporterFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_No_Tool_Was_Intercepted()
+            {
+                // Given
+                var fixture = new SpecFlowTestExecutionReporterFixture();
+                fixture.Action = context => { };
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsCakeException(result, "No tool was started.");
+            }
+
+            [Fact]
+            public void Should_Capture_Tool_And_Arguments_From_Action()
+            {
+                // Given
+                var fixture = new SpecFlowTestExecutionReporterFixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("mstestexecutionreport \"/Working/Tests.csproj\" " +
+                             "/testResult:\"/Working/TestResult.trx\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Action_Is_Not_Supported()
+            {
+                // Given
+                var fixture = new SpecFlowTestExecutionReporterFixture();
+                fixture.Action = context =>
+                {
+                    context.ProcessRunner.Start(
+                        new FilePath("/Working/tools/Test.exe"),
+                        new ProcessSettings
+                        {
+                            Arguments = null
+                        });
+                };
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsCakeException(result, "Unsupported tool /Working/tools/Test.exe.");
+            }
+
+            [Theory]
+            [InlineData(null)]
+            [InlineData(" ")]
+            public void Should_Throw_If_Action_Does_Not_Contain_Arguments(string arguments)
+            {
+                // Given
+                var fixture = new SpecFlowTestExecutionReporterFixture();
+                fixture.Action = context =>
+                {
+                    context.ProcessRunner.Start(
+                        new FilePath("/Working/tools/MSTest.exe"),
+                        new ProcessSettings
+                        {
+                            Arguments = arguments
+                        });
+                };
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsCakeException(result, "No arguments were found for tool.");
+            }
+
+            [Fact]
+            public void Should_Append_Out()
+            {
+                // Given
+                var fixture = new SpecFlowTestExecutionReporterFixture();
+                fixture.Settings.Out = "/Working/out.html";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("mstestexecutionreport \"/Working/Tests.csproj\" " +
+                             "/testResult:\"/Working/TestResult.trx\" " +
+                             "/out:\"/Working/out.html\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_XsltFile()
+            {
+                // Given
+                var fixture = new SpecFlowTestExecutionReporterFixture();
+                fixture.Settings.XsltFile = "/Working/template.xslt";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("mstestexecutionreport \"/Working/Tests.csproj\" " +
+                             "/testResult:\"/Working/TestResult.trx\" " +
+                             "/xsltFile:\"/Working/template.xslt\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Capture_XUnit2()
+            {
+                // Given
+                var fixture = new SpecFlowTestExecutionReporterFixture();
+                fixture.FileSystem.CreateFile("/Working/tools/xunit.console.exe");
+
+                var xUnit2Settings = new XUnit2Settings { ShadowCopy = false };
+                xUnit2Settings.ArgumentCustomization = builder => builder.Append("-nunit \"/Working/TestResult.xml\"");
+
+                fixture.Action = context =>
+                {
+                    context.XUnit2(new FilePath[] { "./Test.dll" }, xUnit2Settings);
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("nunitexecutionreport \"/Working/Tests.csproj\" " +
+                             "/xmlTestResult:\"/Working/TestResult.xml\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Capture_XUnit2_And_Throw_If_NUnit_Is_Missing()
+            {
+                // Given
+                var fixture = new SpecFlowTestExecutionReporterFixture();
+                fixture.FileSystem.CreateFile("/Working/tools/xunit.console.exe");
+
+                fixture.Action = context =>
+                {
+                    context.XUnit2(new FilePath[] { "./Test.dll" }, new XUnit2Settings { ShadowCopy = false });
+                };
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsCakeException(result, "XUnit2 must contain argument \"-nunit <filename>\"");
+            }
+
+            [Fact]
+            public void Should_Capture_NUnit3()
+            {
+                // Given
+                var fixture = new SpecFlowTestExecutionReporterFixture();
+                fixture.FileSystem.CreateFile("/Working/tools/nunit3-console.exe");
+
+                var nUnit3Settings = new NUnit3Settings
+                {
+                    ShadowCopy = false,
+                    Results ="/Working/TestResult.xml",
+                    ResultFormat = "nunit2",
+                    Labels = NUnit3Labels.All,
+                    OutputFile = "/Working/TestResult.txt"
+                };
+
+                fixture.Action = context =>
+                {
+                    context.NUnit3(new FilePath[] { "./Test.dll" }, nUnit3Settings);
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("nunitexecutionreport \"/Working/Tests.csproj\" " +
+                             "/xmlTestResult:\"/Working/TestResult.xml\" " +
+                             "/testOutput:\"/Working/TestResult.txt\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Capture_NUnit3_And_Throw_If_Result_Is_Missing()
+            {
+                // Given
+                var fixture = new SpecFlowTestExecutionReporterFixture();
+                fixture.FileSystem.CreateFile("/Working/tools/nunit3-console.exe");
+
+                var nUnit3Settings = new NUnit3Settings
+                {
+                    ShadowCopy = false,
+                    Labels = NUnit3Labels.All,
+                    OutputFile = "/Working/TestResult.txt"
+                };
+
+                fixture.Action = context =>
+                {
+                    context.NUnit3(new FilePath[] { "./Test.dll" }, nUnit3Settings);
+                };
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsCakeException(result, "NUnit3 must contain argument \"--result=<filename>;format=nunit2\"");
+            }
+
+            [Fact]
+            public void Should_Capture_NUnit3_And_Throw_If_Output_Is_Missing()
+            {
+                // Given
+                var fixture = new SpecFlowTestExecutionReporterFixture();
+                fixture.FileSystem.CreateFile("/Working/tools/nunit3-console.exe");
+
+                var nUnit3Settings = new NUnit3Settings
+                {
+                    ShadowCopy = false,
+                    Results = "/Working/TestResult.xml",
+                    ResultFormat = "nunit2"
+                };
+
+                fixture.Action = context =>
+                {
+                    context.NUnit3(new FilePath[] { "./Test.dll" }, nUnit3Settings);
+                };
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsCakeException(result, "NUnit3 must contain argument \"--out=<filename>\"");
+            }
+
+            [Fact]
+            public void Should_Capture_NUnit3_And_Throw_If_Labels_Is_Missing()
+            {
+                // Given
+                var fixture = new SpecFlowTestExecutionReporterFixture();
+                fixture.FileSystem.CreateFile("/Working/tools/nunit3-console.exe");
+
+                var nUnit3Settings = new NUnit3Settings
+                {
+                    ShadowCopy = false,
+                    Results = "/Working/TestResult.xml",
+                    ResultFormat = "nunit2",
+                    OutputFile = "/Working/TestResult.txt"
+                };
+
+                fixture.Action = context =>
+                {
+                    context.NUnit3(new FilePath[] { "./Test.dll" }, nUnit3Settings);
+                };
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsCakeException(result, "NUnit3 must contain argument \"--labels=All\"");
+            }
+
+            [Fact]
+            public void Should_Capture_MSTest()
+            {
+                // Given
+                var fixture = new SpecFlowTestExecutionReporterFixture();
+                fixture.FileSystem.CreateFile("/Working/tools/MSTest.exe");
+
+                var msTestSettings = new MSTestSettings
+                {
+                    NoIsolation = true
+                };
+                msTestSettings.ArgumentCustomization = builder => builder.Append("/resultsfile:/Working/TestResult.trx");
+                msTestSettings.ToolPath = "/Working/tools/MSTest.exe";
+
+                fixture.Action = context =>
+                {
+                    context.MSTest(new FilePath[] { "./Test.dll" }, msTestSettings);
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("mstestexecutionreport \"/Working/Tests.csproj\" " +
+                             "/testResult:/Working/TestResult.trx", result.Args);
+            }
+
+            [Fact]
+            public void Should_Capture_MSTest_And_Throw_If_ResultsFile_Is_Missing()
+            {
+                // Given
+                var fixture = new SpecFlowTestExecutionReporterFixture();
+                fixture.FileSystem.CreateFile("/Working/tools/MSTest.exe");
+
+                var msTestSettings = new MSTestSettings
+                {
+                    NoIsolation = true
+                };
+                msTestSettings.ToolPath = "/Working/tools/MSTest.exe";
+
+                fixture.Action = context =>
+                {
+                    context.MSTest(new FilePath[] { "./Test.dll" }, msTestSettings);
+                };
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsCakeException(result, "MSTest must contain argument \"/resultsfile:<filename>\"");
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -306,6 +306,16 @@
     <Compile Include="Tools\SignTool\SignToolSignAliases.cs" />
     <Compile Include="Tools\SignTool\SignToolSignRunner.cs" />
     <Compile Include="Tools\SignTool\SignToolSignSettings.cs" />
+    <Compile Include="Tools\SpecFlow\SpecFlowContext.cs" />
+    <Compile Include="Tools\SpecFlow\SpecFlowContextExtensions.cs" />
+    <Compile Include="Tools\SpecFlow\SpecFlowProcessRunner.cs" />
+    <Compile Include="Tools\SpecFlow\TestExecutionReport\SpecFlowTestExecutionReporter.cs" />
+    <Compile Include="Tools\SpecFlow\TestExecutionReport\SpecFlowTestExecutionReportSettings.cs" />
+    <Compile Include="Tools\SpecFlow\StepDefinitionReport\SpecFlowStepDefinitionReporter.cs" />
+    <Compile Include="Tools\SpecFlow\StepDefinitionReport\SpecFlowStepDefinitionReportSettings.cs" />
+    <Compile Include="Tools\SpecFlow\SpecFlowAliases.cs" />
+    <Compile Include="Tools\SpecFlow\SpecFlowSettings.cs" />
+    <Compile Include="Tools\SpecFlow\SpecFlowTool.cs" />
     <Compile Include="Tools\WiX\Architecture.cs" />
     <Compile Include="Tools\WiX\CandleRunner.cs" />
     <Compile Include="Tools\WiX\CandleSettings.cs" />

--- a/src/Cake.Common/Tools/SpecFlow/SpecFlowAliases.cs
+++ b/src/Cake.Common/Tools/SpecFlow/SpecFlowAliases.cs
@@ -1,0 +1,119 @@
+using System;
+using Cake.Common.Tools.SpecFlow.StepDefinitionReport;
+using Cake.Common.Tools.SpecFlow.TestExecutionReport;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.SpecFlow
+{
+    /// <summary>
+    /// Contains functionality for working with SpecFlow.
+    /// </summary>
+    [CakeAliasCategory("SpecFlow")]
+    public static class SpecFlowAliases
+    {
+        /// <summary>
+        /// Creates a report that shows the usage and binding status of the steps for the entire project.
+        /// You can use this report to find both unused code in the automation layer and scenario steps that have no definition yet.
+        /// See <see href="https://github.com/techtalk/SpecFlow/wiki/Reporting#step-definition-report">SpecFlow Documentation</see> for more information.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="projectFile">The path of the project file containing the feature files.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("StepDefinitionReport")]
+        [CakeNamespaceImport("Cake.Common.Tools.SpecFlow.StepDefinitionReport")]
+        public static void SpecFlowStepDefinitionReport(this ICakeContext context, FilePath projectFile)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            SpecFlowStepDefinitionReport(context, projectFile, new SpecFlowStepDefinitionReportSettings());
+        }
+
+        /// <summary>
+        /// Creates a report that shows the usage and binding status of the steps for the entire project.
+        /// You can use this report to find both unused code in the automation layer and scenario steps that have no definition yet.
+        /// See <see href="https://github.com/techtalk/SpecFlow/wiki/Reporting#step-definition-report">SpecFlow Documentation</see> for more information.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="projectFile">The path of the project file containing the feature files.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("StepDefinitionReport")]
+        [CakeNamespaceImport("Cake.Common.Tools.SpecFlow.StepDefinitionReport")]
+        public static void SpecFlowStepDefinitionReport(this ICakeContext context, FilePath projectFile, SpecFlowStepDefinitionReportSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var runner = new SpecFlowStepDefinitionReporter(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber);
+            runner.Run(projectFile, settings ?? new SpecFlowStepDefinitionReportSettings());
+        }
+
+        /// <summary>
+        /// Creates a formatted HTML report of a test execution.
+        /// The report contains a summary about the executed tests and the result and also a detailed report for the individual scenario executions.
+        /// See <see href="https://github.com/techtalk/SpecFlow/wiki/Reporting#test-execution-report">SpecFlow Documentation</see> for more information.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="action">The action to run SpecFlow for. Supported actions are: MSTest, NUnit3 and XUnit2</param>
+        /// <param name="projectFile">The path of the project file containing the feature files.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("TestExecutionReport")]
+        [CakeNamespaceImport("Cake.Common.Tools.SpecFlow.TestExecutionReport")]
+        public static void SpecFlowTestExecutionReport(
+            this ICakeContext context,
+            Action<ICakeContext> action,
+            FilePath projectFile)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            SpecFlowTestExecutionReport(context, action, projectFile, new SpecFlowTestExecutionReportSettings());
+        }
+
+        /// <summary>
+        /// Creates a formatted HTML report of a test execution.
+        /// The report contains a summary about the executed tests and the result and also a detailed report for the individual scenario executions.
+        /// See <see href="https://github.com/techtalk/SpecFlow/wiki/Reporting#test-execution-report">SpecFlow Documentation</see> for more information.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="action">The action to run SpecFlow for. Supported actions are: MSTest, NUNit, NUNit3, XUnit and XUnit2</param>
+        /// <param name="projectFile">The path of the project file containing the feature files.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("TestExecutionReport")]
+        [CakeNamespaceImport("Cake.Common.Tools.SpecFlow.TestExecutionReport")]
+        public static void SpecFlowTestExecutionReport(
+            this ICakeContext context,
+            Action<ICakeContext> action,
+            FilePath projectFile,
+            SpecFlowTestExecutionReportSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            if (settings == null)
+            {
+                settings = new SpecFlowTestExecutionReportSettings();
+            }
+
+            // Create the DotCover analyser.
+            var runner = new SpecFlowTestExecutionReporter(
+                context.FileSystem, context.Environment,
+                context.ProcessRunner, context.Globber);
+
+            // Run DotCover analyse.
+            runner.Run(context, action, projectFile, settings);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/SpecFlow/SpecFlowContext.cs
+++ b/src/Cake.Common/Tools/SpecFlow/SpecFlowContext.cs
@@ -1,0 +1,65 @@
+﻿using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.SpecFlow
+{
+    internal sealed class SpecFlowContext : ICakeContext
+    {
+        private readonly ICakeContext _context;
+        private readonly ICakeLog _log;
+        private readonly SpecFlowProcessRunner _runner;
+
+        public IFileSystem FileSystem
+        {
+            get { return _context.FileSystem; }
+        }
+
+        public ICakeEnvironment Environment
+        {
+            get { return _context.Environment; }
+        }
+
+        public IGlobber Globber
+        {
+            get { return _context.Globber; }
+        }
+
+        public ICakeLog Log
+        {
+            get { return _log; }
+        }
+
+        public ICakeArguments Arguments
+        {
+            get { return _context.Arguments; }
+        }
+
+        public IProcessRunner ProcessRunner
+        {
+            get { return _runner; }
+        }
+
+        public IRegistry Registry
+        {
+            get { return _context.Registry; }
+        }
+
+        public FilePath FilePath
+        {
+            get { return _runner.FilePath; }
+        }
+
+        public ProcessSettings Settings
+        {
+            get { return _runner.ProcessSettings; }
+        }
+
+        public SpecFlowContext(ICakeContext context)
+        {
+            _context = context;
+            _log = new NullLog();
+            _runner = new SpecFlowProcessRunner();
+        }
+    }
+}

--- a/src/Cake.Common/Tools/SpecFlow/SpecFlowContextExtensions.cs
+++ b/src/Cake.Common/Tools/SpecFlow/SpecFlowContextExtensions.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.SpecFlow
+{
+    internal static class SpecFlowContextExtensions
+    {
+        internal static ProcessArgumentBuilder GetArguments(this SpecFlowContext context,
+            FilePath projectFile,
+            ICakeEnvironment environment)
+        {
+            ProcessArgumentBuilder builder;
+            var executable = context.FilePath.ToString();
+
+            if (executable.IndexOf("mstest", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                builder = context.GetMSTestArguments(projectFile, environment);
+            }
+            else if (executable.IndexOf("nunit", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                builder = context.GetNUnitArguments(projectFile, environment);
+            }
+            else if (executable.IndexOf("xunit", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                builder = context.GetXUnitArguments(projectFile, environment);
+            }
+            else
+            {
+                throw new CakeException(string.Format("Unsupported tool {0}.", executable));
+            }
+
+            return builder;
+        }
+
+        internal static ProcessArgumentBuilder GetMSTestArguments(this SpecFlowContext context,
+            FilePath projectFile,
+            ICakeEnvironment environment)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("mstestexecutionreport");
+
+            // Set the project file
+            builder.AppendQuoted(projectFile.MakeAbsolute(environment).FullPath);
+
+            var arguments = context.RenderArguments();
+
+            // Set the test result
+            var testResultMatch = Regex.Match(arguments, "\\/resultsfile:\\s*((?:\".+?\"|[^\\s]+))", RegexOptions.IgnoreCase);
+
+            if (testResultMatch.Success && testResultMatch.Groups[1].Success)
+            {
+                builder.AppendSwitch("/testResult", ":", testResultMatch.Groups[1].Value);
+            }
+            else
+            {
+                throw new CakeException("MSTest must contain argument \"/resultsfile:<filename>\"");
+            }
+
+            return builder;
+        }
+
+        internal static ProcessArgumentBuilder GetNUnitArguments(this SpecFlowContext context,
+            FilePath projectFile,
+            ICakeEnvironment environment)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("nunitexecutionreport");
+
+            // Set the project file
+            builder.AppendQuoted(projectFile.MakeAbsolute(environment).FullPath);
+
+            var arguments = context.RenderArguments();
+
+            // Set the xml test result
+            var xmlTestResultMatch = Regex.Match(arguments, "\"--result=([^;]+);format=nunit2", RegexOptions.IgnoreCase);
+
+            if (xmlTestResultMatch.Success && xmlTestResultMatch.Groups[1].Success)
+            {
+                builder.AppendSwitch("/xmlTestResult", ":", xmlTestResultMatch.Groups[1].Value.Quote());
+            }
+            else
+            {
+                throw new CakeException("NUnit3 must contain argument \"--result=<filename>;format=nunit2\"");
+            }
+
+            // Set the test output
+            var testOutputMatch = Regex.Match(arguments, "\"--out=([^\"]+)\"", RegexOptions.IgnoreCase);
+
+            if (testOutputMatch.Success && testOutputMatch.Groups[1].Success)
+            {
+                builder.AppendSwitch("/testOutput", ":", testOutputMatch.Groups[1].Value.Quote());
+            }
+            else
+            {
+                throw new CakeException("NUnit3 must contain argument \"--out=<filename>\"");
+            }
+
+            // Check for labels switch
+            var testLabelsMatch = Regex.Match(arguments, "--labels=All", RegexOptions.IgnoreCase);
+
+            if (!testLabelsMatch.Success)
+            {
+                throw new CakeException("NUnit3 must contain argument \"--labels=All\"");
+            }
+
+            return builder;
+        }
+
+        internal static ProcessArgumentBuilder GetXUnitArguments(this SpecFlowContext context,
+            FilePath projectFile,
+            ICakeEnvironment environment)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("nunitexecutionreport");
+
+            // Set the project file
+            builder.AppendQuoted(projectFile.MakeAbsolute(environment).FullPath);
+
+            var arguments = RenderArguments(context);
+
+            // Set the xml test result
+            var xmlTestResultMatch = Regex.Match(arguments, "-nunit\\s+((?:\".+?\"|.*))", RegexOptions.IgnoreCase);
+
+            if (xmlTestResultMatch.Success && xmlTestResultMatch.Groups[1].Success)
+            {
+                builder.AppendSwitch("/xmlTestResult", ":", xmlTestResultMatch.Groups[1].Value);
+            }
+            else
+            {
+                throw new CakeException("XUnit2 must contain argument \"-nunit <filename>\"");
+            }
+
+            return builder;
+        }
+
+        private static string RenderArguments(this SpecFlowContext context)
+        {
+            // The arguments to the target application.
+            if (context.Settings == null || context.Settings.Arguments == null)
+            {
+                throw new CakeException("No arguments were found for tool.");
+            }
+
+            var arguments = context.Settings.Arguments.Render();
+
+            if (string.IsNullOrWhiteSpace(arguments))
+            {
+                throw new CakeException("No arguments were found for tool.");
+            }
+
+            return arguments;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/SpecFlow/SpecFlowProcessRunner.cs
+++ b/src/Cake.Common/Tools/SpecFlow/SpecFlowProcessRunner.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.SpecFlow
+{
+    internal sealed class SpecFlowProcessRunner : IProcessRunner
+    {
+        public FilePath FilePath { get; set; }
+
+        public ProcessSettings ProcessSettings { get; set; }
+
+        private sealed class InterceptedProcess : IProcess
+        {
+            public void Dispose()
+            {
+            }
+
+            public void WaitForExit()
+            {
+            }
+
+            public bool WaitForExit(int milliseconds)
+            {
+                return true;
+            }
+
+            public int GetExitCode()
+            {
+                return 0;
+            }
+
+            public IEnumerable<string> GetStandardOutput()
+            {
+                return Enumerable.Empty<string>();
+            }
+
+            public void Kill()
+            {
+            }
+        }
+
+        public IProcess Start(FilePath filePath, ProcessSettings settings)
+        {
+            FilePath = filePath;
+            ProcessSettings = settings;
+            return new InterceptedProcess();
+        }
+    }
+}

--- a/src/Cake.Common/Tools/SpecFlow/SpecFlowSettings.cs
+++ b/src/Cake.Common/Tools/SpecFlow/SpecFlowSettings.cs
@@ -1,0 +1,23 @@
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.SpecFlow
+{
+    /// <summary>
+    /// Contains settings used by <see cref="SpecFlowTool{TSettings}"/>.
+    /// </summary>
+    public abstract class SpecFlowSettings : ToolSettings
+    {
+        /// <summary>
+        /// Gets or sets the generated Output File. Optional.
+        /// Default: TestResult.html
+        /// </summary>
+        public FilePath Out { get; set; }
+
+        /// <summary>
+        /// Gets or sets the custom XSLT file to use, defaults to built-in stylesheet if not provided. Optional.
+        /// Default: not specified
+        /// </summary>
+        public FilePath XsltFile { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/SpecFlow/SpecFlowTool.cs
+++ b/src/Cake.Common/Tools/SpecFlow/SpecFlowTool.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.SpecFlow
+{
+    /// <summary>
+    /// Base class for all SpecFlow related tools
+    /// </summary>
+    /// <typeparam name="TSettings">The settings type</typeparam>
+    public abstract class SpecFlowTool<TSettings> : Tool<TSettings>
+        where TSettings : SpecFlowSettings
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpecFlowTool{TSettings}" /> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
+        protected SpecFlowTool(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IGlobber globber)
+            : base(fileSystem, environment, processRunner, globber)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Gets the name of the tool.
+        /// </summary>
+        /// <returns>The name of the tool.</returns>
+        protected override string GetToolName()
+        {
+            return "SpecFlow";
+        }
+
+        /// <summary>
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return new[] { "specflow.exe", "SpecFlow.exe" };
+        }
+
+        /// <summary>
+        /// Appends the SpecFlowSettings arguments to builder.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="builder">The argument builder.</param>
+        protected void AppendArguments(
+            SpecFlowSettings settings,
+            ProcessArgumentBuilder builder)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+            if (builder == null)
+            {
+                throw new ArgumentNullException("builder");
+            }
+
+            // Set the out file.
+            if (settings.Out != null)
+            {
+                var outFile = settings.Out.MakeAbsolute(_environment);
+                builder.AppendSwitch("/out", ":", outFile.FullPath.Quote());
+            }
+
+            // Set the xslt file.
+            if (settings.XsltFile != null)
+            {
+                var xsltFile = settings.XsltFile.MakeAbsolute(_environment);
+                builder.AppendSwitch("/xsltFile", ":", xsltFile.FullPath.Quote());
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Tools/SpecFlow/StepDefinitionReport/SpecFlowStepDefinitionReportSettings.cs
+++ b/src/Cake.Common/Tools/SpecFlow/StepDefinitionReport/SpecFlowStepDefinitionReportSettings.cs
@@ -1,0 +1,17 @@
+using Cake.Common.Tools.SpecFlow;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.SpecFlow.StepDefinitionReport
+{
+    /// <summary>
+    /// Contains settings used by <see cref="SpecFlowStepDefinitionReporter"/>.
+    /// </summary>
+    public sealed class SpecFlowStepDefinitionReportSettings : SpecFlowSettings
+    {
+        /// <summary>
+        /// Gets or sets the path for the compiled SpecFlow project. Optional.
+        /// Default: bin\Debug
+        /// </summary>
+        public DirectoryPath BinFolder { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/SpecFlow/StepDefinitionReport/SpecFlowStepDefinitionReporter.cs
+++ b/src/Cake.Common/Tools/SpecFlow/StepDefinitionReport/SpecFlowStepDefinitionReporter.cs
@@ -1,0 +1,76 @@
+using System;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.SpecFlow.StepDefinitionReport
+{
+    /// <summary>
+    /// SpecFlow StepDefinition execution report runner.
+    /// </summary>
+    public sealed class SpecFlowStepDefinitionReporter : SpecFlowTool<SpecFlowStepDefinitionReportSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpecFlowStepDefinitionReporter" /> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
+        public SpecFlowStepDefinitionReporter(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IGlobber globber)
+            : base(fileSystem, environment, processRunner, globber)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Runs SpecFlow StepDefinitionReport with the specified settings.
+        /// </summary>
+        /// <param name="projectFile">The project file path.</param>
+        /// <param name="settings">The settings.</param>
+        public void Run(FilePath projectFile,
+            SpecFlowStepDefinitionReportSettings settings)
+        {
+            if (projectFile == null)
+            {
+                throw new ArgumentNullException("projectFile");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            // Run the tool.
+            Run(settings, GetArguments(settings, projectFile));
+        }
+
+        private ProcessArgumentBuilder GetArguments(
+            SpecFlowStepDefinitionReportSettings settings,
+            FilePath projectFile)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("stepdefinitionreport");
+
+            // Set the project file
+            builder.AppendQuoted(projectFile.MakeAbsolute(_environment).FullPath);
+
+            // Set the bin folder.
+            if (settings.BinFolder != null)
+            {
+                var binFolder = settings.BinFolder.MakeAbsolute(_environment);
+                builder.AppendSwitch("/binFolder", ":", binFolder.FullPath.Quote());
+            }
+
+            // Get the SpecFlowSettings arguments
+            AppendArguments(settings, builder);
+
+            return builder;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/SpecFlow/TestExecutionReport/SpecFlowTestExecutionReportSettings.cs
+++ b/src/Cake.Common/Tools/SpecFlow/TestExecutionReport/SpecFlowTestExecutionReportSettings.cs
@@ -1,0 +1,12 @@
+using Cake.Common.Tools.SpecFlow;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.SpecFlow.TestExecutionReport
+{
+    /// <summary>
+    /// Contains settings used by <see cref="SpecFlowTestExecutionReporter"/>.
+    /// </summary>
+    public sealed class SpecFlowTestExecutionReportSettings : SpecFlowSettings
+    {
+    }
+}

--- a/src/Cake.Common/Tools/SpecFlow/TestExecutionReport/SpecFlowTestExecutionReporter.cs
+++ b/src/Cake.Common/Tools/SpecFlow/TestExecutionReport/SpecFlowTestExecutionReporter.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Cake.Common.Diagnostics;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.SpecFlow.TestExecutionReport
+{
+    /// <summary>
+    /// SpecFlow MSTest execution report runner.
+    /// </summary>
+    public sealed class SpecFlowTestExecutionReporter : SpecFlowTool<SpecFlowTestExecutionReportSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpecFlowTestExecutionReporter" /> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="globber">The globber.</param>
+        public SpecFlowTestExecutionReporter(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IGlobber globber)
+            : base(fileSystem, environment, processRunner, globber)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Runs SpecFlow Test Execution Report with the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="action">The action.</param>
+        /// <param name="projectFile">The project file path.</param>
+        /// <param name="settings">The settings.</param>
+        public void Run(ICakeContext context,
+            Action<ICakeContext> action,
+            FilePath projectFile,
+            SpecFlowTestExecutionReportSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            if (action == null)
+            {
+                throw new ArgumentNullException("action");
+            }
+            if (projectFile == null)
+            {
+                throw new ArgumentNullException("projectFile");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            // Run the tool using the interceptor.
+            var interceptor = InterceptAction(context, action);
+
+            // Get / Verify Arguments
+            var builder = GetArguments(interceptor, settings, projectFile);
+
+            // Execute the action
+            try
+            {
+                action(context);
+            }
+            catch (CakeException e)
+            {
+                // Write warning to log
+                context.Warning(e.Message);
+            }
+
+            // Run the tool.
+            Run(settings, builder);
+        }
+
+        private static SpecFlowContext InterceptAction(
+            ICakeContext context,
+            Action<ICakeContext> action)
+        {
+            var interceptor = new SpecFlowContext(context);
+
+            action(interceptor);
+
+            // Validate arguments.
+            if (interceptor.FilePath == null)
+            {
+                throw new CakeException("No tool was started.");
+            }
+
+            return interceptor;
+        }
+
+        private ProcessArgumentBuilder GetArguments(
+            SpecFlowContext context,
+            SpecFlowTestExecutionReportSettings settings,
+            FilePath projectFile)
+        {
+            var builder = context.GetArguments(projectFile, _environment);
+
+            // Get the SpecFlowSettings arguments
+            AppendArguments(settings, builder);
+
+            return builder;
+        }
+    }
+}


### PR DESCRIPTION
Added support for SpecFlow. Solves issue #695

At first I thought it would be nice if SpecFlow tool could intercept the Unit Test runner (NUnit/MSTest) just like OpenCover/DotCover, but SpecFlow sets some requirements on the arguments for the Unit Test runner. So it might be simpler to leave it as is.

Unit Tests still to be written.