### PR TITLE
GH879: Tests for the Project file Parser

### DIFF
--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Fixtures\Build\JenkinsInfoFixture.cs" />
     <Compile Include="Fixtures\Build\TravisCIFixture.cs" />
     <Compile Include="Fixtures\Build\TravisCIInfoFixture.cs" />
+    <Compile Include="Fixtures\Solution\Project\ProjectParserFixture.cs" />
     <Compile Include="Fixtures\Tools\CakeRunnerFixture.cs" />
     <Compile Include="Fixtures\IO\FileCopyFixture.cs" />
     <Compile Include="Fixtures\IO\FileDeleteFixture.cs" />
@@ -217,6 +218,7 @@
     <Compile Include="Unit\IO\Paths\ConvertableDirectoryPathTests.cs" />
     <Compile Include="Unit\IO\Paths\ConvertableFilePathTests.cs" />
     <Compile Include="Unit\Security\FileHashCalculatorTests.cs" />
+    <Compile Include="Unit\Solution\Project\ProjectParserTests.cs" />
     <Compile Include="Unit\Solution\Project\Properties\AssemblyInfoCreatorTests.cs" />
     <Compile Include="Unit\Solution\Project\Properties\AssemblyInfoParserTests.cs" />
     <Compile Include="Unit\Diagnostics\LoggingAliasesTests.cs" />

--- a/src/Cake.Common.Tests/Fixtures/Solution/Project/ProjectParserFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Solution/Project/ProjectParserFixture.cs
@@ -1,0 +1,51 @@
+﻿using Cake.Common.Solution.Project;
+using Cake.Common.Tests.Properties;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using Cake.Testing;
+using NSubstitute;
+
+namespace Cake.Common.Tests.Fixtures.Solution.Project
+{
+    internal sealed class ProjectParserFixture
+    {
+        public ProjectParserFixture()
+        {
+            ProjFilePath = "/Working/Cake.Sample.csproj";
+            Pattern = "/Working/Cake.*.csproj";
+
+            var environment = FakeEnvironment.CreateUnixEnvironment();
+            Environment = environment;
+            var fileSystem = new FakeFileSystem(environment);
+            fileSystem.CreateFile(ProjFilePath.FullPath).SetContent(Resources.Csproj_ProjectFile);
+            fileSystem.CreateFile("/Working/Cake.Incomplete.csproj").SetContent(Resources.Csproj_IncompleteFile);
+            FileSystem = fileSystem;
+
+            Globber = Substitute.For<IGlobber>();
+            Globber.GetFiles(Pattern).Returns(new FilePath[] { "/Working/Cake.Sample.csproj", "/Working/Cake.Incomplete.csproj" });
+
+            Log = Substitute.For<ICakeLog>();
+        }
+
+        public ICakeEnvironment Environment { get; set; }
+
+        public ProjectParserResult Parse()
+        {
+            var parser = new ProjectParser(FileSystem, Environment);
+            return parser.Parse(ProjFilePath);
+        }
+
+        public ProjectParserResult ParseIncomplete()
+        {
+            var parser = new ProjectParser(FileSystem, Environment);
+            return parser.Parse("/Working/Cake.Incomplete.csproj");
+        }
+
+        public string Pattern { get; set; }
+        public IFileSystem FileSystem { get; set; }
+        public IGlobber Globber { get; set; }
+        public ICakeLog Log { get; set; }
+        public FilePath ProjFilePath { get; set; }
+    }
+}

--- a/src/Cake.Common.Tests/Properties/Resources.Designer.cs
+++ b/src/Cake.Common.Tests/Properties/Resources.Designer.cs
@@ -146,6 +146,34 @@ namespace Cake.Common.Tests.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &lt;Project ToolsVersion=&quot;12.0&quot; DefaultTargets=&quot;Build&quot; xmlns=&quot;http://schemas.microsoft.com/developer/msbuild/2003&quot;&gt;
+        ///  &lt;Import Project=&quot;$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props&quot; Condition=&quot;Exists(&apos;$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props&apos;)&quot; /&gt;
+        ///  &lt;PropertyGroup&gt;
+        ///    &lt;MinimumVisualStudioVersion&gt;11.0&lt;/MinimumVisualStudioVersion&gt;
+        ///    &lt;Configuration Condition=&quot; &apos;$(Configuration)&apos; == &apos;&apos; &quot;&gt;Debug&lt;/Configuration&gt;
+        ///    &lt;Platform Condition=&quot; &apos;$(Platform)&apos; ==  [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string Csproj_IncompleteFile {
+            get {
+                return ResourceManager.GetString("Csproj_IncompleteFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;Project ToolsVersion=&quot;12.0&quot; DefaultTargets=&quot;Build&quot; xmlns=&quot;http://schemas.microsoft.com/developer/msbuild/2003&quot;&gt;
+        ///  &lt;Import Project=&quot;$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props&quot; Condition=&quot;Exists(&apos;$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props&apos;)&quot; /&gt;
+        ///  &lt;PropertyGroup&gt;
+        ///    &lt;MinimumVisualStudioVersion&gt;11.0&lt;/MinimumVisualStudioVersion&gt;
+        ///    &lt;Configuration Condition=&quot; &apos;$(Configuration)&apos; == &apos;&apos; &quot;&gt;Debug&lt;/Configuration&gt;
+        ///    &lt;Platform Condition=&quot; &apos;$(Platform)&apos; ==  [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string Csproj_ProjectFile {
+            get {
+                return ResourceManager.GetString("Csproj_ProjectFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;
         ///&lt;DuplicatesReport ToolsVersion=&quot;103.0&quot;&gt;
         ///  &lt;Statistics&gt;

--- a/src/Cake.Common.Tests/Properties/Resources.resx
+++ b/src/Cake.Common.Tests/Properties/Resources.resx
@@ -659,4 +659,87 @@ Line #3]]&gt;&lt;/releaseNotes&gt;
   --&gt;
 &lt;/Project&gt;</value>
   </data>
+  <data name="Csproj_IncompleteFile" xml:space="preserve">
+    <value>&lt;Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"&gt;
+  &lt;Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" /&gt;
+  &lt;PropertyGroup&gt;
+    &lt;MinimumVisualStudioVersion&gt;11.0&lt;/MinimumVisualStudioVersion&gt;
+    &lt;Configuration Condition=" '$(Configuration)' == '' "&gt;Debug&lt;/Configuration&gt;
+    &lt;Platform Condition=" '$(Platform)' == '' "&gt;AnyCPU&lt;/Platform&gt;
+    &lt;ProjectGuid&gt;{864BC2C5-0E27-47EC-B103-0AC11FE40C5B}&lt;/ProjectGuid&gt;
+    &lt;OutputType&gt;Library&lt;/OutputType&gt;
+    &lt;AppDesignerFolder&gt;Properties&lt;/AppDesignerFolder&gt;
+    &lt;RootNamespace&gt;Cake.Common&lt;/RootNamespace&gt;
+	&lt;AssemblyName&gt;Cake.Common&lt;/AssemblyName&gt;
+    &lt;DefaultLanguage&gt;en-US&lt;/DefaultLanguage&gt;
+    &lt;FileAlignment&gt;512&lt;/FileAlignment&gt;
+    &lt;ProjectTypeGuids&gt;{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}&lt;/ProjectTypeGuids&gt;
+    &lt;TargetFrameworkVersion&gt;v4.5&lt;/TargetFrameworkVersion&gt;
+  &lt;/PropertyGroup&gt;
+  &lt;PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "&gt;
+    &lt;DebugSymbols&gt;true&lt;/DebugSymbols&gt;
+    &lt;DebugType&gt;full&lt;/DebugType&gt;
+    &lt;Optimize&gt;false&lt;/Optimize&gt;
+    &lt;OutputPath&gt;bin\Debug\&lt;/OutputPath&gt;
+    &lt;DefineConstants&gt;DEBUG;TRACE&lt;/DefineConstants&gt;
+    &lt;ErrorReport&gt;prompt&lt;/ErrorReport&gt;
+    &lt;WarningLevel&gt;4&lt;/WarningLevel&gt;
+  &lt;/PropertyGroup&gt;
+  &lt;PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "&gt;
+    &lt;DebugType&gt;pdbonly&lt;/DebugType&gt;
+    &lt;Optimize&gt;true&lt;/Optimize&gt;
+    &lt;OutputPath&gt;bin\Release\&lt;/OutputPath&gt;
+    &lt;DefineConstants&gt;TRACE&lt;/DefineConstants&gt;
+    &lt;ErrorReport&gt;prompt&lt;/ErrorReport&gt;
+    &lt;WarningLevel&gt;4&lt;/WarningLevel&gt;
+  &lt;/PropertyGroup&gt;
+  &lt;ItemGroup&gt;
+    &lt;Compile Include="Properties\AssemblyInfo.cs" /&gt;
+    &lt;Compile Include="Class1.cs" /&gt;
+  &lt;/ItemGroup&gt;
+  &lt;Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" /&gt;
+&lt;/Project&gt;</value>
+  </data>
+  <data name="Csproj_ProjectFile" xml:space="preserve">
+    <value>&lt;Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"&gt;
+  &lt;Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" /&gt;
+  &lt;PropertyGroup&gt;
+    &lt;MinimumVisualStudioVersion&gt;11.0&lt;/MinimumVisualStudioVersion&gt;
+    &lt;Configuration Condition=" '$(Configuration)' == '' "&gt;Debug&lt;/Configuration&gt;
+    &lt;Platform Condition=" '$(Platform)' == '' "&gt;AnyCPU&lt;/Platform&gt;
+    &lt;ProjectGuid&gt;{864BC2C5-0E27-47EC-B103-0AC11FE40C5B}&lt;/ProjectGuid&gt;
+    &lt;OutputType&gt;Library&lt;/OutputType&gt;
+    &lt;AppDesignerFolder&gt;Properties&lt;/AppDesignerFolder&gt;
+    &lt;RootNamespace&gt;Cake.Common&lt;/RootNamespace&gt;
+    &lt;AssemblyName&gt;Cake.Common&lt;/AssemblyName&gt;
+    &lt;DefaultLanguage&gt;en-US&lt;/DefaultLanguage&gt;
+    &lt;FileAlignment&gt;512&lt;/FileAlignment&gt;
+    &lt;ProjectTypeGuids&gt;{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}&lt;/ProjectTypeGuids&gt;
+    &lt;TargetFrameworkProfile&gt;Profile111&lt;/TargetFrameworkProfile&gt;
+    &lt;TargetFrameworkVersion&gt;v4.5&lt;/TargetFrameworkVersion&gt;
+  &lt;/PropertyGroup&gt;
+  &lt;PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "&gt;
+    &lt;DebugSymbols&gt;true&lt;/DebugSymbols&gt;
+    &lt;DebugType&gt;full&lt;/DebugType&gt;
+    &lt;Optimize&gt;false&lt;/Optimize&gt;
+    &lt;OutputPath&gt;bin\Debug\&lt;/OutputPath&gt;
+    &lt;DefineConstants&gt;DEBUG;TRACE&lt;/DefineConstants&gt;
+    &lt;ErrorReport&gt;prompt&lt;/ErrorReport&gt;
+    &lt;WarningLevel&gt;4&lt;/WarningLevel&gt;
+  &lt;/PropertyGroup&gt;
+  &lt;PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "&gt;
+    &lt;DebugType&gt;pdbonly&lt;/DebugType&gt;
+    &lt;Optimize&gt;true&lt;/Optimize&gt;
+    &lt;OutputPath&gt;bin\Release\&lt;/OutputPath&gt;
+    &lt;DefineConstants&gt;TRACE&lt;/DefineConstants&gt;
+    &lt;ErrorReport&gt;prompt&lt;/ErrorReport&gt;
+    &lt;WarningLevel&gt;4&lt;/WarningLevel&gt;
+  &lt;/PropertyGroup&gt;
+  &lt;ItemGroup&gt;
+    &lt;Compile Include="Properties\AssemblyInfo.cs" /&gt;
+    &lt;Compile Include="Class1.cs" /&gt;
+  &lt;/ItemGroup&gt;
+  &lt;Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" /&gt;
+&lt;/Project&gt;</value>
+  </data>
 </root>

--- a/src/Cake.Common.Tests/Unit/Solution/Project/ProjectParserTests.cs
+++ b/src/Cake.Common.Tests/Unit/Solution/Project/ProjectParserTests.cs
@@ -1,0 +1,193 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Cake.Common.Solution.Project;
+using Cake.Common.Tests.Fixtures.Solution.Project;
+using Cake.Core;
+using Cake.Core.IO;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Solution.Project
+{
+    public sealed class ProjectParserTests
+    {
+        public sealed class TheConstructor
+        {
+            [Fact]
+            public void Should_Throw_If_File_System_Is_Null()
+            {
+                // Given
+                var environment = Substitute.For<ICakeEnvironment>();
+
+                // When
+                var result = Record.Exception(() => new ProjectParser(null, environment));
+
+                // Then
+                Assert.IsArgumentNullException(result, "fileSystem");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Environment_Is_Null()
+            {
+                // Given
+                var fileSystem = Substitute.For<IFileSystem>();
+
+                // When
+                var result = Record.Exception(() => new ProjectParser(fileSystem, null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "environment");
+            }
+        }
+
+        [Fact]
+        public void Should_Return_Parser_Result()
+        {
+            // Given
+            var fixture = new ProjectParserFixture();
+
+            // When
+            var result = fixture.Parse();
+
+            // Then
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public void Should_Parse_Framework_Version()
+        {
+            // Given
+            var fixture = new ProjectParserFixture();
+
+            // When
+            var result = fixture.Parse();
+
+            // Then
+            Assert.Equal(result.TargetFrameworkVersion, "v4.5");
+        }
+
+        [Fact]
+        public void Should_Parse_Framework_Profile()
+        {
+            // Given
+            var fixture = new ProjectParserFixture();
+
+            // When
+            var result = fixture.Parse();
+
+            // Then
+            Assert.Equal("Profile111", result.TargetFrameworkProfile);
+        }
+
+        [Fact]
+        public void Should_Return_Null_When_Profile_Not_Defined()
+        {
+            // Given
+            var fixture = new ProjectParserFixture();
+
+            // When
+            var result = fixture.ParseIncomplete();
+
+            // Then
+            Assert.NotNull(result);
+            Assert.Null(result.TargetFrameworkProfile);
+        }
+
+        [Fact]
+        public void Should_Parse_Assembly_Name()
+        {
+            // Given
+            var fixture = new ProjectParserFixture();
+
+            // When
+            var result = fixture.Parse();
+
+            // Then
+            Assert.Equal(result.AssemblyName, "Cake.Common");
+        }
+
+        [Fact]
+        public void Should_Parse_Namespace()
+        {
+            // Given
+            var fixture = new ProjectParserFixture();
+
+            // When
+            var result = fixture.Parse();
+
+            // Then
+            Assert.Equal(result.RootNameSpace, "Cake.Common");
+        }
+
+        [Fact]
+        public void Should_Parse_Output_Type()
+        {
+            // Given
+            var fixture = new ProjectParserFixture();
+
+            // When
+            var result = fixture.Parse();
+
+            // Then
+            Assert.Equal(result.OutputType, "Library");
+        }
+
+        [Fact]
+        public void Should_Parse_Configuration()
+        {
+            // Given
+            var fixture = new ProjectParserFixture();
+
+            // When
+            var result = fixture.Parse();
+
+            // Then
+            Assert.Equal(result.Configuration, "Debug");
+        }
+
+        [Fact]
+        public void Should_Parse_Platform()
+        {
+            // Given
+            var fixture = new ProjectParserFixture();
+
+            // When
+            var result = fixture.Parse();
+
+            // Then
+            Assert.Equal(result.Platform, "AnyCPU");
+        }
+
+        [Fact]
+        public void Should_Return_Correct_File_Count()
+        {
+            // Given
+            var fixture = new ProjectParserFixture();
+
+            // When
+            var result = fixture.Parse();
+
+            // Then
+            Assert.Equal(2, result.Files.Count);
+        }
+
+        [Fact]
+        public void Should_Return_Valid_Guid()
+        {
+            // Given
+            var fixture = new ProjectParserFixture();
+
+            // When
+            var result = fixture.Parse();
+
+            // Then
+            var g = new Guid();
+            var parseResult = Guid.TryParseExact(result.ProjectGuid, "B", out g);
+            Assert.True(parseResult);
+            Assert.NotNull(g);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Solution/Project/ProjectParserTests.cs
+++ b/src/Cake.Common.Tests/Unit/Solution/Project/ProjectParserTests.cs
@@ -43,151 +43,154 @@ namespace Cake.Common.Tests.Unit.Solution.Project
             }
         }
 
-        [Fact]
-        public void Should_Return_Parser_Result()
+        public sealed class TheParseMethod
         {
-            // Given
-            var fixture = new ProjectParserFixture();
 
-            // When
-            var result = fixture.Parse();
+            [Fact]
+            public void Should_Return_Parser_Result()
+            {
+                // Given
+                var fixture = new ProjectParserFixture();
 
-            // Then
-            Assert.NotNull(result);
-        }
+                // When
+                var result = fixture.Parse();
 
-        [Fact]
-        public void Should_Parse_Framework_Version()
-        {
-            // Given
-            var fixture = new ProjectParserFixture();
+                // Then
+                Assert.NotNull(result);
+            }
 
-            // When
-            var result = fixture.Parse();
+            [Fact]
+            public void Should_Parse_Framework_Version()
+            {
+                // Given
+                var fixture = new ProjectParserFixture();
 
-            // Then
-            Assert.Equal(result.TargetFrameworkVersion, "v4.5");
-        }
+                // When
+                var result = fixture.Parse();
 
-        [Fact]
-        public void Should_Parse_Framework_Profile()
-        {
-            // Given
-            var fixture = new ProjectParserFixture();
+                // Then
+                Assert.Equal(result.TargetFrameworkVersion, "v4.5");
+            }
 
-            // When
-            var result = fixture.Parse();
+            [Fact]
+            public void Should_Parse_Framework_Profile()
+            {
+                // Given
+                var fixture = new ProjectParserFixture();
 
-            // Then
-            Assert.Equal("Profile111", result.TargetFrameworkProfile);
-        }
+                // When
+                var result = fixture.Parse();
 
-        [Fact]
-        public void Should_Return_Null_When_Profile_Not_Defined()
-        {
-            // Given
-            var fixture = new ProjectParserFixture();
+                // Then
+                Assert.Equal("Profile111", result.TargetFrameworkProfile);
+            }
 
-            // When
-            var result = fixture.ParseIncomplete();
+            [Fact]
+            public void Should_Return_Null_When_Profile_Not_Defined()
+            {
+                // Given
+                var fixture = new ProjectParserFixture();
 
-            // Then
-            Assert.NotNull(result);
-            Assert.Null(result.TargetFrameworkProfile);
-        }
+                // When
+                var result = fixture.ParseIncomplete();
 
-        [Fact]
-        public void Should_Parse_Assembly_Name()
-        {
-            // Given
-            var fixture = new ProjectParserFixture();
+                // Then
+                Assert.NotNull(result);
+                Assert.Null(result.TargetFrameworkProfile);
+            }
 
-            // When
-            var result = fixture.Parse();
+            [Fact]
+            public void Should_Parse_Assembly_Name()
+            {
+                // Given
+                var fixture = new ProjectParserFixture();
 
-            // Then
-            Assert.Equal(result.AssemblyName, "Cake.Common");
-        }
+                // When
+                var result = fixture.Parse();
 
-        [Fact]
-        public void Should_Parse_Namespace()
-        {
-            // Given
-            var fixture = new ProjectParserFixture();
+                // Then
+                Assert.Equal(result.AssemblyName, "Cake.Common");
+            }
 
-            // When
-            var result = fixture.Parse();
+            [Fact]
+            public void Should_Parse_Namespace()
+            {
+                // Given
+                var fixture = new ProjectParserFixture();
 
-            // Then
-            Assert.Equal(result.RootNameSpace, "Cake.Common");
-        }
+                // When
+                var result = fixture.Parse();
 
-        [Fact]
-        public void Should_Parse_Output_Type()
-        {
-            // Given
-            var fixture = new ProjectParserFixture();
+                // Then
+                Assert.Equal(result.RootNameSpace, "Cake.Common");
+            }
 
-            // When
-            var result = fixture.Parse();
+            [Fact]
+            public void Should_Parse_Output_Type()
+            {
+                // Given
+                var fixture = new ProjectParserFixture();
 
-            // Then
-            Assert.Equal(result.OutputType, "Library");
-        }
+                // When
+                var result = fixture.Parse();
 
-        [Fact]
-        public void Should_Parse_Configuration()
-        {
-            // Given
-            var fixture = new ProjectParserFixture();
+                // Then
+                Assert.Equal(result.OutputType, "Library");
+            }
 
-            // When
-            var result = fixture.Parse();
+            [Fact]
+            public void Should_Parse_Configuration()
+            {
+                // Given
+                var fixture = new ProjectParserFixture();
 
-            // Then
-            Assert.Equal(result.Configuration, "Debug");
-        }
+                // When
+                var result = fixture.Parse();
 
-        [Fact]
-        public void Should_Parse_Platform()
-        {
-            // Given
-            var fixture = new ProjectParserFixture();
+                // Then
+                Assert.Equal(result.Configuration, "Debug");
+            }
 
-            // When
-            var result = fixture.Parse();
+            [Fact]
+            public void Should_Parse_Platform()
+            {
+                // Given
+                var fixture = new ProjectParserFixture();
 
-            // Then
-            Assert.Equal(result.Platform, "AnyCPU");
-        }
+                // When
+                var result = fixture.Parse();
 
-        [Fact]
-        public void Should_Return_Correct_File_Count()
-        {
-            // Given
-            var fixture = new ProjectParserFixture();
+                // Then
+                Assert.Equal(result.Platform, "AnyCPU");
+            }
 
-            // When
-            var result = fixture.Parse();
+            [Fact]
+            public void Should_Return_Correct_File_Count()
+            {
+                // Given
+                var fixture = new ProjectParserFixture();
 
-            // Then
-            Assert.Equal(2, result.Files.Count);
-        }
+                // When
+                var result = fixture.Parse();
 
-        [Fact]
-        public void Should_Return_Valid_Guid()
-        {
-            // Given
-            var fixture = new ProjectParserFixture();
+                // Then
+                Assert.Equal(2, result.Files.Count);
+            }
 
-            // When
-            var result = fixture.Parse();
+            [Fact]
+            public void Should_Return_Valid_Guid()
+            {
+                // Given
+                var fixture = new ProjectParserFixture();
 
-            // Then
-            var g = new Guid();
-            var parseResult = Guid.TryParseExact(result.ProjectGuid, "B", out g);
-            Assert.True(parseResult);
-            Assert.NotNull(g);
+                // When
+                var result = fixture.Parse();
+
+                // Then
+                Guid projectGuid;
+                var parseResult = Guid.TryParseExact(result.ProjectGuid, "B", out projectGuid);
+                Assert.True(parseResult);
+            }
         }
     }
 }

--- a/src/Cake.Common/Solution/Project/ProjectParser.cs
+++ b/src/Cake.Common/Solution/Project/ProjectParser.cs
@@ -100,6 +100,10 @@ namespace Cake.Common.Solution.Project
                      TargetFrameworkVersion = propertyGroup
                          .Elements(ProjectXElement.TargetFrameworkVersion)
                          .Select(targetFrameworkVersion => targetFrameworkVersion.Value)
+                         .FirstOrDefault(),
+                     TargetFrameworkProfile = propertyGroup
+                         .Elements(ProjectXElement.TargetFrameworkProfile)
+                         .Select(targetFrameworkProfile => targetFrameworkProfile.Value)
                          .FirstOrDefault()
                  }).FirstOrDefault();
 
@@ -138,6 +142,7 @@ namespace Cake.Common.Solution.Project
                 projectProperties.RootNameSpace,
                 projectProperties.AssemblyName,
                 projectProperties.TargetFrameworkVersion,
+                projectProperties.TargetFrameworkProfile,
                 projectFiles);
         }
     }

--- a/src/Cake.Common/Solution/Project/ProjectParserResult.cs
+++ b/src/Cake.Common/Solution/Project/ProjectParserResult.cs
@@ -15,6 +15,7 @@ namespace Cake.Common.Solution.Project
         private readonly string _rootNameSpace;
         private readonly string _assemblyName;
         private readonly string _targetFrameworkVersion;
+        private readonly string _targetFrameworkProfile;
         private readonly ICollection<ProjectFile> _files;
 
         /// <summary>
@@ -81,6 +82,15 @@ namespace Cake.Common.Solution.Project
         }
 
         /// <summary>
+        /// Gets the compiler target framework profile.
+        /// </summary>
+        /// <value>The target framework profile.</value>
+        public string TargetFrameworkProfile
+        {
+            get { return _targetFrameworkProfile; }
+        }
+
+        /// <summary>
         /// Gets the project content files.
         /// </summary>
         /// <value>The files.</value>
@@ -99,6 +109,7 @@ namespace Cake.Common.Solution.Project
         /// <param name="rootNameSpace">The default root namespace.</param>
         /// <param name="assemblyName">Gets the build target assembly name.</param>
         /// <param name="targetFrameworkVersion">The compiler framework version.</param>
+        /// <param name="targetFrameworkProfile">The compiler framework profile.</param>
         /// <param name="files">The project content files.</param>
         public ProjectParserResult(
             string configuration,
@@ -108,6 +119,7 @@ namespace Cake.Common.Solution.Project
             string rootNameSpace,
             string assemblyName,
             string targetFrameworkVersion,
+            string targetFrameworkProfile,
             IEnumerable<ProjectFile> files)
         {
             _configuration = configuration;
@@ -117,6 +129,7 @@ namespace Cake.Common.Solution.Project
             _rootNameSpace = rootNameSpace;
             _assemblyName = assemblyName;
             _targetFrameworkVersion = targetFrameworkVersion;
+            _targetFrameworkProfile = targetFrameworkProfile;
             _files = files.ToList().AsReadOnly();
         }
     }

--- a/src/Cake.Common/Solution/Project/ProjectXElement.cs
+++ b/src/Cake.Common/Solution/Project/ProjectXElement.cs
@@ -58,6 +58,11 @@
         internal const string TargetFrameworkVersion = "{" + XmlNamespace + "}TargetFrameworkVersion";
 
         /// <summary>
+        /// Gets the namespace for the target framework version element.
+        /// </summary>
+        internal const string TargetFrameworkProfile = "{" + XmlNamespace + "}TargetFrameworkProfile";
+
+        /// <summary>
         /// Gets the namespace for the configuration element.
         /// </summary>
         internal const string Configuration = "{" + XmlNamespace + "}Configuration";


### PR DESCRIPTION
Adds unit tests (and an associated fixture) for the csproj file parser. Also adds support for the Target Framework Profile property in project files (crucial when working with PCLs and the Client profile).

First PR, so let me know if it needs work. Build script didn't highlight anything and I tried to base the tests off some existing ones where possible, so it should be alright from what I can tell.

Thanks!