### PR TITLE
Add ResultsFile Property to MSTestSettings

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSTest/MSTestRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSTest/MSTestRunnerTests.cs
@@ -191,6 +191,19 @@ namespace Cake.Common.Tests.Unit.Tools.MSTest
         }
 
         [Fact]
+        public void Should_Use_TestResultsFile_If_Provided()
+        {
+            //Given
+            var fixture = new MSTestRunnerFixture();
+            fixture.Settings.ResultsFile = @"c:\temp\myresults.trx";
+
+            //When
+            var result = fixture.Run();
+
+            Assert.Equal("\"/testcontainer:/Working/Test1.dll\" /resultsfile:\"c:\\temp\\myresults.trx\" /noisolation", result.Args);
+        }
+
+        [Fact]
         public void Should_Not_Use_TestCategoryFilter_If_Not_Provided()
         {
             //Given

--- a/src/Cake.Common/Tools/MSTest/MSTestRunner.cs
+++ b/src/Cake.Common/Tools/MSTest/MSTestRunner.cs
@@ -69,6 +69,11 @@ namespace Cake.Common.Tools.MSTest
                 builder.Append(string.Concat("/category:", settings.Category.Quote()));
             }
 
+            if (!string.IsNullOrEmpty(settings.ResultsFile))
+            {
+                builder.Append(string.Concat("/resultsfile:", settings.ResultsFile.Quote()));
+            }
+
             if (settings.NoIsolation)
             {
                 builder.Append("/noisolation");

--- a/src/Cake.Common/Tools/MSTest/MSTestSettings.cs
+++ b/src/Cake.Common/Tools/MSTest/MSTestSettings.cs
@@ -29,6 +29,12 @@ namespace Cake.Common.Tools.MSTest
         public string Category { get; set; }
 
         /// <summary>
+        /// Gets or sets the filepath for a named resulting test file. 
+        /// MSTest.exe flag <see href="https://msdn.microsoft.com/en-us/library/ms182489.aspx#resultsfile">/resultsfile</see>.
+        /// </summary>
+        public string ResultsFile { get; set; }
+
+        /// <summary>
         /// Gets or sets the test settings file to pass to MSTest.exe flag <see href="https://msdn.microsoft.com/en-us/library/ms182489.aspx#testsettings">/testsettings</see>.
         /// </summary>
         public FilePath TestSettings { get; set; }


### PR DESCRIPTION
Added a new property to MSTestSettings "resultsfile". Current workaround was via the arguments, but this seems much cleaner.

Related issue: https://github.com/cake-build/cake/issues/730