### PR TITLE
Provided ICakeContext to Setup/Teardown.

### DIFF
--- a/src/Cake.Core.Tests/Unit/CakeEngineTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeEngineTests.cs
@@ -370,7 +370,7 @@ namespace Cake.Core.Tests.Unit
                 var result = new List<string>();
                 var fixture = new CakeEngineFixture();
                 var engine = fixture.CreateEngine();
-                engine.RegisterSetupAction(() => result.Add("Setup"));
+                engine.RegisterSetupAction(context => result.Add("Setup"));
                 engine.RegisterTask("A").Does(() => result.Add("A"));
 
                 // When
@@ -389,7 +389,7 @@ namespace Cake.Core.Tests.Unit
                 var fixture = new CakeEngineFixture();
                 var engine = fixture.CreateEngine();
 
-                engine.RegisterSetupAction(() => { throw new InvalidOperationException("Fail"); });
+                engine.RegisterSetupAction(context => { throw new InvalidOperationException("Fail"); });
                 engine.RegisterTask("A").Does(() => runTask = true);
 
                 // When
@@ -409,8 +409,8 @@ namespace Cake.Core.Tests.Unit
                 var fixture = new CakeEngineFixture();
                 var engine = fixture.CreateEngine();
 
-                engine.RegisterSetupAction(() => result.Add("Setup"));
-                engine.RegisterTeardownAction(() => result.Add("Teardown"));
+                engine.RegisterSetupAction(context => result.Add("Setup"));
+                engine.RegisterTeardownAction(context => result.Add("Teardown"));
                 engine.RegisterTask("A").Does(() => result.Add("A"));
 
                 // When
@@ -428,8 +428,8 @@ namespace Cake.Core.Tests.Unit
                 var fixture = new CakeEngineFixture();
                 var engine = fixture.CreateEngine();
 
-                engine.RegisterSetupAction(() => { });
-                engine.RegisterTeardownAction(() => { });
+                engine.RegisterSetupAction(context => { });
+                engine.RegisterTeardownAction(context => { });
                 engine.RegisterTask("A").Does(() => { throw new InvalidOperationException("Fail"); });
 
                 // When
@@ -450,8 +450,8 @@ namespace Cake.Core.Tests.Unit
                 var fixture = new CakeEngineFixture();
                 var engine = fixture.CreateEngine();
 
-                engine.RegisterSetupAction(() => { throw new InvalidOperationException("Fail"); });
-                engine.RegisterTeardownAction(() => { });
+                engine.RegisterSetupAction(context => { throw new InvalidOperationException("Fail"); });
+                engine.RegisterTeardownAction(context => { });
                 engine.RegisterTask("A").Does(() => { });
 
                 // When
@@ -472,8 +472,8 @@ namespace Cake.Core.Tests.Unit
                 var fixture = new CakeEngineFixture();
                 var engine = fixture.CreateEngine();
 
-                engine.RegisterSetupAction(() => { throw new InvalidOperationException("Setup"); });
-                engine.RegisterTeardownAction(() => { throw new InvalidOperationException("Teardown"); });
+                engine.RegisterSetupAction(context => { throw new InvalidOperationException("Setup"); });
+                engine.RegisterTeardownAction(context => { throw new InvalidOperationException("Teardown"); });
                 engine.RegisterTask("A").Does(() => { });
 
                 // When
@@ -494,7 +494,7 @@ namespace Cake.Core.Tests.Unit
                 var engine = fixture.CreateEngine();
                 var expected = new InvalidOperationException("Teardown");
 
-                engine.RegisterTeardownAction(() => { throw expected; });
+                engine.RegisterTeardownAction(context => { throw expected; });
                 engine.RegisterTask("A").Does(() => { });
 
                 // When
@@ -512,8 +512,8 @@ namespace Cake.Core.Tests.Unit
                 var fixture = new CakeEngineFixture();
                 var engine = fixture.CreateEngine();
 
-                engine.RegisterSetupAction(() => { throw new InvalidOperationException("Setup"); });
-                engine.RegisterTeardownAction(() => { throw new InvalidOperationException("Teardown"); });
+                engine.RegisterSetupAction(context => { throw new InvalidOperationException("Setup"); });
+                engine.RegisterTeardownAction(context => { throw new InvalidOperationException("Teardown"); });
                 engine.RegisterTask("A").Does(() => { });
 
                 // When
@@ -531,8 +531,8 @@ namespace Cake.Core.Tests.Unit
                 var fixture = new CakeEngineFixture();
                 var engine = fixture.CreateEngine();
 
-                engine.RegisterTeardownAction(() => { throw new InvalidOperationException("Teardown"); });
-                engine.RegisterTask("A").Does(() => { throw new InvalidOperationException("Task"); });
+                engine.RegisterTeardownAction(context => { throw new InvalidOperationException("Teardown"); });
+                engine.RegisterTask("A").Does(context => { throw new InvalidOperationException("Task"); });
 
                 // When
                 var result = Record.Exception(() =>
@@ -551,7 +551,7 @@ namespace Cake.Core.Tests.Unit
                 var fixture = new CakeEngineFixture();
                 var engine = fixture.CreateEngine();
 
-                engine.RegisterTeardownAction(() => { throw new InvalidOperationException("Teardown"); });
+                engine.RegisterTeardownAction(context => { throw new InvalidOperationException("Teardown"); });
                 engine.RegisterTask("A").Does(() => { throw new InvalidOperationException("Task"); });
 
                 // When

--- a/src/Cake.Core/CakeEngine.cs
+++ b/src/Cake.Core/CakeEngine.cs
@@ -15,8 +15,8 @@ namespace Cake.Core
     {
         private readonly ICakeLog _log;
         private readonly List<CakeTask> _tasks;
-        private Action _setupAction;
-        private Action _teardownAction;
+        private Action<ICakeContext> _setupAction;
+        private Action<ICakeContext> _teardownAction;
         private Action<ICakeContext, ITaskSetupContext> _taskSetupAction;
         private Action<ICakeContext, ITaskTeardownContext> _taskTeardownAction;
 
@@ -67,7 +67,7 @@ namespace Cake.Core
         /// If setup fails, no tasks will be executed but teardown will be performed.
         /// </summary>
         /// <param name="action">The action to be executed.</param>
-        public void RegisterSetupAction(Action action)
+        public void RegisterSetupAction(Action<ICakeContext> action)
         {
             _setupAction = action;
         }
@@ -77,7 +77,7 @@ namespace Cake.Core
         /// If a setup action or a task fails with or without recovery, the specified teardown action will still be executed.
         /// </summary>
         /// <param name="action">The action to be executed.</param>
-        public void RegisterTeardownAction(Action action)
+        public void RegisterTeardownAction(Action<ICakeContext> action)
         {
             _teardownAction = action;
         }
@@ -116,7 +116,7 @@ namespace Cake.Core
 
             try
             {
-                PerformSetup(strategy);
+                PerformSetup(strategy, context);
 
                 var stopWatch = new Stopwatch();
                 var report = new CakeReport();
@@ -150,7 +150,7 @@ namespace Cake.Core
             }
             finally
             {
-                PerformTeardown(strategy, exceptionWasThrown);
+                PerformTeardown(strategy, context, exceptionWasThrown);
             }
         }
 
@@ -174,11 +174,11 @@ namespace Cake.Core
             _taskTeardownAction = action;
         }
 
-        private void PerformSetup(IExecutionStrategy strategy)
+        private void PerformSetup(IExecutionStrategy strategy, ICakeContext context)
         {
             if (_setupAction != null)
             {
-                strategy.PerformSetup(_setupAction);
+                strategy.PerformSetup(_setupAction, context);
             }
         }
 
@@ -347,13 +347,13 @@ namespace Cake.Core
             }
         }
 
-        private void PerformTeardown(IExecutionStrategy strategy, bool exceptionWasThrown)
+        private void PerformTeardown(IExecutionStrategy strategy, ICakeContext context, bool exceptionWasThrown)
         {
             if (_teardownAction != null)
             {
                 try
                 {
-                    strategy.PerformTeardown(_teardownAction);
+                    strategy.PerformTeardown(_teardownAction, context);
                 }
                 catch (Exception ex)
                 {

--- a/src/Cake.Core/DefaultExecutionStrategy.cs
+++ b/src/Cake.Core/DefaultExecutionStrategy.cs
@@ -23,7 +23,8 @@ namespace Cake.Core
         /// Performs the setup.
         /// </summary>
         /// <param name="action">The action.</param>
-        public void PerformSetup(Action action)
+        /// <param name="context">The context.</param>
+        public void PerformSetup(Action<ICakeContext> action, ICakeContext context)
         {
             if (action != null)
             {
@@ -33,7 +34,7 @@ namespace Cake.Core
                 _log.Information("----------------------------------------");
                 _log.Verbose("Executing custom setup action...");
 
-                action();
+                action(context);
             }
         }
 
@@ -41,7 +42,8 @@ namespace Cake.Core
         /// Performs the teardown.
         /// </summary>
         /// <param name="action">The action.</param>
-        public void PerformTeardown(Action action)
+        /// <param name="context">The context.</param>
+        public void PerformTeardown(Action<ICakeContext> action, ICakeContext context)
         {
             if (action != null)
             {
@@ -51,7 +53,7 @@ namespace Cake.Core
                 _log.Information("----------------------------------------");
                 _log.Verbose("Executing custom teardown action...");
 
-                action();
+                action(context);
             }
         }
 

--- a/src/Cake.Core/ICakeEngine.cs
+++ b/src/Cake.Core/ICakeEngine.cs
@@ -26,14 +26,14 @@ namespace Cake.Core
         /// If setup fails, no tasks will be executed but teardown will be performed.
         /// </summary>
         /// <param name="action">The action to be executed.</param>
-        void RegisterSetupAction(Action action);
+        void RegisterSetupAction(Action<ICakeContext> action);
 
         /// <summary>
         /// Allows registration of an action that's executed after all other tasks have been run.
         /// If a setup action or a task fails with or without recovery, the specified teardown action will still be executed.
         /// </summary>
         /// <param name="action">The action to be executed.</param>
-        void RegisterTeardownAction(Action action);
+        void RegisterTeardownAction(Action<ICakeContext> action);
 
         /// <summary>
         /// Runs the specified target using the specified <see cref="IExecutionStrategy"/>.

--- a/src/Cake.Core/IExecutionStrategy.cs
+++ b/src/Cake.Core/IExecutionStrategy.cs
@@ -11,13 +11,15 @@ namespace Cake.Core
         /// Performs the setup.
         /// </summary>
         /// <param name="action">The action.</param>
-        void PerformSetup(Action action);
+        /// <param name="context">The context.</param>
+        void PerformSetup(Action<ICakeContext> action, ICakeContext context);
 
         /// <summary>
         /// Performs the teardown.
         /// </summary>
         /// <param name="action">The action.</param>
-        void PerformTeardown(Action action);
+        /// <param name="context">The context.</param>
+        void PerformTeardown(Action<ICakeContext> action, ICakeContext context);
 
         /// <summary>
         /// Executes the specified task.

--- a/src/Cake.Core/Scripting/IScriptHost.cs
+++ b/src/Cake.Core/Scripting/IScriptHost.cs
@@ -32,14 +32,30 @@ namespace Cake.Core.Scripting
         /// If setup fails, no tasks will be executed but teardown will be performed.
         /// </summary>
         /// <param name="action">The action to be executed.</param>
+        [Obsolete("Please use Setup(Action<ICakeContext>) instead.", false)]
         void Setup(Action action);
+
+        /// <summary>
+        /// Allows registration of an action that's executed before any tasks are run.
+        /// If setup fails, no tasks will be executed but teardown will be performed.
+        /// </summary>
+        /// <param name="action">The action to be executed.</param>
+        void Setup(Action<ICakeContext> action);
 
         /// <summary>
         /// Allows registration of an action that's executed after all other tasks have been run.
         /// If a setup action or a task fails with or without recovery, the specified teardown action will still be executed.
         /// </summary>
         /// <param name="action">The action to be executed.</param>
+        [Obsolete("Please use Teardown(Action<ICakeContext>) instead.", false)]
         void Teardown(Action action);
+
+        /// <summary>
+        /// Allows registration of an action that's executed after all other tasks have been run.
+        /// If a setup action or a task fails with or without recovery, the specified teardown action will still be executed.
+        /// </summary>
+        /// <param name="action">The action to be executed.</param>
+        void Teardown(Action<ICakeContext> action);
 
         /// <summary>
         /// Allows registration of an action that's executed before each task is run.

--- a/src/Cake.Core/Scripting/ScriptHost.cs
+++ b/src/Cake.Core/Scripting/ScriptHost.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Cake.Core.Diagnostics;
 
 namespace Cake.Core.Scripting
 {
@@ -72,7 +73,29 @@ namespace Cake.Core.Scripting
         /// If setup fails, no tasks will be executed but teardown will be performed.
         /// </summary>
         /// <param name="action">The action to be executed.</param>
+        [Obsolete("Please use Setup(Action<ICakeContext>) instead.", false)]
         public void Setup(Action action)
+        {
+            if (Context != null && Context.Log != null)
+            {
+                Context.Log.Warning("Please use Setup(Action<ICakeContext>) instead.");
+            }
+            Setup(context => action());
+        }
+
+        /// <summary>
+        /// Allows registration of an action that's executed before any tasks are run.
+        /// If setup fails, no tasks will be executed but teardown will be performed.
+        /// </summary>
+        /// <param name="action">The action to be executed.</param>
+        /// <example>
+        /// <code>
+        /// Setup(context => {
+        ///   context.Log.Information("Hello World!");
+        /// });
+        /// </code>
+        /// </example>
+        public void Setup(Action<ICakeContext> action)
         {
             _engine.RegisterSetupAction(action);
         }
@@ -82,7 +105,29 @@ namespace Cake.Core.Scripting
         /// If a setup action or a task fails with or without recovery, the specified teardown action will still be executed.
         /// </summary>
         /// <param name="action">The action to be executed.</param>
+        [Obsolete("Please use Teardown(Action<ICakeContext>) instead.", false)]
         public void Teardown(Action action)
+        {
+            if (Context != null && Context.Log != null)
+            {
+                Context.Log.Warning("Please use Teardown(Action<ICakeContext>) instead.");
+            }
+            Teardown(context => action());
+        }
+
+        /// <summary>
+        /// Allows registration of an action that's executed after all other tasks have been run.
+        /// If a setup action or a task fails with or without recovery, the specified teardown action will still be executed.
+        /// </summary>
+        /// <param name="action">The action to be executed.</param>
+        /// <example>
+        /// <code>
+        /// Teardown(context => {
+        ///   context.Log.Information("Goodbye World!");
+        /// });
+        /// </code>
+        /// </example>
+        public void Teardown(Action<ICakeContext> action)
         {
             _engine.RegisterTeardownAction(action);
         }

--- a/src/Cake/Scripting/DryRunExecutionStrategy.cs
+++ b/src/Cake/Scripting/DryRunExecutionStrategy.cs
@@ -19,11 +19,11 @@ namespace Cake.Scripting
             _counter = 1;
         }
 
-        public void PerformSetup(Action action)
+        public void PerformSetup(Action<ICakeContext> action, ICakeContext context)
         {
         }
 
-        public void PerformTeardown(Action action)
+        public void PerformTeardown(Action<ICakeContext> action, ICakeContext context)
         {
         }
 


### PR DESCRIPTION
Also obsoleted (with warning) old methods that don't use the `ICakeContext` version of the methods. This to have a simpler interface and since there is little use to have two overloads.

Closes #743