### PR TITLE
Made tool definitions preprocessor directives.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,3 +1,9 @@
+// Install tools.
+#tool "nuget:?package=xunit.runner.console&version=2.1.0"
+#tool "nuget:?package=gitreleasemanager&version=0.4.0"
+#tool "nuget:?package=GitVersion.CommandLine&version=3.4.1"
+
+// Load other scripts.
 #load "./build/parameters.cake"
 
 //////////////////////////////////////////////////////////////////////

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
     <package id="Cake" version="0.10.1" />
-    <package id="xunit.runner.console" version="2.1.0" />
-    <package id="gitreleasemanager" version="0.4.0" />
-    <package id="GitVersion.CommandLine" version="3.4.1" />
 </packages>


### PR DESCRIPTION
By moving tools needed from packages.config to the build script itself, we make the build script more portable.

Closes #854