### PR TITLE
Adds /nofetch option support to GitVersion tool

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/GitVersion/GitVersionRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/GitVersion/GitVersionRunnerTests.cs
@@ -198,6 +198,22 @@ namespace Cake.Common.Tests.Unit.Tools.GitVersion
                 // Then
                 Assert.Equal("-l \"c:/temp/gitversion.log\"", result.Args);
             }
+
+            [Theory]
+            [InlineData(true, "-nofetch")]
+            [InlineData(false, "")]
+            public void Should_Add_NoFetch_To_Arguments_If_Set(bool nofetch, string args)
+            {
+                // Given
+                var fixture = new GitVersionRunnerFixture();
+                fixture.Settings.NoFetch = nofetch;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(args, result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common/Tools/GitVersion/GitVersionRunner.cs
+++ b/src/Cake.Common/Tools/GitVersion/GitVersionRunner.cs
@@ -153,6 +153,11 @@ namespace Cake.Common.Tools.GitVersion
                 builder.AppendQuoted(settings.LogFilePath.FullPath);
             }
 
+            if (settings.NoFetch)
+            {
+                builder.Append("-nofetch");
+            }
+
             return builder;
         }
 

--- a/src/Cake.Common/Tools/GitVersion/GitVersionSettings.cs
+++ b/src/Cake.Common/Tools/GitVersion/GitVersionSettings.cs
@@ -62,6 +62,12 @@ namespace Cake.Common.Tools.GitVersion
         public string Commit { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to fetch repository information from remote when calculating version.
+        /// </summary>
+        /// <remarks>If your CI server clones the entire repository you can set this to 'true' to prevent GitVersion attempting any remote repository fetching</remarks>
+        public bool NoFetch { get; set; }
+
+        /// <summary>
         /// Gets or sets the dynamic repository path. Defaults to %TEMP%.
         /// </summary>
         public DirectoryPath DynamicRepositoryPath { get; set; }


### PR DESCRIPTION
Implemented via .NoFetch boolean on GitVersionSettings.

Adds **/nofetch** option support to GitVersion tool Implemented via ```.NoFetch``` boolean on GitVersionSettings.

```c#
var settings = new GitVersionSettings();
settings.NoFetch = true; // defaults to false
```

The /nofetch flag is useful for repositories that are fully cloned but where GitVersion still wants to inspect the remote repository for version history.  Causes particular problems with private repositories.

While the flag can currently be set via ArgumentCustomization this will make the option readily accessible and documented within Cake.