### PR TITLE
Docs: Typos in XBuild docs

### DIFF
--- a/src/Cake.Common/Tools/XBuild/XBuildAliases.cs
+++ b/src/Cake.Common/Tools/XBuild/XBuildAliases.cs
@@ -6,13 +6,13 @@ using Cake.Core.IO;
 namespace Cake.Common.Tools.XBuild
 {
     /// <summary>
-    /// Contains functionality related to MSBuild.
+    /// Contains functionality related to XBuild.
     /// </summary>
     [CakeAliasCategory("XBuild")]
     public static class XBuildAliases
     {
         /// <summary>
-        /// Builds the specified solution using MSBuild.
+        /// Builds the specified solution using XBuild.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="solution">The solution to build.</param>
@@ -23,7 +23,7 @@ namespace Cake.Common.Tools.XBuild
         }
 
         /// <summary>
-        /// Builds the specified solution using MSBuild.
+        /// Builds the specified solution using XBuild.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="solution">The solution to build.</param>
@@ -48,7 +48,7 @@ namespace Cake.Common.Tools.XBuild
         }
 
         /// <summary>
-        /// Builds the specified solution using MSBuild.
+        /// Builds the specified solution using XBuild.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="solution">The solution to build.</param>

--- a/src/Cake.Common/Tools/XBuild/XBuildRunner.cs
+++ b/src/Cake.Common/Tools/XBuild/XBuildRunner.cs
@@ -10,7 +10,7 @@ using Cake.Core.Tooling;
 namespace Cake.Common.Tools.XBuild
 {
     /// <summary>
-    /// The MSBuild runner.
+    /// The XBuild runner.
     /// </summary>
     public sealed class XBuildRunner : Tool<XBuildSettings>
     {
@@ -32,7 +32,7 @@ namespace Cake.Common.Tools.XBuild
         }
 
         /// <summary>
-        /// Runs MSBuild with the specified settings.
+        /// Runs XBuild with the specified settings.
         /// </summary>
         /// <param name="solution">The solution to build.</param>
         /// <param name="settings">The settings.</param>

--- a/src/Cake.Common/Tools/XBuild/XBuildSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/XBuild/XBuildSettingsExtensions.cs
@@ -6,7 +6,7 @@ using Cake.Core.Diagnostics;
 namespace Cake.Common.Tools.XBuild
 {
     /// <summary>
-    /// Contains functionality related to MSBuild settings.
+    /// Contains functionality related to XBuild settings.
     /// </summary>
     public static class XBuildSettingsExtensions
     {


### PR DESCRIPTION
Looks like the XBuild docs were copied from the MSBuild ones, and a few references missed. Did a similar pull request for others I noticed previously (#817) - did a full search this time, so this should cover all the rest!