### PR TITLE
GH1098: Updates AppVeyor UploadTestResults

### DIFF
--- a/src/Cake.Common/Build/AppVeyor/AppVeyorProvider.cs
+++ b/src/Cake.Common/Build/AppVeyor/AppVeyorProvider.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Globalization;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using Cake.Common.Build.AppVeyor.Data;
+using Cake.Common.Net;
 using Cake.Core;
 using Cake.Core.IO;
 
@@ -117,12 +119,11 @@ namespace Cake.Common.Build.AppVeyor
                 throw new CakeException("Failed to get AppVeyor API url.");
             }
 
-            var url = string.Format(CultureInfo.InvariantCulture, "{0}/api/testresults/{1}/{2}", baseUri, resultsType, Environment.JobId);
+            var url = new Uri(string.Format(CultureInfo.InvariantCulture, "{0}/api/testresults/{1}/{2}", baseUri, resultsType, Environment.JobId));
 
-            using (var stream = File.OpenRead(path.FullPath))
             using (var client = new HttpClient())
             {
-                client.PostAsync(url, new StreamContent(stream)).Wait();
+                client.UploadFileAsync(url, path.FullPath).Wait();
             }
         }
 

--- a/src/Cake.Common/Net/HttpAliases.cs
+++ b/src/Cake.Common/Net/HttpAliases.cs
@@ -130,5 +130,119 @@ namespace Cake.Common.Net
 
             context.Log.Verbose("Download complete, saved to: {0}", outputPath.FullPath);
         }
+
+        /// <summary>
+        /// Uploads the specified file via a HTTP POST to the specified uri using multipart/form-data.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var address = new Uri("http://www.example.org/upload");
+        /// UploadFile(address, @"path/to/file.txt");
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="address">The URL of the upload resource.</param>
+        /// <param name="filePath">The file to upload.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Upload")]
+        public static void UploadFile(this ICakeContext context, Uri address, FilePath filePath)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            if (address == null)
+            {
+                throw new ArgumentNullException("address");
+            }
+            if (filePath == null)
+            {
+                throw new ArgumentNullException("filePath");
+            }
+
+            context.Log.Verbose("Uploading file: {0}", address);
+            using (var client = new HttpClient())
+            {
+                client.UploadFileAsync(address, filePath.FullPath).Wait();
+            }
+            context.Log.Verbose("File upload complete");
+        }
+
+        /// <summary>
+        /// Uploads the specified file via a HTTP POST to the specified uri using multipart/form-data.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var address = "http://www.example.org/upload";
+        /// UploadFile(address, @"path/to/file.txt");
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="address">The URL of the upload resource.</param>
+        /// <param name="filePath">The file to upload.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Upload")]
+        public static void UploadFile(this ICakeContext context, string address, FilePath filePath)
+        {
+            UploadFile(context, new Uri(address), filePath);
+        }
+
+        /// <summary>
+        /// Uploads the specified byte array via a HTTP POST to the specified uri using multipart/form-data.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var address = new Uri("http://www.example.org/upload");
+        /// UploadFile(address, @"path/to/file.txt");
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="address">The URL of the upload resource.</param>
+        /// <param name="data">The data to upload.</param>
+        /// <param name="fileName">The filename to give the uploaded data</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Upload")]
+        public static void UploadFile(this ICakeContext context, Uri address, byte[] data, string fileName)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            if (address == null)
+            {
+                throw new ArgumentNullException("address");
+            }
+            if (data == null)
+            {
+                throw new ArgumentNullException("data");
+            }
+
+            context.Log.Verbose("Uploading file: {0}", address);
+            using (var client = new HttpClient())
+            {
+                client.UploadFileAsync(address, data, fileName).Wait();
+            }
+            context.Log.Verbose("File upload complete");
+        }
+
+        /// <summary>
+        /// Uploads the specified byte array via a HTTP POST to the specified uri using multipart/form-data.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var address = "http://www.example.org/upload";
+        /// UploadFile(address, @"path/to/file.txt");
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="address">The URL of the upload resource.</param>
+        /// <param name="data">The data to upload.</param>
+        /// <param name="fileName">The filename to give the uploaded data</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Upload")]
+        public static void UploadFile(this ICakeContext context, string address, byte[] data, string fileName)
+        {
+            UploadFile(context, new Uri(address), data, fileName);
+        }
     }
 }


### PR DESCRIPTION
The updates changes from using HttpClient to WebClient.

The WebClient.UploadFile packages and sends a payload in the format expected by AppVeyor.  WebClient is also supported on Mono (https://searchcode.com/codesearch/view/35714320/).

Resolves #1097 