### PR TITLE
GH908: Add ability to upload test results when running under AppVeyor

### DIFF
--- a/src/Cake.Common.Tests/Unit/Build/AppVeyor/AppVeyorProviderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/AppVeyor/AppVeyorProviderTests.cs
@@ -198,5 +198,37 @@ namespace Cake.Common.Tests.Unit.Build.AppVeyor
                     Arg.Is<ProcessSettings>(p => p.Arguments.Render() == "UpdateBuild -Version \"build-123\""));
             }
         }
+
+        public sealed class TheUploadTestResultsMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Path_Is_Null()
+            {
+                // Given
+                var fixture = new AppVeyorFixture();
+                var appVeyor = fixture.CreateAppVeyorService();
+
+                // When
+                var result = Record.Exception(() => appVeyor.UploadTestResults(null, AppVeyorTestResultsType.XUnit));
+
+                // Then
+                Assert.IsArgumentNullException(result, "path");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Not_Running_On_AppVeyor()
+            {
+                // Given
+                var fixture = new AppVeyorFixture();
+                var appVeyor = fixture.CreateAppVeyorService();
+
+                // When
+                var result = Record.Exception(() => appVeyor.UploadTestResults("./file.xml", AppVeyorTestResultsType.XUnit));
+
+                // Then
+                Assert.IsExceptionWithMessage<CakeException>(result,
+                    "The current build is not running on AppVeyor.");
+            }
+        }
     }
 }

--- a/src/Cake.Common/Build/AppVeyor/AppVeyorTestResultsType.cs
+++ b/src/Cake.Common/Build/AppVeyor/AppVeyorTestResultsType.cs
@@ -1,0 +1,33 @@
+﻿namespace Cake.Common.Build.AppVeyor
+{
+    /// <summary>
+    /// Provides the known values for the AppVeyor test results types.
+    /// </summary>
+    public enum AppVeyorTestResultsType
+    {
+        /// <summary>
+        /// MSTest test results.
+        /// </summary>
+        MSTest,
+
+        /// <summary>
+        /// XUnit test results.
+        /// </summary>
+        XUnit,
+
+        /// <summary>
+        /// NUnit test results.
+        /// </summary>
+        NUnit,
+
+        /// <summary>
+        /// NUnit v3 test results.
+        /// </summary>
+        NUnit3,
+
+        /// <summary>
+        /// JUnit test results.
+        /// </summary>
+        JUnit
+    }
+}

--- a/src/Cake.Common/Build/AppVeyor/IAppVeyorProvider.cs
+++ b/src/Cake.Common/Build/AppVeyor/IAppVeyorProvider.cs
@@ -31,6 +31,13 @@ namespace Cake.Common.Build.AppVeyor
         void UploadArtifact(FilePath path);
 
         /// <summary>
+        /// Uploads test results XML file to AppVeyor. Results type can be one of the following: mstest, xunit, nunit, nunit3, junit.
+        /// </summary>
+        /// <param name="path">The file path of the test results XML to upload.</param>
+        /// <param name="resultsType">The results type. Can be mstest, xunit, nunit, nunit3 or junit.</param>
+        void UploadTestResults(FilePath path, AppVeyorTestResultsType resultsType);
+
+        /// <summary>
         /// Updates the build version.
         /// </summary>
         /// <param name="version">The new build version.</param>

--- a/src/Cake.Common/Build/BuildSystemAliases.cs
+++ b/src/Cake.Common/Build/BuildSystemAliases.cs
@@ -60,6 +60,8 @@ namespace Cake.Common.Build
         /// <param name="context">The context.</param>
         /// <returns>A <see cref="Cake.Common.Build.AppVeyor"/> instance.</returns>
         [CakePropertyAlias(Cache = true)]
+        [CakeNamespaceImport("Cake.Common.Build.AppVeyor")]
+        [CakeNamespaceImport("Cake.Common.Build.AppVeyor.Data")]
         public static IAppVeyorProvider AppVeyor(this ICakeContext context)
         {
             if (context == null)

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -53,6 +53,7 @@
     <Reference Include="System.IO.Compression.FileSystem" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Build\AppVeyor\AppVeyorTestResultsType.cs" />
     <Compile Include="Build\AppVeyor\Data\AppVeyorEnvironmentInfo.cs" />
     <Compile Include="Build\AppVeyor\AppVeyorInfo.cs" />
     <Compile Include="Build\AppVeyor\AppVeyorProvider.cs" />


### PR DESCRIPTION
This change adds an alias to the AppVeyor environment for uploading test results so that it integrates nicely with AppVeyor. This is supported by the AppVeyor API here: http://www.appveyor.com/docs/running-tests#uploading-xml-test-results

Currently test results display is supported by AppVeyor, but only if you use the test runners and framework using the `appveyor.yml` config.

This change allows tests to be run from Cake and then upload the outputted XML file to AppVeyor's test results page (see screenshot).

Fixes: #908 

![image](https://cloud.githubusercontent.com/assets/13191652/15473919/09a6f094-2135-11e6-80ab-5a788de88d74.png)