### PR TITLE
GH932: Added MD5 checking for packages.config to bootstrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ tools/nuget.exe
 tools/gitreleasemanager/
 tools/GitVersion.CommandLine/
 tools/Addins/
+tools/packages.config.md5sum
 
 # mstest test results
 TestResults


### PR DESCRIPTION
Added MD5 checking for packages.config to bootstrapper to ensure correct version of Cake is used.

@patriksvensson This is what we talked about in #922 

Not tested on OS X, ```md5sum``` is not standard on OS X, but ```md5``` is and by adding option ```-r``` it should print sum same way as Linux variant.

I made the checking/content of the hash file to be identical between Windows/Linux in order to use same file on both (tested with Bash for Windows)...