### PR TITLE
GH1045: Change label order for GitReleaseManager

### DIFF
--- a/GitReleaseManager.yaml
+++ b/GitReleaseManager.yaml
@@ -1,9 +1,9 @@
 issue-labels-include:
-- Bug
+- Breaking change
 - Feature
+- Bug
 - Improvement
 - Documentation
-- Breaking change
 issue-labels-exclude:
 - Build
 issue-labels-alias:


### PR DESCRIPTION
Relates to #1045 