### PR TITLE
GH930: Allow XmlPeek and XmlPoke in XML files with DOCTYPE

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/XmlPeekAliasesFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/XmlPeekAliasesFixture.cs
@@ -14,7 +14,7 @@ namespace Cake.Common.Tests.Fixtures
        public FilePath XmlPath { get; set; }
        public XmlPeekSettings Settings { get; set; }
 
-       public XmlPeekAliasesFixture(bool xmlExists = true)
+       public XmlPeekAliasesFixture(bool xmlExists = true, bool xmlWithDtd = false)
        {
            Settings = new XmlPeekSettings();
 
@@ -24,7 +24,8 @@ namespace Cake.Common.Tests.Fixtures
 
            if (xmlExists)
            {
-               var xmlFile = fileSystem.CreateFile("/Working/web.config").SetContent(Resources.XmlPeek_Xml);
+               string content = xmlWithDtd ? Resources.XmlPeek_Xml_Dtd : Resources.XmlPeek_Xml;
+               var xmlFile = fileSystem.CreateFile("/Working/web.config").SetContent(content);
                XmlPath = xmlFile.Path;
            }
 

--- a/src/Cake.Common.Tests/Fixtures/XmlPokeFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/XmlPokeFixture.cs
@@ -17,7 +17,7 @@ namespace Cake.Common.Tests.Fixtures
        public FilePath XmlPath { get; set; }
        public XmlPokeSettings Settings { get; set; }
 
-       public XmlPokeFixture(bool xmlExists = true)
+       public XmlPokeFixture(bool xmlExists = true, bool xmlWithDtd = false)
        {
            Settings = new XmlPokeSettings();
 
@@ -27,7 +27,8 @@ namespace Cake.Common.Tests.Fixtures
 
            if (xmlExists)
            {
-               var xmlFile = fileSystem.CreateFile("/Working/web.config").SetContent(Resources.XmlPoke_Xml);
+               string content = xmlWithDtd ? Resources.XmlPoke_Xml_Dtd : Resources.XmlPoke_Xml;
+               var xmlFile = fileSystem.CreateFile("/Working/web.config").SetContent(content);
                XmlPath = xmlFile.Path;
            }
 
@@ -43,6 +44,11 @@ namespace Cake.Common.Tests.Fixtures
            XmlPokeAliases.XmlPoke(Context, XmlPath, xpath, value, Settings);
        }
 
+       public string PokeString(string xml, string xpath, string value)
+       {
+           return XmlPokeAliases.XmlPokeString(Context, xml, xpath, value, Settings);
+       }
+
         public bool TestIsValue(string xpath, string value)
         {
             var xmlString = new StreamReader(FileSystem.GetFile(XmlPath).OpenRead()).ReadToEnd();
@@ -52,7 +58,7 @@ namespace Cake.Common.Tests.Fixtures
         public bool TestIsValue(string xml, string xpath, string value)
         {
             using (var reader = new StringReader(xml))
-            using (var xmlReader = XmlReader.Create(reader))
+            using (var xmlReader = XmlReader.Create(reader, GetXmlReaderSettings(Settings)))
             {
 
                 var document = new XmlDocument();
@@ -78,7 +84,7 @@ namespace Cake.Common.Tests.Fixtures
         public bool TestIsRemoved(string xml, string xpath)
         {
             using (var reader = new StringReader(xml))
-            using (var xmlReader = XmlReader.Create(reader))
+            using (var xmlReader = XmlReader.Create(reader, GetXmlReaderSettings(Settings)))
             {
 
                 var document = new XmlDocument();
@@ -93,6 +99,19 @@ namespace Cake.Common.Tests.Fixtures
                 var nodes = document.SelectNodes(xpath, namespaceManager);
                 return nodes != null && nodes.Count == 0;
             }
+        }
+
+        /// <summary>
+        /// Gets a XmlReaderSettings from a XmlPokeSettings
+        /// </summary>
+        /// <returns>The xml reader settings.</returns>
+        /// <param name="settings">Additional settings to tweak Xml Poke behavior.</param>
+        private static XmlReaderSettings GetXmlReaderSettings(XmlPokeSettings settings)
+        {
+            var xmlReaderSettings = new XmlReaderSettings();
+            xmlReaderSettings.DtdProcessing = (DtdProcessing)settings.DtdProcessing;
+
+            return xmlReaderSettings;
         }
     }
 }

--- a/src/Cake.Common.Tests/Properties/Resources.Designer.cs
+++ b/src/Cake.Common.Tests/Properties/Resources.Designer.cs
@@ -448,6 +448,23 @@ namespace Cake.Common.Tests.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
+        ///&lt;!DOCTYPE plist PUBLIC &quot;-//Apple//DTD PLIST 1.0//EN&quot; &quot;http://www.apple.com/DTDs/PropertyList-1.0.dtd&quot;&gt;
+        ///&lt;plist version=&quot;1.0&quot;&gt;
+        ///&lt;dict&gt;
+        ///    &lt;key&gt;CFBundleDisplayName&lt;/key&gt;
+        ///    &lt;string&gt;Cake&lt;/string&gt;
+        ///&lt;/dict&gt;
+        ///&lt;/plist&gt;
+        ///.
+        /// </summary>
+        internal static string XmlPeek_Xml_Dtd {
+            get {
+                return ResourceManager.GetString("XmlPeek_Xml_Dtd", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; ?&gt;
         ///&lt;configuration&gt;
         ///    &lt;appSettings&gt;
@@ -459,6 +476,22 @@ namespace Cake.Common.Tests.Properties {
         internal static string XmlPoke_Xml {
             get {
                 return ResourceManager.GetString("XmlPoke_Xml", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
+        ///&lt;!DOCTYPE plist PUBLIC &quot;-//Apple//DTD PLIST 1.0//EN&quot; &quot;http://www.apple.com/DTDs/PropertyList-1.0.dtd&quot;&gt;
+        ///&lt;plist version=&quot;1.0&quot;&gt;
+        ///&lt;dict&gt;
+        ///    &lt;key&gt;CFBundleDisplayName&lt;/key&gt;
+        ///    &lt;string&gt;Cake&lt;/string&gt;
+        ///&lt;/dict&gt;
+        ///&lt;/plist&gt;.
+        /// </summary>
+        internal static string XmlPoke_Xml_Dtd {
+            get {
+                return ResourceManager.GetString("XmlPoke_Xml_Dtd", resourceCulture);
             }
         }
         

--- a/src/Cake.Common.Tests/Properties/Resources.resx
+++ b/src/Cake.Common.Tests/Properties/Resources.resx
@@ -524,6 +524,17 @@ Line #3]]&gt;&lt;/releaseNotes&gt;
     &lt;/appSettings&gt;
 &lt;/configuration&gt;</value>
   </data>
+  <data name="XmlPoke_Xml_Dtd" xml:space="preserve">
+    <value>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
+&lt;!DOCTYPE plist PUBLIC &quot;-//Apple//DTD PLIST 1.0//EN&quot; &quot;http://www.apple.com/DTDs/PropertyList-1.0.dtd&quot;&gt;
+&lt;plist version=&quot;1.0&quot;&gt;
+&lt;dict&gt;
+	&lt;key&gt;CFBundleDisplayName&lt;/key&gt;
+	&lt;string&gt;Cake&lt;/string&gt;
+&lt;/dict&gt;
+&lt;/plist&gt;
+    </value>
+  </data>
   <data name="XmlPeek_Xml" xml:space="preserve">
     <value>&lt;?xml version="1.0" encoding="utf-8" ?&gt;
 &lt;configuration&gt;
@@ -534,6 +545,17 @@ Line #3]]&gt;&lt;/releaseNotes&gt;
     &lt;test&gt;test value&lt;/test&gt;
 &lt;/configuration&gt;
 </value>
+  </data>
+  <data name="XmlPeek_Xml_Dtd" xml:space="preserve">
+    <value>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
+&lt;!DOCTYPE plist PUBLIC &quot;-//Apple//DTD PLIST 1.0//EN&quot; &quot;http://www.apple.com/DTDs/PropertyList-1.0.dtd&quot;&gt;
+&lt;plist version=&quot;1.0&quot;&gt;
+&lt;dict&gt;
+	&lt;key&gt;CFBundleDisplayName&lt;/key&gt;
+	&lt;string&gt;Cake&lt;/string&gt;
+&lt;/dict&gt;
+&lt;/plist&gt;
+    </value>
   </data>
   <data name="XmlTransformation_Htm" xml:space="preserve">
     <value>&lt;?xml version="1.0" encoding="utf-8"?&gt;&lt;html&gt;&lt;body style="font-family:Arial;font-size:12pt;background-color:#EEEEEE"&gt;&lt;div style="background-color:teal;color:white;padding:4px"&gt;&lt;span style="font-weight:bold"&gt;Belgian Waffles

--- a/src/Cake.Common.Tests/Unit/XML/XmlPeekAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/XML/XmlPeekAliasesTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using Cake.Common.Tests.Fixtures;
+using Cake.Common.Xml;
 using Xunit;
 
 namespace Cake.Common.Tests.Unit.XML
@@ -47,6 +48,19 @@ namespace Cake.Common.Tests.Unit.XML
                 // Then
                 Assert.IsArgumentNullException(result, "xpath");
             }
+
+            [Fact]
+            public void Should_Throw_If_File_Has_Dtd()
+            {
+                // Given
+                var fixture = new XmlPeekAliasesFixture(xmlWithDtd: true);
+
+                // When
+                var result = Record.Exception(() => fixture.Peek("CFBundleDisplayName"));
+
+                // Then
+                Assert.IsType<System.Xml.XmlException>(result);
+            }
             
             [Fact]
             public void Should_Get_Attribute_Value()
@@ -72,6 +86,20 @@ namespace Cake.Common.Tests.Unit.XML
 
                 // Then
                 Assert.Equal("test value", result);
+            }
+
+            [Fact]
+            public void Should_Get_Node_Value_From_File_With_Dtd()
+            {
+                // Given
+                var fixture = new XmlPeekAliasesFixture(xmlWithDtd:true);
+                fixture.Settings.DtdProcessing = XmlDtdProcessing.Parse;
+
+                // When
+                var result = fixture.Peek("/plist/dict/key/text()");
+
+                // Then
+                Assert.Equal("CFBundleDisplayName", result);
             }
         }
     }

--- a/src/Cake.Common.Tests/Unit/XML/XmlPokeTests.cs
+++ b/src/Cake.Common.Tests/Unit/XML/XmlPokeTests.cs
@@ -1,6 +1,9 @@
 ﻿using System.IO;
 using Cake.Common.Tests.Fixtures;
+using Cake.Common.Xml;
 using Xunit;
+using Cake.Common.Tests.Properties;
+using System.Text;
 
 namespace Cake.Common.Tests.Unit.XML
 {
@@ -47,6 +50,32 @@ namespace Cake.Common.Tests.Unit.XML
                 // Then
                 Assert.IsArgumentNullException(result, "xpath");
             }
+
+            [Fact]
+            public void Should_Throw_If_Xml_File_Has_Dtd()
+            {
+                // Given
+                var fixture = new XmlPokeFixture(xmlWithDtd: true);
+
+                // When
+                var result = Record.Exception(() => fixture.Poke("/plist/dict/string/text()",""));
+
+                // Then
+                Assert.IsType<System.Xml.XmlException>(result);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Xml_String_Has_Dtd()
+            {
+                // Given
+                var fixture = new XmlPokeFixture(xmlExists:false);
+
+                // When
+                var result = Record.Exception(() => fixture.PokeString(Resources.XmlPoke_Xml_Dtd, "/plist/dict/string/text()",""));
+
+                // Then
+                Assert.IsType<System.Xml.XmlException>(result);
+            }
         }
 
         public sealed class Transform
@@ -61,9 +90,9 @@ namespace Cake.Common.Tests.Unit.XML
                 fixture.Poke("/configuration/appSettings/add[@key = 'server']/@value", "productionhost.somecompany.com");
 
                 // Then
-                fixture.TestIsValue(
+                Assert.True(fixture.TestIsValue(
                     "/configuration/appSettings/add[@key = 'server']/@value",
-                    "productionhost.somecompany.com");
+                    "productionhost.somecompany.com"));
             }
 
             [Fact]
@@ -76,8 +105,24 @@ namespace Cake.Common.Tests.Unit.XML
                 fixture.Poke("/configuration/appSettings/add[@key = 'server']", null);
 
                 // Then
-                fixture.TestIsRemoved(
-                    "/configuration/appSettings/add[@key = 'server']");
+                Assert.True(fixture.TestIsRemoved(
+                    "/configuration/appSettings/add[@key = 'server']"));
+            }
+
+            [Fact]
+            public void Should_Change_Attribute_From_Xml_File_With_Dtd()
+            {
+                // Given
+                var fixture = new XmlPokeFixture(xmlWithDtd:true);
+                fixture.Settings.DtdProcessing = XmlDtdProcessing.Parse;
+
+                // When
+                fixture.Poke("/plist/dict/string", "Cake Version");
+
+                // Then
+                Assert.True(fixture.TestIsValue(
+                    "/plist/dict/string/text()",
+                    "Cake Version"));
             }
         }
     }

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -409,6 +409,7 @@
     <Compile Include="Build\Bamboo\Data\BambooPlanInfo.cs" />
     <Compile Include="Xml\XmlPeekAliases.cs" />
     <Compile Include="Xml\XmlPeekSettings.cs" />
+    <Compile Include="Xml\XmlDtdProcessing.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cake.Core\Cake.Core.csproj">

--- a/src/Cake.Common/Xml/XmlDtdProcessing.cs
+++ b/src/Cake.Common/Xml/XmlDtdProcessing.cs
@@ -1,0 +1,25 @@
+﻿namespace Cake.Common.Xml
+{
+    /// <summary>
+    /// Speficies how will an XmlReader handle DTDs in the XML document.
+    /// </summary>
+    public enum XmlDtdProcessing 
+    {
+        /// <summary>
+        /// The XmlReader will throw an exception when it finds a 'DOCTYPE' markup.
+        /// </summary>
+        Prohibit,
+
+        /// <summary>
+        /// The DTD will be ignored. Any reference to a general entity in the XML document 
+        /// will cause an exception (except for the predefined entities &lt; &gt; &amp; &quot; and &apos;).
+        /// The DocumentType node will not be reported.
+        /// </summary>
+        Ignore,
+
+        /// <summary>
+        /// The DTD will be parsed and fully processed (entities expanded, default attributes added etc.)
+        /// </summary>
+        Parse,
+    }
+}

--- a/src/Cake.Common/Xml/XmlPeekAliases.cs
+++ b/src/Cake.Common/Xml/XmlPeekAliases.cs
@@ -71,15 +71,20 @@ namespace Cake.Common.Xml
             {
                 throw new ArgumentNullException("filePath");
             }
+
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
             
             var file = context.FileSystem.GetFile(filePath);
             if (!file.Exists)
             {
                 throw new FileNotFoundException("Source File not found.", file.Path.FullPath);
             }
-            
+
             using (var fileStream = file.Open(FileMode.Open, FileAccess.Read, FileShare.None))
-            using (var xmlReader = XmlReader.Create(fileStream))
+            using (var xmlReader = XmlReader.Create(fileStream, GetXmlReaderSettings(settings)))
             {
                 var xmlValue = XmlPeek(xmlReader, xpath, settings);
                 if (xmlValue == null)
@@ -127,6 +132,18 @@ namespace Cake.Common.Xml
             var node = document.SelectSingleNode(xpath, namespaceManager);
             
             return node != null ? node.Value : null;
+        }
+    
+        /// <summary>
+        /// Gets a XmlReaderSettings from a XmlPeekSettings
+        /// </summary>
+        /// <returns>The xml reader settings.</returns>
+        /// <param name="settings">Additional settings to tweak Xml Peek behavior.</param>
+        private static XmlReaderSettings GetXmlReaderSettings(XmlPeekSettings settings)
+        {
+            var xmlReaderSettings = new XmlReaderSettings();
+            xmlReaderSettings.DtdProcessing = (DtdProcessing)settings.DtdProcessing;
+            return xmlReaderSettings;
         }
     }
 }

--- a/src/Cake.Common/Xml/XmlPeekSettings.cs
+++ b/src/Cake.Common/Xml/XmlPeekSettings.cs
@@ -18,12 +18,18 @@ namespace Cake.Common.Xml
         public bool PreserveWhitespace { get; set; }
 
         /// <summary>
+        /// Gets or sets a value that determines the processing of DTDs.
+        /// </summary>
+        public XmlDtdProcessing DtdProcessing { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="XmlPeekSettings"/> class.
         /// </summary>
         public XmlPeekSettings()
         {
             PreserveWhitespace = true;
             Namespaces = new Dictionary<string, string>();
+            DtdProcessing = XmlDtdProcessing.Prohibit;
         }
     }
 }

--- a/src/Cake.Common/Xml/XmlPokeAliases.cs
+++ b/src/Cake.Common/Xml/XmlPokeAliases.cs
@@ -225,6 +225,11 @@ namespace Cake.Common.Xml
                 throw new ArgumentNullException("filePath");
             }
 
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
             var file = context.FileSystem.GetFile(filePath);
             if (!file.Exists)
             {
@@ -234,7 +239,7 @@ namespace Cake.Common.Xml
             using (var memoryStream = new MemoryStream())
             {
                 using (var fileStream = file.Open(FileMode.Open, FileAccess.Read, FileShare.None))
-                using (var xmlReader = XmlReader.Create(fileStream))
+                using (var xmlReader = XmlReader.Create(fileStream, GetXmlReaderSettings(settings)))
                 using (var xmlWriter = XmlWriter.Create(memoryStream))
                 {
                     XmlPoke(xmlReader, xmlWriter, xpath, value, settings);
@@ -495,7 +500,7 @@ namespace Cake.Common.Xml
 
             using (var resultStream = new MemoryStream())
             using (var fileReader = new StringReader(sourceXml))
-            using (var xmlReader = XmlReader.Create(fileReader))
+            using (var xmlReader = XmlReader.Create(fileReader, GetXmlReaderSettings(settings)))
             using (var xmlWriter = XmlWriter.Create(resultStream))
             {
                 XmlPoke(xmlReader, xmlWriter, xpath, value, settings);
@@ -570,6 +575,19 @@ namespace Cake.Common.Xml
             }
 
             document.Save(destination);
+        }
+
+        /// <summary>
+        /// Gets a XmlReaderSettings from a XmlPokeSettings
+        /// </summary>
+        /// <returns>The xml reader settings.</returns>
+        /// <param name="settings">Additional settings to tweak Xml Poke behavior.</param>
+        private static XmlReaderSettings GetXmlReaderSettings(XmlPokeSettings settings)
+        {
+            var xmlReaderSettings = new XmlReaderSettings();
+            xmlReaderSettings.DtdProcessing = (DtdProcessing)settings.DtdProcessing;
+
+            return xmlReaderSettings;
         }
     }
 }

--- a/src/Cake.Common/Xml/XmlPokeSettings.cs
+++ b/src/Cake.Common/Xml/XmlPokeSettings.cs
@@ -24,6 +24,11 @@ namespace Cake.Common.Xml
         public Encoding Encoding { get; set; }
 
         /// <summary>
+        /// Gets or sets a value that determines the processing of DTDs.
+        /// </summary>
+        public XmlDtdProcessing DtdProcessing { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="XmlPokeSettings"/> class.
         /// </summary>
         public XmlPokeSettings()
@@ -31,6 +36,7 @@ namespace Cake.Common.Xml
             PreserveWhitespace = true;
             Namespaces = new Dictionary<string, string>();
             Encoding = Encoding.UTF8;
+            DtdProcessing = XmlDtdProcessing.Prohibit;
         }
     }
 }


### PR DESCRIPTION
Added the DtdProcessing property to XmlPeekSettings and XmlPokeSettings class.
This property is used to instanciate a XmlReaderSettings used by XmlReader.Create to determine the processing of DTDs.

Relates to #930 