### PR TITLE
GH997: Adding outputPath to project properties based on configuration and pl…

### DIFF
--- a/src/Cake.Common.Tests/Unit/Solution/Project/ProjectParserTests.cs
+++ b/src/Cake.Common.Tests/Unit/Solution/Project/ProjectParserTests.cs
@@ -168,6 +168,19 @@ namespace Cake.Common.Tests.Unit.Solution.Project
             }
 
             [Fact]
+            public void Should_Parse_OutputAssembly()
+            {
+                // Given
+                var fixture = new ProjectParserFixture();
+
+                // When
+                var result = fixture.Parse();
+
+                // Then
+                Assert.Equal(@"bin/Debug", result.OutputPath.FullPath);
+            }
+
+            [Fact]
             public void Should_Return_Correct_File_Count()
             {
                 // Given

--- a/src/Cake.Common/Solution/Project/ProjectAliases.cs
+++ b/src/Cake.Common/Solution/Project/ProjectAliases.cs
@@ -28,13 +28,15 @@ namespace Cake.Common.Solution.Project
         ///     Configuration         : {0}
         ///     Platform              : {1}
         ///     OutputType            : {2}
-        ///     RootNameSpace         : {3}
-        ///     AssemblyName          : {4}
-        ///     TargetFrameworkVersion: {5}
-        ///     Files                 : {6}",
+        ///     OutputPath            : {3}
+        ///     RootNameSpace         : {4}
+        ///     AssemblyName          : {5}
+        ///     TargetFrameworkVersion: {6}
+        ///     Files                 : {7}",
         ///     parsedProject.Configuration,
         ///     parsedProject.Platform,
         ///     parsedProject.OutputType,
+        ///     parsedProject.OutputPath,
         ///     parsedProject.RootNameSpace,
         ///     parsedProject.AssemblyName,
         ///     parsedProject.TargetFrameworkVersion,

--- a/src/Cake.Common/Solution/Project/ProjectParser.cs
+++ b/src/Cake.Common/Solution/Project/ProjectParser.cs
@@ -76,14 +76,18 @@ namespace Cake.Common.Solution.Project
                      .Elements(ProjectXElement.Configuration)
                      .Select(cfg => cfg.Value)
                      .FirstOrDefault()
+                 let platform = propertyGroup
+                     .Elements(ProjectXElement.Platform)
+                     .Select(cfg => cfg.Value)
+                     .FirstOrDefault()
+                 let configPropertyGroups = project.Elements(ProjectXElement.PropertyGroup)
+                                            .Where(x => x.Elements(ProjectXElement.OutputPath) != null && x.Attribute("Condition") != null)
+                                            .Where(x => x.Attribute("Condition").Value.Contains(string.Format("== '{0}|{1}'", configuration, platform)))
                  where !string.IsNullOrWhiteSpace(configuration)
                  select new
                  {
                      Configuration = configuration,
-                     Platform = propertyGroup
-                         .Elements(ProjectXElement.Platform)
-                         .Select(platform => platform.Value)
-                         .FirstOrDefault(),
+                     Platform = platform,
                      ProjectGuid = propertyGroup
                          .Elements(ProjectXElement.ProjectGuid)
                          .Select(projectGuid => projectGuid.Value)
@@ -91,6 +95,10 @@ namespace Cake.Common.Solution.Project
                      OutputType = propertyGroup
                          .Elements(ProjectXElement.OutputType)
                          .Select(outputType => outputType.Value)
+                         .FirstOrDefault(),
+                     OutputPath = configPropertyGroups
+                         .Elements(ProjectXElement.OutputPath)
+                         .Select(outputPath => DirectoryPath.FromString(outputPath.Value))
                          .FirstOrDefault(),
                      RootNameSpace = propertyGroup
                          .Elements(ProjectXElement.RootNamespace)
@@ -142,6 +150,7 @@ namespace Cake.Common.Solution.Project
                 projectProperties.Platform,
                 projectProperties.ProjectGuid,
                 projectProperties.OutputType,
+                projectProperties.OutputPath,
                 projectProperties.RootNameSpace,
                 projectProperties.AssemblyName,
                 projectProperties.TargetFrameworkVersion,

--- a/src/Cake.Common/Solution/Project/ProjectParserResult.cs
+++ b/src/Cake.Common/Solution/Project/ProjectParserResult.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 using System.Collections.Generic;
 using System.Linq;
+using Cake.Core.IO;
 
 namespace Cake.Common.Solution.Project
 {
@@ -15,6 +16,7 @@ namespace Cake.Common.Solution.Project
         private readonly string _platform;
         private readonly string _projectGuid;
         private readonly string _outputType;
+        private readonly DirectoryPath _outputPath;
         private readonly string _rootNameSpace;
         private readonly string _assemblyName;
         private readonly string _targetFrameworkVersion;
@@ -55,6 +57,15 @@ namespace Cake.Common.Solution.Project
         public string OutputType
         {
             get { return _outputType; }
+        }
+
+        /// <summary>
+        /// Gets the compiler output path.
+        /// </summary>
+        /// <value>The output path.</value>
+        public DirectoryPath OutputPath
+        {
+            get { return _outputPath; }
         }
 
         /// <summary>
@@ -109,6 +120,7 @@ namespace Cake.Common.Solution.Project
         /// <param name="platform">The target platform.</param>
         /// <param name="projectGuid">The unique project identifier.</param>
         /// <param name="outputType">The compiler output type.</param>
+        /// <param name="outputPath">The compiler output path</param>
         /// <param name="rootNameSpace">The default root namespace.</param>
         /// <param name="assemblyName">Gets the build target assembly name.</param>
         /// <param name="targetFrameworkVersion">The compiler framework version.</param>
@@ -119,6 +131,7 @@ namespace Cake.Common.Solution.Project
             string platform,
             string projectGuid,
             string outputType,
+            DirectoryPath outputPath,
             string rootNameSpace,
             string assemblyName,
             string targetFrameworkVersion,
@@ -129,6 +142,7 @@ namespace Cake.Common.Solution.Project
             _platform = platform;
             _projectGuid = projectGuid;
             _outputType = outputType;
+            _outputPath = outputPath;
             _rootNameSpace = rootNameSpace;
             _assemblyName = assemblyName;
             _targetFrameworkVersion = targetFrameworkVersion;

--- a/src/Cake.Common/Solution/Project/ProjectXElement.cs
+++ b/src/Cake.Common/Solution/Project/ProjectXElement.cs
@@ -51,6 +51,11 @@ namespace Cake.Common.Solution.Project
         internal const string OutputType = "{" + XmlNamespace + "}OutputType";
 
         /// <summary>
+        /// Namespace output path element
+        /// </summary>
+        internal const string OutputPath = "{" + XmlNamespace + "}OutputPath";
+
+        /// <summary>
         /// Namespace assembly name element
         /// </summary>
         internal const string AssemblyName = "{" + XmlNamespace + "}AssemblyName";


### PR DESCRIPTION
This PR is for #997 and adds an additional property to the `ProjectParser` which is the `OutputPath` value for the csproj file's current configuration|platform.

This makes it possible to use the remaining information to calculate the output assembly, something not easily possible using the current MSBuild alias.

`[ProjectPath] / [OutputPath] / [AssemblyName].[Type](dll|exe)`
