### PR TITLE
Return custom message for specific error codes in NUnit/NUnit3 tools

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/NUnit/NUnit3RunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NUnit/NUnit3RunnerTests.cs
@@ -148,19 +148,25 @@ namespace Cake.Common.Tests.Unit.Tools.NUnit
                 Assert.Equal("NUnit3: Process was not started.", result.Message);
             }
 
-            [Fact]
-            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            [Theory]
+            [InlineData(10, "NUnit3: 10 test(s) failed (exit code 10).")]
+            [InlineData(-1, "NUnit3: Invalid argument (exit code -1).")]
+            [InlineData(-2, "NUnit3: Invalid assembly (exit code -2).")]
+            [InlineData(-4, "NUnit3: Invalid test fixture (exit code -4).")]
+            [InlineData(-100, "NUnit3: Unexpected error (exit code -100).")]
+            [InlineData(-10, "NUnit3: Unrecognised error (exit code -10).")]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code(int exitCode, string expectedMessage)
             {
                 // Given
                 var fixture = new NUnit3RunnerFixture();
-                fixture.GivenProcessExitsWithCode(1);
+                fixture.GivenProcessExitsWithCode(exitCode);
 
                 // When
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
                 Assert.IsType<CakeException>(result);
-                Assert.Equal("NUnit3: Process returned an error (exit code 1).", result.Message);
+                Assert.Equal(expectedMessage, result.Message);
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/NUnit/NUnitRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NUnit/NUnitRunnerTests.cs
@@ -148,19 +148,25 @@ namespace Cake.Common.Tests.Unit.Tools.NUnit
                 Assert.Equal("NUnit: Process was not started.", result.Message);
             }
 
-            [Fact]
-            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            [Theory]
+            [InlineData(10, "NUnit: 10 test(s) failed (exit code 10).")]
+            [InlineData(-1, "NUnit: Invalid argument (exit code -1).")]
+            [InlineData(-2, "NUnit: File not found (exit code -2).")]
+            [InlineData(-3, "NUnit: Test fixture not found (exit code -3).")]
+            [InlineData(-100, "NUnit: Unexpected error (exit code -100).")]
+            [InlineData(-10, "NUnit: Unrecognised error (exit code -10).")]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code(int exitCode, string expectedMessage)
             {
                 // Given
                 var fixture = new NUnitRunnerFixture();
-                fixture.GivenProcessExitsWithCode(1);
+                fixture.GivenProcessExitsWithCode(exitCode);
 
                 // When
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
                 Assert.IsType<CakeException>(result);
-                Assert.Equal("NUnit: Process returned an error (exit code 1).", result.Message);
+                Assert.Equal(expectedMessage, result.Message);
             }
 
             [Fact]

--- a/src/Cake.Common/Tools/NUnit/NUnit3Runner.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnit3Runner.cs
@@ -228,5 +228,46 @@ namespace Cake.Common.Tools.NUnit
         {
             return new[] { "nunit3-console.exe" };
         }
+
+        /// <summary>
+        /// Customized exit code handling.
+        /// Throws <see cref="CakeException"/> on non-zero exit code
+        /// </summary>
+        /// <param name="exitCode">The process exit code</param>
+        protected override void ProcessExitCode(int exitCode)
+        {
+            string error;
+
+            if (exitCode <= 0)
+            {
+                switch (exitCode)
+                {
+                    case 0:
+                        return;
+                    case -1:
+                        error = "Invalid argument";
+                        break;
+                    case -2:
+                        error = "Invalid assembly";
+                        break;
+                    case -4:
+                        error = "Invalid test fixture";
+                        break;
+                    case -100:
+                        error = "Unexpected error";
+                        break;
+                    default:
+                        error = "Unrecognised error";
+                        break;
+                }
+            }
+            else
+            {
+                error = string.Format(CultureInfo.InvariantCulture, "{0} test(s) failed", exitCode);
+            }
+
+            const string message = "{0}: {1} (exit code {2}).";
+            throw new CakeException(string.Format(CultureInfo.InvariantCulture, message, GetToolName(), error, exitCode));
+        }
     }
 }

--- a/src/Cake.Common/Tools/NUnit/NUnitRunner.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnitRunner.cs
@@ -172,5 +172,46 @@ namespace Cake.Common.Tools.NUnit
         {
             return new[] { "nunit-console.exe" };
         }
+
+        /// <summary>
+        /// Customized exit code handling.
+        /// Throws <see cref="CakeException"/> on non-zero exit code
+        /// </summary>
+        /// <param name="exitCode">The process exit code</param>
+        protected override void ProcessExitCode(int exitCode)
+        {
+            string error;
+
+            if (exitCode <= 0)
+            {
+                switch (exitCode)
+                {
+                    case 0:
+                        return;
+                    case -1:
+                        error = "Invalid argument";
+                        break;
+                    case -2:
+                        error = "File not found";
+                        break;
+                    case -3:
+                        error = "Test fixture not found";
+                        break;
+                    case -100:
+                        error = "Unexpected error";
+                        break;
+                    default:
+                        error = "Unrecognised error";
+                        break;
+                }
+            }
+            else
+            {
+                error = string.Format(CultureInfo.InvariantCulture, "{0} test(s) failed", exitCode);
+            }
+
+            const string message = "{0}: {1} (exit code {2}).";
+            throw new CakeException(string.Format(CultureInfo.InvariantCulture, message, GetToolName(), error, exitCode));
+        }
     }
 }


### PR DESCRIPTION
Fixes #517.

Uses the new custom error code functionality in #1031 for the NUnit tools. Have been eyeing this up for a while, however now the frameworks already been discussed and put in, it seemed too simple not to do.

I've never used XUnit before - is that `Theory/InlineData` thing the correct approach to doing this sort of test?

For reference:
- [NUnit2 exit codes](https://github.com/nunit/nunitv2/blob/master/src/ConsoleRunner/nunit-console/ConsoleUi.cs#L26)
- [NUnit3 exit codes](https://github.com/nunit/nunit/blob/master/src/NUnitConsole/nunit3-console/ConsoleRunner.cs#L44)