### PR TITLE
GH974: Supress obsolete warnings from generated code

### DIFF
--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/Obsolete_ExplicitWarning_WithMessage
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/Obsolete_ExplicitWarning_WithMessage
@@ -1,5 +1,7 @@
 ﻿public void Obsolete_ExplicitWarning_WithMessage()
 {
     Context.Log.Warning("Warning: The alias Obsolete_ExplicitWarning_WithMessage has been made obsolete. Please use Foo.Bar instead.");
+#pragma warning disable 0618
     Cake.Core.Tests.Data.MethodAliasGeneratorData.Obsolete_ExplicitWarning_WithMessage(Context);
+#pragma warning restore 0618
 }

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/Obsolete_ImplicitWarning_NoMessage
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/Obsolete_ImplicitWarning_NoMessage
@@ -1,5 +1,7 @@
 ﻿public void Obsolete_ImplicitWarning_NoMessage()
 {
     Context.Log.Warning("Warning: The alias Obsolete_ImplicitWarning_NoMessage has been made obsolete.");
+#pragma warning disable 0618
     Cake.Core.Tests.Data.MethodAliasGeneratorData.Obsolete_ImplicitWarning_NoMessage(Context);
+#pragma warning restore 0618
 }

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/Obsolete_ImplicitWarning_WithMessage
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/Obsolete_ImplicitWarning_WithMessage
@@ -1,5 +1,7 @@
 ﻿public void Obsolete_ImplicitWarning_WithMessage()
 {
     Context.Log.Warning("Warning: The alias Obsolete_ImplicitWarning_WithMessage has been made obsolete. Please use Foo.Bar instead.");
+#pragma warning disable 0618
     Cake.Core.Tests.Data.MethodAliasGeneratorData.Obsolete_ImplicitWarning_WithMessage(Context);
+#pragma warning restore 0618
 }

--- a/src/Cake.Core/Scripting/CodeGen/MethodAliasGenerator.cs
+++ b/src/Cake.Core/Scripting/CodeGen/MethodAliasGenerator.cs
@@ -55,7 +55,8 @@ namespace Cake.Core.Scripting.CodeGen
 
             // Method is obsolete?
             var obsolete = method.GetCustomAttribute<ObsoleteAttribute>();
-            if (obsolete != null)
+            var isObsolete = obsolete != null;
+            if (isObsolete)
             {
                 var message = GetObsoleteMessage(method, obsolete);
 
@@ -79,6 +80,11 @@ namespace Cake.Core.Scripting.CodeGen
                     "    Context.Log.Warning(\"Warning: {0}\");", message));
             }
 
+            if (isObsolete)
+            {
+                builder.AppendLine("#pragma warning disable 0618");
+            }
+
             builder.Append("    ");
 
             if (isFunction)
@@ -100,6 +106,11 @@ namespace Cake.Core.Scripting.CodeGen
             builder.Append(string.Concat(GetProxyParameters(parameters, false)));
             builder.Append(");");
             builder.AppendLine();
+
+            if (isObsolete)
+            {
+                builder.AppendLine("#pragma warning restore 0618");
+            }
 
             // End method.
             builder.Append("}");


### PR DESCRIPTION
* Fixes #974
* Fixes cake-build/example#15

Currently when running Mono you get below warnings for obsolete methods even if they're not uses, this is a proposed fix for this by suppressing warnings for obsolete methods in generated code.
```
unknown.cake (512,38): `Cake.Common.Tools.DNU.DNUAliases.DNURestore(this Cake.Core.ICakeContext)' is obsolete: `Please use DotNetCoreRestore() instead.'
unknown.cake (519,38): `Cake.Common.Tools.DNU.DNUAliases.DNURestore(this Cake.Core.ICakeContext, Cake.Core.IO.FilePath)' is obsolete: `Please use DotNetCoreRestore(string) instead.'
unknown.cake (526,38): `Cake.Common.Tools.DNU.DNUAliases.DNURestore(this Cake.Core.ICakeContext, Cake.Common.Tools.DNU.Restore.DNURestoreSettings)' is obsolete: `Please use DotNetCoreRestore(DotNetCoreRestoreSettings) instead.'
unknown.cake (533,38): `Cake.Common.Tools.DNU.DNUAliases.DNURestore(this Cake.Core.ICakeContext, Cake.Core.IO.FilePath, Cake.Common.Tools.DNU.Restore.DNURestoreSettings)' is obsolete: `Please use DotNetCoreRestore(string, DotNetCoreRestoreSettings) instead.'
unknown.cake (540,38): `Cake.Common.Tools.DNU.DNUAliases.DNUBuild(this Cake.Core.ICakeContext, string)' is obsolete: `Please use DotNetCoreBuild(string) instead.'
unknown.cake (547,38): `Cake.Common.Tools.DNU.DNUAliases.DNUBuild(this Cake.Core.ICakeContext, string, Cake.Common.Tools.DNU.Build.DNUBuildSettings)' is obsolete: `Please use DotNetCoreBuild(string, DotNetCoreBuildSettings) instead.'
unknown.cake (554,38): `Cake.Common.Tools.DNU.DNUAliases.DNUPack(this Cake.Core.ICakeContext, string)' is obsolete: `Please use DotNetCorePack(string) instead.'
unknown.cake (561,38): `Cake.Common.Tools.DNU.DNUAliases.DNUPack(this Cake.Core.ICakeContext, string, Cake.Common.Tools.DNU.Pack.DNUPackSettings)' is obsolete: `Please use DotNetCorePack(string, DotNetCorePackSettings) instead.'
unknown.cake (1750,43): `Cake.Common.Xml.XmlPokeAliases.XmlPoke(this Cake.Core.ICakeContext, string, string, string)' is obsolete: `Please use XmlPokeString(string, string, string) instead.'
unknown.cake (1757,43): `Cake.Common.Xml.XmlPokeAliases.XmlPoke(this Cake.Core.ICakeContext, string, string, string, Cake.Common.Xml.XmlPokeSettings)' is obsolete: `Please use XmlPokeString(string, string, string, XmlPokeSettings) instead.'
```

