### PR TITLE
GH810: Support for octo push command, common Octopus base classes

### DIFF
--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Fixtures\Tools\DNU\DNUFixture.cs" />
     <Compile Include="Fixtures\Tools\DNU\Pack\DNUPackerFixture.cs" />
     <Compile Include="Fixtures\Tools\DNU\Restorer\DNURestorerFixture.cs" />
+    <Compile Include="Fixtures\Tools\OctopusDeployPusherFixture.cs" />
     <Compile Include="Fixtures\Tools\VSTestRunnerFixture.cs" />
     <Compile Include="Fixtures\Tools\SpecFlow\StepDefinitionReport\SpecFlowStepDefinitionReporterFixture.cs" />
     <Compile Include="Fixtures\Tools\SpecFlow\TestExecutionReport\SpecFlowTestExecutionReporterFixture.cs" />
@@ -301,6 +302,7 @@
     <Compile Include="Unit\Tools\NUnit\NUnitRunnerTests.cs" />
     <Compile Include="Unit\Tools\NUnit\NUnitSettingsTests.cs" />
     <Compile Include="Unit\Tools\OctopusDeploy\OctoCreateReleaseTests.cs" />
+    <Compile Include="Unit\Tools\OctopusDeploy\OctoPushTests.cs" />
     <Compile Include="Unit\Tools\OpenCover\OpenCoverTests.cs" />
     <Compile Include="Unit\Tools\ReportUnit\ReportUnitRunnerTests.cs" />
     <Compile Include="Unit\Tools\ReportGenerator\ReportGeneratorRunnerTests.cs" />

--- a/src/Cake.Common.Tests/Fixtures/Tools/OctopusDeployPusherFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/OctopusDeployPusherFixture.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System.Collections.Generic;
+using Cake.Common.Tools.OctopusDeploy;
+using Cake.Core.IO;
+using Cake.Testing.Fixtures;
+
+namespace Cake.Common.Tests.Fixtures.Tools
+{
+    internal sealed class OctopusDeployPusherFixture : ToolFixture<OctopusPushSettings>
+    {
+        internal string Server { get; set; }
+        internal string ApiKey { get; set; }
+        public List<FilePath> Packages { get; set; }
+
+        public OctopusDeployPusherFixture()
+            : base("Octo.exe")
+        {
+            Packages = new List<FilePath>
+            {
+                "MyPackage.1.0.0.zip",
+                "MyOtherPackage.1.0.1.nupkg"
+            };
+
+            Server = "http://octopus";
+            ApiKey = "API-12345";
+        }
+
+        protected override void RunTool()
+        {
+            var tool = new OctopusDeployPusher(FileSystem, Environment, ProcessRunner, Tools);
+            tool.PushPackage(Server, ApiKey, Packages == null ? null : Packages.ToArray(), Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctoPushTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctoPushTests.cs
@@ -1,0 +1,328 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System.Collections.Generic;
+using Cake.Testing;
+using Cake.Common.Tests.Fixtures.Tools;
+using Cake.Core.IO;
+using Cake.Testing.Xunit;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.OctopusDeploy
+{
+    public sealed class OctoPushTests
+    {
+        public sealed class TheBaseArgumentBuilder
+        {
+            [Fact]
+            public void Should_Throw_If_Server_Is_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployPusherFixture();
+                fixture.Server = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentException(result, "settings", "No server specified.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Api_Key_Is_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployPusherFixture();
+                fixture.ApiKey = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentException(result, "settings", "No API key specified.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Is_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployPusherFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Add_Username_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployPusherFixture();
+                fixture.Settings.Username = "mike123";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("push --package \"/Working/MyPackage.1.0.0.zip\" --package \"/Working/MyOtherPackage.1.0.1.nupkg\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--user \"mike123\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Password_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployPusherFixture();
+                fixture.Settings.Password = "secret";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("push --package \"/Working/MyPackage.1.0.0.zip\" --package \"/Working/MyOtherPackage.1.0.1.nupkg\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--pass \"secret\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Configuration_File_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployPusherFixture();
+                fixture.Settings.ConfigurationFile = "configFile.txt";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("push --package \"/Working/MyPackage.1.0.0.zip\" --package \"/Working/MyOtherPackage.1.0.1.nupkg\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--configFile \"/Working/configFile.txt\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Debug_Flag_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployPusherFixture();
+                fixture.Settings.EnableDebugLogging = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("push --package \"/Working/MyPackage.1.0.0.zip\" --package \"/Working/MyOtherPackage.1.0.1.nupkg\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--debug", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Ignore_Ssl_Errors_Flag_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployPusherFixture();
+                fixture.Settings.IgnoreSslErrors = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("push --package \"/Working/MyPackage.1.0.0.zip\" --package \"/Working/MyOtherPackage.1.0.1.nupkg\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--ignoreSslErrors", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Enable_Service_Messages_Flag_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployPusherFixture();
+                fixture.Settings.EnableServiceMessages = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("push --package \"/Working/MyPackage.1.0.0.zip\" --package \"/Working/MyOtherPackage.1.0.1.nupkg\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--enableServiceMessages", result.Args);
+            }
+        }
+        public sealed class ThePushPackageMethod
+        {
+            [Fact]
+            public void Should_Throw_If_No_Packages_Provided()
+            {
+                // Given
+                var fixture = new OctopusDeployPusherFixture();
+                fixture.Packages = new List<FilePath>();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "packagePaths");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Package_List_Is_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployPusherFixture();
+                fixture.Packages = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "packagePaths");
+            }
+
+            [Fact]
+            public void Should_Add_Single_Argument_For_Single_Package()
+            {
+                // Given
+                var fixture = new OctopusDeployPusherFixture();
+                fixture.Packages = new List<FilePath> { "MyPackage.1.0.0.zip" };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("push --package \"/Working/MyPackage.1.0.0.zip\" " +
+                             "--server http://octopus --apiKey API-12345", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Multiple_Arguments_For_Multiple_Packages()
+            {
+                // Given
+                var fixture = new OctopusDeployPusherFixture();
+                fixture.Packages = new List<FilePath>
+                {
+                    "MyPackage.1.0.0.zip",
+                    "MyOtherPackage.1.0.1.nupkg",
+                    "MyExtraPackage.1.0.1.nupkg"
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("push --package \"/Working/MyPackage.1.0.0.zip\" " +
+                             "--package \"/Working/MyOtherPackage.1.0.1.nupkg\" " +
+                             "--package \"/Working/MyExtraPackage.1.0.1.nupkg\" " +
+                             "--server http://octopus --apiKey API-12345", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Replace_Existing_Flag_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployPusherFixture();
+                fixture.Settings.ReplaceExisting = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("push --package \"/Working/MyPackage.1.0.0.zip\" " +
+                             "--package \"/Working/MyOtherPackage.1.0.1.nupkg\" " +
+                             "--replace-existing " +
+                             "--server http://octopus --apiKey API-12345", result.Args);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Octo_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new OctopusDeployPusherFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsCakeException(result, "Octo: Could not locate executable.");
+            }
+
+            [Theory]
+            [InlineData("/bin/tools/octopus/octo.exe", "/bin/tools/octopus/octo.exe")]
+            [InlineData("./tools/octopus/octo.exe", "/Working/tools/octopus/octo.exe")]
+            public void Should_Use_Octo_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new OctopusDeployPusherFixture();
+                fixture.Settings.ToolPath = toolPath;
+                fixture.GivenSettingsToolPathExist();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Path.FullPath);
+            }
+
+            [WindowsTheory]
+            [InlineData("C:/octopusDeploy/octo.exe", "C:/octopusDeploy/octo.exe")]
+            public void Should_Use_Octo_Executable_From_Tool_Path_If_Provided_On_Windows(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new OctopusDeployPusherFixture();
+                fixture.Settings.ToolPath = toolPath;
+                fixture.GivenSettingsToolPathExist();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Path.FullPath);
+            }
+
+            [Fact]
+            public void Should_Find_Octo_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new OctopusDeployPusherFixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/Working/tools/Octo.exe", result.Path.FullPath);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new OctopusDeployPusherFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsCakeException(result, "Octo: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new OctopusDeployPusherFixture();
+                fixture.GivenProcessExitsWithCode(1);
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsCakeException(result, "Octo: Process returned an error (exit code 1).");
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -325,8 +325,12 @@
     <Compile Include="Tools\OctopusDeploy\CreateReleaseArgumentBuilder.cs" />
     <Compile Include="Tools\OctopusDeploy\OctopusDeployAliases.cs" />
     <Compile Include="Tools\OctopusDeploy\CreateReleaseSettings.cs" />
+    <Compile Include="Tools\OctopusDeploy\OctopusDeployArgumentBuilder.cs" />
+    <Compile Include="Tools\OctopusDeploy\OctopusDeployPusher.cs" />
     <Compile Include="Tools\OctopusDeploy\OctopusDeployReleaseCreator.cs" />
     <Compile Include="Tools\OctopusDeploy\OctopusDeploySettings.cs" />
+    <Compile Include="Tools\OctopusDeploy\OctopusPushArgumentBuilder.cs" />
+    <Compile Include="Tools\OctopusDeploy\OctopusPushSettings.cs" />
     <Compile Include="Tools\OpenCover\OpenCoverAliases.cs" />
     <Compile Include="Tools\OpenCover\OpenCoverContext.cs" />
     <Compile Include="Tools\OpenCover\OpenCoverRunner.cs" />

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployAliases.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployAliases.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Cake.Core;
 using Cake.Core.Annotations;
+using Cake.Core.IO;
 
 namespace Cake.Common.Tools.OctopusDeploy
 {
@@ -77,6 +80,36 @@ namespace Cake.Common.Tools.OctopusDeploy
 
             var packer = new OctopusDeployReleaseCreator(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             packer.CreateRelease(projectName, settings);
+        }
+
+        /// <summary>
+        /// Pushes the specified package to the Octopus Deploy repository
+        /// </summary>
+        /// <param name="context">The cake context</param>
+        /// /// <param name="server">The Octopus server URL</param>
+        /// <param name="apiKey">The user's API key</param>
+        /// <param name="packagePath">Path to the package</param>
+        /// <param name="settings">The settings</param>
+        [CakeMethodAlias]
+        public static void OctoPush(this ICakeContext context, string server, string apiKey, FilePath packagePath, OctopusPushSettings settings)
+        {
+            OctoPush(context, server, apiKey, new[] { packagePath }, settings);
+        }
+
+        /// <summary>
+        /// Pushes the specified packages to the Octopus Deploy repository
+        /// </summary>
+        /// <param name="context">The cake context</param>
+        /// <param name="server">The Octopus server URL</param>
+        /// <param name="apiKey">The user's API key</param>
+        /// <param name="packagePaths">Paths to the packages</param>
+        /// <param name="settings">The settings</param>
+        [CakeMethodAlias]
+        public static void OctoPush(this ICakeContext context, string server, string apiKey, IEnumerable<FilePath> packagePaths, OctopusPushSettings settings)
+        {
+            var pusher = new OctopusDeployPusher(context.FileSystem, context.Environment, context.ProcessRunner,
+                context.Tools);
+            pusher.PushPackage(server, apiKey, packagePaths.ToArray(), settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployArgumentBuilder.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployArgumentBuilder.cs
@@ -1,0 +1,83 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.OctopusDeploy
+{
+    internal abstract class OctopusDeployArgumentBuilder<T> where T : OctopusDeploySettings
+    {
+        protected readonly ICakeEnvironment Environment;
+        protected readonly ProcessArgumentBuilder Builder;
+        protected readonly T Settings;
+        private readonly string _serverUrl;
+        private readonly string _apiKey;
+
+        protected OctopusDeployArgumentBuilder(ICakeEnvironment environment, T settings)
+            : this(settings.Server, settings.ApiKey, environment, settings)
+        {
+        }
+
+        protected OctopusDeployArgumentBuilder(string server, string apiKey, ICakeEnvironment environment, T settings)
+        {
+            Settings = settings;
+            _serverUrl = server;
+            _apiKey = apiKey;
+            Environment = environment;
+            Builder = new ProcessArgumentBuilder();
+        }
+
+        protected void AppendArgumentIfNotNull(string argumentName, string value)
+        {
+            if (value != null)
+            {
+                Builder.Append("--" + argumentName);
+                Builder.AppendQuoted(value);
+            }
+        }
+
+        protected void AppendArgumentIfNotNull(string argumentName, FilePath value)
+        {
+            if (value != null)
+            {
+                Builder.Append("--" + argumentName);
+                Builder.AppendQuoted(value.MakeAbsolute(Environment).FullPath);
+            }
+        }
+
+        protected void AppendCommonArguments()
+        {
+            Builder.Append("--server");
+            Builder.Append(_serverUrl);
+
+            Builder.Append("--apiKey");
+            Builder.AppendSecret(_apiKey);
+
+            AppendArgumentIfNotNull("user", Settings.Username);
+
+            if (Settings.Password != null)
+            {
+                Builder.Append("--pass");
+                Builder.AppendQuotedSecret(Settings.Password);
+            }
+
+            AppendArgumentIfNotNull("configFile", Settings.ConfigurationFile);
+
+            if (Settings.EnableDebugLogging)
+            {
+                Builder.Append("--debug");
+            }
+
+            if (Settings.IgnoreSslErrors)
+            {
+                Builder.Append("--ignoreSslErrors");
+            }
+
+            if (Settings.EnableServiceMessages)
+            {
+                Builder.Append("--enableServiceMessages");
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployPusher.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployPusher.cs
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.OctopusDeploy
+{
+    /// <summary>
+    /// The Octopus Deploy package push runner
+    /// </summary>
+    public class OctopusDeployPusher : Tool<OctopusPushSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OctopusDeployPusher"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="tools">The tool locator.</param>
+        public OctopusDeployPusher(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IToolLocator tools)
+            : base(fileSystem, environment, processRunner, tools)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Gets the name of the tool.
+        /// </summary>
+        /// <returns>The name of the tool.</returns>
+        protected override string GetToolName()
+        {
+            return "Octo";
+        }
+
+        /// <summary>
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return new[] { "Octo.exe" };
+        }
+
+        /// <summary>
+        /// Pushes the specified packages to Octopus Deploy internal repository
+        /// </summary>
+        /// <param name="server">The Octopus server URL</param>
+        /// <param name="apiKey">The user's API key</param>
+        /// <param name="packagePaths">Paths to the packages to be pushed</param>
+        /// <param name="settings">The settings</param>
+        public void PushPackage(string server, string apiKey, FilePath[] packagePaths, OctopusPushSettings settings)
+        {
+            if (packagePaths == null || !packagePaths.Any())
+            {
+                throw new ArgumentNullException("packagePaths");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+            if (string.IsNullOrEmpty(server))
+            {
+                throw new ArgumentException("No server specified.", "settings");
+            }
+            if (string.IsNullOrEmpty(apiKey))
+            {
+                throw new ArgumentException("No API key specified.", "settings");
+            }
+            var builder = new OctopusPushArgumentBuilder(packagePaths, server, apiKey, _environment, settings);
+            Run(settings, builder.Get());
+        }
+    }
+}

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusPushArgumentBuilder.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusPushArgumentBuilder.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System.Collections.Generic;
+using System.Linq;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.OctopusDeploy
+{
+    internal class OctopusPushArgumentBuilder : OctopusDeployArgumentBuilder<OctopusPushSettings>
+    {
+        private readonly List<FilePath> _packagePaths;
+
+        public OctopusPushArgumentBuilder(IEnumerable<FilePath> packagePaths, string server, string apiKey, ICakeEnvironment environment, OctopusPushSettings settings) : base(server, apiKey, environment, settings)
+        {
+            _packagePaths = packagePaths as List<FilePath> ?? packagePaths.ToList();
+        }
+
+        public ProcessArgumentBuilder Get()
+        {
+            AppendPackageArguments();
+            AppendCommonArguments();
+            return Builder;
+        }
+
+        private void AppendPackageArguments()
+        {
+            Builder.Append("push");
+
+            foreach (var packagePath in _packagePaths)
+            {
+                Builder.AppendSwitchQuoted("--package", packagePath.MakeAbsolute(Environment).FullPath);
+            }
+
+            if (Settings.ReplaceExisting)
+            {
+                Builder.Append("--replace-existing");
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusPushSettings.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusPushSettings.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Tools.OctopusDeploy
+{
+    /// <summary>
+    /// Contains settings used by <see cref="OctopusDeployPusher.PushPackage"/>.
+    /// </summary>
+    public sealed class OctopusPushSettings : OctopusDeploySettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to overwrite an existing package
+        /// </summary>
+        public bool ReplaceExisting { get; set; }
+    }
+}


### PR DESCRIPTION
Resolves #810 

This PR integrates support for the octo.exe push command alongside the existing release creation. In order to play nice with the existing alias, I have created the `OctopusDeployPusher` as a separate `Tool<T>`.

Tests have all been added as well.

I have refactored the new `Tool` and `Settings` classes to use a *new* common `OctopusDeployArgumentBuilder` tied to the *existing* `OctopusDeploySettings` class. I have *not* however refactored the existing release creation alias to use this structure. It should be basically drop-in, but I will leave that as a call for someone more familiar with the code base.

This is a much bigger contribution than my usual, so feedback is welcome as always :) 