### PR TITLE
GH874: To support Windows path with blanks, NSIS script file names must be w…

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/NSIS/MakeNSISRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NSIS/MakeNSISRunnerTests.cs
@@ -158,7 +158,7 @@ namespace Cake.Common.Tests.Unit.Tools.NSIS
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/DFoo=Bar /DTest /DTest2 /Working/Test.nsi", result.Args);
+                Assert.Equal("/DFoo=Bar /DTest /DTest2 \"/Working/Test.nsi\"", result.Args);
             }
 
             [Fact]
@@ -172,7 +172,7 @@ namespace Cake.Common.Tests.Unit.Tools.NSIS
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/NOCD /Working/Test.nsi", result.Args);
+                Assert.Equal("/NOCD \"/Working/Test.nsi\"", result.Args);
             }
 
             [Fact]
@@ -186,7 +186,7 @@ namespace Cake.Common.Tests.Unit.Tools.NSIS
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/NOCONFIG /Working/Test.nsi", result.Args);
+                Assert.Equal("/NOCONFIG \"/Working/Test.nsi\"", result.Args);
             }
         }
     }

--- a/src/Cake.Common/Tools/NSIS/MakeNSISRunner.cs
+++ b/src/Cake.Common/Tools/NSIS/MakeNSISRunner.cs
@@ -92,8 +92,8 @@ namespace Cake.Common.Tools.NSIS
                 builder.Append("/NOCONFIG");
             }
 
-            // Script file
-            builder.Append(scriptFile.MakeAbsolute(_environment).FullPath);
+            // Quoted Script file
+            builder.AppendQuoted(scriptFile.MakeAbsolute(_environment).FullPath);
 
             return builder;
         }


### PR DESCRIPTION
To support Windows path with blanks, NSIS script file names must be wrapped in double quotes. (Example: "C:\Path with blanks\setup.nsi")