### PR TITLE
GH1104: Made MSBuildSettings.MaxCpuCount nullable

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -563,7 +563,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/m /v:normal /target:Build " +
+                Assert.Equal("/v:normal /target:Build " +
                              "\"/Working/src/Solution.sln\"", result.Args);
             }
 
@@ -578,7 +578,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/m /v:normal /nr:true /target:Build " +
+                Assert.Equal("/v:normal /nr:true /target:Build " +
                              "\"/Working/src/Solution.sln\"", result.Args);
             }
 
@@ -594,7 +594,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/m /v:normal /target:A;B " +
+                Assert.Equal("/v:normal /target:A;B " +
                              "\"/Working/src/Solution.sln\"", result.Args);
             }
 
@@ -610,7 +610,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/m /v:normal /p:A=B /p:C=D /target:Build " +
+                Assert.Equal("/v:normal /p:A=B /p:C=D /target:Build " +
                              "\"/Working/src/Solution.sln\"", result.Args);
             }
 
@@ -626,13 +626,13 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/m /v:normal /p:A=B /p:A=E /p:C=D /target:Build " +
+                Assert.Equal("/v:normal /p:A=B /p:A=E /p:C=D /target:Build " +
                              "\"/Working/src/Solution.sln\"", result.Args);
             }
 
             [Theory]
-            [InlineData("Release", "/m /v:normal /p:Configuration=\"Release\" /target:Build \"/Working/src/Solution.sln\"")]
-            [InlineData("Custom Spaced", "/m /v:normal /p:Configuration=\"Custom Spaced\" /target:Build \"/Working/src/Solution.sln\"")]
+            [InlineData("Release", "/v:normal /p:Configuration=\"Release\" /target:Build \"/Working/src/Solution.sln\"")]
+            [InlineData("Custom Spaced", "/v:normal /p:Configuration=\"Custom Spaced\" /target:Build \"/Working/src/Solution.sln\"")]
             public void Should_Append_Configuration_As_Property_To_Process_Arguments(string configuration, string expected)
             {
                 // Given
@@ -647,11 +647,11 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             }
 
             [Theory]
-            [InlineData(PlatformTarget.MSIL, "/m /v:normal /p:Platform=\"Any CPU\" /target:Build \"/Working/src/Solution.sln\"")]
-            [InlineData(PlatformTarget.x86, "/m /v:normal /p:Platform=x86 /target:Build \"/Working/src/Solution.sln\"")]
-            [InlineData(PlatformTarget.x64, "/m /v:normal /p:Platform=x64 /target:Build \"/Working/src/Solution.sln\"")]
-            [InlineData(PlatformTarget.ARM, "/m /v:normal /p:Platform=arm /target:Build \"/Working/src/Solution.sln\"")]
-            [InlineData(PlatformTarget.Win32, "/m /v:normal /p:Platform=Win32 /target:Build \"/Working/src/Solution.sln\"")]
+            [InlineData(PlatformTarget.MSIL, "/v:normal /p:Platform=\"Any CPU\" /target:Build \"/Working/src/Solution.sln\"")]
+            [InlineData(PlatformTarget.x86, "/v:normal /p:Platform=x86 /target:Build \"/Working/src/Solution.sln\"")]
+            [InlineData(PlatformTarget.x64, "/v:normal /p:Platform=x64 /target:Build \"/Working/src/Solution.sln\"")]
+            [InlineData(PlatformTarget.ARM, "/v:normal /p:Platform=arm /target:Build \"/Working/src/Solution.sln\"")]
+            [InlineData(PlatformTarget.Win32, "/v:normal /p:Platform=Win32 /target:Build \"/Working/src/Solution.sln\"")]
             public void Should_Append_Platform_As_Property_To_Process_Arguments(PlatformTarget platform, string expected)
             {
                 // Given
@@ -677,7 +677,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/m /v:normal /p:Platform=AnyCPU /target:Build \"/Working/src/Project.csproj\"", result.Args);
+                Assert.Equal("/v:normal /p:Platform=AnyCPU /target:Build \"/Working/src/Project.csproj\"", result.Args);
             }
 
             [Fact]
@@ -692,7 +692,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/m /v:normal /p:Platform=arm /target:Build " +
+                Assert.Equal("/v:normal /p:Platform=arm /target:Build " +
                              "\"/Working/src/Solution.sln\"", result.Args);
                 Assert.Equal("/Program86/MSBuild/12.0/Bin/MSBuild.exe", result.Path.FullPath);
             }
@@ -707,7 +707,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/m /v:normal /target:Build " +
+                Assert.Equal("/v:normal /target:Build " +
                              "\"/Working/src/Solution.sln\"", result.Args);
             }
 
@@ -753,11 +753,11 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             }
 
             [Theory]
-            [InlineData(Verbosity.Quiet, "/m /v:quiet /target:Build \"/Working/src/Solution.sln\"")]
-            [InlineData(Verbosity.Minimal, "/m /v:minimal /target:Build \"/Working/src/Solution.sln\"")]
-            [InlineData(Verbosity.Normal, "/m /v:normal /target:Build \"/Working/src/Solution.sln\"")]
-            [InlineData(Verbosity.Verbose, "/m /v:detailed /target:Build \"/Working/src/Solution.sln\"")]
-            [InlineData(Verbosity.Diagnostic, "/m /v:diagnostic /target:Build \"/Working/src/Solution.sln\"")]
+            [InlineData(Verbosity.Quiet, "/v:quiet /target:Build \"/Working/src/Solution.sln\"")]
+            [InlineData(Verbosity.Minimal, "/v:minimal /target:Build \"/Working/src/Solution.sln\"")]
+            [InlineData(Verbosity.Normal, "/v:normal /target:Build \"/Working/src/Solution.sln\"")]
+            [InlineData(Verbosity.Verbose, "/v:detailed /target:Build \"/Working/src/Solution.sln\"")]
+            [InlineData(Verbosity.Diagnostic, "/v:diagnostic /target:Build \"/Working/src/Solution.sln\"")]
             public void Should_Append_Correct_Verbosity(Verbosity verbosity, string expected)
             {
                 // Given

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsTests.cs
@@ -103,13 +103,13 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
         public sealed class TheMaxCpuCountProperty
         {
             [Fact]
-            public void Should_Be_Empty_By_Default()
+            public void Should_Be_Null_By_Default()
             {
                 // Given
                 var settings = new MSBuildSettings();
 
                 // Then
-                Assert.Equal(0, settings.MaxCpuCount);
+                Assert.Null(settings.MaxCpuCount);
             }
         }
     }

--- a/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
@@ -51,8 +51,11 @@ namespace Cake.Common.Tools.MSBuild
         {
             var builder = new ProcessArgumentBuilder();
 
-            // Set the maximum number of processors.
-            builder.Append(settings.MaxCpuCount > 0 ? string.Concat("/m:", settings.MaxCpuCount) : "/m");
+            // Set the maximum number of processors?
+            if (settings.MaxCpuCount != null)
+            {
+                builder.Append(settings.MaxCpuCount > 0 ? string.Concat("/m:", settings.MaxCpuCount) : "/m");
+            }
 
             // Set the verbosity.
             builder.Append(string.Format(CultureInfo.InvariantCulture, "/v:{0}", GetVerbosityName(settings.Verbosity)));
@@ -183,7 +186,7 @@ namespace Cake.Common.Tools.MSBuild
                 throw new ArgumentNullException("settings");
             }
 
-            MSBuildPlatform buildPlatform = settings.MSBuildPlatform;
+            var buildPlatform = settings.MSBuildPlatform;
 
             // If we haven't explicitly set an MSBuild target then use the Platform Target
             if (buildPlatform == MSBuildPlatform.Automatic)

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
@@ -60,9 +60,11 @@ namespace Cake.Common.Tools.MSBuild
 
         /// <summary>
         /// Gets or sets the maximum CPU count.
+        /// If this value is zero, MSBuild will use as many processes as
+        /// there are available CPUs to build the project.
         /// </summary>
         /// <value>The maximum CPU count.</value>
-        public int MaxCpuCount { get; set; }
+        public int? MaxCpuCount { get; set; }
 
         /// <summary>
         /// Gets or sets whether or not node reuse is used.

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
@@ -122,15 +122,22 @@ namespace Cake.Common.Tools.MSBuild
         /// Sets the maximum CPU count.
         /// </summary>
         /// <param name="settings">The settings.</param>
-        /// <param name="maxCpuCount">The maximum CPU count.</param>
+        /// <param name="maxCpuCount">The maximum CPU count. Set this value to zero to use as many MSBuild processes as available CPUs.</param>
         /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
-        public static MSBuildSettings SetMaxCpuCount(this MSBuildSettings settings, int maxCpuCount)
+        public static MSBuildSettings SetMaxCpuCount(this MSBuildSettings settings, int? maxCpuCount)
         {
             if (settings == null)
             {
                 throw new ArgumentNullException("settings");
             }
-            settings.MaxCpuCount = Math.Max(0, maxCpuCount);
+            if (maxCpuCount.HasValue)
+            {
+                settings.MaxCpuCount = Math.Max(0, maxCpuCount.Value);
+            }
+            else
+            {
+                settings.MaxCpuCount = null;
+            }
             return settings;
         }
 


### PR DESCRIPTION
This means that there will be a semantic change in how the MSBuild alias work. Instead of spawning as
many processes as there are available CPUs in the computer, it will use a single process by default.

This is how MSBuild normally works when not specifying the `/m` switch explicitly.

Closes #1104