### PR TITLE
Obsolete XmlPoke string overload add XmlPokeString alias

### DIFF
--- a/src/Cake.Common/Xml/XmlPokeAliases.cs
+++ b/src/Cake.Common/Xml/XmlPokeAliases.cs
@@ -68,7 +68,7 @@ namespace Cake.Common.Xml
         ///     .Does(() =>
         /// {
         ///     var file = File("test.xml");
-        ///     XmlPoke(file, "/Commands/@xsi:noNamespaceSchemaLocation", "d:\Commands.xsd", new XmlPokeSettings {
+        ///     XmlPoke(file, "/Commands/@xsi:noNamespaceSchemaLocation", "d:\\Commands.xsd", new XmlPokeSettings {
         ///         Namespaces = new Dictionary<string, string> {
         ///             { /* Prefix */ "xsi", /* URI */ "http://www.w3.org/2001/XMLSchema-instance" }
         ///         }
@@ -170,7 +170,7 @@ namespace Cake.Common.Xml
         ///     .Does(() =>
         /// {
         ///     var file = File("test.xml");
-        ///     XmlPoke(file, "/Commands/@xsi:noNamespaceSchemaLocation", "d:\Commands.xsd", new XmlPokeSettings {
+        ///     XmlPoke(file, "/Commands/@xsi:noNamespaceSchemaLocation", "d:\\Commands.xsd", new XmlPokeSettings {
         ///         Namespaces = new Dictionary<string, string> {
         ///             { /* Prefix */ "xsi", /* URI */ "http://www.w3.org/2001/XMLSchema-instance" }
         ///         }
@@ -256,6 +256,44 @@ namespace Cake.Common.Xml
         /// <param name="xpath">The xpath of the nodes to set.</param>
         /// <param name="value">The value to set too. Leave blank to remove the selected nodes.</param>
         /// <returns>Resulting XML.</returns>
+        /// <remarks>
+        /// The method is now obsolete replaced by <see cref="XmlPokeString(Cake.Core.ICakeContext,string,string,string)"/>
+        /// </remarks>
+        [CakeMethodAlias]
+        [Obsolete("Please use XmlPokeString(string, string, string) instead.", false)]
+        public static string XmlPoke(this ICakeContext context, string sourceXml, string xpath, string value)
+        {
+            return context.XmlPokeString(sourceXml, xpath, value, new XmlPokeSettings());
+        }
+
+        /// <summary>
+        /// Set the value of, or remove, target nodes.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="sourceXml">The source xml to transform.</param>
+        /// <param name="xpath">The xpath of the nodes to set.</param>
+        /// <param name="value">The value to set too. Leave blank to remove the selected nodes.</param>
+        /// <param name="settings">Additional settings to tweak Xml Poke behavior.</param>
+        /// <returns>Resulting XML.</returns>
+        /// <remarks>
+        /// The method is now obsolete replaced by <see cref="XmlPokeString(Cake.Core.ICakeContext,string,string,string,XmlPokeSettings)"/>
+        /// </remarks>
+        [CakeMethodAlias]
+        [Obsolete("Please use XmlPokeString(string, string, string, XmlPokeSettings) instead.", false)]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
+        public static string XmlPoke(this ICakeContext context, string sourceXml, string xpath, string value, XmlPokeSettings settings)
+        {
+            return context.XmlPokeString(sourceXml, xpath, value, settings);
+        }
+
+        /// <summary>
+        /// Set the value of, or remove, target nodes.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="sourceXml">The source xml to transform.</param>
+        /// <param name="xpath">The xpath of the nodes to set.</param>
+        /// <param name="value">The value to set too. Leave blank to remove the selected nodes.</param>
+        /// <returns>Resulting XML.</returns>
         /// <example>
         ///   <para>
         ///   Change the <c>server</c> setting in the configuration from <c>testhost.somecompany.com</c>
@@ -278,7 +316,7 @@ namespace Cake.Common.Xml
         /// Task("Transform")
         ///     .Does(() =>
         /// {
-        ///     var result = XmlPoke(xmlString, "/configuration/appSettings/add[@key = 'server']/@value", "productionhost.somecompany.com");
+        ///     var result = XmlPokeString(xmlString, "/configuration/appSettings/add[@key = 'server']/@value", "productionhost.somecompany.com");
         /// });
         ///     ]]>
         ///   </code>
@@ -301,7 +339,7 @@ namespace Cake.Common.Xml
         /// Task("Transform")
         ///     .Does(() =>
         /// {
-        ///     var result = XmlPoke(xmlString, "/Commands/@xsi:noNamespaceSchemaLocation", "d:\Commands.xsd", new XmlPokeSettings {
+        ///     var result = XmlPokeString(xmlString, "/Commands/@xsi:noNamespaceSchemaLocation", "d:\\Commands.xsd", new XmlPokeSettings {
         ///         Namespaces = new Dictionary<string, string> {
         ///             { /* Prefix */ "xsi", /* URI */ "http://www.w3.org/2001/XMLSchema-instance" }
         ///         }
@@ -331,7 +369,7 @@ namespace Cake.Common.Xml
         /// Task("Transform")
         ///     .Does(() =>
         /// {
-        ///     var result = XmlPoke(xmlString, "/configuration/appSettings/add[@testing]", null);
+        ///     var result = XmlPokeString(xmlString, "/configuration/appSettings/add[@testing]", null);
         /// });
         ///     ]]>
         ///   </code>
@@ -342,9 +380,9 @@ namespace Cake.Common.Xml
         /// </para>
         /// </example>
         [CakeMethodAlias]
-        public static string XmlPoke(this ICakeContext context, string sourceXml, string xpath, string value)
+        public static string XmlPokeString(this ICakeContext context, string sourceXml, string xpath, string value)
         {
-            return context.XmlPoke(sourceXml, xpath, value, new XmlPokeSettings());
+            return context.XmlPokeString(sourceXml, xpath, value, new XmlPokeSettings());
         }
 
         /// <summary>
@@ -378,7 +416,7 @@ namespace Cake.Common.Xml
         /// Task("Transform")
         ///     .Does(() =>
         /// {
-        ///     var result = XmlPoke(xmlString, "/configuration/appSettings/add[@key = 'server']/@value", "productionhost.somecompany.com");
+        ///     var result = XmlPokeString(xmlString, "/configuration/appSettings/add[@key = 'server']/@value", "productionhost.somecompany.com");
         /// });
         ///     ]]>
         ///   </code>
@@ -401,7 +439,7 @@ namespace Cake.Common.Xml
         /// Task("Transform")
         ///     .Does(() =>
         /// {
-        ///     var result = XmlPoke(xmlString, "/Commands/@xsi:noNamespaceSchemaLocation", "d:\Commands.xsd", new XmlPokeSettings {
+        ///     var result = XmlPokeString(xmlString, "/Commands/@xsi:noNamespaceSchemaLocation", "d:\\Commands.xsd", new XmlPokeSettings {
         ///         Namespaces = new Dictionary<string, string> {
         ///             { /* Prefix */ "xsi", /* URI */ "http://www.w3.org/2001/XMLSchema-instance" }
         ///         }
@@ -431,7 +469,7 @@ namespace Cake.Common.Xml
         /// Task("Transform")
         ///     .Does(() =>
         /// {
-        ///     var result = XmlPoke(xmlString, "/configuration/appSettings/add[@testing]", null);
+        ///     var result = XmlPokeString(xmlString, "/configuration/appSettings/add[@testing]", null);
         /// });
         ///     ]]>
         ///   </code>
@@ -443,7 +481,7 @@ namespace Cake.Common.Xml
         /// </example>
         [CakeMethodAlias]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
-        public static string XmlPoke(this ICakeContext context, string sourceXml, string xpath, string value, XmlPokeSettings settings)
+        public static string XmlPokeString(this ICakeContext context, string sourceXml, string xpath, string value, XmlPokeSettings settings)
         {
             if (context == null)
             {


### PR DESCRIPTION
* Fixes #835 
* Also fixes existing issue/typo in the sample where `\` wasn't escaped correctly.

Example:
```cake
var xmlString = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
<configuration>
    <appSettings>
        <add key=""server"" value=""testhost.somecompany.com"" />
    </appSettings>
</configuration>";
```
This will method will give a warning `Warning: The alias XmlPoke has been made obsolete. Use XmlPokeString alias instead`
```
var result = XmlPoke(xmlString, "/configuration/appSettings/add[@key = 'server']/@value", "productionhost.somecompany.com");
```
This method will not
```cake
var resultString = XmlPokeString(xmlString, "/configuration/appSettings/add[@key = 'server']/@value", "productionhost.somecompany.com");
```

Example with settings:
```cake
var xmlStringSetting = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
<Commands xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xsi:noNamespaceSchemaLocation=""Path Value"">
</Commands>";
```
This will method will give a warning `Warning: The alias XmlPoke has been made obsolete. Use XmlPokeString alias instead`
```cake
var resultSetting = XmlPoke(xmlStringSetting, "/Commands/@xsi:noNamespaceSchemaLocation", "d:\\Commands.xsd", new XmlPokeSettings {
    Namespaces = new Dictionary<string, string> {
        { /* Prefix */ "xsi", /* URI */ "http://www.w3.org/2001/XMLSchema-instance" }
    }
});
```
This method will not
```cake
var resultStringSetting = XmlPokeString(xmlStringSetting, "/Commands/@xsi:noNamespaceSchemaLocation", "d:\\Commands.xsd", new XmlPokeSettings {
    Namespaces = new Dictionary<string, string> {
        { /* Prefix */ "xsi", /* URI */ "http://www.w3.org/2001/XMLSchema-instance" }
    }
});
```