### PR TITLE
GH895: Adds minClientVersion to support developmentDependency flag

### DIFF
--- a/nuspec/Cake.Common.nuspec
+++ b/nuspec/Cake.Common.nuspec
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd" minClientVersion="2.8">
     <id>Cake.Common</id>
     <version>0.0.0</version>
     <authors>Patrik Svensson</authors>


### PR DESCRIPTION
As recommended in #895