### PR TITLE
Added AddiationalParameters to DotNetCoreTestSettings

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Test/DotNetCoreTesterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Test/DotNetCoreTesterTests.cs
@@ -97,6 +97,22 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Test
                 // Then
                 Assert.Equal("test --output \"/Working/artifacts\" --build-base-path \"/Working/temp\" --runtime runtime1 --framework dnxcore50 --configuration Release --no-build", result.Args);
             }
+
+            [Fact]
+            public void Should_Add_Additional_Parameters_If_Any()
+            {
+                // Given
+                var fixture = new DotNetCoreTesterFixture();
+                fixture.Settings.Configuration = "Release";
+                fixture.Settings.OutputDirectory = "./artifacts/";
+                fixture.Settings.AdditionalParameters.Add("--testresultfile", "testresult.xml");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("test --output \"/Working/artifacts\" --configuration Release --testresultfile testresult.xml", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTestSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTestSettings.cs
@@ -1,4 +1,5 @@
-﻿using Cake.Core.IO;
+﻿using System.Collections.Generic;
+using Cake.Core.IO;
 
 namespace Cake.Common.Tools.DotNetCore.Test
 {
@@ -7,6 +8,14 @@ namespace Cake.Common.Tools.DotNetCore.Test
     /// </summary>
     public sealed class DotNetCoreTestSettings : DotNetCoreSettings
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotNetCoreTestSettings"/> class
+        /// </summary>
+        public DotNetCoreTestSettings()
+        {
+            this.AdditionalParameters = new Dictionary<string, string>();
+        }
+
         /// <summary>
         /// Gets or sets the directory in which to place temporary outputs.
         /// </summary>
@@ -36,5 +45,10 @@ namespace Cake.Common.Tools.DotNetCore.Test
         /// Gets or sets a value indicating whether to not build the project before testing.
         /// </summary>
         public bool NoBuild { get; set; }
+
+        /// <summary>
+        /// Gets or sets the additional parameters to be sent to the test command
+        /// </summary>
+        public IDictionary<string, string> AdditionalParameters { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTester.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTester.cs
@@ -95,6 +95,15 @@ namespace Cake.Common.Tools.DotNetCore.Test
                 builder.Append("--no-build");
             }
 
+            foreach (var additionalParameter in settings.AdditionalParameters)
+            {
+                builder.Append(additionalParameter.Key);
+                if (!string.IsNullOrEmpty(additionalParameter.Value))
+                {
+                    builder.Append(additionalParameter.Value);
+                }
+            }
+
             return builder;
         }
     }


### PR DESCRIPTION
Please find a small PR which allow custom parameters to be sent to the DotNetCore test command.
Its allow the scenario where you need to pass specifics arguments for the test runner like the ```-xml resultsfile.xml``` for xunit.