### PR TITLE
GH1023: Support custom exit code validation for tool.

### DIFF
--- a/src/Cake.Core.Tests/Fixtures/DummyToolFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/DummyToolFixture.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+using System;
 using Cake.Core.Tests.Stubs;
 using Cake.Testing.Fixtures;
 
@@ -8,14 +10,17 @@ namespace Cake.Core.Tests.Fixtures
 {
     public sealed class DummyToolFixture : ToolFixture<DummySettings>
     {
-        public DummyToolFixture()
-            : base("dummy.exe")
-        {
-        }
+	    public Action<int> ExitCodeValidation { get; set; }
 
-        protected override void RunTool()
+	    public DummyToolFixture()
+            : base("dummy.exe")
+	    {
+		    ExitCodeValidation = null;
+	    }
+
+	    protected override void RunTool()
         {
-            var tool = new DummyTool(FileSystem, Environment, ProcessRunner, Tools);
+            var tool = new DummyTool(FileSystem, Environment, ProcessRunner, Tools, ExitCodeValidation);
             tool.Run(Settings);
         }
     }

--- a/src/Cake.Core.Tests/Stubs/DummyTool.cs
+++ b/src/Cake.Core.Tests/Stubs/DummyTool.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
@@ -9,20 +11,34 @@ namespace Cake.Core.Tests.Stubs
 {
     public sealed class DummyTool : Tool<DummySettings>
     {
-        public DummyTool(
+	    private readonly Action<int> _exitCodeValidation;
+
+	    public DummyTool(
             IFileSystem fileSystem,
             ICakeEnvironment environment,
             IProcessRunner processRunner,
-            IToolLocator tools) : base(fileSystem, environment, processRunner, tools)
-        {
-        }
+            IToolLocator tools,
+			Action<int> exitCodeValidation) : base(fileSystem, environment, processRunner, tools)
+	    {
+		    _exitCodeValidation = exitCodeValidation;
+	    }
 
-        public void Run(DummySettings settings)
-        {
-            Run(settings, new ProcessArgumentBuilder().Append("--foo"));
-        }
+	    public void Run(DummySettings settings)
+		{
+			Run(settings, new ProcessArgumentBuilder().Append("--foo"), new ProcessSettings(), null);
+		}
 
-        protected override string GetToolName()
+	    protected override void ProcessExitCode(int exitCode)
+	    {
+		    if (_exitCodeValidation == null)
+		    {
+			    base.ProcessExitCode(exitCode);
+			    return;
+		    }
+		    _exitCodeValidation(exitCode);
+	    }
+
+	    protected override string GetToolName()
         {
             return "dummy";
         }

--- a/src/Cake.Core.Tests/Unit/Tooling/ToolTests.cs
+++ b/src/Cake.Core.Tests/Unit/Tooling/ToolTests.cs
@@ -1,8 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+using System;
 using Cake.Core.IO;
 using Cake.Core.Tests.Fixtures;
+using Cake.Testing;
 using Xunit;
 
 namespace Cake.Core.Tests.Unit.Tooling
@@ -71,6 +74,76 @@ namespace Cake.Core.Tests.Unit.Tooling
                 // Then
                 Assert.Equal("/Other", result.Process.WorkingDirectory.FullPath);
             }
-        }
+
+			[Fact]
+			public void Should_Succeed_On_Zero_ExitCode_Without_Custom_Validation()
+			{
+				// Given
+				var fixture = new DummyToolFixture();
+				fixture.GivenProcessExitsWithCode(0);
+
+				// When
+				var result = fixture.Run();
+
+				// Then
+				Assert.IsNotType<Exception>(result);
+			}
+
+			[Fact]
+			public void Should_Throw_On_NonZero_ExitCode_Without_Custom_Validation()
+			{
+				// Given
+				var fixture = new DummyToolFixture();
+				fixture.GivenProcessExitsWithCode(11);
+
+				// When
+				var result = Record.Exception(() => fixture.Run());
+
+				// Then
+				Assert.IsCakeException(result, "dummy: Process returned an error (exit code 11).");
+			}
+
+			[Fact]
+			public void Should_Succeed_On_NonZero_ExitCode_Validated_By_Custom_Validator()
+			{
+				// Given
+				var fixture = new DummyToolFixture();
+				fixture.ExitCodeValidation = ec =>
+				{
+					if (ec >= 10)
+					{
+						throw new CakeException("UnitTest");
+					}
+				};
+				fixture.GivenProcessExitsWithCode(7);
+
+				// When
+				var result = fixture.Run();
+				
+				// Then
+				Assert.IsNotType<Exception>(result);
+			}
+
+			[Fact]
+			public void Should_Throw_On_Invalid_ExitCode_Validated_By_Custom_Validator()
+			{
+				// Given
+				var fixture = new DummyToolFixture();
+				fixture.ExitCodeValidation = ec =>
+				{
+					if (ec != 1)
+					{
+						throw new CakeException("UnitTest");
+					}
+				};
+				fixture.GivenProcessExitsWithCode(10);
+
+				// When
+				var result = Record.Exception(() => fixture.Run());
+
+				// Then
+				Assert.IsCakeException(result, "UnitTest");
+			}
+		}
     }
 }

--- a/src/Cake.Core/Tooling/Tool.cs
+++ b/src/Cake.Core/Tooling/Tool.cs
@@ -115,12 +115,7 @@ namespace Cake.Core.Tooling
 
             try
             {
-                // Did an error occur?
-                if (process.GetExitCode() != 0)
-                {
-                    const string message = "{0}: Process returned an error (exit code {1}).";
-                    throw new CakeException(string.Format(CultureInfo.InvariantCulture, message, GetToolName(), process.GetExitCode()));
-                }
+                ProcessExitCode(process.GetExitCode());
             }
             finally
             {
@@ -129,6 +124,21 @@ namespace Cake.Core.Tooling
                 {
                     postAction(process);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Customized exit code handling.
+        /// Standard behavior is to fail when non zero.
+        /// </summary>
+        /// <param name="exitCode">The process exit code</param>
+        protected virtual void ProcessExitCode(int exitCode)
+        {
+            // Did an error occur?
+            if (exitCode != 0)
+            {
+                const string message = "{0}: Process returned an error (exit code {1}).";
+                throw new CakeException(string.Format(CultureInfo.InvariantCulture, message, GetToolName(), exitCode));
             }
         }
 


### PR DESCRIPTION
Added custom exit code validation for `Tool` by adding a `Func<int, bool>` lamda expression to the `Tool.Run` method. Similar to `postAction`.
This can be used when developing custom tool support e.g. for Robocopy which runs sucessful but provides other exit codes than zero.