### PR TITLE
Replace the command line argument switches for GitVersion

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/GitVersion/GitVersionRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/GitVersion/GitVersionRunnerTests.cs
@@ -93,7 +93,7 @@ namespace Cake.Common.Tests.Unit.Tools.GitVersion
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/output json", result.Args);
+                Assert.Equal("-output json", result.Args);
             }
 
             [Fact]
@@ -107,7 +107,7 @@ namespace Cake.Common.Tests.Unit.Tools.GitVersion
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/showvariable FullSemVer", result.Args);
+                Assert.Equal("-showvariable FullSemVer", result.Args);
             }
 
             [Fact]
@@ -122,7 +122,7 @@ namespace Cake.Common.Tests.Unit.Tools.GitVersion
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/u \"bob\" /p \"password\"", result.Args);
+                Assert.Equal("-u \"bob\" -p \"password\"", result.Args);
             }
 
             [Fact]
@@ -136,7 +136,7 @@ namespace Cake.Common.Tests.Unit.Tools.GitVersion
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/updateassemblyinfo", result.Args);
+                Assert.Equal("-updateassemblyinfo", result.Args);
             }
 
             [Fact]
@@ -151,7 +151,7 @@ namespace Cake.Common.Tests.Unit.Tools.GitVersion
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/updateassemblyinfo \"c:/temp/assemblyinfo.cs\"", result.Args);
+                Assert.Equal("-updateassemblyinfo \"c:/temp/assemblyinfo.cs\"", result.Args);
             }
 
             [Fact]
@@ -165,7 +165,7 @@ namespace Cake.Common.Tests.Unit.Tools.GitVersion
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/targetpath \"c:/temp\"", result.Args);
+                Assert.Equal("-targetpath \"c:/temp\"", result.Args);
             }
 
             [Fact]
@@ -182,7 +182,7 @@ namespace Cake.Common.Tests.Unit.Tools.GitVersion
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/url \"http://mygitrepo.co.uk\" /b master /c \"abcdef\" /dynamicRepoLocation \"c:/temp\"", result.Args);
+                Assert.Equal("-url \"http://mygitrepo.co.uk\" -b master -c \"abcdef\" -dynamicRepoLocation \"c:/temp\"", result.Args);
             }
 
             [Fact]
@@ -196,7 +196,7 @@ namespace Cake.Common.Tests.Unit.Tools.GitVersion
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/l \"c:/temp/gitversion.log\"", result.Args);
+                Assert.Equal("-l \"c:/temp/gitversion.log\"", result.Args);
             }
         }
     }

--- a/src/Cake.Common/Tools/GitVersion/GitVersionRunner.cs
+++ b/src/Cake.Common/Tools/GitVersion/GitVersionRunner.cs
@@ -79,11 +79,11 @@ namespace Cake.Common.Tools.GitVersion
                 switch (settings.OutputType.Value)
                 {
                     case GitVersionOutput.Json:
-                        builder.Append("/output");
+                        builder.Append("-output");
                         builder.Append("json");
                         break;
                     case GitVersionOutput.BuildServer:
-                        builder.Append("/output");
+                        builder.Append("-output");
                         builder.Append("buildserver");
                         break;
                 }
@@ -91,22 +91,22 @@ namespace Cake.Common.Tools.GitVersion
 
             if (!string.IsNullOrWhiteSpace(settings.ShowVariable))
             {
-                builder.Append("/showvariable");
+                builder.Append("-showvariable");
                 builder.Append(settings.ShowVariable);
             }
 
             if (!string.IsNullOrWhiteSpace(settings.UserName))
             {
-                builder.Append("/u");
+                builder.Append("-u");
                 builder.AppendQuoted(settings.UserName);
 
-                builder.Append("/p");
+                builder.Append("-p");
                 builder.AppendQuotedSecret(settings.Password);
             }
 
             if (settings.UpdateAssemblyInfo)
             {
-                builder.Append("/updateassemblyinfo");
+                builder.Append("-updateassemblyinfo");
 
                 if (settings.UpdateAssemblyInfoFilePath != null)
                 {
@@ -116,17 +116,17 @@ namespace Cake.Common.Tools.GitVersion
 
             if (settings.RepositoryPath != null)
             {
-                builder.Append("/targetpath");
+                builder.Append("-targetpath");
                 builder.AppendQuoted(settings.RepositoryPath.FullPath);
             }
             else if (!string.IsNullOrWhiteSpace(settings.Url))
             {
-                builder.Append("/url");
+                builder.Append("-url");
                 builder.AppendQuoted(settings.Url);
 
                 if (!string.IsNullOrWhiteSpace(settings.Branch))
                 {
-                    builder.Append("/b");
+                    builder.Append("-b");
                     builder.Append(settings.Branch);
                 }
                 else
@@ -136,20 +136,20 @@ namespace Cake.Common.Tools.GitVersion
 
                 if (!string.IsNullOrWhiteSpace(settings.Commit))
                 {
-                    builder.Append("/c");
+                    builder.Append("-c");
                     builder.AppendQuoted(settings.Commit);
                 }
 
                 if (settings.DynamicRepositoryPath != null)
                 {
-                    builder.Append("/dynamicRepoLocation");
+                    builder.Append("-dynamicRepoLocation");
                     builder.AppendQuoted(settings.DynamicRepositoryPath.FullPath);
                 }
             }
 
             if (settings.LogFilePath != null)
             {
-                builder.Append("/l");
+                builder.Append("-l");
                 builder.AppendQuoted(settings.LogFilePath.FullPath);
             }
 


### PR DESCRIPTION
This PR replaces slash with dash in the command line argument switches for `gitversion.exe`, so it is more Unix friendly. It will still fail exeucting on OS X due to GitTools/GitVersion#890, but once that has been fixed, this should ensure that GitVersion executes successfully on OS X.