### PR TITLE
Support NuGet 3 new parameters

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/NuGet/Install/NuGetInstallerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NuGet/Install/NuGetInstallerTests.cs
@@ -1,10 +1,7 @@
-﻿using Cake.Common.Tests.Fixtures.Tools.NuGet;
-using Cake.Common.Tests.Fixtures.Tools.NuGet.Installer;
+﻿using Cake.Common.Tests.Fixtures.Tools.NuGet.Installer;
 using Cake.Common.Tools.NuGet;
-using Cake.Core.IO;
 using Cake.Testing;
 using Cake.Testing.Xunit;
-using NSubstitute;
 using Xunit;
 
 namespace Cake.Common.Tests.Unit.Tools.NuGet.Install
@@ -244,6 +241,21 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Install
                 // Then
                 Assert.Equal("install \"Cake\" -ConfigFile \"/Working/nuget.config\" " +
                              "-NonInteractive", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_FallbackSources_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new NuGetInstallerFixture();
+                fixture.Settings.Source = new[] { "A;B;C" };
+                fixture.Settings.FallbackSource = new[] { "D;E;F" };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("install \"Cake\" -Source \"A;B;C\" -FallbackSource \"D;E;F\" -NonInteractive", result.Args);
             }
         }
 
@@ -485,6 +497,22 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Install
                 // Then
                 Assert.Equal("install \"/Working/packages.config\" " +
                              "-ConfigFile \"/Working/nuget.config\" " +
+                             "-NonInteractive", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_FallbackSources_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new NuGetInstallerFromConfigFixture();
+                fixture.Settings.Source = new[] { "A;B;C" };
+                fixture.Settings.FallbackSource = new[] { "D;E;F" };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("install \"/Working/packages.config\" -Source \"A;B;C\" -FallbackSource \"D;E;F\" " +
                              "-NonInteractive", result.Args);
             }
         }

--- a/src/Cake.Common.Tests/Unit/Tools/NuGet/Pack/NuGetPackerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NuGet/Pack/NuGetPackerTests.cs
@@ -441,6 +441,23 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Pack
                         Resources.Nuspec_Metadata_WithoutNamespaces_WithDependencies.NormalizeLineEndings(),
                         result.NuspecContent.NormalizeLineEndings());
                 }
+
+                [Theory]
+                [InlineData(NuGetMSBuildVersion.MSBuild4, "pack \"/Working/existing.temp.nuspec\" -MSBuildVersion 4")]
+                [InlineData(NuGetMSBuildVersion.MSBuild12, "pack \"/Working/existing.temp.nuspec\" -MSBuildVersion 12")]
+                [InlineData(NuGetMSBuildVersion.MSBuild14, "pack \"/Working/existing.temp.nuspec\" -MSBuildVersion 14")]
+                public void Should_Add_MSBuildVersion_To_Arguments_If_Set(NuGetMSBuildVersion msBuildVersion, string expected)
+                {
+                    // Given
+                    var fixture = new NuGetPackerWithNuSpecFixture();
+                    fixture.Settings.MSBuildVersion = msBuildVersion;
+
+                    // When
+                    var result = fixture.Run();
+
+                    // Then
+                    Assert.Equal(expected, result.Args);
+                }
             }
 
             public sealed class WithProjectFile
@@ -738,6 +755,24 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Pack
 
                     // Then
                     Assert.IsCakeException(result, "Properties values can not be null or empty.");
+                }
+
+                [Theory]
+                [InlineData(NuGetMSBuildVersion.MSBuild4, "pack \"/Working/existing.csproj\" -MSBuildVersion 4")]
+                [InlineData(NuGetMSBuildVersion.MSBuild12, "pack \"/Working/existing.csproj\" -MSBuildVersion 12")]
+                [InlineData(NuGetMSBuildVersion.MSBuild14, "pack \"/Working/existing.csproj\" -MSBuildVersion 14")]
+                public void Should_Add_MSBuildVersion_To_Arguments_If_Set(NuGetMSBuildVersion msBuildVersion, string expected)
+                {
+
+                    // Given
+                    var fixture = new NuGetPackerWithProjectFileFixture();
+                    fixture.Settings.MSBuildVersion = msBuildVersion;
+
+                    // When
+                    var result = fixture.Run();
+
+                    // Then
+                    Assert.Equal(expected, result.Args);
                 }
             }
 

--- a/src/Cake.Common.Tests/Unit/Tools/NuGet/Restore/NuGetRestorerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NuGet/Restore/NuGetRestorerTests.cs
@@ -245,6 +245,41 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Restore
                 // Then
                 Assert.Equal("restore \"/Working/project.sln\" -ConfigFile \"/Working/nuget.config\" -NonInteractive", result.Args);
             }
+
+
+
+            [Fact]
+            public void Should_Add_FallbackSources_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new NuGetRestorerFixture();
+                fixture.Settings.Source = new[] { "A;B;C" };
+                fixture.Settings.FallbackSource = new[] { "D;E;F" };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("restore \"/Working/project.sln\" -Source \"A;B;C\" -FallbackSource \"D;E;F\" -NonInteractive", result.Args);
+            }
+
+            [Theory]
+            [InlineData(NuGetMSBuildVersion.MSBuild4, "restore \"/Working/project.sln\" -MSBuildVersion 4 -NonInteractive")]
+            [InlineData(NuGetMSBuildVersion.MSBuild12, "restore \"/Working/project.sln\" -MSBuildVersion 12 -NonInteractive")]
+            [InlineData(NuGetMSBuildVersion.MSBuild14, "restore \"/Working/project.sln\" -MSBuildVersion 14 -NonInteractive")]
+            public void Should_Add_MSBuildVersion_To_Arguments_If_Set(NuGetMSBuildVersion msBuildVersion, string expected)
+            {
+
+                // Given
+                var fixture = new NuGetRestorerFixture();
+                fixture.Settings.MSBuildVersion = msBuildVersion;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/NuGet/Update/NuGetUpdaterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NuGet/Update/NuGetUpdaterTests.cs
@@ -1,12 +1,9 @@
 ﻿using System.Collections.Generic;
-using Cake.Common.Tests.Fixtures.Tools.NuGet;
 using Cake.Common.Tests.Fixtures.Tools.NuGet.Update;
 using Cake.Common.Tools.NuGet;
 using Cake.Core;
-using Cake.Core.IO;
 using Cake.Testing;
 using Cake.Testing.Xunit;
-using NSubstitute;
 using Xunit;
 
 namespace Cake.Common.Tests.Unit.Tools.NuGet.Update
@@ -222,6 +219,23 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Update
                 // Then
                 Assert.Equal("update \"/Working/packages.config\" -Source \"A;B;C\" " +
                              "-NonInteractive", result.Args);
+            }
+
+            [Theory]
+            [InlineData(NuGetMSBuildVersion.MSBuild4, "update \"/Working/packages.config\" -MSBuildVersion 4 -NonInteractive")]
+            [InlineData(NuGetMSBuildVersion.MSBuild12, "update \"/Working/packages.config\" -MSBuildVersion 12 -NonInteractive")]
+            [InlineData(NuGetMSBuildVersion.MSBuild14, "update \"/Working/packages.config\" -MSBuildVersion 14 -NonInteractive")]
+            public void Should_Add_MSBuildVersion_To_Arguments_If_Set(NuGetMSBuildVersion msBuildVersion, string expected)
+            {
+                // Given
+                var fixture = new NuGetUpdateFixture();
+                fixture.Settings.MSBuildVersion = msBuildVersion;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
             }
         }
     }

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -264,6 +264,7 @@
     <Compile Include="Tools\NSIS\NSISAliases.cs" />
     <Compile Include="Tools\NuGet\Install\NuGetInstaller.cs" />
     <Compile Include="Tools\NuGet\Install\NugetInstallSettings.cs" />
+    <Compile Include="Tools\NuGet\NuGetMSBuildVersion.cs" />
     <Compile Include="Tools\NuGet\NuGetTool.cs" />
     <Compile Include="Tools\NuGet\Pack\NuSpecContent.cs" />
     <Compile Include="Tools\NuGet\Pack\NuSpecDependency.cs" />

--- a/src/Cake.Common/Tools/NuGet/Install/NuGetInstaller.cs
+++ b/src/Cake.Common/Tools/NuGet/Install/NuGetInstaller.cs
@@ -74,14 +74,14 @@ namespace Cake.Common.Tools.NuGet.Install
             builder.Append("install");
             builder.AppendQuoted(packageId);
 
-            // Output Directory
+            // Output Directory.
             if (settings.OutputDirectory != null)
             {
                 builder.Append("-OutputDirectory");
                 builder.AppendQuoted(settings.OutputDirectory.MakeAbsolute(_environment).FullPath);
             }
 
-            // Version
+            // Version.
             if (settings.Version != null)
             {
                 builder.Append("-Version");
@@ -106,18 +106,25 @@ namespace Cake.Common.Tools.NuGet.Install
                 builder.Append("-RequireConsent");
             }
 
-            // Solution Directory
+            // Solution Directory.
             if (settings.SolutionDirectory != null)
             {
                 builder.Append("-SolutionDirectory");
                 builder.AppendQuoted(settings.SolutionDirectory.MakeAbsolute(_environment).FullPath);
             }
 
-            // List of package sources
+            // List of package sources.
             if (settings.Source != null && settings.Source.Count > 0)
             {
                 builder.Append("-Source");
                 builder.AppendQuoted(string.Join(";", settings.Source));
+            }
+
+            // List of package fallback sources.
+            if (settings.FallbackSource != null && settings.FallbackSource.Count > 0)
+            {
+                builder.Append("-FallbackSource");
+                builder.AppendQuoted(string.Join(";", settings.FallbackSource));
             }
 
             // No Cache?
@@ -139,7 +146,7 @@ namespace Cake.Common.Tools.NuGet.Install
                 builder.Append(settings.Verbosity.Value.ToString().ToLowerInvariant());
             }
 
-            // Configuration file
+            // Configuration file.
             if (settings.ConfigFile != null)
             {
                 builder.Append("-ConfigFile");

--- a/src/Cake.Common/Tools/NuGet/Install/NugetInstallSettings.cs
+++ b/src/Cake.Common/Tools/NuGet/Install/NugetInstallSettings.cs
@@ -90,5 +90,12 @@ namespace Cake.Common.Tools.NuGet.Install
         /// </summary>
         /// <value>The NuGet configuration file.</value>
         public FilePath ConfigFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets a list of packages sources to use as fallbacks for this command.
+        /// This setting requires NuGet V3 or later.
+        /// </summary>
+        /// <value>The list of packages sources to use as fallbacks for this command.</value>
+        public ICollection<string> FallbackSource { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/NuGet/NuGetMSBuildVersion.cs
+++ b/src/Cake.Common/Tools/NuGet/NuGetMSBuildVersion.cs
@@ -1,0 +1,23 @@
+﻿namespace Cake.Common.Tools.NuGet
+{
+    /// <summary>
+    /// NuGet MSBuild version
+    /// </summary>
+    public enum NuGetMSBuildVersion
+    {
+        /// <summary>
+        /// MSBuildVersion : <c>4</c>
+        /// </summary>
+        MSBuild4 = 4,
+
+        /// <summary>
+        /// MSBuildVersion : <c>12</c>
+        /// </summary>
+        MSBuild12 = 12,
+        
+        /// <summary>
+        /// MSBuildVersion : <c>14</c>
+        /// </summary>
+        MSBuild14 = 14
+    }
+}

--- a/src/Cake.Common/Tools/NuGet/Pack/NuGetPackSettings.cs
+++ b/src/Cake.Common/Tools/NuGet/Pack/NuGetPackSettings.cs
@@ -150,6 +150,14 @@ namespace Cake.Common.Tools.NuGet.Pack
         /// <value>
         /// The properties.
         /// </value>
-        public IDictionary<string, string> Properties { get; set; } 
+        public IDictionary<string, string> Properties { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version of MSBuild to be used with this command.
+        /// By default the MSBuild in your path is picked, otherwise it defaults to the highest installed version of MSBuild.
+        /// This setting requires NuGet V3 or later.
+        /// </summary>
+        /// <value>The version of MSBuild to be used with this command.</value>
+        public NuGetMSBuildVersion? MSBuildVersion { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/NuGet/Pack/NuGetPacker.cs
+++ b/src/Cake.Common/Tools/NuGet/Pack/NuGetPacker.cs
@@ -176,6 +176,13 @@ namespace Cake.Common.Tools.NuGet.Pack
                 builder.Append(settings.Verbosity.Value.ToString().ToLowerInvariant());
             }
 
+            // MSBuildVersion?
+            if (settings.MSBuildVersion.HasValue)
+            {
+                builder.Append("-MSBuildVersion");
+                builder.Append(settings.MSBuildVersion.Value.ToString("D"));
+            }
+
             // Properties
             if (settings.Properties != null && settings.Properties.Count > 0)
             {

--- a/src/Cake.Common/Tools/NuGet/Restore/NuGetRestorer.cs
+++ b/src/Cake.Common/Tools/NuGet/Restore/NuGetRestorer.cs
@@ -59,18 +59,25 @@ namespace Cake.Common.Tools.NuGet.Restore
                 builder.Append("-RequireConsent");
             }
 
-            // Packages Directory
+            // Packages Directory.
             if (settings.PackagesDirectory != null)
             {
                 builder.Append("-PackagesDirectory");
                 builder.AppendQuoted(settings.PackagesDirectory.MakeAbsolute(_environment).FullPath);
             }
 
-            // List of package sources
+            // List of package sources.
             if (settings.Source != null && settings.Source.Count > 0)
             {
                 builder.Append("-Source");
                 builder.AppendQuoted(string.Join(";", settings.Source));
+            }
+
+            // List of package fallback sources.
+            if (settings.FallbackSource != null && settings.FallbackSource.Count > 0)
+            {
+                builder.Append("-FallbackSource");
+                builder.AppendQuoted(string.Join(";", settings.FallbackSource));
             }
 
             // No Cache?
@@ -92,11 +99,18 @@ namespace Cake.Common.Tools.NuGet.Restore
                 builder.Append(settings.Verbosity.Value.ToString().ToLowerInvariant());
             }
 
-            // Configuration file
+            // Configuration file.
             if (settings.ConfigFile != null)
             {
                 builder.Append("-ConfigFile");
                 builder.AppendQuoted(settings.ConfigFile.MakeAbsolute(_environment).FullPath);
+            }
+
+            // MSBuildVersion?
+            if (settings.MSBuildVersion.HasValue)
+            {
+                builder.Append("-MSBuildVersion");
+                builder.Append(settings.MSBuildVersion.Value.ToString("D"));
             }
 
             builder.Append("-NonInteractive");

--- a/src/Cake.Common/Tools/NuGet/Restore/NugetRestoreSettings.cs
+++ b/src/Cake.Common/Tools/NuGet/Restore/NugetRestoreSettings.cs
@@ -53,5 +53,20 @@ namespace Cake.Common.Tools.NuGet.Restore
         /// If not specified, the file <c>%AppData%\NuGet\NuGet.config</c> is used as the configuration file.
         /// </summary>
         public FilePath ConfigFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets a list of packages sources to use as fallbacks for this command.
+        /// This setting requires NuGet V3 or later.
+        /// </summary>
+        /// <value>The list of packages sources to use as fallbacks for this command.</value>
+        public ICollection<string> FallbackSource { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version of MSBuild to be used with this command.
+        /// By default the MSBuild in your path is picked, otherwise it defaults to the highest installed version of MSBuild.
+        /// This setting requires NuGet V3 or later.
+        /// </summary>
+        /// <value>The version of MSBuild to be used with this command.</value>
+        public NuGetMSBuildVersion? MSBuildVersion { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/NuGet/Update/NuGetUpdateSettings.cs
+++ b/src/Cake.Common/Tools/NuGet/Update/NuGetUpdateSettings.cs
@@ -41,5 +41,13 @@ namespace Cake.Common.Tools.NuGet.Update
         /// Gets or sets the amount of output details.
         /// </summary>
         public NuGetVerbosity? Verbosity { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version of MSBuild to be used with this command.
+        /// By default the MSBuild in your path is picked, otherwise it defaults to the highest installed version of MSBuild.
+        /// This setting requires NuGet V3 or later.
+        /// </summary>
+        /// <value>The version of MSBuild to be used with this command.</value>
+        public NuGetMSBuildVersion? MSBuildVersion { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/NuGet/Update/NuGetUpdater.cs
+++ b/src/Cake.Common/Tools/NuGet/Update/NuGetUpdater.cs
@@ -88,6 +88,13 @@ namespace Cake.Common.Tools.NuGet.Update
                 builder.Append("-Prerelease");
             }
 
+            // MSBuildVersion?
+            if (settings.MSBuildVersion.HasValue)
+            {
+                builder.Append("-MSBuildVersion");
+                builder.Append(settings.MSBuildVersion.Value.ToString("D"));
+            }
+
             builder.Append("-NonInteractive");
 
             return builder;


### PR DESCRIPTION
* Fixes #438
* Restore
  * `-MSBuildVersion` Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14. By default the MSBuild in your path is picked, otherwise it defaults to the highest installed version of MSBuild.
  * `-FallbackSource` A list of packages sources to use as fallbacks for this command.
* Install
  * `-FallbackSource` A list of packages sources to use as fallbacks for this command.
* Pack
  * `-MSBuildVersion` Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14. By default the MSBuild in your path is picked, otherwise it defaults to the highest installed version of MSBuild.
* Update
  * `-MSBuildVersion` Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14. By default the MSBuild in your path is picked, otherwise it defaults to the highest installed version of MSBuild.