### PR TITLE
Refactored Mono GetScriptHostProxy into base class

### DIFF
--- a/src/Cake/Cake.csproj
+++ b/src/Cake/Cake.csproj
@@ -163,6 +163,7 @@
     <Compile Include="Scripting\DescriptionScriptHost.cs" />
     <Compile Include="Scripting\DryRunExecutionStrategy.cs" />
     <Compile Include="Scripting\DryRunScriptHost.cs" />
+    <Compile Include="Scripting\Mono\CodeGen\CakeBuildScriptImplBase.cs" />
     <Compile Include="Scripting\Mono\CodeGen\Parsing\ScriptBuffer.cs" />
     <Compile Include="Scripting\Mono\CodeGen\Parsing\ScriptToken.cs" />
     <Compile Include="Scripting\Mono\CodeGen\Parsing\ScriptTokenizer.cs" />

--- a/src/Cake/Scripting/Mono/CodeGen/CakeBuildScriptImplBase.cs
+++ b/src/Cake/Scripting/Mono/CodeGen/CakeBuildScriptImplBase.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using Cake.Core;
+using Cake.Core.Scripting;
+
+namespace Cake.Scripting.Mono.CodeGen
+{
+    /// <summary>
+    /// Base class used for the Mono script code generation
+    /// </summary>
+    public class CakeBuildScriptImplBase : IScriptHost
+    {
+        /// <summary>
+        /// Gets the script host.
+        /// </summary>
+        /// <value>The script host.</value>
+        public IScriptHost ScriptHost { get; private set; }
+
+        /// <summary>
+        /// Gets the context.
+        /// </summary>
+        /// <value>The context.</value>
+        public ICakeContext Context
+        {
+            get { return ScriptHost.Context; }
+        }
+
+        /// <summary>
+        /// Gets all registered tasks.
+        /// </summary>
+        /// <value>The registered tasks.</value>
+        public IReadOnlyList<CakeTask> Tasks
+        {
+            get { return ScriptHost.Tasks; }
+        }
+
+        /// <summary>
+        /// Registers a new task.
+        /// </summary>
+        /// <param name="name">The name of the task.</param>
+        /// <returns>A <see cref="CakeTaskBuilder{ActionTask}"/>.</returns>
+        public CakeTaskBuilder<ActionTask> Task(string name)
+        {
+            return ScriptHost.Task(name);
+        }
+
+        /// <summary>
+        /// Allows registration of an action that's executed before any tasks are run.
+        /// If setup fails, no tasks will be executed but teardown will be performed.
+        /// </summary>
+        /// <param name="action">The action to be executed.</param>
+        [Obsolete("Please use Setup(Action<ICakeContext>) instead.", false)]
+        public void Setup(Action action)
+        {
+            ScriptHost.Setup(context => action());
+        }
+
+        /// <summary>
+        /// Allows registration of an action that's executed before any tasks are run.
+        /// If setup fails, no tasks will be executed but teardown will be performed.
+        /// </summary>
+        /// <param name="action">The action to be executed.</param>
+        public void Setup(Action<ICakeContext> action)
+        {
+            ScriptHost.Setup(action);
+        }
+
+        /// <summary>
+        /// Allows registration of an action that's executed after all other tasks have been run.
+        /// If a setup action or a task fails with or without recovery, the specified teardown action will still be executed.
+        /// </summary>
+        /// <param name="action">The action to be executed.</param>
+        [Obsolete("Please use Teardown(Action<ICakeContext>) instead.", false)]
+        public void Teardown(Action action)
+        {
+            ScriptHost.Teardown(context => action());
+        }
+
+        /// <summary>
+        /// Allows registration of an action that's executed after all other tasks have been run.
+        /// If a setup action or a task fails with or without recovery, the specified teardown action will still be executed.
+        /// </summary>
+        /// <param name="action">The action to be executed.</param>
+        public void Teardown(Action<ICakeContext> action)
+        {
+            ScriptHost.Teardown(action);
+        }
+
+        /// <summary>
+        /// Allows registration of an action that's executed before each task is run.
+        /// If the task setup fails, its task will not be executed but the task teardown will be performed.
+        /// </summary>
+        /// <param name="action">The action to be executed.</param>
+        public void TaskSetup(Action<ICakeContext, ITaskSetupContext> action)
+        {
+            ScriptHost.TaskSetup(action);
+        }
+
+        /// <summary>
+        /// Allows registration of an action that's executed after each task has been run.
+        /// If a task setup action or a task fails with or without recovery, the specified task teardown action will still be executed.
+        /// </summary>
+        /// <param name="action">The action to be executed.</param>
+        public void TaskTeardown(Action<ICakeContext, ITaskTeardownContext> action)
+        {
+            ScriptHost.TaskTeardown(action);
+        }
+
+        /// <summary>
+        /// Runs the specified target.
+        /// </summary>
+        /// <param name="target">The target to run.</param>
+        /// <returns>The resulting report.</returns>
+        public CakeReport RunTarget(string target)
+        {
+            return ScriptHost.RunTarget(target);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CakeBuildScriptImplBase"/> class.
+        /// </summary>
+        /// <param name="scriptHost">The script host.</param>
+        public CakeBuildScriptImplBase(IScriptHost scriptHost)
+        {
+            ScriptHost = scriptHost;
+        }
+    }
+}

--- a/src/Cake/Scripting/Mono/CodeGen/MonoCodeGenerator.cs
+++ b/src/Cake/Scripting/Mono/CodeGen/MonoCodeGenerator.cs
@@ -6,7 +6,7 @@ using Cake.Scripting.Mono.CodeGen.Parsing;
 
 namespace Cake.Scripting.Mono.CodeGen
 {
-    internal sealed class MonoCodeGenerator
+    internal static class MonoCodeGenerator
     {
         public static string Generate(Script script)
         {
@@ -25,16 +25,11 @@ namespace Cake.Scripting.Mono.CodeGen
                 code.AppendLine();
             }
 
-            code.AppendLine("public class CakeBuildScriptImpl");
+            code.AppendLine("public class CakeBuildScriptImpl : Cake.Scripting.Mono.CodeGen.CakeBuildScriptImplBase");
             code.AppendLine("{");
-            code.AppendLine("    public CakeBuildScriptImpl (IScriptHost scriptHost)");
-            code.AppendLine("    {");
-            code.AppendLine("        ScriptHost = scriptHost;");
-            code.AppendLine("    }");
+            code.AppendLine("    public CakeBuildScriptImpl (IScriptHost scriptHost):base(scriptHost) { }");
             code.AppendLine();
             code.AppendLine(GetAliasCode(script));
-            code.AppendLine();
-            code.AppendLine(GetScriptHostProxy());
             code.AppendLine();
 
             foreach (var block in blocks)
@@ -64,23 +59,6 @@ namespace Cake.Scripting.Mono.CodeGen
                     : PropertyAliasGenerator.Generate(alias.Method));
             }
             return string.Join("\r\n", result);
-        }
-
-        private static string GetScriptHostProxy()
-        {
-            // TODO: Generate this from interface.
-            var rules = new[]
-            {
-                "IScriptHost ScriptHost { get; set; }",
-                "ICakeContext Context { get { return ScriptHost.Context; } }",
-                "IReadOnlyList<CakeTask> Tasks { get { return ScriptHost.Tasks; } }",
-                "CakeTaskBuilder<ActionTask> Task(string name) { return ScriptHost.Task (name); }",
-                "void Setup (Action action) { ScriptHost.Setup (action); }",
-                "void Teardown(Action action) { ScriptHost.Teardown (action); }",
-                "CakeReport RunTarget(string target) { return ScriptHost.RunTarget (target); }"
-            };
-
-            return "    " + string.Join("\r\n    ", rules);
         }
     }
 }


### PR DESCRIPTION
* Added CakeBuildScriptImplBase base class that inherits from IScriptHost
* Removed GetScriptHostProxy() from CakeBuildScriptImpl
* Added so CakeBuildScriptImpl inherits from CakeBuildScriptImplBase

This fixes #883 and should ensure we avoid missing members in the future and reduces chance of  errors thru "dynamic" code not compiled with Cake.