### PR TITLE
Removed task setup/teardown logging.

### DIFF
--- a/src/Cake.Core/DefaultExecutionStrategy.cs
+++ b/src/Cake.Core/DefaultExecutionStrategy.cs
@@ -142,15 +142,9 @@ namespace Cake.Core
             {
                 throw new ArgumentNullException("setupContext");
             }
-
             if (action != null)
             {
-                _log.Information(string.Empty);
-                _log.Information("----------------------------------------");
-                _log.Information("Task Setup ({0})", setupContext.Task.Name);
-                _log.Information("----------------------------------------");
-                _log.Verbose("Executing custom task setup action ({0})...", setupContext.Task.Name);
-
+                _log.Debug("Executing custom task setup action ({0})...", setupContext.Task.Name);
                 action(context, setupContext);
             }
         }
@@ -167,15 +161,9 @@ namespace Cake.Core
             {
                 throw new ArgumentNullException("teardownContext");
             }
-
             if (action != null)
             {
-                _log.Information(string.Empty);
-                _log.Information("----------------------------------------");
-                _log.Information("Task Teardown ({0})", teardownContext.Task.Name);
-                _log.Information("----------------------------------------");
-                _log.Verbose("Executing custom task teardown action ({0})...", teardownContext.Task.Name);
-
+                _log.Debug("Executing custom task teardown action ({0})...", teardownContext.Task.Name);
                 action(context, teardownContext);
             }
         }


### PR DESCRIPTION
At the moment, the task setup/teardown blocks log information every time they're invoked. This makes the log difficult to read and to follow.