### PR TITLE
Fix TeamCity tests on TeamCity

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Build/TeamCityFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/TeamCityFixture.cs
@@ -1,5 +1,7 @@
 using Cake.Common.Build.TeamCity;
 using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Testing;
 using NSubstitute;
 
 namespace Cake.Common.Tests.Fixtures.Build
@@ -7,12 +9,14 @@ namespace Cake.Common.Tests.Fixtures.Build
     internal sealed class TeamCityFixture
     {
         public ICakeEnvironment Environment { get; set; }
+        public FakeLog Log { get; set; }
 
         public TeamCityFixture()
         {
             Environment = Substitute.For<ICakeEnvironment>();
             Environment.WorkingDirectory.Returns("C:\\build\\CAKE-CAKE-JOB1");
             Environment.GetEnvironmentVariable("TEAMCITY_VERSION").Returns((string)null);
+            Log = new FakeLog();
         }
 
         public void IsRunningOnTeamCity()
@@ -22,7 +26,7 @@ namespace Cake.Common.Tests.Fixtures.Build
 
         public TeamCityProvider CreateTeamCityService()
         {
-            return new TeamCityProvider(Environment);
+            return new TeamCityProvider(Environment, Log);
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Build/TeamCity/TeamCityProviderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TeamCity/TeamCityProviderTests.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using System.IO;
 using Cake.Common.Build.TeamCity;
 using Cake.Common.Tests.Fixtures.Build;
 using Cake.Core.IO;
+using Cake.Testing.Extensions;
 using Xunit;
 
 namespace Cake.Common.Tests.Unit.Build.TeamCity
@@ -15,10 +15,23 @@ namespace Cake.Common.Tests.Unit.Build.TeamCity
             public void Should_Throw_If_Environment_Is_Null()
             {
                 // Given, When
-                var result = Record.Exception(() => new TeamCityProvider(null));
+                var result = Record.Exception(() => new TeamCityProvider(null, null));
 
                 // Then
                 Assert.IsArgumentNullException(result, "environment");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Log_Is_Null()
+            {
+                // Given
+                var fixture = new TeamCityFixture();
+
+                // When
+                var result = Record.Exception(() => new TeamCityProvider(fixture.Environment, null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "log");
             }
         }
 
@@ -54,22 +67,8 @@ namespace Cake.Common.Tests.Unit.Build.TeamCity
             }
         }
 
-        public sealed class TheImportDotCoverCoverageMethod : IDisposable
+        public sealed class TheImportDotCoverCoverageMethod
         {
-            private StringWriter _console;
-
-            public TheImportDotCoverCoverageMethod()
-            {
-                _console = new StringWriter();
-                Console.SetOut(_console);
-            }
-
-            public void Dispose()
-            {
-                Console.SetOut(new StreamWriter(Console.OpenStandardOutput()));
-                _console.Dispose();
-            }
-
             [Fact]
             public void Should_Use_Bundled_DotCover_If_ToolPath_Is_Null()
             {
@@ -85,7 +84,7 @@ namespace Cake.Common.Tests.Unit.Build.TeamCity
                 // Then
                 Assert.Equal("##teamcity[dotNetCoverage ]" + Environment.NewLine +
                     "##teamcity[importData type='dotNetCoverage' tool='dotcover' path='/path/to/result.dcvr']" + Environment.NewLine,
-                    _console.ToString());
+                    fixture.Log.AggregateLogMessages());
             }
 
             [Fact]
@@ -104,7 +103,7 @@ namespace Cake.Common.Tests.Unit.Build.TeamCity
                 // Then
                 Assert.Equal("##teamcity[dotNetCoverage dotcover_home='/path/to/dotcover_home']" + Environment.NewLine +
                     "##teamcity[importData type='dotNetCoverage' tool='dotcover' path='/path/to/result.dcvr']" + Environment.NewLine,
-                    _console.ToString());
+                    fixture.Log.AggregateLogMessages());
             }
         }
     }

--- a/src/Cake.Common/Build/BuildSystemAliases.cs
+++ b/src/Cake.Common/Build/BuildSystemAliases.cs
@@ -36,7 +36,7 @@ namespace Cake.Common.Build
                 throw new ArgumentNullException("context");
             }
             var appVeyorProvider = new AppVeyorProvider(context.Environment, context.ProcessRunner);
-            var teamCityProvider = new TeamCityProvider(context.Environment);
+            var teamCityProvider = new TeamCityProvider(context.Environment, context.Log);
             var myGetProvider = new MyGetProvider(context.Environment);
             var bambooProvider = new BambooProvider(context.Environment);
             var continuaCIProvider = new ContinuaCIProvider(context.Environment);

--- a/src/Cake.Common/Build/TeamCity/TeamCityProvider.cs
+++ b/src/Cake.Common/Build/TeamCity/TeamCityProvider.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using Cake.Core;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 
 namespace Cake.Common.Build.TeamCity
@@ -17,6 +18,7 @@ namespace Cake.Common.Build.TeamCity
         private const string MessagePostfix = "]";
         private static readonly Dictionary<string, string> _sanitizationTokens;
         private readonly ICakeEnvironment _environment;
+        private readonly ICakeLog _log;
 
         static TeamCityProvider()
         {
@@ -35,14 +37,21 @@ namespace Cake.Common.Build.TeamCity
         /// Initializes a new instance of the <see cref="TeamCityProvider"/> class.
         /// </summary>
         /// <param name="environment">The cake environment.</param>
-        public TeamCityProvider(ICakeEnvironment environment)
+        /// <param name="log">The cake log.</param>
+        public TeamCityProvider(ICakeEnvironment environment, ICakeLog log)
         {
             if (environment == null)
             {
                 throw new ArgumentNullException("environment");
             }
 
+            if (log == null)
+            {
+                throw new ArgumentNullException("log");
+            }
+
             _environment = environment;
+            _log = log;
         }
 
         /// <summary>
@@ -225,18 +234,18 @@ namespace Cake.Common.Build.TeamCity
             WriteServiceMessage("buildNumber", buildNumber);
         }
 
-        private static void WriteServiceMessage(string messageName, string attributeValue)
+        private void WriteServiceMessage(string messageName, string attributeValue)
         {
             WriteServiceMessage(messageName, new Dictionary<string, string> { { " ", attributeValue } });
         }
 
-        private static void WriteServiceMessage(string messageName, string attributeName, string attributeValue)
+        private void WriteServiceMessage(string messageName, string attributeName, string attributeValue)
         {
             WriteServiceMessage(messageName, new Dictionary<string, string> { { attributeName, attributeValue } });
         }
 
         [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = "Reviewed.")]
-        private static void WriteServiceMessage(string messageName, Dictionary<string, string> values)
+        private void WriteServiceMessage(string messageName, Dictionary<string, string> values)
         {
             var valueString =
                 string.Join(" ",
@@ -250,7 +259,7 @@ namespace Cake.Common.Build.TeamCity
                             return string.Format(CultureInfo.InvariantCulture, "{0}='{1}'", keypair.Key, Sanitize(keypair.Value));
                         })
                         .ToArray());
-            Console.WriteLine("{0}{1} {2}{3}", MessagePrefix, messageName, valueString, MessagePostfix);
+            _log.Write(Verbosity.Quiet, LogLevel.Information, "{0}{1} {2}{3}", MessagePrefix, messageName, valueString, MessagePostfix);
         }
 
         private static string Sanitize(string source)

--- a/src/Cake.Testing/Cake.Testing.csproj
+++ b/src/Cake.Testing/Cake.Testing.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Extensions\FakeDirectoryExtensions.cs" />
     <Compile Include="Extensions\FakeFileExtensions.cs" />
     <Compile Include="Extensions\FakeFileSystemExtensions.cs" />
+    <Compile Include="Extensions\FakeLogExtensions.cs" />
     <Compile Include="FakeConsole.cs" />
     <Compile Include="FakeDirectory.cs" />
     <Compile Include="FakeDirectoryContent.cs" />

--- a/src/Cake.Testing/Extensions/FakeLogExtensions.cs
+++ b/src/Cake.Testing/Extensions/FakeLogExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Cake.Testing.Extensions
+{
+    /// <summary>
+    /// Contains extensions for <see cref="FakeLog"/>.
+    /// </summary>
+    public static class FakeLogExtensions
+    {
+        /// <summary>
+        /// Aggregates all current log entries message
+        /// </summary>
+        /// <param name="fakeLog">The fake log.</param>
+        /// <returns>Log messages as <see cref="System.String"/></returns>
+        public static string AggregateLogMessages(this FakeLog fakeLog)
+        {
+            return fakeLog.Entries.Aggregate(
+                new StringBuilder(),
+                (sb, entry) => sb.AppendLine(entry.Message),
+                sb => sb.ToString());
+        }
+    }
+}


### PR DESCRIPTION
This fixes #766 by not using System.Console directly and instead using ICakeLog and mock that during tests.
* Change TeamCityProvider WriteServiceMessage to use ICakeLog instead of System.Console
* Change TeamCityProviderTests to not change System.Console stream so TeamCityFixture instead has a FakeLog/ICakeLog instance
* Add AggregateLogMessages method to FakeLog to get all current log entries message as a string