### PR TITLE
GH968: Added build label to exclusion list for GitReleaseManager

### DIFF
--- a/GitReleaseManager.yaml
+++ b/GitReleaseManager.yaml
@@ -3,3 +3,5 @@ issue-labels-include:
 - Feature
 - Improvement
 - Documentation
+issue-labels-exclude:
+- Build


### PR DESCRIPTION
Fixes #968 