### PR TITLE
GH966: Signtool: Add support for description URL (/du)

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/SignTool/SignToolSignRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/SignTool/SignToolSignRunnerTests.cs
@@ -1,4 +1,5 @@
-﻿using Cake.Common.Tests.Fixtures.Tools;
+﻿using System;
+using Cake.Common.Tests.Fixtures.Tools;
 using Cake.Core;
 using Cake.Testing;
 using Xunit;
@@ -243,6 +244,20 @@ namespace Cake.Common.Tests.Unit.Tools.SignTool
 
                 // Then
                 Assert.Equal("SIGN /t \"https://t.com/\" /f \"/Working/cert.pfx\" /p secret /d \"DescriptionTest\" \"/Working/a.dll\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Call_Sign_Tool_With_Correct_Parameters_With_DescriptionUri()
+            {
+                // Given
+                var fixture = new SignToolSignRunnerFixture();
+                fixture.Settings.DescriptionUri = new Uri("https://example.com");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("SIGN /t \"https://t.com/\" /f \"/Working/cert.pfx\" /p secret /du \"https://example.com/\" \"/Working/a.dll\"", result.Args);
             }
 
             [Fact]

--- a/src/Cake.Common/Tools/SignTool/SignToolSignRunner.cs
+++ b/src/Cake.Common/Tools/SignTool/SignToolSignRunner.cs
@@ -169,6 +169,13 @@ namespace Cake.Common.Tools.SignTool
                 builder.AppendQuoted(settings.Description);
             }
 
+            // Signed content expanded description URL.
+            if (settings.DescriptionUri != null)
+            {
+                builder.Append("/du");
+                builder.AppendQuoted(settings.DescriptionUri.AbsoluteUri);
+            }
+
             // Target Assembly to sign.
             builder.AppendQuoted(assemblyPath.MakeAbsolute(_environment).FullPath);
 

--- a/src/Cake.Common/Tools/SignTool/SignToolSignSettings.cs
+++ b/src/Cake.Common/Tools/SignTool/SignToolSignSettings.cs
@@ -33,5 +33,10 @@ namespace Cake.Common.Tools.SignTool
         /// Gets or sets the signed content's description.
         /// </summary>
         public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the signed content's expanded description URL.
+        /// </summary>
+        public Uri DescriptionUri { get; set; }
     }
 }


### PR DESCRIPTION
From https://msdn.microsoft.com/en-us/library/8s9b9yaz(v=vs.110).aspx#Anchor_3:
>/du _URL_ - Specifies a Uniform Resource Locator (URL) for the expanded description of the signed content.

Adds `SignToolSignSettings.DescriptionUri` and corresponding changes in `SignToolSignRunner`.