### PR TITLE
Added Assert.NotNull() overload accepting user message

### DIFF
--- a/src/Cake.Testing.Xunit/Asserts/NullAsserts.cs
+++ b/src/Cake.Testing.Xunit/Asserts/NullAsserts.cs
@@ -19,6 +19,18 @@ namespace Xunit
         }
 
         /// <summary>
+        /// Verifies that an object reference is not null.
+        /// </summary>
+        /// <param name="object">The object to be validated</param>
+        /// <param name="userMessage">The user message to be displayed</param>
+        /// <exception cref="NotNullException">Thrown when the object is not null</exception>
+        public static void NotNull(object @object, string userMessage)
+        {
+            if (@object == null)
+                throw new NotNullException(userMessage);
+        }
+
+        /// <summary>
         /// Verifies that an object reference is null.
         /// </summary>
         /// <param name="object">The object to be inspected</param>

--- a/src/Cake.Testing.Xunit/Asserts/Sdk/Exceptions/NotNullException.cs
+++ b/src/Cake.Testing.Xunit/Asserts/Sdk/Exceptions/NotNullException.cs
@@ -12,7 +12,29 @@ namespace Xunit.Sdk
         /// Creates a new instance of the <see cref="NotNullException"/> class.
         /// </summary>
         public NotNullException()
-            : base("Assert.NotNull() Failure")
-        { }
+            : this(null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="NotNullException"/> class.
+        /// </summary>
+        /// <param name="userMessage">The user message to be displayed</param>
+        public NotNullException(string userMessage)
+            : base(CreateMessage(userMessage))
+        {
+        }
+
+        private static string CreateMessage(string userMessage)
+        {
+            string message = "Assert.NotNull() Failure.";
+
+            if (!string.IsNullOrWhiteSpace(userMessage))
+            {
+                message = string.Concat(userMessage, ". ", message);
+            }
+
+            return message;
+        }
     }
 }

--- a/src/Cake.Tests/Cake.Tests.csproj
+++ b/src/Cake.Tests/Cake.Tests.csproj
@@ -76,6 +76,7 @@
     </Compile>
     <Compile Include="Unit\Arguments\ArgumentParserTests.cs" />
     <Compile Include="Unit\Arguments\ArgumentTokenizerTests.cs" />
+    <Compile Include="Unit\Asserts\AssertTests.cs" />
     <Compile Include="Unit\Composition\ContainerRegistrationBuilderTests.cs" />
     <Compile Include="Unit\Composition\ContainerRegistryTests.cs" />
     <Compile Include="Unit\CakeApplicationTests.cs">

--- a/src/Cake.Tests/Unit/Asserts/AssertTests.cs
+++ b/src/Cake.Tests/Unit/Asserts/AssertTests.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using Xunit.Sdk;
+
+namespace Cake.Tests.Unit.Asserts
+{
+    public sealed class AssertTests
+    {
+        public sealed class NotNull
+        {
+            [Fact]
+            public void Should_Not_Throw_If_Object_Is_Not_Null()
+            {
+                // Given
+                var @object = new object();
+
+                // When, Then
+                Assert.NotNull(@object);
+            }
+
+            [Fact]
+            public void Should_Not_Throw_With_User_Message_If_Object_Is_Not_Null()
+            {
+                // Given
+                var @object = new object();
+
+                // When, Then
+                Assert.NotNull(@object, "User Message");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Object_Is_Null()
+            {
+                // Given
+                object @object = null;
+
+                // When
+                var exception = Assert.Throws<NotNullException>(() => Assert.NotNull(@object));
+
+                // Then
+                Assert.Equal("Assert.NotNull() Failure.", exception.Message);
+            }
+
+            [Fact]
+            public void Should_Throw_With_User_Message_If_Object_Is_Null()
+            {
+                // Given
+                object @object = null;
+
+                // When
+                var exception = Assert.Throws<NotNullException>(() => Assert.NotNull(@object, "User Message"));
+
+                // Then
+                Assert.Equal("User Message. Assert.NotNull() Failure.", exception.Message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added `Assert.NotNull()` overload accepting user message to make debugging failing assertions easier. Also added tests for `Assert.NotNull()`.

I'd like this merged to make it easier to debug and fix the fact that the `GitVersion()` alias returns an empty `GitVersion` object if the `GitVersionSettings.OutputType` is set to `GitVersionOutput.BuildServer`. I'm working on adding integration tests for that and being able to output a user message with the assertion makes that integration testing a lot more convenient.