### PR TITLE
Alias examples for Net/Tools added - issue #750

### DIFF
--- a/src/Cake.Common/Net/HttpAliases.cs
+++ b/src/Cake.Common/Net/HttpAliases.cs
@@ -16,6 +16,11 @@ namespace Cake.Common.Net
         /// <summary>
         /// Downloads the specified resource over HTTP to a temporary file.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var resource = DownloadFile("http://www.example.org/index.html");
+        /// </code>
+        /// </example>
         /// <param name="context">The context.</param>
         /// <param name="address">The URL of the resource to download.</param>
         /// <returns>The path to the downloaded file.</returns>
@@ -29,6 +34,12 @@ namespace Cake.Common.Net
         /// <summary>
         /// Downloads the specified resource over HTTP to a temporary file.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var address = new Uri("http://www.example.org/index.html");
+        /// var resource = DownloadFile(address);
+        /// </code>
+        /// </example>
         /// <param name="context">The context.</param>
         /// <param name="address">The URL of file to download.</param>
         /// <returns>The path to the downloaded file.</returns>
@@ -49,6 +60,11 @@ namespace Cake.Common.Net
         /// <summary>
         /// Downloads the specified resource over HTTP to the specified output path.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// DownloadFile("http://www.example.org/index.html", "./outputdir");
+        /// </code>
+        /// </example>
         /// <param name="context">The context.</param>
         /// <param name="address">The URL of the resource to download.</param>
         /// <param name="outputPath">The output path.</param>
@@ -62,6 +78,12 @@ namespace Cake.Common.Net
         /// <summary>
         /// Downloads the specified resource over HTTP to the specified output path.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var address = new Uri("http://www.example.org/index.html");
+        /// DownloadFile(address, "./outputdir");
+        /// </code>
+        /// </example>
         /// <param name="context">The context.</param>
         /// <param name="address">The URL of the resource to download.</param>
         /// <param name="outputPath">The output path.</param>

--- a/src/Cake.Common/Tools/DotNetBuildAliases.cs
+++ b/src/Cake.Common/Tools/DotNetBuildAliases.cs
@@ -16,6 +16,11 @@ namespace Cake.Common.Tools
         /// <summary>
         /// Builds the specified solution using MSBuild or XBuild.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// DotNetBuild("./project/project.sln");
+        /// </code>
+        /// </example>
         /// <param name="context">The context.</param>
         /// <param name="solution">The solution.</param>
         [CakeMethodAlias]
@@ -27,6 +32,15 @@ namespace Cake.Common.Tools
         /// <summary>
         /// Builds the specified solution using MSBuild or XBuild.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// DotNetBuild("./project/project.sln", settings => 
+        ///     settings.SetConfiguration("Debug")
+        ///         .SetVerbosity(Core.Diagnostics.Verbosity.Minimal)
+        ///         .WithTarget("Build")
+        ///         .WithProperty("TreatWarningsAsErrors","true")
+        /// </code>
+        /// </example>
         /// <param name="context">The context.</param>
         /// <param name="solution">The solution.</param>
         /// <param name="configurator">The configurator.</param>

--- a/src/Cake.Common/Tools/GitLink/GitLinkAliases.cs
+++ b/src/Cake.Common/Tools/GitLink/GitLinkAliases.cs
@@ -39,7 +39,7 @@ namespace Cake.Common.Tools.GitLink
         /// <example>
         /// <code>
         /// GitLink("C:/temp/solution", new GitLinkSettings {
-        ///     RepositoryUrl = "http://mydomain.com",
+        ///     RepositoryUrl = new Uri("http://mydomain.com"),
         ///     Branch        = "master",
         ///     ShaHash       = "abcdef",
         /// });

--- a/src/Cake.Common/Tools/NUnit/NUnit3Aliases.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnit3Aliases.cs
@@ -19,11 +19,6 @@ namespace Cake.Common.Tools.NUnit
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="pattern">The pattern.</param>
-        /// <example>
-        /// <code>
-        /// NUnit3("./src/**/bin/Release/*.Tests.dll");
-        /// </code>
-        /// </example>
         [CakeMethodAlias]
         public static void NUnit3(this ICakeContext context, string pattern)
         {
@@ -49,13 +44,6 @@ namespace Cake.Common.Tools.NUnit
         /// <param name="context">The context.</param>
         /// <param name="pattern">The pattern.</param>
         /// <param name="settings">The settings.</param>
-        /// <example>
-        /// <code>
-        /// NUnit3("./src/**/bin/Release/*.Tests.dll", new NUnit3Settings {
-        ///     NoResults = true
-        ///     });
-        /// </code>
-        /// </example>
         [CakeMethodAlias]
         public static void NUnit3(this ICakeContext context, string pattern, NUnit3Settings settings)
         {
@@ -79,11 +67,6 @@ namespace Cake.Common.Tools.NUnit
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="assemblies">The assemblies.</param>
-        /// <example>
-        /// <code>
-        /// NUnit3(new [] { "./src/Example.Tests/bin/Release/Example.Tests.dll" });
-        /// </code>
-        /// </example>
         [CakeMethodAlias]
         public static void NUnit3(this ICakeContext context, IEnumerable<string> assemblies)
         {
@@ -100,12 +83,6 @@ namespace Cake.Common.Tools.NUnit
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="assemblies">The assemblies.</param>
-        /// <example>
-        /// <code>
-        /// var testAssemblies = GetFiles("./src/**/bin/Release/*.Tests.dll");
-        /// NUnit3(testAssemblies);
-        /// </code>
-        /// </example>
         [CakeMethodAlias]
         public static void NUnit3(this ICakeContext context, IEnumerable<FilePath> assemblies)
         {
@@ -119,13 +96,6 @@ namespace Cake.Common.Tools.NUnit
         /// <param name="context">The context.</param>
         /// <param name="assemblies">The assemblies.</param>
         /// <param name="settings">The settings.</param>
-        /// <example>
-        /// <code>
-        /// NUnit3(new [] { "./src/Example.Tests/bin/Release/Example.Tests.dll" }, new NUnit3Settings {
-        ///     NoResults = true
-        ///     });
-        /// </code>
-        /// </example>
         [CakeMethodAlias]
         public static void NUnit3(this ICakeContext context, IEnumerable<string> assemblies, NUnit3Settings settings)
         {
@@ -144,14 +114,6 @@ namespace Cake.Common.Tools.NUnit
         /// <param name="context">The context.</param>
         /// <param name="assemblies">The assemblies.</param>
         /// <param name="settings">The settings.</param>
-        /// <example>
-        /// <code>
-        /// var testAssemblies = GetFiles("./src/**/bin/Release/*.Tests.dll");
-        /// NUnit3(testAssemblies, new NUnit3Settings {
-        ///     NoResults = true
-        ///     });
-        /// </code>
-        /// </example>
         [CakeMethodAlias]
         public static void NUnit3(this ICakeContext context, IEnumerable<FilePath> assemblies, NUnit3Settings settings)
         {


### PR DESCRIPTION
I've completed the following example entries as per #750 and I'd like a sanity/formatting check on these before continuing down the list:

Cake.Common.Net​.DownloadFile(string)​
Cake.Common.Net​.DownloadFile(Uri)​
Cake.Common.Net​.DownloadFile(string, ​FilePath)​
Cake.Common.Net​.DownloadFile(Uri, ​FilePath)​
Cake.Common.Tools​.DotNetBuild(FilePath)
Cake.Common.Tools​.DotNetBuild(FilePath, ​Action<DotNetBuildSettings>)

I believe the Start Process entry at the top of #750 list can be ticked too as it has an example already?

Thanks.