### PR TITLE
Make sure that cake.config can be found

### DIFF
--- a/src/Cake.Core.Tests/Fixtures/CakeConfigurationProviderFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/CakeConfigurationProviderFixture.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 using System.Collections.Generic;
 using Cake.Core.Configuration;
+using Cake.Core.IO;
 using Cake.Testing;
 
 namespace Cake.Core.Tests.Fixtures
@@ -11,19 +12,22 @@ namespace Cake.Core.Tests.Fixtures
     {
         public FakeFileSystem FileSystem { get; set; }
         public FakeEnvironment Environment { get; set; }
+
+        public DirectoryPath Path { get; set; }
         public IDictionary<string, string> Arguments { get; set; }
 
         public CakeConfigurationProviderFixture()
         {
             Environment = FakeEnvironment.CreateUnixEnvironment();
             FileSystem = new FakeFileSystem(Environment);
+            Path = "./";
             Arguments = new Dictionary<string, string>();
         }
 
         public ICakeConfiguration Create()
         {
             var provider = new CakeConfigurationProvider(FileSystem, Environment);
-            return provider.CreateConfiguration(Arguments);
+            return provider.CreateConfiguration(Path, Arguments);
         }
     }
 }

--- a/src/Cake.Core.Tests/Unit/Configuration/CakeConfigurationProviderTests.cs
+++ b/src/Cake.Core.Tests/Unit/Configuration/CakeConfigurationProviderTests.cs
@@ -43,6 +43,20 @@ namespace Cake.Core.Tests.Unit.Configuration
         public sealed class TheCreateMethod
         {
             [Fact]
+            public void Should_Throw_If_Path_Is_Null()
+            {
+                // Given
+                var fixture = new CakeConfigurationProviderFixture();
+                fixture.Path = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Create());
+
+                // Then
+                Assert.IsArgumentNullException(result, "path");
+            }
+
+            [Fact]
             public void Should_Throw_If_Arguments_Are_Null()
             {
                 // Given

--- a/src/Cake.Core/Configuration/CakeConfigurationProvider.cs
+++ b/src/Cake.Core/Configuration/CakeConfigurationProvider.cs
@@ -38,10 +38,15 @@ namespace Cake.Core.Configuration
         /// <summary>
         /// Creates a configuration from the provided arguments.
         /// </summary>
+        /// <param name="path">The directory to look for the configuration file.</param>
         /// <param name="arguments">The arguments.</param>
         /// <returns>The created configuration.</returns>
-        public ICakeConfiguration CreateConfiguration(IDictionary<string, string> arguments)
+        public ICakeConfiguration CreateConfiguration(DirectoryPath path, IDictionary<string, string> arguments)
         {
+            if (path == null)
+            {
+                throw new ArgumentNullException("path");
+            }
             if (arguments == null)
             {
                 throw new ArgumentNullException("arguments");
@@ -60,11 +65,11 @@ namespace Cake.Core.Configuration
             }
 
             // Parse the configuration file.
-            var path = new FilePath("./cake.config").MakeAbsolute(_environment);
-            if (_fileSystem.Exist(path))
+            var configurationPath = path.CombineWithFilePath("cake.config").MakeAbsolute(_environment);
+            if (_fileSystem.Exist(configurationPath))
             {
                 var parser = new ConfigurationParser(_fileSystem, _environment);
-                var configuration = parser.Read(path);
+                var configuration = parser.Read(configurationPath);
                 foreach (var key in configuration.Keys)
                 {
                     result[KeyNormalizer.Normalize(key)] = configuration[key];

--- a/src/Cake.Tests/Cake.Tests.csproj
+++ b/src/Cake.Tests/Cake.Tests.csproj
@@ -33,6 +33,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
+    </Reference>
     <Reference Include="NSubstitute">
       <HintPath>..\packages\NSubstitute.1.8.1.0\lib\net45\NSubstitute.dll</HintPath>
     </Reference>
@@ -83,6 +87,7 @@
     <Compile Include="Unit\Diagnostics\CakeBuildLogTests.cs" />
     <Compile Include="Unit\Diagnostics\FormatParserTests.cs" />
     <Compile Include="Unit\Commands\DebugCommandTests.cs" />
+    <Compile Include="Unit\Modules\ConfigurationModuleTests.cs" />
     <Compile Include="Unit\Scripting\BuildScriptHostTests.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -133,6 +138,7 @@
     <EmbeddedResource Include="Data\MonoScriptProcessor\Mixed\input" />
     <EmbeddedResource Include="Data\MonoScriptProcessor\Mixed\output" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Cake.Tests/Unit/Modules/ConfigurationModuleTests.cs
+++ b/src/Cake.Tests/Unit/Modules/ConfigurationModuleTests.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Composition;
+using Cake.Core.Composition;
+using Cake.Core.Configuration;
+using Cake.Core.IO;
+using Cake.Modules;
+using Cake.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Tests.Unit.Modules
+{
+    public sealed class ConfigurationModuleTests
+    {
+        public sealed class TheRegisterMethod
+        {
+            [Fact]
+            public void Should_Use_The_Script_Directory_As_Root_For_Configuration_File()
+            {
+                // Given
+                var fileSystem = Substitute.For<IFileSystem>();
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+                var provider = new CakeConfigurationProvider(fileSystem, environment);
+                var registry = new ContainerRegistry();
+                var options = new CakeOptions { Script = "./foo/bar/build.cake" };
+                var module = new ConfigurationModule(provider, options);
+
+                // When
+                module.Register(registry);
+
+                // Then
+                fileSystem.Received(1).Exist(Arg.Is<FilePath>(f => f.FullPath == "/Working/foo/bar/cake.config"));
+            }
+        }
+    }
+}

--- a/src/Cake/Modules/ConfigurationModule.cs
+++ b/src/Cake/Modules/ConfigurationModule.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 using System;
-using System.Diagnostics;
-using Autofac;
 using Cake.Core.Composition;
 using Cake.Core.Configuration;
 
@@ -14,9 +12,9 @@ namespace Cake.Modules
         private readonly CakeConfigurationProvider _provider;
         private readonly CakeOptions _options;
 
-        public ConfigurationModule(IContainer container, CakeOptions options)
+        public ConfigurationModule(CakeConfigurationProvider provider, CakeOptions options)
         {
-            _provider = container.Resolve<CakeConfigurationProvider>();
+            _provider = provider;
             _options = options;
         }
 
@@ -27,8 +25,8 @@ namespace Cake.Modules
                 throw new ArgumentNullException("registry");
             }
 
-            var configuration = _provider.CreateConfiguration(_options.Arguments);
-            Debug.Assert(configuration != null, "Configuration should not be null.");
+            var root = _options.Script.GetDirectory();
+            var configuration = _provider.CreateConfiguration(root, _options.Arguments);
             registry.RegisterInstance(configuration).As<ICakeConfiguration>();
         }
     }

--- a/src/Cake/Program.cs
+++ b/src/Cake/Program.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Autofac;
 using Cake.Arguments;
 using Cake.Composition;
+using Cake.Core.Configuration;
 using Cake.Core.Diagnostics;
 using Cake.Core.Modules;
 using Cake.Diagnostics;
@@ -55,8 +56,9 @@ namespace Cake
 
                     // Rebuild the container.
                     builder = new CakeContainerBuilder();
+                    var provider = container.Resolve<CakeConfigurationProvider>();
+                    builder.Registry.RegisterModule(new ConfigurationModule(provider, options));
                     builder.Registry.RegisterModule(new ArgumentsModule(options));
-                    builder.Registry.RegisterModule(new ConfigurationModule(container, options));
                     builder.Registry.RegisterModule(new ScriptingModule(options));
                     builder.Update(container);
 


### PR DESCRIPTION
For some reason, we used the working directory to locate the cake.config which works fine if the script that is being executed resides in the root directory. This PR will make sure that Cake always will look for cake.config in the same directory as the build script.

Closes #1002