### PR TITLE
Added documentation for multiple arguments for ToolSettings

### DIFF
--- a/src/Cake.Core/Tooling/ToolSettings.cs
+++ b/src/Cake.Core/Tooling/ToolSettings.cs
@@ -34,11 +34,20 @@ namespace Cake.Core.Tooling
         /// This allows you to support new tool arguments, customize arguments or address potential argument issues.
         /// </summary>
         /// <example>
+        /// <para>Combining tool specific settings and tool arguments:</para>
         /// <code>
         /// NuGetAddSource("Cake", "https://www.myget.org/F/cake/api/v3/index.json",
         ///     new NuGetSourcesSettings { UserName = "user", Password = "incorrect",
         ///     ArgumentCustomization = args=&gt;args.Append("-StorePasswordInClearText")
         /// });
+        /// </code>
+        /// </example>
+        /// <example>
+        /// <para>Setting multiple tool arguments:</para>
+        /// <code>
+        /// MSTest(pathPattern, new MSTestSettings() 
+        ///     { ArgumentCustomization = args=&gt;args.Append("/detail:errormessage")
+        ///                                            .Append("/resultsfile:TestResults.trx") });
         /// </code>
         /// </example>
         /// <value>The delegate used to customize the <see cref="Cake.Core.IO.ProcessArgumentBuilder" />.</value>


### PR DESCRIPTION
New PR (with a clean start) based on the comments from the older one https://github.com/cake-build/cake/pull/1043

This will just add a second example to show how to set multiple arguments on the toolsettings.