### PR TITLE
[WIP] build.cake Refactor Semantic Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 [Ll]ib/
 [Pp]ackages/
 /[Bb]uild/
+/[Aa]rtifacts/
 *.sln.ide/
 
 # Build related

--- a/build.cake
+++ b/build.cake
@@ -1,40 +1,10 @@
-//////////////////////////////////////////////////////////////////////
-// ARGUMENTS
-//////////////////////////////////////////////////////////////////////
-
-var target = Argument("target", "Default");
-var configuration = Argument("configuration", "Release");
+#load "./build/parameters.cake"
 
 //////////////////////////////////////////////////////////////////////
-// PREPARATION
+// PARAMETERS
 //////////////////////////////////////////////////////////////////////
 
-// Get whether or not this is a local build.
-var local = BuildSystem.IsLocalBuild;
-var isRunningOnUnix = IsRunningOnUnix();
-var isRunningOnWindows = IsRunningOnWindows();
-var isRunningOnAppVeyor = AppVeyor.IsRunningOnAppVeyor;
-var isPullRequest = AppVeyor.Environment.PullRequest.IsPullRequest;
-var isMainCakeRepo = StringComparer.OrdinalIgnoreCase.Equals("cake-build/cake", AppVeyor.Environment.Repository.Name);
-
-// Parse release notes.
-var releaseNotes = ParseReleaseNotes("./ReleaseNotes.md");
-
-// Get version.
-var buildNumber = AppVeyor.Environment.Build.Number;
-GitVersion assertedVersions        = null;
-var version = string.Empty;
-var semVersion = string.Empty;
-var milestone = string.Empty;
-
-// Define directories.
-var buildDir = Directory("./src/Cake/bin") + Directory(configuration);
-var buildResultDir = Directory("./build") + Directory("v" + semVersion);
-var testResultsDir = buildResultDir + Directory("test-results");
-var nugetRoot = buildResultDir + Directory("nuget");
-var binDir = buildResultDir + Directory("bin");
-var userName = EnvironmentVariable("CAKE_GITHUB_USERNAME");
-var password = EnvironmentVariable("CAKE_GITHUB_PASSWORD");
+BuildParameters parameters = BuildParameters.GetParameters(Context, BuildSystem);
 
 ///////////////////////////////////////////////////////////////////////////////
 // SETUP / TEARDOWN
@@ -42,7 +12,37 @@ var password = EnvironmentVariable("CAKE_GITHUB_PASSWORD");
 
 Setup(() =>
 {
-    Information("Building version {0} of Cake.", semVersion);
+    parameters.SetVersion(
+        BuildVersion.CalculateSemanticVersion(
+            context: Context,
+            isLocalBuild: parameters.IsLocalBuild,
+            isPublishBuild: parameters.IsPublishBuild,
+            isReleaseBuild: parameters.IsReleaseBuild
+        )
+    );
+
+    parameters.SetPaths(
+        BuildPaths.GetPaths(
+            context: Context,
+            configuration: parameters.Configuration,
+            semVersion: parameters.Version.SemVersion
+        )
+    );
+
+    parameters.SetPackages(
+        BuildPackages.GetPackages(
+        nugetRooPath: parameters.Paths.Directories.NugetRoot,
+        semVersion: parameters.Version.SemVersion,
+        nugetPackageIds: new [] { "Cake", "Cake.Core", "Cake.Common", "Cake.Testing", "Cake.NuGet" },
+        chocolateyPackageIds: new [] { "cake.portable" }
+        )
+    );
+
+    Information("Building version {0} of Cake ({1}, {2}) using version {3} of Cake...",
+        parameters.Version.SemVersion,
+        parameters.Configuration,
+        parameters.Target,
+        parameters.Version.CakeVersion);
 });
 
 //////////////////////////////////////////////////////////////////////
@@ -50,11 +50,9 @@ Setup(() =>
 //////////////////////////////////////////////////////////////////////
 
 Task("Clean")
-    .Does(() =>
-{
-    CleanDirectories(new DirectoryPath[] {
-        buildResultDir, binDir, testResultsDir, nugetRoot});
-});
+    .Does(() => {
+        CleanDirectories(parameters.Paths.Directories.ToClean);
+        });
 
 Task("Restore-NuGet-Packages")
     .IsDependentOn("Clean")
@@ -62,71 +60,20 @@ Task("Restore-NuGet-Packages")
 {
     NuGetRestore("./src/Cake.sln", new NuGetRestoreSettings {
         Source = new List<string> {
-            "https://www.nuget.org/api/v2/",
-            "https://www.myget.org/F/roslyn-nightly/"
+            "https://api.nuget.org/v3/index.json",
+            "https://www.myget.org/F/roslyn-nightly/api/v3/index.json"
         }
     });
 });
 
-Task("Run-GitVersion")
-    .IsDependentOn("Restore-NuGet-Packages")
-    .IsDependentOn("Run-GitVersion-AppVeyor")
-    .IsDependentOn("Run-GitVersion-Local");
-
-Task("Run-GitVersion-AppVeyor")
-    .WithCriteria(AppVeyor.IsRunningOnAppVeyor)
-    .Does(() =>
-{
-    GitVersion(new GitVersionSettings {
-        UpdateAssemblyInfoFilePath = "./src/SolutionInfo.cs",
-        UpdateAssemblyInfo = true,
-        OutputType = GitVersionOutput.BuildServer
-    });
-
-    version = EnvironmentVariable("GitVersion_MajorMinorPatch");
-    semVersion = EnvironmentVariable("GitVersion_LegacySemVerPadded");
-    milestone = string.Concat("v", version);
-
-    // Due to the way that GitVersion is executed on AppVeyor, the Environment Variables although populated
-    // are not accessible yet, so have to run GitVersion again, using OutputType of JSON
-    if(string.IsNullOrEmpty(semVersion))
-    {
-        assertedVersions = GitVersion(new GitVersionSettings {
-            OutputType = GitVersionOutput.Json,
-        });
-
-        version = assertedVersions.MajorMinorPatch;
-        semVersion = assertedVersions.LegacySemVerPadded;
-        milestone = string.Concat("v", version);
-    }
-
-    Information("Calculated Semantic Version: {0}", semVersion);
-});
-
-Task("Run-GitVersion-Local")
-    .WithCriteria(!AppVeyor.IsRunningOnAppVeyor)
-    .WithCriteria(isRunningOnWindows)
-    .Does(() =>
-{
-    assertedVersions = GitVersion(new GitVersionSettings {
-        OutputType = GitVersionOutput.Json,
-    });
-
-    version = assertedVersions.MajorMinorPatch;
-    semVersion = assertedVersions.LegacySemVerPadded;
-    milestone = string.Concat("v", version);
-
-    Information("Calculated Semantic Version: {0}", semVersion);
-});
-
 Task("Build")
-    .IsDependentOn("Run-GitVersion")
+    .IsDependentOn("Restore-NuGet-Packages")
     .Does(() =>
 {
-    if(isRunningOnUnix)
+    if(parameters.IsRunningOnUnix)
     {
         XBuild("./src/Cake.sln", new XBuildSettings()
-            .SetConfiguration(configuration)
+            .SetConfiguration(parameters.Configuration)
             .WithProperty("POSIX", "True")
             .WithProperty("TreatWarningsAsErrors", "True")
             .SetVerbosity(Verbosity.Minimal)
@@ -135,7 +82,7 @@ Task("Build")
     else
     {
         MSBuild("./src/Cake.sln", new MSBuildSettings()
-            .SetConfiguration(configuration)
+            .SetConfiguration(parameters.Configuration)
             .WithProperty("Windows", "True")
             .WithProperty("TreatWarningsAsErrors", "True")
             .UseToolVersion(MSBuildToolVersion.NET45)
@@ -148,8 +95,8 @@ Task("Run-Unit-Tests")
     .IsDependentOn("Build")
     .Does(() =>
 {
-    XUnit2("./src/**/bin/" + configuration + "/*.Tests.dll", new XUnit2Settings {
-        OutputDirectory = testResultsDir,
+    XUnit2("./src/**/bin/" + parameters.Configuration + "/*.Tests.dll", new XUnit2Settings {
+        OutputDirectory = parameters.Paths.Directories.TestResults,
         XmlReportV1 = true,
         NoAppDomain = true
     });
@@ -160,137 +107,71 @@ Task("Copy-Files")
     .IsDependentOn("Run-Unit-Tests")
     .Does(() =>
 {
-    CopyFileToDirectory(buildDir + File("Cake.exe"), binDir);
-    CopyFileToDirectory(buildDir + File("Cake.Core.dll"), binDir);
-    CopyFileToDirectory(buildDir + File("Cake.Core.pdb"), binDir);
-    CopyFileToDirectory(buildDir + File("Cake.Core.xml"), binDir);
-    CopyFileToDirectory(buildDir + File("Cake.NuGet.dll"), binDir);
-    CopyFileToDirectory(buildDir + File("Cake.NuGet.pdb"), binDir);
-    CopyFileToDirectory(buildDir + File("Cake.NuGet.xml"), binDir);
-    CopyFileToDirectory(buildDir + File("Cake.Common.dll"), binDir);
-    CopyFileToDirectory(buildDir + File("Cake.Common.pdb"), binDir);
-    CopyFileToDirectory(buildDir + File("Cake.Common.xml"), binDir);
-    CopyFileToDirectory(buildDir + File("Mono.CSharp.dll"), binDir);
-    CopyFileToDirectory(buildDir + File("Autofac.dll"), binDir);
-    CopyFileToDirectory(buildDir + File("NuGet.Core.dll"), binDir);
-
-    // Copy testing assemblies.
-    var testingDir = Directory("./src/Cake.Testing/bin") + Directory(configuration);
-    CopyFileToDirectory(testingDir + File("Cake.Testing.dll"), binDir);
-    CopyFileToDirectory(testingDir + File("Cake.Testing.pdb"), binDir);
-    CopyFileToDirectory(testingDir + File("Cake.Testing.xml"), binDir);
-
-    CopyFiles(new FilePath[] { "LICENSE", "README.md", "ReleaseNotes.md" }, binDir);
+    CopyFiles(
+        parameters.Paths.Files.ArtifactsSourcePaths,
+        parameters.Paths.Directories.ArtifactsBin
+    );
 });
 
 Task("Zip-Files")
     .IsDependentOn("Copy-Files")
-    .IsDependentOn("Run-GitVersion")
     .Does(() =>
 {
-    var packageFile = File("Cake-bin-v" + semVersion + ".zip");
-    var packagePath = buildResultDir + packageFile;
+    var files = GetFiles(parameters.Paths.Directories.ArtifactsBin.FullPath + "/*")
+      - GetFiles(parameters.Paths.Directories.ArtifactsBin.FullPath + "/*.Testing.*");
 
-    var files = GetFiles(binDir.Path.FullPath + "/*")
-      - GetFiles(binDir.Path.FullPath + "/*.Testing.*");
-
-    Zip(binDir, packagePath, files);
+    Zip(parameters.Paths.Directories.ArtifactsBin, parameters.Paths.Files.ZipArtifactPath, files);
 });
 
 Task("Create-Chocolatey-Packages")
     .IsDependentOn("Copy-Files")
-    .IsDependentOn("Run-GitVersion")
     .IsDependentOn("Package")
-    .WithCriteria(() => isRunningOnWindows)
+    .WithCriteria(() => parameters.IsRunningOnWindows)
     .Does(() =>
 {
-    // Create Cake package.
-    ChocolateyPack("./nuspec/Cake.Portable.nuspec", new ChocolateyPackSettings {
-        Version = semVersion,
-        ReleaseNotes = releaseNotes.Notes.ToArray(),
-        OutputDirectory = nugetRoot,
-        Files = new [] {
-            new ChocolateyNuSpecContent {Source = string.Concat("./../", binDir.Path.FullPath, "/Cake.exe")},
-            new ChocolateyNuSpecContent {Source = string.Concat("./../", binDir.Path.FullPath, "/Cake.Core.dll")},
-            new ChocolateyNuSpecContent {Source = string.Concat("./../", binDir.Path.FullPath, "/Cake.Core.xml")},
-            new ChocolateyNuSpecContent {Source = string.Concat("./../", binDir.Path.FullPath, "/Cake.NuGet.dll")},
-            new ChocolateyNuSpecContent {Source = string.Concat("./../", binDir.Path.FullPath, "/Cake.NuGet.xml")},
-            new ChocolateyNuSpecContent {Source = string.Concat("./../", binDir.Path.FullPath, "/Cake.Common.dll")},
-            new ChocolateyNuSpecContent {Source = string.Concat("./../", binDir.Path.FullPath, "/Cake.Common.xml")},
-            new ChocolateyNuSpecContent {Source = string.Concat("./../", binDir.Path.FullPath, "/NuGet.Core.dll")},
-            new ChocolateyNuSpecContent {Source = string.Concat("./../", binDir.Path.FullPath, "/Mono.CSharp.dll")},
-            new ChocolateyNuSpecContent {Source = string.Concat("./../", binDir.Path.FullPath, "/Autofac.dll")},
-            new ChocolateyNuSpecContent {Source = string.Concat("./../", binDir.Path.FullPath, "/LICENSE")}
-        }
-    });
+    foreach(var package in parameters.Packages.Chocolatey)
+    {
+        // Create package.
+        ChocolateyPack(package.NuspecPath, new ChocolateyPackSettings {
+            Version = parameters.Version.SemVersion,
+            ReleaseNotes = parameters.ReleaseNotes.Notes.ToArray(),
+            OutputDirectory = parameters.Paths.Directories.NugetRoot,
+            Files = parameters.Paths.ChocolateyFiles
+        });
+    }
 });
 
 Task("Create-NuGet-Packages")
     .IsDependentOn("Copy-Files")
-    .IsDependentOn("Run-GitVersion")
     .Does(() =>
 {
-    // Create Cake package.
-    NuGetPack("./nuspec/Cake.nuspec", new NuGetPackSettings {
-        Version = semVersion,
-        ReleaseNotes = releaseNotes.Notes.ToArray(),
-        BasePath = binDir,
-        OutputDirectory = nugetRoot,
-        Symbols = false,
-        NoPackageAnalysis = true
-    });
-
-    // Create Core package.
-    NuGetPack("./nuspec/Cake.Core.nuspec", new NuGetPackSettings {
-        Version = semVersion,
-        ReleaseNotes = releaseNotes.Notes.ToArray(),
-        BasePath = binDir,
-        OutputDirectory = nugetRoot,
-        Symbols = false
-    });
-
-    // Create Common package.
-    NuGetPack("./nuspec/Cake.Common.nuspec", new NuGetPackSettings {
-        Version = semVersion,
-        ReleaseNotes = releaseNotes.Notes.ToArray(),
-        BasePath = binDir,
-        OutputDirectory = nugetRoot,
-        Symbols = false
-    });
-
-    // Create Testing package.
-    NuGetPack("./nuspec/Cake.Testing.nuspec", new NuGetPackSettings {
-        Version = semVersion,
-        ReleaseNotes = releaseNotes.Notes.ToArray(),
-        BasePath = binDir,
-        OutputDirectory = nugetRoot,
-        Symbols = false
-    });
-});
-
-Task("Update-AppVeyor-Build-Number")
-    .WithCriteria(() => isRunningOnAppVeyor)
-    .IsDependentOn("Run-GitVersion")
-    .Does(() =>
-{
-    AppVeyor.UpdateBuildVersion(semVersion);
+    foreach(var package in parameters.Packages.Nuget)
+    {
+        // Create package.
+        NuGetPack(package.NuspecPath, new NuGetPackSettings {
+            Version = parameters.Version.SemVersion,
+            ReleaseNotes = parameters.ReleaseNotes.Notes.ToArray(),
+            BasePath = parameters.Paths.Directories.ArtifactsBin,
+            OutputDirectory = parameters.Paths.Directories.NugetRoot,
+            Symbols = false,
+            NoPackageAnalysis = true
+        });
+    }
 });
 
 Task("Upload-AppVeyor-Artifacts")
     .IsDependentOn("Create-Chocolatey-Packages")
-    .IsDependentOn("Run-GitVersion")
-    .WithCriteria(() => isRunningOnAppVeyor)
+    .WithCriteria(() => parameters.IsRunningOnAppVeyor)
     .Does(() =>
 {
-    var artifact = buildResultDir + File("Cake-bin-v" + semVersion + ".zip");
-    AppVeyor.UploadArtifact(artifact);
+    AppVeyor.UploadArtifact(parameters.Paths.Files.ZipArtifactPath);
 });
 
 Task("Publish-MyGet")
-    .IsDependentOn("Run-GitVersion")
-    .WithCriteria(() => !local)
-    .WithCriteria(() => !isPullRequest)
-    .WithCriteria(() => isMainCakeRepo)
+    .IsDependentOn("Package")
+    .WithCriteria(() => !parameters.IsLocalBuild)
+    .WithCriteria(() => !parameters.IsPullRequest)
+    .WithCriteria(() => parameters.IsMainCakeRepo)
     .Does(() =>
 {
     // Resolve the API key.
@@ -299,13 +180,10 @@ Task("Publish-MyGet")
         throw new InvalidOperationException("Could not resolve MyGet API key.");
     }
 
-    foreach(var package in new[] { "Cake", "Cake.Core", "Cake.Common", "Cake.Testing", "cake.portable" })
+    foreach(var package in parameters.Packages.All)
     {
-        // Get the path to the package.
-        var packagePath = nugetRoot + File(string.Concat(package, ".", semVersion, ".nupkg"));
-
         // Push the package.
-        NuGetPush(packagePath, new NuGetPushSettings {
+        NuGetPush(package.PackagePath, new NuGetPushSettings {
             Source = "https://www.myget.org/F/cake/api/v2/package",
             ApiKey = apiKey
         });
@@ -313,9 +191,8 @@ Task("Publish-MyGet")
 });
 
 Task("Publish-NuGet")
-    .IsDependentOn("Run-GitVersion")
     .IsDependentOn("Create-NuGet-Packages")
-    .WithCriteria(() => local)
+    .WithCriteria(() => parameters.IsLocalBuild)
     .Does(() =>
 {
     // Resolve the API key.
@@ -324,22 +201,18 @@ Task("Publish-NuGet")
         throw new InvalidOperationException("Could not resolve NuGet API key.");
     }
 
-    foreach(var package in new[] { "Cake", "Cake.Core", "Cake.Common", "Cake.Testing" })
+    foreach(var package in parameters.Packages.Nuget)
     {
-        // Get the path to the package.
-        var packagePath = nugetRoot + File(string.Concat(package, ".", semVersion, ".nupkg"));
-
         // Push the package.
-        NuGetPush(packagePath, new NuGetPushSettings {
+        NuGetPush(package.PackagePath, new NuGetPushSettings {
           ApiKey = apiKey
         });
     }
 });
 
 Task("Publish-Chocolatey")
-    .IsDependentOn("Run-GitVersion")
     .IsDependentOn("Create-Chocolatey-Packages")
-    .WithCriteria(() => local)
+    .WithCriteria(() => parameters.IsLocalBuild)
     .Does(() =>
 {
     // Resolve the API key.
@@ -348,52 +221,40 @@ Task("Publish-Chocolatey")
         throw new InvalidOperationException("Could not resolve Chocolatey API key.");
     }
 
-    foreach(var package in new[] { "cake.portable" })
+    foreach(var package in parameters.Packages.Chocolatey)
     {
-        // Get the path to the package.
-        var packagePath = nugetRoot + File(string.Concat(package, ".", semVersion, ".nupkg"));
-
         // Push the package.
-        ChocolateyPush(packagePath, new ChocolateyPushSettings {
+        ChocolateyPush(package.PackagePath, new ChocolateyPushSettings {
           ApiKey = apiKey
         });
     }
 });
 
 Task("Publish-HomeBrew")
-    .IsDependentOn("Run-GitVersion")
     .IsDependentOn("Zip-Files")
 	.Does(() =>
 {
-    var packageFile = File("Cake-bin-v" + semVersion + ".zip");
-    var packagePath = buildResultDir + packageFile;
-
-    var hash = CalculateFileHash(packagePath).ToHex();
+    var hash = CalculateFileHash(parameters.Paths.Files.ZipArtifactPath).ToHex();
 
     Information("Hash for creating HomeBrew PullRequest: {0}", hash);
 });
 
 Task("Publish-GitHub-Release")
-    .IsDependentOn("Run-GitVersion")
     .Does(() =>
 {
-    var packageFile = File("Cake-bin-v" + semVersion + ".zip");
-    var packagePath = buildResultDir + packageFile;
+    GitReleaseManagerAddAssets(parameters.GitHub.UserName, parameters.GitHub.Password, "cake-build", "cake", parameters.Version.Milestone, parameters.Paths.Files.ZipArtifactPath.ToString());
 
-    GitReleaseManagerAddAssets(userName, password, "cake-build", "cake", milestone, packagePath.ToString());
+    GitReleaseManagerPublish(parameters.GitHub.UserName, parameters.GitHub.Password, "cake-build", "cake", parameters.Version.Milestone);
 
-    GitReleaseManagerPublish(userName, password, "cake-build", "cake", milestone);
-
-    GitReleaseManagerClose(userName, password, "cake-build", "cake", milestone);
+    GitReleaseManagerClose(parameters.GitHub.UserName, parameters.GitHub.Password, "cake-build", "cake", parameters.Version.Milestone);
 });
 
 Task("Create-Release-Notes")
-    .IsDependentOn("Run-GitVersion")
     .Does(() =>
 {
-    GitReleaseManagerCreate(userName, password, "cake-build", "cake", new GitReleaseManagerCreateSettings {
-        Milestone         = milestone,
-        Name              = milestone,
+    GitReleaseManagerCreate(parameters.GitHub.UserName, parameters.GitHub.Password, "cake-build", "cake", new GitReleaseManagerCreateSettings {
+        Milestone         = parameters.Version.Milestone,
+        Name              = parameters.Version.Milestone,
         Prerelease        = true,
         TargetCommitish   = "main"
     });
@@ -417,7 +278,6 @@ Task("Publish")
   .IsDependentOn("Publish-GitHub-Release");
 
 Task("AppVeyor")
-  .IsDependentOn("Update-AppVeyor-Build-Number")
   .IsDependentOn("Upload-AppVeyor-Artifacts")
   .IsDependentOn("Publish-MyGet");
 
@@ -431,4 +291,4 @@ Task("ReleaseNotes")
 // EXECUTION
 //////////////////////////////////////////////////////////////////////
 
-RunTarget(target);
+RunTarget(parameters.Target);

--- a/build/packages.cake
+++ b/build/packages.cake
@@ -1,0 +1,56 @@
+public class BuildPackages
+{
+    public ICollection<BuildPackage> All { get; private set; }
+    public ICollection<BuildPackage> Nuget { get; private set; }
+    public ICollection<BuildPackage> Chocolatey { get; private set; }
+
+    public static BuildPackages GetPackages(
+        DirectoryPath nugetRooPath,
+        string semVersion,
+        string[] nugetPackageIds,
+        string[] chocolateyPackageIds
+        )
+    {
+        var toNugetPackage = BuildPackage(nugetRooPath, semVersion);
+        var toChocolateyPackage = BuildPackage(nugetRooPath, semVersion, isChocolateyPackage: true);
+        var nugetPackages = nugetPackageIds.Select(toNugetPackage).ToArray();
+        var chocolateyPackages = chocolateyPackageIds.Select(toChocolateyPackage).ToArray();
+        return new BuildPackages {
+            All = nugetPackages.Union(chocolateyPackages).ToArray(),
+            Nuget = nugetPackages,
+            Chocolatey = chocolateyPackages
+        };
+    }
+
+    private static Func<string, BuildPackage> BuildPackage(DirectoryPath nugetRooPath, string semVersion,
+        bool isChocolateyPackage = false)
+    {
+        return package => new BuildPackage(
+            id: package,
+            nuspecPath: string.Concat("./nuspec/", package, ".nuspec"),
+            packagePath: nugetRooPath.CombineWithFilePath(string.Concat(package, ".", semVersion, ".nupkg")),
+            isChocolateyPackage: isChocolateyPackage
+            );
+    }
+}
+
+public class BuildPackage
+{
+    public string Id { get; private set; }
+    public FilePath NuspecPath { get; private set; }
+    public FilePath PackagePath { get; private set; }
+    public bool IsChocolateyPackage { get; private set; }
+
+    public BuildPackage(
+        string id,
+        FilePath nuspecPath,
+        FilePath packagePath,
+        bool isChocolateyPackage
+        )
+    {
+        Id = id;
+        NuspecPath = nuspecPath;
+        PackagePath = packagePath;
+        IsChocolateyPackage = isChocolateyPackage;
+    }
+}

--- a/build/parameters.cake
+++ b/build/parameters.cake
@@ -1,0 +1,94 @@
+#load "./paths.cake"
+#load "./packages.cake"
+#load "./version.cake"
+
+public class BuildParameters
+{
+    public string Target { get; private set; }
+    public string Configuration { get; private set; }
+    public bool IsLocalBuild { get; private set; }
+    public bool IsRunningOnUnix { get; private set; }
+    public bool IsRunningOnWindows { get; private set; }
+    public bool IsRunningOnAppVeyor { get; private set; }
+    public bool IsPullRequest { get; private set; }
+    public bool IsMainCakeRepo { get; private set; }
+    public bool IsPublishBuild { get; private set; }
+    public bool IsReleaseBuild { get; private set; }
+    public BuildCredentials GitHub { get; private set; }
+    public ReleaseNotes ReleaseNotes { get; private set; }
+    public BuildVersion Version { get; private set; }
+    public BuildPaths Paths { get; private set; }
+    public BuildPackages Packages { get; private set; }
+
+    public void SetVersion(BuildVersion version)
+    {
+        Version  = version;
+    }
+
+    public void SetPaths(BuildPaths paths)
+    {
+        Paths  = paths;
+    }
+
+    public void SetPackages(BuildPackages packages)
+    {
+        Packages  = packages;
+    }
+
+    public static BuildParameters GetParameters(
+        ICakeContext context,
+        BuildSystem buildSystem
+        )
+    {
+        if (context == null)
+        {
+            throw new ArgumentNullException("context");
+        }
+
+        var target = context.Argument("target", "Default");
+
+        return new BuildParameters {
+            Target = target,
+            Configuration = context.Argument("configuration", "Release"),
+            IsLocalBuild = buildSystem.IsLocalBuild,
+            IsRunningOnUnix = context.IsRunningOnUnix(),
+            IsRunningOnWindows = context.IsRunningOnWindows(),
+            IsRunningOnAppVeyor = context.IsRunningOnWindows(),
+            IsPullRequest = buildSystem.AppVeyor.Environment.PullRequest.IsPullRequest,
+            IsMainCakeRepo =  StringComparer.OrdinalIgnoreCase.Equals("cake-build/cake", buildSystem.AppVeyor.Environment.Repository.Name),
+            GitHub = new BuildCredentials (
+                userName: context.EnvironmentVariable("CAKE_GITHUB_USERNAME"),
+                password: context.EnvironmentVariable("CAKE_GITHUB_PASSWORD")
+            ),
+            ReleaseNotes = context.ParseReleaseNotes("./ReleaseNotes.md"),
+            IsPublishBuild = new [] {
+                "ReleaseNotes",
+                "Create-Release-Notes"
+            }.Any(
+                releaseTarget => StringComparer.OrdinalIgnoreCase.Equals(releaseTarget, target)
+            ),
+            IsReleaseBuild = new [] {
+                "Publish",
+                "Publish-NuGet",
+                "Publish-Chocolatey",
+                "Publish-HomeBrew",
+                "Publish-GitHub-Release"
+            }.Any(
+                publishTarget => StringComparer.OrdinalIgnoreCase.Equals(publishTarget, target)
+            )
+        };
+    }
+}
+
+public class BuildCredentials
+{
+    public string UserName { get; private set; }
+    public string Password { get; private set; }
+
+    public BuildCredentials(string userName, string password)
+    {
+        UserName = userName;
+        Password = password;
+    }
+}
+

--- a/build/paths.cake
+++ b/build/paths.cake
@@ -1,0 +1,143 @@
+public class BuildPaths
+{
+    public BuildFiles Files { get; private set; }
+    public BuildDirectories Directories { get; private set; }
+    public ICollection<ChocolateyNuSpecContent> ChocolateyFiles { get; private set; }
+
+    public static BuildPaths GetPaths(
+        ICakeContext context,
+        string configuration,
+        string semVersion
+        )
+    {
+        if (context == null)
+        {
+            throw new ArgumentNullException("context");
+        }
+
+        if (string.IsNullOrEmpty(configuration))
+        {
+            throw new ArgumentNullException("configuration");
+        }
+
+        if (string.IsNullOrEmpty(semVersion))
+        {
+            throw new ArgumentNullException("semVersion");
+        }
+
+        var buildDir = context.Directory("./src/Cake/bin") + context.Directory(configuration);
+        var artifactsDir = (DirectoryPath)(context.Directory("./artifacts") + context.Directory("v" + semVersion));
+        var artifactsBinDir = artifactsDir.Combine("bin");
+        var testResultsDir = artifactsDir.Combine("test-results");
+        var nugetRoot = artifactsDir.Combine("nuget");
+        var testingDir = context.Directory("./src/Cake.Testing/bin") + context.Directory(configuration);
+
+        var cakeAssemblyPaths = new FilePath[] {
+            buildDir + context.File("Cake.exe"),
+            buildDir + context.File("Cake.Core.dll"),
+            buildDir + context.File("Cake.Core.pdb"),
+            buildDir + context.File("Cake.Core.xml"),
+            buildDir + context.File("Cake.NuGet.dll"),
+            buildDir + context.File("Cake.NuGet.pdb"),
+            buildDir + context.File("Cake.NuGet.xml"),
+            buildDir + context.File("Cake.Common.dll"),
+            buildDir + context.File("Cake.Common.pdb"),
+            buildDir + context.File("Cake.Common.xml"),
+            buildDir + context.File("Mono.CSharp.dll"),
+            buildDir + context.File("Autofac.dll"),
+            buildDir + context.File("NuGet.Core.dll")
+        };
+
+        var testingAssemblyPaths = new FilePath[] {
+            testingDir + context.File("Cake.Testing.dll"),
+            testingDir + context.File("Cake.Testing.pdb"),
+            testingDir + context.File("Cake.Testing.xml")
+        };
+
+        var repoFilesPaths = new FilePath[] {
+            "LICENSE",
+            "README.md",
+            "ReleaseNotes.md"
+        };
+
+        var artifactSourcePaths = cakeAssemblyPaths.Concat(testingAssemblyPaths.Concat(repoFilesPaths)).ToArray();
+
+        var chocolateyFiles = cakeAssemblyPaths.Concat(new FilePath[] {"LICENSE"})
+            .Select(
+                file => new ChocolateyNuSpecContent { Source = string.Concat("./../", file.FullPath) }
+            ).ToArray();
+
+        var zipArtifactPath = artifactsDir.CombineWithFilePath("Cake-bin-v" + semVersion + ".zip");
+
+        var buildDirectories = new BuildDirectories(
+            artifactsDir: artifactsDir,
+            testResultsDir: testResultsDir,
+            nugetRootDir: nugetRoot,
+            artifactsBinDir: artifactsBinDir);
+
+        var buildFiles = new BuildFiles(
+            cakeAssemblyPaths: cakeAssemblyPaths,
+            testingAssemblyPaths: testingAssemblyPaths,
+            repoFilesPaths: repoFilesPaths,
+            artifactsSourcePaths: artifactSourcePaths,
+            zipArtifactPath: zipArtifactPath);
+
+        return new BuildPaths {
+            Files = buildFiles,
+            Directories = buildDirectories,
+            ChocolateyFiles = chocolateyFiles
+        };
+    }
+}
+
+public class BuildFiles
+{
+    public ICollection<FilePath> CakeAssemblyPaths { get; private set; }
+    public ICollection<FilePath> TestingAssemblyPaths { get; private set; }
+    public ICollection<FilePath> RepoFilesPaths { get; private set; }
+    public ICollection<FilePath> ArtifactsSourcePaths { get; private set; }
+    public FilePath ZipArtifactPath { get; private set; }
+
+    public BuildFiles(
+        FilePath[] cakeAssemblyPaths,
+        FilePath[] testingAssemblyPaths,
+        FilePath[] repoFilesPaths,
+        FilePath[] artifactsSourcePaths,
+        FilePath zipArtifactPath
+        )
+    {
+        CakeAssemblyPaths = cakeAssemblyPaths;
+        TestingAssemblyPaths = testingAssemblyPaths;
+        RepoFilesPaths = repoFilesPaths;
+        ArtifactsSourcePaths = artifactsSourcePaths;
+        ZipArtifactPath = zipArtifactPath;
+    }
+}
+
+public class BuildDirectories
+{
+    public DirectoryPath Artifacts { get; private set; }
+    public DirectoryPath TestResults { get; private set; }
+    public DirectoryPath NugetRoot { get; private set; }
+    public DirectoryPath ArtifactsBin { get; private set; }
+    public ICollection<DirectoryPath> ToClean { get; private set; }
+
+    public BuildDirectories(
+        DirectoryPath artifactsDir,
+        DirectoryPath testResultsDir,
+        DirectoryPath nugetRootDir,
+        DirectoryPath artifactsBinDir
+        )
+    {
+        Artifacts = artifactsDir;
+        TestResults = testResultsDir;
+        NugetRoot = nugetRootDir;
+        ArtifactsBin = artifactsBinDir;
+        ToClean = new[] {
+            Artifacts,
+            TestResults,
+            NugetRoot,
+            ArtifactsBin
+        };
+    }
+}

--- a/build/version.cake
+++ b/build/version.cake
@@ -1,0 +1,87 @@
+public class BuildVersion
+{
+    public string Version { get; private set; }
+    public string SemVersion { get; private set; }
+    public string Milestone { get; private set; }
+    public string CakeVersion { get; private set; }
+    public string SolutionVersion { get; private set; }
+    public string SolutionSemVer { get ; private set; }
+
+    public static BuildVersion CalculateSemanticVersion(
+        ICakeContext context,
+        bool isLocalBuild,
+        bool isPublishBuild,
+        bool isReleaseBuild
+        )
+    {
+        if (context == null)
+        {
+            throw new ArgumentNullException("context");
+        }
+
+        string version = null;
+        string semVersion = null;
+        string milestone = null;
+
+        var cakeVersion = typeof(ICakeContext).Assembly.GetName().Version.ToString();
+
+        if (context.IsRunningOnWindows())
+        {
+            context.Information("Calculating Semantic Version...");
+            if (!isLocalBuild)
+            {
+                context.GitVersion(new GitVersionSettings {
+                    UpdateAssemblyInfoFilePath = "./src/SolutionInfo.cs",
+                    UpdateAssemblyInfo = true,
+                    OutputType = GitVersionOutput.BuildServer
+                });
+
+                version = context.EnvironmentVariable("GitVersion_MajorMinorPatch");
+                semVersion = context.EnvironmentVariable("GitVersion_LegacySemVerPadded");
+                milestone = string.Concat("v", version);
+            }
+
+            if (string.IsNullOrEmpty(version) || string.IsNullOrEmpty(semVersion))
+            {
+                GitVersionSettings gitVersionSettings = (isPublishBuild || isReleaseBuild)
+                    ? new GitVersionSettings {
+                        UpdateAssemblyInfoFilePath = "./src/SolutionInfo.cs",
+                        UpdateAssemblyInfo = true,
+                        OutputType = GitVersionOutput.Json
+                        }
+                    : new GitVersionSettings { OutputType = GitVersionOutput.Json };
+
+                GitVersion assertedVersions = context.GitVersion(gitVersionSettings);
+
+                version = assertedVersions.MajorMinorPatch;
+                semVersion = assertedVersions.LegacySemVerPadded;
+                milestone = string.Concat("v", version);
+            }
+
+            context.Information("Calculated Semantic Version: {0}", semVersion);
+        }
+
+        context.Information("Fetching version from SolutionInfo...");
+        var assemblyInfo = context.ParseAssemblyInfo("./src/SolutionInfo.cs");
+        var solutionVersion = assemblyInfo.AssemblyVersion;
+        var solutionSemVer = assemblyInfo.AssemblyInformationalVersion;
+        context.Information("SolutionInfo Version: {0}", solutionVersion);
+
+        if (string.IsNullOrEmpty(version) || string.IsNullOrEmpty(semVersion))
+        {
+            context.Information("No GitVersion found using solution version...");
+            version = solutionVersion;
+            semVersion = solutionSemVer;
+            milestone = string.Concat("v", solutionVersion);
+        }
+
+        return new BuildVersion {
+            Version = version,
+            SemVersion = semVersion,
+            Milestone = milestone,
+            CakeVersion = cakeVersion,
+            SolutionVersion = solutionVersion,
+            SolutionSemVer = solutionSemVer
+        };
+    }
+}

--- a/nuspec/Cake.NuGet.nuspec
+++ b/nuspec/Cake.NuGet.nuspec
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <id>Cake.NuGet</id>
+    <version>0.0.0</version>
+    <authors>Patrik Svensson</authors>
+    <owners>Patrik Svensson</owners>
+    <summary>Cake (C# Make) is a build automation system with a C# DSL to do things like compiling code, copy files/folders, running unit tests, compress files and build NuGet packages.</summary>
+    <description>Provides aliases (extension methods on Cake context) that support CI, build, unit tests, zip, signing, etc. for Cake.</description>
+    <licenseUrl>https://github.com/cake-build/cake/blob/develop/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/cake-build/cake</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/cake-build/graphics/master/png/cake-medium.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <copyright>Copyright (c) Patrik Svensson, Mattias Karlsson, Gary Ewan Park and contributors</copyright>
+    <tags>Cake Script Build</tags>
+    <dependencies>
+      <dependency id="Cake.Core" version="$version$" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="Cake.NuGet.dll" target="lib/net45" />
+    <file src="Cake.NuGet.xml" target="lib/net45" />
+    <file src="Cake.NuGet.pdb" target="lib/net45" />
+    <file src="LICENSE" />
+  </files>
+</package>


### PR DESCRIPTION
Currently semver is used in a couple of places before it's assigned (i.e. build output en setup message), also on posix it was never assigned.

This WIP PR proposes the following changes
* Semantic version now calculated at setup
* SolutionInfo used as fallback
* Directory paths instantiated post semver
* Use V3 nuget feeds
* Remove code duplication (create nuget & copy files)