### PR TITLE
GH1019: Add more logging to NuGet package installer

### DIFF
--- a/src/Cake.NuGet/NuGetPackageInstaller.cs
+++ b/src/Cake.NuGet/NuGetPackageInstaller.cs
@@ -137,9 +137,17 @@ namespace Cake.NuGet
             {
                 Arguments = GetArguments(package, path),
                 RedirectStandardOutput = true,
-                Silent = true
+                Silent = _log.Verbosity < Verbosity.Diagnostic
             });
             process.WaitForExit();
+
+            var exitCode = process.GetExitCode();
+            if (exitCode != 0)
+            {
+                _log.Warning("NuGet exited with {0}", exitCode);
+                var output = string.Join(Environment.NewLine, process.GetStandardOutput());
+                _log.Verbose(Verbosity.Diagnostic, "Output:\r\n{0}", output);
+            }
 
             // Return the files.
             return _contentResolver.GetFiles(packagePath, type);


### PR DESCRIPTION
Currently it's very hard to diagnose addin/tool nuget install issues, this PR proposes logging error code if non 0 and if Verbosity set to Diagnostic also log nuget call and stdout.

* Fixes #1019