### PR TITLE
Renamed ProcessArgumentBuilderExtensions class

### DIFF
--- a/src/Cake.Core/Cake.Core.csproj
+++ b/src/Cake.Core/Cake.Core.csproj
@@ -86,7 +86,7 @@
     <Compile Include="Extensions\DirectoryExtensions.cs" />
     <Compile Include="Extensions\HashSetExtensions.cs" />
     <Compile Include="Extensions\MethodInfoExtensions.cs" />
-    <Compile Include="Extensions\ProcessArgumentBuilderExtensions.cs" />
+    <Compile Include="Extensions\ProcessArgumentListExtensions.cs" />
     <Compile Include="Extensions\ProcessRunnerExtensions.cs" />
     <Compile Include="Extensions\ProcessSettingsExtensions.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />

--- a/src/Cake.Core/Extensions/ProcessArgumentListExtensions.cs
+++ b/src/Cake.Core/Extensions/ProcessArgumentListExtensions.cs
@@ -9,7 +9,7 @@ namespace Cake.Core
     /// <summary>
     /// Contains extension methods for <see cref="ProcessArgumentBuilder" />.
     /// </summary>
-    public static class ProcessArgumentBuilderExtensions
+    public static class ProcessArgumentListExtensions
     {
         /// <summary>
         /// Appends the specified text to the argument builder.


### PR DESCRIPTION
Due to a regression the ProcessArgumentBuilderExtensions
class had to be renamed back to ProcessArgumentListExtensions.

Closes #846