### PR TITLE
Fixes DotNetCoreTest() calling wrong method

### DIFF
--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -474,7 +474,7 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Test")]
         public static void DotNetCoreTest(this ICakeContext context)
         {
-            context.DotNetCoreRun(null, null);
+            context.DotNetCoreTest(null, null);
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes so [DotNetCoreTest()](https://github.com/cake-build/cake/blob/develop/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs#L475) calls [DotNetCoreTest(string project, DotNetCoreTestSettings settings)](https://github.com/cake-build/cake/blob/develop/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs#L517)
* Fixes #948