### PR TITLE
Inconsistencies in XBuildToolVersion docs

### DIFF
--- a/src/Cake.Common/Tools/XBuild/XBuildToolVersion.cs
+++ b/src/Cake.Common/Tools/XBuild/XBuildToolVersion.cs
@@ -1,12 +1,12 @@
 ﻿namespace Cake.Common.Tools.XBuild
 {
     /// <summary>
-    /// Represents a MSBuild tool version.
+    /// Represents a XBuild tool version.
     /// </summary>
     public enum XBuildToolVersion
     {
         /// <summary>
-        /// The highest available MSBuild tool version.
+        /// The highest available XBuild tool version.
         /// </summary>
         Default = 0,
 
@@ -16,17 +16,17 @@
         NET20 = 1,
 
         /// <summary>
-        /// MSBuild tool version: <c>.NET 3.0</c>
+        /// XBuild tool version: <c>.NET 3.0</c>
         /// </summary>
         NET30 = 1,
 
         /// <summary>
-        /// MSBuild tool version: <c>.NET 3.5</c>
+        /// XBuild tool version: <c>.NET 3.5</c>
         /// </summary>
         NET35 = 2,
 
         /// <summary>
-        /// MSBuild tool version: <c>.NET 4.0</c>
+        /// XBuild tool version: <c>.NET 4.0</c>
         /// </summary>
         NET40 = 3,
     }


### PR DESCRIPTION
XBuildToolVersion's xml comments refer to MSBuild tool versions in some places, and XBuild tool versions in others. Should always be XBuild.