### PR TITLE
[HOLD] Cake argument changes

### DIFF
--- a/src/Cake.Core/ICakeArguments.cs
+++ b/src/Cake.Core/ICakeArguments.cs
@@ -1,6 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
 namespace Cake.Core
 {
     /// <summary>
@@ -8,6 +11,12 @@ namespace Cake.Core
     /// </summary>
     public interface ICakeArguments
     {
+        /// <summary>
+        /// Gets the arguments provided via the command line and their specified values.
+        /// </summary>
+        /// <value>The arguments dictionary.</value>
+        IReadOnlyDictionary<string, string> AsDictionary { get; }
+
         /// <summary>
         /// Determines whether or not the specified argument exist.
         /// </summary>

--- a/src/Cake.Core/ICakeArguments.cs
+++ b/src/Cake.Core/ICakeArguments.cs
@@ -18,6 +18,18 @@ namespace Cake.Core
         IReadOnlyDictionary<string, string> AsDictionary { get; }
 
         /// <summary>
+        /// Gets the argument names defined within the executing the Cake script.
+        /// </summary>
+        /// <value>The argument names defined within the executing Cake script.</value>
+        IEnumerable<string> DefinedArgumentNames { get; }
+
+        /// <summary>
+        /// Gets the argument names provided via the command line that have not been defined within the executing Cake script.
+        /// </summary>
+        /// <value>The argument names not defined within the executing Cake script.</value>
+        IEnumerable<string> UnrecognizedArgumentNames { get; }
+
+        /// <summary>
         /// Determines whether or not the specified argument exist.
         /// </summary>
         /// <param name="name">The argument name.</param>

--- a/src/Cake.Core/ICakeArguments.cs
+++ b/src/Cake.Core/ICakeArguments.cs
@@ -21,7 +21,7 @@ namespace Cake.Core
         /// Gets an argument.
         /// </summary>
         /// <param name="name">The argument name.</param>
-        /// <returns>The argument value.</returns>
+        /// <returns>The argument value if the argument exists, otherwise <c>null</c>.</returns>
         string GetArgument(string name);
     }
 }

--- a/src/Cake.Tests/Unit/CakeArgumentsTest.cs
+++ b/src/Cake.Tests/Unit/CakeArgumentsTest.cs
@@ -42,6 +42,25 @@ namespace Cake.Tests.Unit
                 // Then
                 Assert.Equal(expected, result);
             }
+
+            [Theory]
+            [InlineData("a", true)]
+            [InlineData("  a  ", true)]
+            [InlineData("b", false)]
+            [InlineData("  b  ", false)]
+            public void Should_Trim_Argument_Name(string key, bool expected)
+            {
+                // Given
+                var options = new CakeOptions();
+                options.Arguments.Add("A", "B");
+                var arguments = new CakeArguments(options);
+
+                // When
+                var result = arguments.HasArgument(key);
+
+                // Then
+                Assert.Equal(expected, result);
+            }
         }
 
         public sealed class GetArguments
@@ -67,6 +86,23 @@ namespace Cake.Tests.Unit
             [InlineData("a", "B")]
             [InlineData("b", null)]
             public void Should_Be_Case_Insensitive(string key, string expected)
+            {
+                // Given
+                var options = new CakeOptions();
+                options.Arguments.Add("A", "B");
+                var arguments = new CakeArguments(options);
+
+                // When
+                var result = arguments.GetArgument(key);
+
+                // Then
+                Assert.Equal(expected, result);
+            }
+
+            [Theory]
+            [InlineData("a", "B")]
+            [InlineData("  a  ", "B")]
+            public void Should_Trim_Argument_Name(string key, string expected)
             {
                 // Given
                 var options = new CakeOptions();

--- a/src/Cake.Tests/Unit/CakeArgumentsTest.cs
+++ b/src/Cake.Tests/Unit/CakeArgumentsTest.cs
@@ -33,6 +33,58 @@ namespace Cake.Tests.Unit
             }
         }
 
+        public sealed class DefinedArgumentNames
+        {
+            [Theory]
+            [InlineData(new string[] { "A" }, new string[] { "A" } )]
+            [InlineData(new string[] { "A", "B" }, new string[] { "A", "B" })]
+            public void Should_Return_All_Defined_Arguments(string[] defined, string[] expected)
+            {
+                // Given
+                var options = new CakeOptions();
+                options.Arguments.Add("A", "B");
+                options.Arguments.Add("C", "D");
+                var arguments = new CakeArguments(options);
+
+                foreach (var arg in defined)
+                {
+                    arguments.GetArgument(arg);
+                }
+
+                // When
+                var result = arguments.DefinedArgumentNames;
+
+                // Then
+                Assert.Equal(expected, result);
+            }
+        }
+
+        public sealed class UnrecognizedArgumentNames
+        {
+            [Theory]
+            [InlineData(new string[] { "A" }, new string[] { "C" })]
+            [InlineData(new string[] { "A", "B", "C" }, new string[] { })]
+            public void Should_Return_All_Unrecognized_Arguments(string[] defined, string[] expected)
+            {
+                // Given
+                var options = new CakeOptions();
+                options.Arguments.Add("A", "B");
+                options.Arguments.Add("C", "D");
+                var arguments = new CakeArguments(options);
+
+                foreach (var arg in defined)
+                {
+                    arguments.GetArgument(arg);
+                }
+
+                // When
+                var result = arguments.UnrecognizedArgumentNames;
+
+                // Then
+                Assert.Equal(expected, result);
+            }
+        }
+
         public sealed class HasArguments
         {
             [Theory]

--- a/src/Cake.Tests/Unit/CakeArgumentsTest.cs
+++ b/src/Cake.Tests/Unit/CakeArgumentsTest.cs
@@ -1,12 +1,38 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
 using Xunit;
 
 namespace Cake.Tests.Unit
 {
     public sealed class CakeArgumentsTests
     {
+        public sealed class AsDictionary
+        {
+            [Fact]
+            public void Should_Return_All_Arguments()
+            {
+                // Given
+                var options = new CakeOptions();
+                options.Arguments.Add("A", "B");
+                options.Arguments.Add("C", "D");
+                var arguments = new CakeArguments(options);
+
+                // When
+                var result = arguments.AsDictionary;
+
+                // Then
+                var expected = new Dictionary<string, string>
+                {
+                    { "A", "B" },
+                    { "C", "D" }
+                };
+                Assert.Equal(expected, result);
+            }
+        }
+
         public sealed class HasArguments
         {
             [Theory]

--- a/src/Cake/CakeArguments.cs
+++ b/src/Cake/CakeArguments.cs
@@ -49,7 +49,7 @@ namespace Cake
         /// Gets an argument.
         /// </summary>
         /// <param name="name">The argument name.</param>
-        /// <returns>The argument value.</returns>
+        /// <returns>The argument value if the argument exists, otherwise <c>null</c>.</returns>
         public string GetArgument(string name)
         {
             name = name.Trim();

--- a/src/Cake/CakeArguments.cs
+++ b/src/Cake/CakeArguments.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Cake.Core;
 
 namespace Cake
@@ -10,6 +11,7 @@ namespace Cake
     internal sealed class CakeArguments : ICakeArguments
     {
         private readonly Dictionary<string, string> _arguments;
+        private readonly ISet<string> _definedArgumentNames;
 
         /// <summary>
         /// Gets the arguments provided via the command line and their specified values.
@@ -17,6 +19,22 @@ namespace Cake
         public IReadOnlyDictionary<string, string> AsDictionary
         {
             get { return _arguments; }
+        }
+
+        /// <summary>
+        /// Gets the argument names defined within the executing the Cake script.
+        /// </summary>
+        public IEnumerable<string> DefinedArgumentNames
+        {
+            get { return _definedArgumentNames; }
+        }
+
+        /// <summary>
+        /// Gets the argument names provided via the command line that have not been defined within the executing Cake script.
+        /// </summary>
+        public IEnumerable<string> UnrecognizedArgumentNames
+        {
+            get { return _arguments.Keys.Except(_definedArgumentNames, StringComparer.OrdinalIgnoreCase); }
         }
 
         /// <summary>
@@ -28,6 +46,8 @@ namespace Cake
             _arguments = new Dictionary<string, string>(
                 (options ?? new CakeOptions()).Arguments ?? new Dictionary<string, string>(),
                 StringComparer.OrdinalIgnoreCase);
+
+            _definedArgumentNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -52,6 +72,8 @@ namespace Cake
         public string GetArgument(string name)
         {
             name = name.Trim();
+
+            _definedArgumentNames.Add(name);
 
             return _arguments.ContainsKey(name)
                 ? _arguments[name] : null;

--- a/src/Cake/CakeArguments.cs
+++ b/src/Cake/CakeArguments.cs
@@ -36,7 +36,7 @@ namespace Cake
         /// </summary>
         /// <param name="name">The argument name.</param>
         /// <returns>
-        ///   <c>true</c> if the argument exist; otherwise <c>false</c>.
+        ///   <c>true</c> if the argument exists; otherwise <c>false</c>.
         /// </returns>
         public bool HasArgument(string name)
         {

--- a/src/Cake/CakeArguments.cs
+++ b/src/Cake/CakeArguments.cs
@@ -40,6 +40,8 @@ namespace Cake
         /// </returns>
         public bool HasArgument(string name)
         {
+            name = name.Trim();
+
             return _arguments.ContainsKey(name);
         }
 
@@ -50,6 +52,8 @@ namespace Cake
         /// <returns>The argument value.</returns>
         public string GetArgument(string name)
         {
+            name = name.Trim();
+
             return _arguments.ContainsKey(name)
                 ? _arguments[name] : null;
         }

--- a/src/Cake/CakeArguments.cs
+++ b/src/Cake/CakeArguments.cs
@@ -12,10 +12,9 @@ namespace Cake
         private readonly Dictionary<string, string> _arguments;
 
         /// <summary>
-        /// Gets the arguments.
+        /// Gets the arguments provided via the command line and their specified values.
         /// </summary>
-        /// <value>The arguments.</value>
-        public IReadOnlyDictionary<string, string> Arguments
+        public IReadOnlyDictionary<string, string> AsDictionary
         {
             get { return _arguments; }
         }


### PR DESCRIPTION
This is just a preliminary PR related to some changes we'd like to make to the `ICakeArguments` interface. Feedback/better ideas are very much welcome.

Summary:
1. `CakeArguments.HasArgument` and `CakeArguments.GetArgument` both now `String.Trim()` their `name` parameter. This helps avoid difficult-to-spot bugs with using something like `Argument<bool>("foo ", true);`
2. Exposes an `ICakeArguments.AsDictionary` property as mentioned in #315 
3. Adds `ICakeArguments.DefinedArgumentNames` and `ICakeArgumetns.UnrecognizedArgumentNames` to facilitate "throw on unrecognized arguments" input validation / safe-guard against typos at the command line
4. A couple of small doc string typos/updates

The impetus for these changes is the following `Setup` we've been using in one of our cake scripts:

``` c#
var knownArgs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);

private T Arg<T>(string argumentName)
{
    argumentName = argumentName.Trim();
    knownArgs.Add(argumentName);
    return Argument<T>(argumentName);
}

private T Arg<T>(string argumentName, T defaultValue)
{
    argumentName = argumentName.Trim();
    knownArgs.Add(argumentName);
    return Argument<T>(argumentName, defaultValue);
}

var target        = Arg<string>("target", "Default");
var cakeToolsPath = Arg<string>("cakeToolsPath");
var nugetSource   = Arg<string>("nugetSource");

// moar arguments...

Setup(cakeContext => {
    var builtInArguments = new [] { "verbosity" };
    var rawArguments = (IReadOnlyDictionary<string, string>)cakeContext.Arguments.GetType().GetProperty("Arguments").GetValue(cakeContext.Arguments);
    var unrecognizedArguments = rawArguments.Keys.Except(knownArgs.Concat(builtInArguments), StringComparer.OrdinalIgnoreCase).ToList();

    if (unrecognizedArguments.Any())
    {
        unrecognizedArguments.ForEach(arg => Error("'{0}' is not a recognized argument", arg));
        throw new InvalidOperationException("Unrecognized arguments!");
    }
});
```

If something like this PR were to land upstream, we could reduce that to something more like the following:

``` c#
var target        = Argument<string>("target", "Default");
var cakeToolsPath = Argument<string>("cakeToolsPath");
var nugetSource   = Argument<string>("nugetSource");

// moar arguments...

Setup(cakeContext => {
    if (cakeContext.Arguments.UnrecognizedArgumentNames.Any())
    {
        cakeContext.Arguments.UnrecognizedArgumentNames.ForEach(arg => Error("'{0}' is not a recognized argument", arg));
        throw new InvalidOperationException("Unrecognized arguments!");
    }
});
```

If something like our "throw on unrecognized arguments" were a popular/useful feature, that could potentially be rolled into Cake's configuration as an option or possibly even be exposed via a method like `ICakeArguments.ThrowIfUnrecognizedArgumentsPresent()`
