### PR TITLE
[HOLD] Add integration tests for the GitVersion alias

### DIFF
--- a/src/Cake.Common/Tools/GitVersion/GitVersionRunner.cs
+++ b/src/Cake.Common/Tools/GitVersion/GitVersionRunner.cs
@@ -51,12 +51,16 @@ namespace Cake.Common.Tools.GitVersion
                 throw new ArgumentNullException("settings");
             }
 
+            var arguments = GetArguments(settings);
+
             if (settings.OutputType != GitVersionOutput.BuildServer)
             {
                 var jsonString = string.Empty;
 
-                Run(settings, GetArguments(settings), new ProcessSettings { RedirectStandardOutput = true },
-                process => jsonString = string.Join("\n", process.GetStandardOutput()));
+                Run(settings,
+                    arguments,
+                    new ProcessSettings { RedirectStandardOutput = true },
+                    process => jsonString = string.Join("\n", process.GetStandardOutput()));
 
                 var jsonSerializer = new DataContractJsonSerializer(typeof(GitVersion));
 
@@ -66,7 +70,7 @@ namespace Cake.Common.Tools.GitVersion
                 }
             }
 
-            Run(settings, GetArguments(settings));
+            Run(settings, arguments);
 
             return new GitVersion();
         }

--- a/tests/integration/Cake.Common/Tools/GitVersion/GitVersionAliases.cake
+++ b/tests/integration/Cake.Common/Tools/GitVersion/GitVersionAliases.cake
@@ -1,3 +1,4 @@
+#load "./../../../utilities/xunit.cake"
 #load "./../../../utilities/gitversion.cake"
 
 //////////////////////////////////////////////////////////////////////////////
@@ -12,15 +13,15 @@ Task("Cake.Common.Tools.GitVersionAliases.OutputTypeIsBuildServer")
     });
 
     // Then
-    Assert.NotNull(gitVersion.AssemblySemVer, "AssemblySemVer");
-    Assert.NotNull(gitVersion.BranchName, "BranchName");
-    Assert.NotNull(gitVersion.BuildMetaData, "BuildMetaData");
-    Assert.NotNull(gitVersion.BuildMetaDataPadded, "BuildMetaDataPadded");
-    Assert.NotNull(gitVersion.CommitDate, "CommitDate");
-    Assert.NotNull(gitVersion.CommitsSinceVersionSource, "CommitsSinceVersionSource");
-    Assert.NotNull(gitVersion.CommitsSinceVersionSourcePadded, "CommitsSinceVersionSourcePadded");
-    Assert.NotNull(gitVersion.FullBuildMetaData, "FullBuildMetaData");
-    Assert.NotNull(gitVersion.AssemblySemVer, "AssemblySemVer");
+    AssertNotNull(gitVersion.AssemblySemVer, "AssemblySemVer");
+    AssertNotNull(gitVersion.BranchName, "BranchName");
+    AssertNotNull(gitVersion.BuildMetaData, "BuildMetaData");
+    AssertNotNull(gitVersion.BuildMetaDataPadded, "BuildMetaDataPadded");
+    AssertNotNull(gitVersion.CommitDate, "CommitDate");
+    AssertNotNull(gitVersion.CommitsSinceVersionSource, "CommitsSinceVersionSource");
+    AssertNotNull(gitVersion.CommitsSinceVersionSourcePadded, "CommitsSinceVersionSourcePadded");
+    AssertNotNull(gitVersion.FullBuildMetaData, "FullBuildMetaData");
+    AssertNotNull(gitVersion.AssemblySemVer, "AssemblySemVer");
 });
 
 Task("Cake.Common.Tools.GitVersionAliases.OutputTypeIsJson")
@@ -33,15 +34,15 @@ Task("Cake.Common.Tools.GitVersionAliases.OutputTypeIsJson")
     });
 
     // Then
-    Assert.NotNull(gitVersion.AssemblySemVer, "AssemblySemVer");
-    Assert.NotNull(gitVersion.BranchName, "BranchName");
-    Assert.NotNull(gitVersion.BuildMetaData, "BuildMetaData");
-    Assert.NotNull(gitVersion.BuildMetaDataPadded, "BuildMetaDataPadded");
-    Assert.NotNull(gitVersion.CommitDate, "CommitDate");
-    Assert.NotNull(gitVersion.CommitsSinceVersionSource, "CommitsSinceVersionSource");
-    Assert.NotNull(gitVersion.CommitsSinceVersionSourcePadded, "CommitsSinceVersionSourcePadded");
-    Assert.NotNull(gitVersion.FullBuildMetaData, "FullBuildMetaData");
-    Assert.NotNull(gitVersion.AssemblySemVer, "AssemblySemVer");
+    AssertNotNull(gitVersion.AssemblySemVer, "AssemblySemVer");
+    AssertNotNull(gitVersion.BranchName, "BranchName");
+    AssertNotNull(gitVersion.BuildMetaData, "BuildMetaData");
+    AssertNotNull(gitVersion.BuildMetaDataPadded, "BuildMetaDataPadded");
+    AssertNotNull(gitVersion.CommitDate, "CommitDate");
+    AssertNotNull(gitVersion.CommitsSinceVersionSource, "CommitsSinceVersionSource");
+    AssertNotNull(gitVersion.CommitsSinceVersionSourcePadded, "CommitsSinceVersionSourcePadded");
+    AssertNotNull(gitVersion.FullBuildMetaData, "FullBuildMetaData");
+    AssertNotNull(gitVersion.AssemblySemVer, "AssemblySemVer");
 });
 
 Task("Cake.Common.Tools.GitVersionAliases")

--- a/tests/integration/Cake.Common/Tools/GitVersion/GitVersionAliases.cake
+++ b/tests/integration/Cake.Common/Tools/GitVersion/GitVersionAliases.cake
@@ -1,0 +1,49 @@
+#load "./../../../utilities/gitversion.cake"
+
+//////////////////////////////////////////////////////////////////////////////
+
+Task("Cake.Common.Tools.GitVersionAliases.OutputTypeIsBuildServer")
+    .Does(() =>
+{
+    // Given, When
+    var gitVersion = GitVersion(new GitVersionSettings
+    {
+        OutputType = GitVersionOutput.BuildServer,
+    });
+
+    // Then
+    Assert.NotNull(gitVersion.AssemblySemVer, "AssemblySemVer");
+    Assert.NotNull(gitVersion.BranchName, "BranchName");
+    Assert.NotNull(gitVersion.BuildMetaData, "BuildMetaData");
+    Assert.NotNull(gitVersion.BuildMetaDataPadded, "BuildMetaDataPadded");
+    Assert.NotNull(gitVersion.CommitDate, "CommitDate");
+    Assert.NotNull(gitVersion.CommitsSinceVersionSource, "CommitsSinceVersionSource");
+    Assert.NotNull(gitVersion.CommitsSinceVersionSourcePadded, "CommitsSinceVersionSourcePadded");
+    Assert.NotNull(gitVersion.FullBuildMetaData, "FullBuildMetaData");
+    Assert.NotNull(gitVersion.AssemblySemVer, "AssemblySemVer");
+});
+
+Task("Cake.Common.Tools.GitVersionAliases.OutputTypeIsJson")
+    .Does(() =>
+{
+    // Given, When
+    var gitVersion = GitVersion(new GitVersionSettings
+    {
+        OutputType = GitVersionOutput.Json,
+    });
+
+    // Then
+    Assert.NotNull(gitVersion.AssemblySemVer, "AssemblySemVer");
+    Assert.NotNull(gitVersion.BranchName, "BranchName");
+    Assert.NotNull(gitVersion.BuildMetaData, "BuildMetaData");
+    Assert.NotNull(gitVersion.BuildMetaDataPadded, "BuildMetaDataPadded");
+    Assert.NotNull(gitVersion.CommitDate, "CommitDate");
+    Assert.NotNull(gitVersion.CommitsSinceVersionSource, "CommitsSinceVersionSource");
+    Assert.NotNull(gitVersion.CommitsSinceVersionSourcePadded, "CommitsSinceVersionSourcePadded");
+    Assert.NotNull(gitVersion.FullBuildMetaData, "FullBuildMetaData");
+    Assert.NotNull(gitVersion.AssemblySemVer, "AssemblySemVer");
+});
+
+Task("Cake.Common.Tools.GitVersionAliases")
+  .IsDependentOn("Cake.Common.Tools.GitVersionAliases.OutputTypeIsJson")
+  .IsDependentOn("Cake.Common.Tools.GitVersionAliases.OutputTypeIsBuildServer");

--- a/tests/integration/build.cake
+++ b/tests/integration/build.cake
@@ -7,6 +7,7 @@
 #load "./Cake.Common/EnvironmentAliases.cake"
 #load "./Cake.Common/IO/DirectoryAliases.cake"
 #load "./Cake.Core/Tooling/ToolLocator.cake"
+#load "./Cake.Common/Tools/GitVersion/GitVersionAliases.cake"
 
 //////////////////////////////////////////////////
 // ARGUMENTS
@@ -35,9 +36,13 @@ Task("Cake.Common")
     .IsDependentOn("Cake.Common.EnvironmentAliases")
     .IsDependentOn("Cake.Common.IO.DirectoryAliases");
 
+Task("Cake.Common.Tools")
+    .IsDependentOn("Cake.Common.Tools.GitVersionAliases");
+
 Task("Run-All-Tests")
     .IsDependentOn("Cake.Core")
-    .IsDependentOn("Cake.Common");
+    .IsDependentOn("Cake.Common")
+    .IsDependentOn("Cake.Common.Tools");
 
 //////////////////////////////////////////////////
 

--- a/tests/integration/utilities/gitversion.cake
+++ b/tests/integration/utilities/gitversion.cake
@@ -1,0 +1,1 @@
+#tool "nuget:?package=GitVersion.CommandLine&version=3.6.2"

--- a/tests/integration/utilities/xunit.cake
+++ b/tests/integration/utilities/xunit.cake
@@ -2,3 +2,11 @@
 
 // Usings
 using Xunit;
+
+public void AssertNotNull(object obj, string message)
+{
+   if (obj == null)
+   {
+      throw new CakeException(message);
+   }
+}


### PR DESCRIPTION
This PR attempts to fix the problem where the  `GitVersion()` alias returns an empty `GitVersion` object if the `GitVersionSettings.OutputType` is set to `GitVersionOutput.BuildServer`. I'm trying to add integration tests for the `GitVersion()` alias, but I'm having problems with the `Assert.NotNull(object, string)` method not being available in my `GitVersionAliases.cake` script.

The `Assert.NotNull()` overload is implemented in #1029, which would be nice to have merged before continuing with this PR. I do need help to figure out why I can't do `Assert.NotNull(gitVersion.AssemblySemVer, "AssemblySemVer")` in `GitVersionAliases.cake`. It fails with the following exception:

> Error: `./tests/integration/Cake.Common/Tools/GitVersion/GitVersionAliases.cake(15,5)`:
> error `CS1501`: No overload for method `NotNull` takes 2 arguments.
