### PR TITLE
Add OldStyle flag for OpenCover

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/OpenCover/OpenCoverTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/OpenCover/OpenCoverTests.cs
@@ -272,6 +272,23 @@ namespace Cake.Common.Tests.Unit.Tools.OpenCover
                              "-skipautoprops " +
                              "-register:user -output:\"/Working/result.xml\"", result.Args);
             }
+
+            [Fact]
+            public void Should_Append_OldStyle()
+            {
+                // Given
+                var fixture = new OpenCoverFixture();
+                fixture.Settings.OldStyle = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-target:\"/Working/tools/Test.exe\" " +
+                             "-targetargs:\"-argument\" " +
+                             "-oldStyle " +
+                             "-register:user -output:\"/Working/result.xml\"", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverRunner.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverRunner.cs
@@ -132,6 +132,11 @@ namespace Cake.Common.Tools.OpenCover
                 builder.Append("-skipautoprops");
             }
 
+            if (settings.OldStyle)
+            {
+                builder.Append("-oldStyle");
+            }
+
             builder.AppendSwitch("-register", ":", settings.Register);
 
             if (settings.ReturnTargetCodeOffset != null)

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverSettings.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverSettings.cs
@@ -62,6 +62,11 @@ namespace Cake.Common.Tools.OpenCover
         public int? ReturnTargetCodeOffset { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the OldStyle option for OpenCover should be used
+        /// </summary>
+        public bool OldStyle { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="OpenCoverSettings"/> class.
         /// </summary>
         public OpenCoverSettings()


### PR DESCRIPTION
OldStyle flag for OpenCover is required for using it with dotnet cli for some reason.