### PR TITLE
GH1096: Updates AppVeyor UploadArtifact method

### DIFF
--- a/src/Cake.Common/Build/AppVeyor/AppVeyorProvider.cs
+++ b/src/Cake.Common/Build/AppVeyor/AppVeyorProvider.cs
@@ -68,6 +68,16 @@ namespace Cake.Common.Build.AppVeyor
         /// <param name="path">The file path of the artifact to upload.</param>
         public void UploadArtifact(FilePath path)
         {
+            UploadArtifact(path, settings => settings.SetArtifactType(AppVeyorUploadArtifactType.Auto));
+        }
+
+        /// <summary>
+        /// Uploads an AppVeyor artifact.
+        /// </summary>
+        /// <param name="path">The file path of the artifact to upload.</param>
+        /// <param name="settings">The settings to apply when uploading an artifact</param>
+        public void UploadArtifact(FilePath path, AppVeyorUploadArtifactsSettings settings)
+        {
             if (path == null)
             {
                 throw new ArgumentNullException("path");
@@ -88,9 +98,32 @@ namespace Cake.Common.Build.AppVeyor
             arguments.AppendQuoted(path.FullPath);
             arguments.Append("-FileName");
             arguments.AppendQuoted(path.GetFilename().FullPath);
+            arguments.Append("-ArtifactType");
+            arguments.AppendQuoted(settings.ArtifactType.ToString());
+            if (!string.IsNullOrEmpty(settings.DeploymentName))
+            {
+                if (settings.DeploymentName.Contains(" "))
+                {
+                    throw new CakeException("The deployment name can not contain spaces");
+                }
+                arguments.Append("-DeploymentName");
+                arguments.AppendQuoted(settings.DeploymentName);
+            }
 
             // Start the process.
             _processRunner.Start("appveyor", new ProcessSettings { Arguments = arguments });
+        }
+
+        /// <summary>
+        /// Uploads an AppVeyor artifact.
+        /// </summary>
+        /// <param name="path">The file path of the artifact to upload.</param>
+        /// <param name="settingsAction">The settings to apply when uploading an artifact</param>
+        public void UploadArtifact(FilePath path, Action<AppVeyorUploadArtifactsSettings> settingsAction)
+        {
+            var settings = new AppVeyorUploadArtifactsSettings();
+            settingsAction(settings);
+            UploadArtifact(path, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Build/AppVeyor/AppVeyorUploadArtifactType.cs
+++ b/src/Cake.Common/Build/AppVeyor/AppVeyorUploadArtifactType.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+namespace Cake.Common.Build.AppVeyor
+{
+    /// <summary>
+    /// Provides the known artifact upload types for the AppVeyor
+    /// </summary>
+    public enum AppVeyorUploadArtifactType
+    {
+        /// <summary>
+        /// Automatically deploy artifact type
+        /// </summary>
+        Auto,
+
+        /// <summary>
+        /// The artifact is a web deploy package (.zip)
+        /// </summary>
+        WebDeployPackage,
+
+        /// <summary>
+        /// The artifact is a NuGet package (.nupkg)
+        /// </summary>
+        NuGetPackage
+    }
+}

--- a/src/Cake.Common/Build/AppVeyor/AppVeyorUploadArtifactsSettings.cs
+++ b/src/Cake.Common/Build/AppVeyor/AppVeyorUploadArtifactsSettings.cs
@@ -1,0 +1,40 @@
+namespace Cake.Common.Build.AppVeyor
+{
+    /// <summary>
+    /// Appveyor upload artifacts settings
+    /// </summary>
+    public class AppVeyorUploadArtifactsSettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating the type of artifact being uploaded to AppVeyor.
+        /// </summary>
+        public AppVeyorUploadArtifactType ArtifactType { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating a deployment name to set for the uploaded artifact
+        /// </summary>
+        public string DeploymentName { get; set; }
+
+        /// <summary>
+        /// Sets the type of artifact being uploaded to AppVeyor
+        /// </summary>
+        /// <param name="type">The type of artifact being uploaded</param>
+        /// <returns>The settings</returns>
+        public AppVeyorUploadArtifactsSettings SetArtifactType(AppVeyorUploadArtifactType type)
+        {
+            ArtifactType = type;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the deployment name
+        /// </summary>
+        /// <param name="deploymentName">The deployment name to attach to the artifact, required when using the AppVeyor deployment agent.  <paramref name="deploymentName"/> should not have any spaces</param>
+        /// <returns>The settings</returns>
+        public AppVeyorUploadArtifactsSettings SetDeploymentName(string deploymentName)
+        {
+            DeploymentName = deploymentName;
+            return this;
+        }
+    }
+}

--- a/src/Cake.Common/Build/AppVeyor/IAppVeyorProvider.cs
+++ b/src/Cake.Common/Build/AppVeyor/IAppVeyorProvider.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Cake.Common.Build.AppVeyor.Data;
+using Cake.Core;
 using Cake.Core.IO;
 
 namespace Cake.Common.Build.AppVeyor
@@ -33,6 +35,20 @@ namespace Cake.Common.Build.AppVeyor
         /// </summary>
         /// <param name="path">The file path of the artifact to upload.</param>
         void UploadArtifact(FilePath path);
+
+        /// <summary>
+        /// Uploads an AppVeyor artifact.
+        /// </summary>
+        /// <param name="path">The file path of the artifact to upload.</param>
+        /// <param name="settings">The settings to apply when uploading an artifact</param>
+        void UploadArtifact(FilePath path, AppVeyorUploadArtifactsSettings settings);
+
+        /// <summary>
+        /// Uploads an AppVeyor artifact.
+        /// </summary>
+        /// <param name="path">The file path of the artifact to upload.</param>
+        /// <param name="settingsAction">The settings to apply when uploading an artifact</param>
+        void UploadArtifact(FilePath path, Action<AppVeyorUploadArtifactsSettings> settingsAction);
 
         /// <summary>
         /// Uploads test results XML file to AppVeyor. Results type can be one of the following: mstest, xunit, nunit, nunit3, junit.

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -56,6 +56,8 @@
     <Compile Include="Build\AppVeyor\AppVeyorMessageCategoryType.cs" />
     <Compile Include="Build\AppVeyor\AppVeyorProviderAddMessageExtensions.cs" />
     <Compile Include="Build\AppVeyor\AppVeyorTestResultsType.cs" />
+    <Compile Include="Build\AppVeyor\AppVeyorUploadArtifactsSettings.cs" />
+    <Compile Include="Build\AppVeyor\AppVeyorUploadArtifactType.cs" />
     <Compile Include="Build\AppVeyor\Data\AppVeyorEnvironmentInfo.cs" />
     <Compile Include="Build\AppVeyor\AppVeyorInfo.cs" />
     <Compile Include="Build\AppVeyor\AppVeyorProvider.cs" />


### PR DESCRIPTION
Adds support for the additional options available on the underlying ```appveyor PushArtifact``` command line.

* ```-Type "Auto|WebDeployPackage|NuGetPackage"```
* ```-DeploymentName "<string>"```

```c#
BuildSystem.AppVeyor.UploadArtifact("./artifacts/package.zip"); // Uploads as "Auto"

BuildSystem.AppVeyor.UploadArtifact("./artifacts/webdeploy.zip", AppVeyorUploadArtifactType.WebDeployPackage);

BuildSystem.AppVeyor.UploadArtifact("./artifacts/webdeploy.zip", AppVeyorUploadArtifactType.WebDeployPackage, "MyApp.Web"); // assigns deployment name as required when using the deployment agent

```


Resolves #1096