### PR TITLE
Added support for skipautoprops flag to OpenCover

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/OpenCover/OpenCoverTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/OpenCover/OpenCoverTests.cs
@@ -256,6 +256,23 @@ namespace Cake.Common.Tests.Unit.Tools.OpenCover
                              "-returntargetcode:100 " +
                              "-output:\"/Working/result.xml\"", result.Args);
             }
+
+            [Fact]
+            public void Should_Append_SkipAutoProps()
+            {
+                // Given
+                var fixture = new OpenCoverFixture();
+                fixture.Settings.SkipAutoProps = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-target:\"/Working/tools/Test.exe\" " +
+                             "-targetargs:\"-argument\" " +
+                             "-skipautoprops " +
+                             "-register:user -output:\"/Working/result.xml\"", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverRunner.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverRunner.cs
@@ -127,6 +127,11 @@ namespace Cake.Common.Tools.OpenCover
                 builder.AppendSwitch("-excludebyfile", ":", filters.Quote());
             }
 
+            if (settings.SkipAutoProps)
+            {
+                builder.Append("-skipautoprops");
+            }
+
             builder.AppendSwitch("-register", ":", settings.Register);
 
             if (settings.ReturnTargetCodeOffset != null)

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverSettings.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverSettings.cs
@@ -47,6 +47,11 @@ namespace Cake.Common.Tools.OpenCover
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether or not auto-implemented properties should be skipped.
+        /// </summary>
+        public bool SkipAutoProps { get; set; }
+
+        /// <summary>
         /// Gets or sets the register option
         /// </summary>
         public string Register { get; set; }


### PR DESCRIPTION
Hi,

I noticed that the OpenCover tool didn't support the `-skipautoprops` flag that is documented in the [OpenCover Usage guide](https://github.com/opencover/opencover/wiki/Usage).

This pull request adds support for this flag to `OpenCoverSettings`. By default, it's false, so that the behaviour remains the same.

A unit test has been provided.