### PR TITLE
Fix for tool installation path bug.

### DIFF
--- a/src/Cake.Core.Tests/Unit/Scripting/ScriptRunnerTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/ScriptRunnerTests.cs
@@ -252,6 +252,22 @@ namespace Cake.Core.Tests.Unit.Scripting
                 fixture.ScriptAnalyzer.Received(1).Analyze(
                     Arg.Is<FilePath>(f => f.FullPath == "build.cake"));
             }
+
+            [Fact]
+            public void Should_Send_Absolute_Install_Path_To_Script_Processor_When_Installing_Tools()
+            {
+                // Given
+                var fixture = new ScriptRunnerFixture("/Working/foo/build.cake");
+                var runner = fixture.CreateScriptRunner();
+
+                // When
+                runner.Run(fixture.Host, "./foo/build.cake", fixture.ArgumentDictionary);
+
+                // Then
+                fixture.ScriptProcessor.Received(1).InstallTools(
+                    Arg.Any<ScriptAnalyzerResult>(),
+                    Arg.Is<DirectoryPath>(p => p.FullPath == "/Working/foo/tools"));
+            }
         }
     }
 }

--- a/src/Cake.Core/Scripting/ScriptRunner.cs
+++ b/src/Cake.Core/Scripting/ScriptRunner.cs
@@ -99,8 +99,11 @@ namespace Cake.Core.Scripting
                 throw new ArgumentNullException("arguments");
             }
 
+            // Make the script path absolute.
+            scriptPath = scriptPath.MakeAbsolute(_environment);
+
             // Prepare the environment.
-            _environment.WorkingDirectory = scriptPath.MakeAbsolute(_environment).GetDirectory();
+            _environment.WorkingDirectory = scriptPath.GetDirectory();
 
             // Analyze the script file.
             _log.Verbose("Analyzing build script...");


### PR DESCRIPTION
When passing a relative path to a script not in the same
directory as the bootstrapper, tools would be installed in
the wrong directory.

Closes #867