### PR TITLE
Added EnsureDirectoryExists alias

### DIFF
--- a/src/Cake.Common.Tests/Unit/IO/DirectoryAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/DirectoryAliasesTests.cs
@@ -499,6 +499,95 @@ namespace Cake.Common.Tests.Unit.IO
             }
         }
 
+        public sealed class TheEnsureExistsMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Context_Is_Null ()
+            {
+                // Given
+                var path = new DirectoryPath ("/Temp");
+
+                // When
+                var result = Record.Exception (() =>
+                     DirectoryAliases.EnsureDirectoryExists (null, path));
+
+                // Then
+                Assert.IsArgumentNullException (result, "context");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Directory_Is_Null ()
+            {
+                // Given
+                var context = Substitute.For<ICakeContext> ();
+
+                // When
+                var result = Record.Exception (() =>
+                     DirectoryAliases.EnsureDirectoryExists (context, null));
+
+                // Then
+                Assert.IsArgumentNullException (result, "path");
+            }
+
+            [Fact]
+            public void Should_Create_Non_Existing_Directory ()
+            {
+                // Given
+                var fileSystem = Substitute.For<IFileSystem> ();
+                var directory = Substitute.For<IDirectory> ();
+                directory.Exists.Returns (false);
+                fileSystem.GetDirectory (Arg.Is<DirectoryPath> (p => p.FullPath == "/Temp")).Returns (directory);
+
+                var context = Substitute.For<ICakeContext> ();
+                context.FileSystem.Returns (fileSystem);
+
+                // When
+                DirectoryAliases.EnsureDirectoryExists (context, "/Temp");
+
+                // Then
+                directory.Received (1).Create ();
+            }
+
+            [Fact]
+            public void Should_Not_Create_Directory_Or_Fail_If_It_Already_Exist ()
+            {
+                // Given
+                var fileSystem = Substitute.For<IFileSystem> ();
+                var directory = Substitute.For<IDirectory> ();
+                directory.Exists.Returns (true);
+                fileSystem.GetDirectory (Arg.Is<DirectoryPath> (p => p.FullPath == "/Temp")).Returns (directory);
+
+                var context = Substitute.For<ICakeContext> ();
+                context.FileSystem.Returns (fileSystem);
+
+                // When
+                DirectoryAliases.EnsureDirectoryExists (context, "/Temp");
+
+                // Then
+                directory.Received (0).Create ();
+            }
+
+            [Fact]
+            public void Should_Make_Relative_Path_Absolute ()
+            {
+                // Given
+                var fileSystem = Substitute.For<IFileSystem> ();
+                var context = Substitute.For<ICakeContext> ();
+                var environment = Substitute.For<ICakeEnvironment> ();
+                environment.WorkingDirectory.Returns ("/Temp");
+
+                context.FileSystem.Returns (fileSystem);
+                context.Environment.Returns (environment);
+
+                // When
+                DirectoryAliases.EnsureDirectoryExists (context, "Hello");
+
+                // Then
+                fileSystem.Received (1).GetDirectory (Arg.Is<DirectoryPath> (
+                    p => p.FullPath == "/Temp/Hello"));
+            }
+        }
+
         public sealed class TheDeleteDirectoryMethod
         {
             [Fact]

--- a/src/Cake.Common/IO/DirectoryAliases.cs
+++ b/src/Cake.Common/IO/DirectoryAliases.cs
@@ -285,6 +285,26 @@ namespace Cake.Common.IO
         {
             DirectoryCreator.Create(context, path);
         }
+        
+        /// <summary>
+        /// Creates the specified directory if it does not exist.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// EnsureDirectoryExists("publish");
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="path">The directory path.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Exists")]
+        public static void EnsureDirectoryExists(this ICakeContext context, DirectoryPath path)
+        {
+            if (!DirectoryExists(context, path))
+            {
+                CreateDirectory(context, path);
+            }
+        }
 
         /// <summary>
         /// Copies the contents of a directory to the specified location.


### PR DESCRIPTION
Simply wraps the DirectoryExists and CreateDirectory aliases to create a directory if it doesn't already exist.

This PR supersedes #822