### PR TITLE
Added Skip GitVersion support

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -15,9 +15,7 @@ Setup(() =>
     parameters.SetBuildVersion(
         BuildVersion.CalculatingSemanticVersion(
             context: Context,
-            isLocalBuild: parameters.IsLocalBuild,
-            isPublishBuild: parameters.IsPublishBuild,
-            isReleaseBuild: parameters.IsReleaseBuild
+            parameters: parameters
         )
     );
 

--- a/build/parameters.cake
+++ b/build/parameters.cake
@@ -14,6 +14,7 @@ public class BuildParameters
     public bool IsMainCakeRepo { get; private set; }
     public bool IsPublishBuild { get; private set; }
     public bool IsReleaseBuild { get; private set; }
+    public bool SkipGitVersion { get; private set; }
     public BuildCredentials GitHub { get; private set; }
     public ReleaseNotes ReleaseNotes { get; private set; }
     public BuildVersion Version { get; private set; }
@@ -75,7 +76,8 @@ public class BuildParameters
                 "Publish-GitHub-Release"
             }.Any(
                 publishTarget => StringComparer.OrdinalIgnoreCase.Equals(publishTarget, target)
-            )
+            ),
+            SkipGitVersion = StringComparer.OrdinalIgnoreCase.Equals("True", context.EnvironmentVariable("CAKE_SKIP_GITVERSION"))
         };
     }
 }

--- a/build/version.cake
+++ b/build/version.cake
@@ -7,9 +7,7 @@ public class BuildVersion
 
     public static BuildVersion CalculatingSemanticVersion(
         ICakeContext context,
-        bool isLocalBuild,
-        bool isPublishBuild,
-        bool isReleaseBuild
+        BuildParameters parameters
         )
     {
         if (context == null)
@@ -21,10 +19,10 @@ public class BuildVersion
         string semVersion = null;
         string milestone = null;
 
-        if (context.IsRunningOnWindows())
+        if (context.IsRunningOnWindows() && !parameters.SkipGitVersion)
         {
             context.Information("Calculating Semantic Version");
-            if (!isLocalBuild || isPublishBuild || isReleaseBuild)
+            if (!parameters.IsLocalBuild || parameters.IsPublishBuild || parameters.IsReleaseBuild)
             {
                 context.GitVersion(new GitVersionSettings{
                     UpdateAssemblyInfoFilePath = "./src/SolutionInfo.cs",


### PR DESCRIPTION
Added possibility to skip runing git version via setting environment variable CAKE_SKIP_GITVERSION to `True` as a convenient way to by configuration disable GitVersion if needed i.e. if not supported by build environment.