### PR TITLE
GH894: Added new VSTest alias to support executing unit tests using the newer

### DIFF
--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Fixtures\Tools\DNU\DNUFixture.cs" />
     <Compile Include="Fixtures\Tools\DNU\Pack\DNUPackerFixture.cs" />
     <Compile Include="Fixtures\Tools\DNU\Restorer\DNURestorerFixture.cs" />
+    <Compile Include="Fixtures\Tools\VSTestRunnerFixture.cs" />
     <Compile Include="Fixtures\Tools\SpecFlow\StepDefinitionReport\SpecFlowStepDefinitionReporterFixture.cs" />
     <Compile Include="Fixtures\Tools\SpecFlow\TestExecutionReport\SpecFlowTestExecutionReporterFixture.cs" />
     <Compile Include="Fixtures\Tools\SpecFlow\SpecFlowFixture.cs" />
@@ -310,6 +311,7 @@
     <Compile Include="Unit\Tools\SpecFlow\TestExecutionReport\SpecFlowTestExecutionReporterTests.cs" />
     <Compile Include="Unit\Tools\TextTransform\TextTemplateAliasTests.cs" />
     <Compile Include="Unit\Tools\TextTransform\TextTransformRunnerTests.cs" />
+    <Compile Include="Unit\Tools\VSTest\VSTestRunnerTests.cs" />
     <Compile Include="Unit\Tools\WiX\LightRunnerTests.cs" />
     <Compile Include="Unit\Tools\WiX\CandleRunnerTests.cs" />
     <Compile Include="Unit\Tools\XBuild\XBuildSettingsExtensionsTests.cs" />

--- a/src/Cake.Common.Tests/Fixtures/Tools/VSTestRunnerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/VSTestRunnerFixture.cs
@@ -1,0 +1,30 @@
+﻿using Cake.Common.Tools.VSTest;
+using Cake.Core.IO;
+using Cake.Testing.Fixtures;
+using System.Collections.Generic;
+
+namespace Cake.Common.Tests.Fixtures.Tools
+{
+    internal sealed class VSTestRunnerFixture : ToolFixture<VSTestSettings>
+    {
+        public IEnumerable<FilePath> AssemblyPaths { get; set; }
+
+        public VSTestRunnerFixture()
+            : base("vstest.console.exe")
+        {
+            AssemblyPaths = new[] { new FilePath("./Test1.dll") };
+            Environment.SetSpecialPath(SpecialPath.ProgramFilesX86, "/ProgramFilesX86");
+        }
+
+        protected override FilePath GetDefaultToolPath(string toolFilename)
+        {
+            return new FilePath("/ProgramFilesX86/Microsoft Visual Studio 11.0/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe");
+        }
+
+        protected override void RunTool()
+        {
+            var tool = new VSTestRunner(FileSystem, Environment, ProcessRunner, Tools);
+            tool.Run(AssemblyPaths, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/VSTest/VSTestRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/VSTest/VSTestRunnerTests.cs
@@ -1,0 +1,244 @@
+﻿using Cake.Common.Tests.Fixtures.Tools;
+using Cake.Common.Tools.VSTest;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Testing;
+using Cake.Testing.Xunit;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.VSTest
+{
+    public sealed class VSTestRunnerTests
+    {
+        [Fact]
+        public void Should_Throw_If_Assembly_Path_Is_Null()
+        {
+            // Given
+            var fixture = new VSTestRunnerFixture();
+            fixture.AssemblyPaths = null;
+
+            // When
+            var result = Record.Exception(() => fixture.Run());
+
+            // Then
+            Assert.IsArgumentNullException(result, "assemblyPaths");
+        }
+
+        [Fact]
+        public void Should_Throw_If_Settings_Are_Null()
+        {
+            // Given
+            var fixture = new VSTestRunnerFixture();
+            fixture.Settings = null;
+
+            // When
+            var result = Record.Exception(() => fixture.Run());
+
+            // Then
+            Assert.IsArgumentNullException(result, "settings");
+        }
+
+        [Fact]
+        public void Should_Throw_If_Tool_Path_Was_Not_Found()
+        {
+            // Given
+            var fixture = new VSTestRunnerFixture();
+            fixture.GivenDefaultToolDoNotExist();
+
+            // When
+            var result = Record.Exception(() => fixture.Run());
+
+            // Then
+            Assert.IsType<CakeException>(result);
+            Assert.Equal("VSTest: Could not locate executable.", result.Message);
+        }
+
+        [Theory]
+        [InlineData("/bin/VSTest/vstest.console.exe", "/bin/VSTest/vstest.console.exe")]
+        [InlineData("./tools/VSTest/vstest.console.exe", "/Working/tools/VSTest/vstest.console.exe")]
+        public void Should_Use_VSTest_From_Tool_Path_If_Provided(string toolPath, string expected)
+        {
+            // Given
+            var fixture = new VSTestRunnerFixture();
+            fixture.Settings.ToolPath = toolPath;
+            fixture.GivenSettingsToolPathExist();
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            Assert.Equal(expected, result.Path.FullPath);
+        }
+
+        [WindowsTheory]
+        [InlineData("C:/VSTest/vstest.console.exe", "C:/VSTest/vstest.console.exe")]
+        public void Should_Use_VSTest_From_Tool_Path_If_Provided_On_Windows(string toolPath, string expected)
+        {
+            // Given
+            var fixture = new VSTestRunnerFixture();
+            fixture.Settings.ToolPath = toolPath;
+            fixture.GivenSettingsToolPathExist();
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            Assert.Equal(expected, result.Path.FullPath);
+        }
+
+        [Theory]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio 15.0/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio 14.0/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio 12.0/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio 11.0/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
+        public void Should_Use_Available_Tool_Path(string existingToolPath)
+        {
+            // Given
+            var fixture = new VSTestRunnerFixture();
+            fixture.GivenDefaultToolDoNotExist();
+            fixture.FileSystem.CreateFile(existingToolPath);
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            Assert.Equal(existingToolPath, result.Path.FullPath);
+        }
+
+        [Fact]
+        public void Should_Set_Working_Directory()
+        {
+            // Given
+            var fixture = new VSTestRunnerFixture();
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            Assert.Equal("/Working", result.Process.WorkingDirectory.FullPath);
+        }
+
+        [Fact]
+        public void Should_Throw_If_Process_Was_Not_Started()
+        {
+            // Given
+            var fixture = new VSTestRunnerFixture();
+            fixture.GivenProcessCannotStart();
+
+            // When
+            var result = Record.Exception(() => fixture.Run());
+
+            // Then
+            Assert.IsType<CakeException>(result);
+            Assert.Equal("VSTest: Process was not started.", result.Message);
+        }
+
+        [Fact]
+        public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+        {
+            // Given
+            var fixture = new VSTestRunnerFixture();
+            fixture.GivenProcessExitsWithCode(1);
+
+            // When
+            var result = Record.Exception(() => fixture.Run());
+
+            // Then
+            Assert.IsType<CakeException>(result);
+            Assert.Equal("VSTest: Process returned an error (exit code 1).", result.Message);
+        }
+
+        [Fact]
+        public void Should_Not_Use_Isolation_By_Default()
+        {
+            // Given
+            var fixture = new VSTestRunnerFixture();
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            Assert.Equal("\"/Working/Test1.dll\"", result.Args);
+        }
+
+        [Fact]
+        public void Should_Use_Isolation_If_Enabled_In_Settings()
+        {
+            // Given
+            var fixture = new VSTestRunnerFixture();
+            fixture.Settings.InIsolation = true;
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            Assert.Equal("\"/Working/Test1.dll\" /InIsolation", result.Args);
+        }
+
+        [Fact]
+        public void Should_Use_Logger_If_Provided()
+        {
+            //Given
+            var fixture = new VSTestRunnerFixture();
+            fixture.Settings.Logger = VSTestLogger.Trx;
+
+            //When
+            var result = fixture.Run();
+
+            Assert.Equal("\"/Working/Test1.dll\" /Logger:trx", result.Args);
+        }
+
+        [Fact]
+        public void Should_Use_SettingsFile_If_Provided()
+        {
+            //Given
+            var fixture = new VSTestRunnerFixture();
+            fixture.Settings.SettingsFile = new FilePath("Local.RunSettings");
+
+            //When
+            var result = fixture.Run();
+
+            Assert.Equal("\"/Working/Test1.dll\" /Settings:Local.RunSettings", result.Args);
+        }
+
+        [Fact]
+        public void Should_Use_PlatformArchitecture_If_Provided()
+        {
+            //Given
+            var fixture = new VSTestRunnerFixture();
+            fixture.Settings.PlatformArchitecture = VSTestPlatform.x64;
+
+            //When
+            var result = fixture.Run();
+
+            Assert.Equal("\"/Working/Test1.dll\" /Platform:x64", result.Args);
+        }
+
+        [Fact]
+        public void Should_Use_FrameworkVersion_If_Provided()
+        {
+            //Given
+            var fixture = new VSTestRunnerFixture();
+            fixture.Settings.FrameworkVersion = VSTestFrameworkVersion.NET40;
+
+            //When
+            var result = fixture.Run();
+
+            Assert.Equal("\"/Working/Test1.dll\" /Framework:Framework40", result.Args);
+        }
+
+        [Fact]
+        public void Should_Add_FilePath_For_Each_Assembly()
+        {
+            // Given
+            var fixture = new VSTestRunnerFixture();
+            fixture.AssemblyPaths = new[] { new FilePath("./Test1.dll"), new FilePath("./Test2.dll") };
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            Assert.Equal("\"/Working/Test1.dll\" \"/Working/Test2.dll\"", result.Args);
+        }
+    }
+}

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -362,6 +362,12 @@
     <Compile Include="Tools\TextTransform\TextTransformAliases.cs" />
     <Compile Include="Tools\TextTransform\TextTransformRunner.cs" />
     <Compile Include="Tools\TextTransform\TextTransformSettings.cs" />
+    <Compile Include="Tools\VSTest\VSTestAliases.cs" />
+    <Compile Include="Tools\VSTest\VSTestPlatform.cs" />
+    <Compile Include="Tools\VSTest\VSTestFrameworkVersion.cs" />
+    <Compile Include="Tools\VSTest\VSTestLogger.cs" />
+    <Compile Include="Tools\VSTest\VSTestRunner.cs" />
+    <Compile Include="Tools\VSTest\VSTestSettings.cs" />
     <Compile Include="Tools\WiX\Architecture.cs" />
     <Compile Include="Tools\WiX\CandleRunner.cs" />
     <Compile Include="Tools\WiX\CandleSettings.cs" />

--- a/src/Cake.Common/Tools/VSTest/VSTestAliases.cs
+++ b/src/Cake.Common/Tools/VSTest/VSTestAliases.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.VSTest
+{
+    /// <summary>
+    /// Contains functionality related to running VSTest unit tests.
+    /// </summary>
+    [CakeAliasCategory("VSTest")]
+    public static class VSTestAliases
+    {
+        /// <summary>
+        /// Runs all VSTest unit tests in the assemblies matching the specified pattern.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// VSTest("./Tests/*.UnitTests.dll");
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="pattern">The pattern.</param>
+        [CakeMethodAlias]
+        public static void VSTest(this ICakeContext context, string pattern)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var assemblies = context.Globber.GetFiles(pattern).ToArray();
+            if (assemblies.Length == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any files.");
+                return;
+            }
+
+            VSTest(context, assemblies);
+        }
+
+        /// <summary>
+        /// Runs all VSTest unit tests in the assemblies matching the specified pattern.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// VSTest("./Tests/*.UnitTests.dll", new VSTestSettings() { Logger = VSTestLogger.Trx });
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="pattern">The pattern.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        public static void VSTest(this ICakeContext context, string pattern, VSTestSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var assemblies = context.Globber.GetFiles(pattern).ToArray();
+            if (assemblies.Length == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any files.");
+                return;
+            }
+
+            VSTest(context, assemblies, settings);
+        }
+
+        /// <summary>
+        /// Runs all VSTest unit tests in the specified assemblies.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var paths = new List&lt;FilePath&gt;() { "./assemblydir1", "./assemblydir2" };
+        /// VSTest(paths);
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="assemblyPaths">The assembly paths.</param>
+        [CakeMethodAlias]
+        public static void VSTest(this ICakeContext context, IEnumerable<FilePath> assemblyPaths)
+        {
+            VSTest(context, assemblyPaths, new VSTestSettings());
+        }
+
+        /// <summary>
+        /// Runs all VSTest unit tests in the specified assemblies.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var paths = new List&lt;FilePath&gt;() { "./assemblydir1", "./assemblydir2" };
+        /// VSTest(paths, new VSTestSettings() { InIsolation = true });
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="assemblyPaths">The assembly paths.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        public static void VSTest(this ICakeContext context, IEnumerable<FilePath> assemblyPaths, VSTestSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            if (assemblyPaths == null)
+            {
+                throw new ArgumentNullException("assemblyPaths");
+            }
+
+            var runner = new VSTestRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            runner.Run(assemblyPaths, settings);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/VSTest/VSTestFrameworkVersion.cs
+++ b/src/Cake.Common/Tools/VSTest/VSTestFrameworkVersion.cs
@@ -1,0 +1,28 @@
+﻿namespace Cake.Common.Tools.VSTest
+{
+    /// <summary>
+    /// Target .NET Framework version to be used for test execution.
+    /// </summary>
+    public enum VSTestFrameworkVersion
+    {
+        /// <summary>
+        /// Use default .NET Framework version.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// .NET Framework version: <c>3.5</c>.
+        /// </summary>
+        NET35,
+
+        /// <summary>
+        /// .NET Framework version: <c>4.0</c>.
+        /// </summary>
+        NET40,
+
+        /// <summary>
+        /// .NET Framework version: <c>4.5</c>.
+        /// </summary>
+        NET45
+    }
+}

--- a/src/Cake.Common/Tools/VSTest/VSTestLogger.cs
+++ b/src/Cake.Common/Tools/VSTest/VSTestLogger.cs
@@ -1,0 +1,18 @@
+﻿namespace Cake.Common.Tools.VSTest
+{
+    /// <summary>
+    /// Loggers available for outputting test results.
+    /// </summary>
+    public enum VSTestLogger
+    {
+        /// <summary>
+        /// No logging of test results.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Log results to a Visual Studio test results file.
+        /// </summary>
+        Trx
+    }
+}

--- a/src/Cake.Common/Tools/VSTest/VSTestPlatform.cs
+++ b/src/Cake.Common/Tools/VSTest/VSTestPlatform.cs
@@ -1,0 +1,31 @@
+﻿namespace Cake.Common.Tools.VSTest
+{
+    /// <summary>
+    /// Target platform architecture to be used for test execution.
+    /// </summary>
+    public enum VSTestPlatform
+    {
+        /// <summary>
+        /// Use default platform architecture.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Platform architecture: <c>x86</c>.
+        /// </summary>
+        // ReSharper disable once InconsistentNaming
+        x86,
+
+        /// <summary>
+        /// Platform architecture: <c>x64</c>.
+        /// </summary>
+        // ReSharper disable once InconsistentNaming
+        x64,
+
+        /// <summary>
+        /// Platform architecture: <c>ARM</c>.
+        /// </summary>
+        // ReSharper disable once InconsistentNaming
+        ARM
+    }
+}

--- a/src/Cake.Common/Tools/VSTest/VSTestRunner.cs
+++ b/src/Cake.Common/Tools/VSTest/VSTestRunner.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.VSTest
+{
+    /// <summary>
+    /// The VSTest unit test runner.
+    /// Used by Visual Studio 2012 and newer.
+    /// </summary>
+    public sealed class VSTestRunner : Tool<VSTestSettings>
+    {
+        private readonly IFileSystem _fileSystem;
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VSTestRunner"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="toolLocator">The tool servce.</param>
+        public VSTestRunner(IFileSystem fileSystem, 
+            ICakeEnvironment environment, 
+            IProcessRunner processRunner,
+            IToolLocator toolLocator)
+            : base(fileSystem, environment, processRunner, toolLocator)
+        {
+            _fileSystem = fileSystem;
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Runs the tests in the specified assembly.
+        /// </summary>
+        /// <param name="assemblyPaths">The assembly path.</param>
+        /// <param name="settings">The settings.</param>
+        public void Run(IEnumerable<FilePath> assemblyPaths, VSTestSettings settings)
+        {
+            if (assemblyPaths == null)
+            {
+                throw new ArgumentNullException("assemblyPaths");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            base.Run(settings, GetArguments(assemblyPaths, settings));
+        }
+
+        private ProcessArgumentBuilder GetArguments(IEnumerable<FilePath> assemblyPaths, VSTestSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            // Add the assembly to build.
+            foreach (var assemblyPath in assemblyPaths)
+            {
+                builder.Append(assemblyPath.MakeAbsolute(_environment).FullPath.Quote());
+            }
+
+            if (settings.SettingsFile != null)
+            {
+                builder.Append(string.Format(CultureInfo.InvariantCulture, "/Settings:{0}", settings.SettingsFile));
+            }
+
+            if (settings.InIsolation)
+            {
+                builder.Append("/InIsolation");
+            }
+
+            if (settings.PlatformArchitecture != VSTestPlatform.Default)
+            {
+                builder.Append(string.Format(CultureInfo.InvariantCulture, "/Platform:{0}", settings.PlatformArchitecture));
+            }
+
+            if (settings.FrameworkVersion != VSTestFrameworkVersion.Default)
+            {
+                builder.Append(string.Format(CultureInfo.InvariantCulture, "/Framework:{0}", settings.FrameworkVersion.ToString().Replace("NET", "Framework")));
+            }
+
+            if (settings.Logger == VSTestLogger.Trx)
+            {
+                builder.Append("/Logger:trx");
+            }
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Gets the name of the tool.
+        /// </summary>
+        /// <returns>The tool name.</returns>
+        protected override string GetToolName()
+        {
+            return "VSTest";
+        }
+
+        /// <summary>
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return Enumerable.Empty<string>();
+        }
+
+        /// <summary>
+        /// Gets alternative file paths which the tool may exist in
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The default tool path.</returns>
+        protected override IEnumerable<FilePath> GetAlternativeToolPaths(VSTestSettings settings)
+        {
+            foreach (var version in new[] { "15.0", "14.0", "12.0", "11.0" })
+            {
+                var path = GetToolPath(version);
+                if (_fileSystem.Exist(path))
+                {
+                    yield return path;
+                }
+            }
+        }
+
+        private FilePath GetToolPath(string version)
+        {
+            var programFiles = _environment.GetSpecialPath(SpecialPath.ProgramFilesX86);
+            var root = programFiles.Combine(string.Concat("Microsoft Visual Studio ", version, "/Common7/IDE/CommonExtensions/Microsoft/TestWindow"));
+            return root.CombineWithFilePath("vstest.console.exe");
+        }
+    }
+}

--- a/src/Cake.Common/Tools/VSTest/VSTestSettings.cs
+++ b/src/Cake.Common/Tools/VSTest/VSTestSettings.cs
@@ -1,0 +1,41 @@
+﻿using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.VSTest
+{
+    /// <summary>
+    /// Contains settings used by <see cref="VSTestRunner"/>.
+    /// </summary>
+    public sealed class VSTestSettings : ToolSettings
+    {
+        /// <summary>
+        /// Gets or sets the settings filename to be used to control additional settings such as data collectors.
+        /// </summary>
+        public FilePath SettingsFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run tests within the vstest.console.exe process.
+        /// This makes vstest.console.exe process less likely to be stopped on an error in the tests, but tests might run slower.
+        /// Defaults to <c>false</c>.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if running in isolation; otherwise, <c>false</c>.
+        /// </value>
+        public bool InIsolation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the target platform architecture to be used for test execution.
+        /// </summary>
+        public VSTestPlatform PlatformArchitecture { get; set; }
+
+        /// <summary>
+        /// Gets or sets the target .NET Framework version to be used for test execution.
+        /// </summary>
+        public VSTestFrameworkVersion FrameworkVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets the logger to use for test results.
+        /// </summary>
+        public VSTestLogger Logger { get; set; }
+    }
+}


### PR DESCRIPTION
New feature request for consideration.

Update 5/17/2016: I just found the more detailed CONTRIBUTING.md doc (with the `Get buyoff or find open community issues or features` section). I can delete this pull request and create an issue first if preferred.

#### Overview
Visual Studio 2012 and newer introduces a new unit test runner (https://msdn.microsoft.com/en-us/library/jj155800.aspx). This runner can have some subtle differences when compared to MSTest.exe. This pull request allows the Cake build script to use the same runner as Visual Studio.

#### Example
```
VSTest("src/**bin/Release/*.Test.dll", new VSTestSettings { Logger = VsTestLogger.Trx });
```
