### PR TITLE
GH945: Fix dotnet restore settings

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Build/DotNetCoreBuilderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Build/DotNetCoreBuilderTests.cs
@@ -89,7 +89,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Build
             {
                 // Given
                 var fixture = new DotNetCoreBuilderFixture();
-                fixture.Settings.Frameworks = new[] { "net451", "dnxcore50" };
+                fixture.Settings.Framework = "net451";
                 fixture.Settings.Runtime = "runtime1";
                 fixture.Settings.Configuration = "Release";
                 fixture.Settings.VersionSuffix = "rc1";
@@ -99,7 +99,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Build
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("build ./src/* --runtime runtime1 --framework \"net451;dnxcore50\" --configuration Release --version-suffix rc1", result.Args);
+                Assert.Equal("build ./src/* --runtime runtime1 --framework net451 --configuration Release --version-suffix rc1", result.Args);
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Restore/DotNetCoreRestorerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Restore/DotNetCoreRestorerTests.cs
@@ -85,7 +85,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Restore
             {
                 // Given
                 var fixture = new DotNetCoreRestorerFixture();
-                fixture.Settings.Source = "https://www.example.com/source";
+                fixture.Settings.Sources = new[] { "https://www.example.com/source1", "https://www.example.com/source2" };
                 fixture.Settings.FallbackSources = new[] { "https://www.example.com/fallback1", "https://www.example.com/fallback2" };
                 fixture.Settings.Quiet = true;
                 fixture.Settings.NoCache = true;
@@ -101,13 +101,16 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Restore
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("restore" +
-                             " --packages \"/Working/packages\"" +
-                             " --source https://www.example.com/source" +
-                             " --fallbacksource \"https://www.example.com/fallback1;https://www.example.com/fallback2\"" +
-                             " --configfile \"/Working/NuGet.config\"" +
-                             " --infer-runtimes \"runtime1;runtime2\"" +
-                             " --quiet --no-cache --disable-parallel --ignore-failed-sources --force-english-output" +
+                Assert.Equal("restore" + 
+                             " --packages \"/Working/packages\"" + 
+                             " --source \"https://www.example.com/source1\"" + 
+                             " --source \"https://www.example.com/source2\"" + 
+                             " --fallbacksource \"https://www.example.com/fallback1\"" + 
+                             " --fallbacksource \"https://www.example.com/fallback2\"" + 
+                             " --configfile \"/Working/NuGet.config\"" + 
+                             " --infer-runtimes \"runtime1\"" +
+                             " --infer-runtimes \"runtime2\"" + 
+                             " --quiet --no-cache --disable-parallel --ignore-failed-sources --force-english-output" + 
                              " --verbosity Information", result.Args);
             }
         }

--- a/src/Cake.Common/Tools/DotNetCore/Build/DotNetCoreBuildSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Build/DotNetCoreBuildSettings.cs
@@ -29,9 +29,9 @@ namespace Cake.Common.Tools.DotNetCore.Build
         public string Configuration { get; set; }
 
         /// <summary>
-        /// Gets or sets specific frameworks to compile.
+        /// Gets or sets the specific framework to compile.
         /// </summary>
-        public ICollection<string> Frameworks { get; set; }
+        public string Framework { get; set; }
 
         /// <summary>
         /// Gets or sets the value that defines what `*` should be replaced with in version field in project.json.

--- a/src/Cake.Common/Tools/DotNetCore/Build/DotNetCoreBuilder.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Build/DotNetCoreBuilder.cs
@@ -80,11 +80,11 @@ namespace Cake.Common.Tools.DotNetCore.Build
                 builder.Append(settings.Runtime);
             }
 
-            // Frameworks
-            if (settings.Frameworks != null && settings.Frameworks.Count > 0)
+            // Framework
+            if (!string.IsNullOrEmpty(settings.Framework))
             {
                 builder.Append("--framework");
-                builder.AppendQuoted(string.Join(";", settings.Frameworks));
+                builder.Append(settings.Framework);
             }
 
             // Configuration

--- a/src/Cake.Common/Tools/DotNetCore/Restore/DotNetCoreRestoreSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Restore/DotNetCoreRestoreSettings.cs
@@ -9,9 +9,9 @@ namespace Cake.Common.Tools.DotNetCore.Restore
     public sealed class DotNetCoreRestoreSettings : DotNetCoreSettings
     {
         /// <summary>
-        /// Gets or sets the specified NuGet package source to use during the restore.
+        /// Gets or sets the specified NuGet package sources to use during the restore.
         /// </summary>
-        public string Source { get; set; }
+        public ICollection<string> Sources { get; set; }
 
         /// <summary>
         /// Gets or sets the NuGet configuration file to use.

--- a/src/Cake.Common/Tools/DotNetCore/Restore/DotNetCoreRestorer.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Restore/DotNetCoreRestorer.cs
@@ -62,18 +62,24 @@ namespace Cake.Common.Tools.DotNetCore.Restore
                 builder.AppendQuoted(settings.PackagesDirectory.MakeAbsolute(_environment).FullPath);
             }
 
-            // Source
-            if (!string.IsNullOrEmpty(settings.Source))
+            // Sources
+            if (settings.Sources != null)
             {
-                builder.Append("--source");
-                builder.Append(settings.Source);
+                foreach (var source in settings.Sources)
+                {
+                    builder.Append("--source");
+                    builder.AppendQuoted(source);
+                }
             }
 
             // List of fallback package sources
-            if (settings.FallbackSources != null && settings.FallbackSources.Count > 0)
+            if (settings.FallbackSources != null)
             {
-                builder.Append("--fallbacksource");
-                builder.AppendQuoted(string.Join(";", settings.FallbackSources));
+                foreach (var source in settings.FallbackSources)
+                {
+                    builder.Append("--fallbacksource");
+                    builder.AppendQuoted(source);
+                }
             }
 
             // Config file
@@ -84,10 +90,13 @@ namespace Cake.Common.Tools.DotNetCore.Restore
             }
 
             // List of runtime identifiers
-            if (settings.InferRuntimes != null && settings.InferRuntimes.Count > 0)
+            if (settings.InferRuntimes != null)
             {
-                builder.Append("--infer-runtimes");
-                builder.AppendQuoted(string.Join(";", settings.InferRuntimes));
+                foreach (var runtime in settings.InferRuntimes)
+                {
+                    builder.Append("--infer-runtimes");
+                    builder.AppendQuoted(runtime);
+                }
             }
 
             // Quiet


### PR DESCRIPTION
source, fallbacksource and inferedruntimes all allow multiple arguments by specifying the same arg multiple times.

Same fix as this: https://github.com/cake-build/cake/pull/838