### PR TITLE
GH952: Refactor DotNetCore args string->ArgumentBuilder

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Run/DotNetCoreRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Run/DotNetCoreRunnerTests.cs
@@ -73,12 +73,12 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Run
                 // Given
                 var fixture = new DotNetCoreRunnerFixture();
                 fixture.Project = "./tools/tool/";
-                fixture.Arguments = "--args";
+                fixture.Arguments = "--args=\"value\"";
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("run --project \"./tools/tool/\" -- \"--args\"", result.Args);
+                Assert.Equal("run --project \"./tools/tool/\" -- --args=\"value\"", result.Args);
             }
 
             [Fact]

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -55,7 +55,7 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Execute")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Execute")]
-        public static void DotNetCoreExecute(this ICakeContext context, FilePath assemblyPath, string arguments)
+        public static void DotNetCoreExecute(this ICakeContext context, FilePath assemblyPath, ProcessArgumentBuilder arguments)
         {
             context.DotNetCoreExecute(assemblyPath, arguments, null);
         }
@@ -80,7 +80,7 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Execute")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Execute")]
-        public static void DotNetCoreExecute(this ICakeContext context, FilePath assemblyPath, string arguments, DotNetCoreSettings settings)
+        public static void DotNetCoreExecute(this ICakeContext context, FilePath assemblyPath, ProcessArgumentBuilder arguments, DotNetCoreSettings settings)
         {
             if (context == null)
             {
@@ -363,7 +363,7 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Run")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Run")]
-        public static void DotNetCoreRun(this ICakeContext context, string project, string arguments)
+        public static void DotNetCoreRun(this ICakeContext context, string project, ProcessArgumentBuilder arguments)
         {
             context.DotNetCoreRun(project, arguments, null);
         }
@@ -389,7 +389,7 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Run")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Run")]
-        public static void DotNetCoreRun(this ICakeContext context, string project, string arguments, DotNetCoreRunSettings settings)
+        public static void DotNetCoreRun(this ICakeContext context, string project, ProcessArgumentBuilder arguments, DotNetCoreRunSettings settings)
         {
             if (context == null)
             {

--- a/src/Cake.Common/Tools/DotNetCore/Execute/DotNetCoreExecutor.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Execute/DotNetCoreExecutor.cs
@@ -34,7 +34,7 @@ namespace Cake.Common.Tools.DotNetCore.Execute
         /// <param name="assemblyPath">The assembly path.</param>
         /// <param name="arguments">The arguments.</param>
         /// <param name="settings">The settings.</param>
-        public void Execute(FilePath assemblyPath, string arguments, DotNetCoreSettings settings)
+        public void Execute(FilePath assemblyPath, ProcessArgumentBuilder arguments, DotNetCoreSettings settings)
         {
             if (assemblyPath == null)
             {
@@ -48,16 +48,16 @@ namespace Cake.Common.Tools.DotNetCore.Execute
             Run(settings, GetArguments(assemblyPath, arguments, settings));
         }
 
-        private ProcessArgumentBuilder GetArguments(FilePath assemblyPath, string arguments, DotNetCoreSettings settings)
+        private ProcessArgumentBuilder GetArguments(FilePath assemblyPath, ProcessArgumentBuilder arguments, DotNetCoreSettings settings)
         {
             var builder = CreateArgumentBuilder(settings);
 
             assemblyPath = assemblyPath.IsRelative ? assemblyPath.MakeAbsolute(_environment) : assemblyPath;
             builder.Append(assemblyPath.FullPath);
 
-            if (!string.IsNullOrEmpty(arguments))
+            if (!arguments.IsNullOrEmpty())
             {
-                builder.Append(arguments);
+                arguments.CopyTo(builder);
             }
 
             return builder;

--- a/src/Cake.Common/Tools/DotNetCore/Run/DotNetCoreRunner.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Run/DotNetCoreRunner.cs
@@ -31,7 +31,7 @@ namespace Cake.Common.Tools.DotNetCore.Run
         /// <param name="project">The target project path.</param>
         /// <param name="arguments">The arguments.</param>
         /// <param name="settings">The settings.</param>
-        public void Run(string project, string arguments, DotNetCoreRunSettings settings)
+        public void Run(string project, ProcessArgumentBuilder arguments, DotNetCoreRunSettings settings)
         {
             if (settings == null)
             {
@@ -41,7 +41,7 @@ namespace Cake.Common.Tools.DotNetCore.Run
             Run(settings, GetArguments(project, arguments, settings));
         }
 
-        private ProcessArgumentBuilder GetArguments(string project, string arguments, DotNetCoreRunSettings settings)
+        private ProcessArgumentBuilder GetArguments(string project, ProcessArgumentBuilder arguments, DotNetCoreRunSettings settings)
         {
             var builder = CreateArgumentBuilder(settings);
 
@@ -68,10 +68,11 @@ namespace Cake.Common.Tools.DotNetCore.Run
                 builder.Append(settings.Configuration);
             }
 
-            if (!string.IsNullOrEmpty(arguments))
+            // Arguments
+            if (!arguments.IsNullOrEmpty())
             {
                 builder.Append("--");
-                builder.AppendQuoted(arguments);
+                arguments.CopyTo(builder);
             }
 
             return builder;

--- a/src/Cake.Core/Extensions/ProcessArgumentListExtensions.cs
+++ b/src/Cake.Core/Extensions/ProcessArgumentListExtensions.cs
@@ -380,5 +380,39 @@ namespace Cake.Core
             }
             return builder;
         }
+
+        /// <summary>
+        /// Indicates whether a <see cref="ProcessArgumentBuilder"/> is null or renders empty.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <returns><c>true</c> if <paramref name="builder"/> refers to a null or empty <see cref="ProcessArgumentBuilder"/>;
+        /// <c>false</c> if the <paramref name="builder"/>refers to non null or empty <see cref="ProcessArgumentBuilder"/></returns>
+        public static bool IsNullOrEmpty(this ProcessArgumentBuilder builder)
+        {
+            return builder == null || builder.Count == 0 || string.IsNullOrEmpty(builder.Render());
+        }
+
+        /// <summary>
+        /// Copies all the arguments of the source <see cref="ProcessArgumentBuilder"/> to target <see cref="ProcessArgumentBuilder"/>.
+        /// </summary>
+        /// <param name="source">The argument builder to copy from..</param>
+        /// <param name="target">The argument builder to copy to.</param>
+        public static void CopyTo(this ProcessArgumentBuilder source, ProcessArgumentBuilder target)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException("source");
+            }
+
+            if (target == null)
+            {
+                throw new ArgumentNullException("target");
+            }
+
+            foreach (var token in source)
+            {
+                target.Append(token);
+            }
+        }
     }
 }

--- a/src/Cake.Core/IO/ProcessArgumentBuilder.cs
+++ b/src/Cake.Core/IO/ProcessArgumentBuilder.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Cake.Core.IO.Arguments;
@@ -8,9 +10,17 @@ namespace Cake.Core.IO
     /// <summary>
     /// Utility for building process arguments.
     /// </summary>
-    public sealed class ProcessArgumentBuilder
+    public sealed class ProcessArgumentBuilder : IReadOnlyCollection<IProcessArgument>
     {
         private readonly List<IProcessArgument> _tokens;
+
+        /// <summary>
+        /// Gets the number of arguments contained in the <see cref="ProcessArgumentBuilder"/>.
+        /// </summary>
+        public int Count
+        {
+            get { return _tokens.Count; }
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ProcessArgumentBuilder"/> class.
@@ -102,6 +112,16 @@ namespace Cake.Core.IO
             var builder = new ProcessArgumentBuilder();
             builder.Append(new TextArgument(value));
             return builder;
+        }
+
+        IEnumerator<IProcessArgument> IEnumerable<IProcessArgument>.GetEnumerator()
+        {
+            return _tokens.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable)_tokens).GetEnumerator();
         }
     }
 }


### PR DESCRIPTION
This is a proposed fix for #952

Currently the DotNetCore DotNetCoreExecute and DotNetCoreRun uses a quoted single string for args, this breaks in some scenarios also wont allow filtering sensitive data.

This PR
* Refactors arguments from string to ProcessArgumentBuilder
  * This takes benefit from all ProcessArgumentBuilder extensions available
  * Enables RenderSafe to work for verbose logging
* Adds `CopyTo(ProcessArgumentBuilder target)` method to `ProcessArgumentBuilder`
  * This allows without exposing internals to append the content of one `ProcessArgumentBuilder` to another
* Adds an `IsEmpty()` method to `ProcessArgumentBuilder`
  * This indicates if `ProcessArgumentBuilder` has any args / would render empty.