### PR TITLE
GH 1092: Add environment variable support for StartProcess & Tools

### DIFF
--- a/src/Cake.Core/CakeRuntime.cs
+++ b/src/Cake.Core/CakeRuntime.cs
@@ -17,6 +17,11 @@ namespace Cake.Core
         public FrameworkName TargetFramework { get; private set; }
 
         /// <summary>
+        /// Gets the version of Cake executing the script.
+        /// </summary>
+        public Version CakeVersion { get; private set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="CakeRuntime"/> class.
         /// </summary>
         public CakeRuntime()
@@ -26,6 +31,7 @@ namespace Cake.Core
             // that this actually is what happens on Mono.
             var frameworkName = AppDomain.CurrentDomain.SetupInformation.TargetFrameworkName;
             TargetFramework = new FrameworkName(frameworkName ?? ".NETFramework,Version=v4.5");
+            CakeVersion = typeof(ICakeRuntime).Assembly.GetName().Version;
         }
     }
 }

--- a/src/Cake.Core/ICakeRuntime.cs
+++ b/src/Cake.Core/ICakeRuntime.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+using System;
 using System.Runtime.Versioning;
 
 namespace Cake.Core
@@ -15,5 +17,11 @@ namespace Cake.Core
         /// </summary>
         /// <returns>The target framework.</returns>
         FrameworkName TargetFramework { get; }
+
+        /// <summary>
+        /// Gets the version of Cake executing the script.
+        /// </summary>
+        /// <returns>The Cake.exe version.</returns>
+        Version CakeVersion { get; }
     }
 }

--- a/src/Cake.Core/IO/ProcessRunner.cs
+++ b/src/Cake.Core/IO/ProcessRunner.cs
@@ -78,6 +78,17 @@ namespace Cake.Core.IO
                 RedirectStandardOutput = settings.RedirectStandardOutput
             };
 
+            // Add environment variables
+            info.EnvironmentVariables["CAKE"] = "True";
+            info.EnvironmentVariables["CAKE_VERSION"] = _environment.Runtime.CakeVersion.ToString(3);
+            if (settings.EnvironmentVariables != null)
+            {
+                foreach (var environmentVariable in settings.EnvironmentVariables)
+                {
+                    info.EnvironmentVariables[environmentVariable.Key] = environmentVariable.Value;
+                }
+            }
+
             // Start and return the process.
             var process = Process.Start(info);
 

--- a/src/Cake.Core/IO/ProcessSettings.cs
+++ b/src/Cake.Core/IO/ProcessSettings.cs
@@ -1,6 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
 namespace Cake.Core.IO
 {
     /// <summary>
@@ -38,5 +41,21 @@ namespace Cake.Core.IO
         ///   <c>true</c> if process output will be suppressed; otherwise, <c>false</c>.
         /// </value>
         public bool Silent { get; set; }
+
+        /// <summary>
+        /// Gets or sets search paths for files, directories for temporary files, application-specific options, and other similar information.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// StartProcess("cmd", new ProcessSettings{
+        ///         Arguments = "/c set",
+        ///         EnvironmentVariables = new Dictionary&lt;string, string&gt;{
+        ///             { "CI", "True" },
+        ///             { "TEMP", MakeAbsolute(Directory("./Temp")).FullPath }
+        ///         }
+        ///     }); 
+        /// </code>
+        /// </example>
+        public IDictionary<string, string> EnvironmentVariables { get; set; }
     }
 }

--- a/src/Cake.Core/Tooling/Tool.cs
+++ b/src/Cake.Core/Tooling/Tool.cs
@@ -205,6 +205,10 @@ namespace Cake.Core.Tooling
             {
                 info.WorkingDirectory = workingDirectory.MakeAbsolute(_environment).FullPath;
             }
+            if (info.EnvironmentVariables == null)
+            {
+                info.EnvironmentVariables = GetEnvironmentVariables(settings);
+            }
 
             // Run the process.
             var process = _processRunner.Start(toolPath, info);
@@ -252,6 +256,16 @@ namespace Cake.Core.Tooling
         protected virtual IEnumerable<FilePath> GetAlternativeToolPaths(TSettings settings)
         {
             return Enumerable.Empty<FilePath>();
+        }
+
+        /// <summary>
+        /// Gets the environment variables.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The environment variables for the tool.</returns>
+        protected virtual IDictionary<string, string> GetEnvironmentVariables(TSettings settings)
+        {
+            return settings.EnvironmentVariables;
         }
 
         private FilePath GetToolPath(TSettings settings)

--- a/src/Cake.Core/Tooling/ToolSettings.cs
+++ b/src/Cake.Core/Tooling/ToolSettings.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 using System;
+using System.Collections.Generic;
 using Cake.Core.IO;
 
 namespace Cake.Core.Tooling
@@ -52,5 +53,18 @@ namespace Cake.Core.Tooling
         /// </example>
         /// <value>The delegate used to customize the <see cref="Cake.Core.IO.ProcessArgumentBuilder" />.</value>
         public Func<ProcessArgumentBuilder, ProcessArgumentBuilder> ArgumentCustomization { get; set; }
+
+        /// <summary>
+        /// Gets or sets search paths for files, directories for temporary files, application-specific options, and other similar information.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// MSBuild("./src/Cake.sln", new MSBuildSettings {
+        ///     EnvironmentVariables = new Dictionary&lt;string, string&gt;{
+        ///         { "TOOLSPATH", MakeAbsolute(Directory("./tools")).FullPath }
+        ///     }});
+        /// </code>
+        /// </example>
+        public IDictionary<string, string> EnvironmentVariables { get; set; }
     }
 }

--- a/src/Cake.Testing/FakeRuntime.cs
+++ b/src/Cake.Testing/FakeRuntime.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Versioning;
+﻿using System;
+using System.Runtime.Versioning;
 using Cake.Core;
 
 namespace Cake.Testing
@@ -14,11 +15,17 @@ namespace Cake.Testing
         public FrameworkName TargetFramework { get; set; }
 
         /// <summary>
+        /// Gets the version of Cake executing the script.
+        /// </summary>
+        public Version CakeVersion { get; private set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="FakeRuntime"/> class.
         /// </summary>
         public FakeRuntime()
         {
             TargetFramework = new FrameworkName(".NETFramework,Version=v4.5");
+            CakeVersion = typeof(ICakeRuntime).Assembly.GetName().Version;
         }
     }
 }


### PR DESCRIPTION
* Add EnvironmentVariables to ProcessSettings
* Add EnvironmentVariables to ToolSettings
* Adds CakeVersion ICakeRuntime
* Fixes #1092

### Example Process usage
```cake
StartProcess("cmd", new ProcessSettings{
        Arguments = "/c set",
        EnvironmentVariables = new Dictionary<string, string>{
            { "CI", "True" },
            { "TEMP", MakeAbsolute(Directory("./Temp")).FullPath }
        }
    });
```

### Example Tool usage:
```cake
MSBuild("c:/temp/dev/gh/devlead/cake/src/Cake.sln", new MSBuildSettings {
    EnvironmentVariables = new Dictionary<string, string>{
        { "TOOLSPATH", MakeAbsolute(Directory("./tools")).FullPath }
    }});
```

This PR also adds 2 default variables CAKE & CAKE_VERSION which enables tools to pickup that it's running under and which version Cake.