### PR TITLE
actual type of RepositoryUrl is String not Uri

### DIFF
--- a/src/Cake.Common/Tools/GitLink/GitLinkAliases.cs
+++ b/src/Cake.Common/Tools/GitLink/GitLinkAliases.cs
@@ -39,7 +39,7 @@ namespace Cake.Common.Tools.GitLink
         /// <example>
         /// <code>
         /// GitLink("C:/temp/solution", new GitLinkSettings {
-        ///     RepositoryUrl = new Uri("http://mydomain.com"),
+        ///     RepositoryUrl = "http://mydomain.com",
         ///     Branch        = "master",
         ///     ShaHash       = "abcdef",
         /// });


### PR DESCRIPTION
In this case, I think the API doc is actually correct and the implementation of GitLink is at fault. This changes the API doc to match the actual API, feel free to close the PR and fix the API instead.