### PR TITLE
Alias examples for Http/DotNetBuild/MSTest #750

### DIFF
--- a/src/Cake.Common/Net/HttpAliases.cs
+++ b/src/Cake.Common/Net/HttpAliases.cs
@@ -16,6 +16,11 @@ namespace Cake.Common.Net
         /// <summary>
         /// Downloads the specified resource over HTTP to a temporary file.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var resource = DownloadFile("http://www.example.org/index.html");
+        /// </code>
+        /// </example>
         /// <param name="context">The context.</param>
         /// <param name="address">The URL of the resource to download.</param>
         /// <returns>The path to the downloaded file.</returns>
@@ -29,6 +34,12 @@ namespace Cake.Common.Net
         /// <summary>
         /// Downloads the specified resource over HTTP to a temporary file.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var address = new Uri("http://www.example.org/index.html");
+        /// var resource = DownloadFile(address);
+        /// </code>
+        /// </example>
         /// <param name="context">The context.</param>
         /// <param name="address">The URL of file to download.</param>
         /// <returns>The path to the downloaded file.</returns>
@@ -49,6 +60,11 @@ namespace Cake.Common.Net
         /// <summary>
         /// Downloads the specified resource over HTTP to the specified output path.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// DownloadFile("http://www.example.org/index.html", "./outputdir");
+        /// </code>
+        /// </example>
         /// <param name="context">The context.</param>
         /// <param name="address">The URL of the resource to download.</param>
         /// <param name="outputPath">The output path.</param>
@@ -62,6 +78,12 @@ namespace Cake.Common.Net
         /// <summary>
         /// Downloads the specified resource over HTTP to the specified output path.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var address = new Uri("http://www.example.org/index.html");
+        /// DownloadFile(address, "./outputdir");
+        /// </code>
+        /// </example>
         /// <param name="context">The context.</param>
         /// <param name="address">The URL of the resource to download.</param>
         /// <param name="outputPath">The output path.</param>

--- a/src/Cake.Common/Tools/DotNetBuildAliases.cs
+++ b/src/Cake.Common/Tools/DotNetBuildAliases.cs
@@ -16,6 +16,11 @@ namespace Cake.Common.Tools
         /// <summary>
         /// Builds the specified solution using MSBuild or XBuild.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// DotNetBuild("./project/project.sln");
+        /// </code>
+        /// </example>
         /// <param name="context">The context.</param>
         /// <param name="solution">The solution.</param>
         [CakeMethodAlias]
@@ -27,6 +32,15 @@ namespace Cake.Common.Tools
         /// <summary>
         /// Builds the specified solution using MSBuild or XBuild.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// DotNetBuild("./project/project.sln", settings => 
+        ///     settings.SetConfiguration("Debug")
+        ///         .SetVerbosity(Core.Diagnostics.Verbosity.Minimal)
+        ///         .WithTarget("Build")
+        ///         .WithProperty("TreatWarningsAsErrors","true")
+        /// </code>
+        /// </example>
         /// <param name="context">The context.</param>
         /// <param name="solution">The solution.</param>
         /// <param name="configurator">The configurator.</param>

--- a/src/Cake.Common/Tools/MSTest/MSTestAliases.cs
+++ b/src/Cake.Common/Tools/MSTest/MSTestAliases.cs
@@ -17,6 +17,11 @@ namespace Cake.Common.Tools.MSTest
         /// <summary>
         /// Runs all MSTest unit tests in the assemblies matching the specified pattern.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// MSTest("./Tests/*.UnitTests.dll");
+        /// </code>
+        /// </example>
         /// <param name="context">The context.</param>
         /// <param name="pattern">The pattern.</param>
         [CakeMethodAlias]
@@ -40,6 +45,11 @@ namespace Cake.Common.Tools.MSTest
         /// <summary>
         /// Runs all MSTest unit tests in the assemblies matching the specified pattern.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// MSTest("./Tests/*.UnitTests.dll", new MSTestSettings() { NoIsolation = false });
+        /// </code>
+        /// </example>
         /// <param name="context">The context.</param>
         /// <param name="pattern">The pattern.</param>
         /// <param name="settings">The settings.</param>
@@ -64,6 +74,12 @@ namespace Cake.Common.Tools.MSTest
         /// <summary>
         /// Runs all MSTest unit tests in the specified assemblies.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var paths = new List&lt;FilePath&gt;() { "./assemblydir1", "./assemblydir2" };
+        /// MSTest(paths);
+        /// </code>
+        /// </example>
         /// <param name="context">The context.</param>
         /// <param name="assemblyPaths">The assembly paths.</param>
         [CakeMethodAlias]
@@ -75,6 +91,12 @@ namespace Cake.Common.Tools.MSTest
         /// <summary>
         /// Runs all MSTest unit tests in the specified assemblies.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var paths = new List&lt;FilePath&gt;() { "./assemblydir1", "./assemblydir2" };
+        /// MSTest(paths, new MSTestSettings() { NoIsolation = false });
+        /// </code>
+        /// </example>
         /// <param name="context">The context.</param>
         /// <param name="assemblyPaths">The assembly paths.</param>
         /// <param name="settings">The settings.</param>


### PR DESCRIPTION
Reopened a new PR to squash and rebase to develop correctly (closed #790 as accidental merge/learning experience :8ball: :) )

Following have had examples added:
Cake.Common.Net​.DownloadFile(string)​
Cake.Common.Net​.DownloadFile(Uri)​
Cake.Common.Net​.DownloadFile(string, ​FilePath)​
Cake.Common.Net​.DownloadFile(Uri, ​FilePath)
Cake.Common.Tools​.DotNetBuild(FilePath)​
Cake.Common.Tools​.DotNetBuild(FilePath, ​Action<DotNetBuildSettings>)​
Cake.Common.Tools.MSTest​.MSTest(string)​
Cake.Common.Tools.MSTest​.MSTest(string, ​MSTestSettings)​
Cake.Common.Tools.MSTest​.MSTest(IEnumerable<FilePath>)​
Cake.Common.Tools.MSTest​.MSTest(IEnumerable<FilePath>, ​MSTestSettings)

Thanks.