### PR TITLE
Add support for 'setParameter' service message to TeamCityProvider + …

### DIFF
--- a/src/Cake.Common.Tests/Unit/Build/TeamCity/TeamCityProviderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TeamCity/TeamCityProviderTests.cs
@@ -109,5 +109,23 @@ namespace Cake.Common.Tests.Unit.Build.TeamCity
                     fixture.Log.AggregateLogMessages());
             }
         }
+
+        public sealed class TheSetParameterMethod
+        {
+            [Fact]
+            public void SetParameter_Should_Write_To_The_Log_Correctly()
+            {
+                // Given
+                var fixture = new TeamCityFixture();
+                var teamCity = fixture.CreateTeamCityService();
+                
+                // When
+                teamCity.SetParameter("internal.artifactVersion", "1.2.3.4");
+
+                // Then
+                Assert.Equal("##teamcity[setParameter name='internal.artifactVersion' value='1.2.3.4']" + Environment.NewLine, 
+                    fixture.Log.AggregateLogMessages());
+            }
+        }
     }
 }

--- a/src/Cake.Common/Build/TeamCity/TeamCityProvider.cs
+++ b/src/Cake.Common/Build/TeamCity/TeamCityProvider.cs
@@ -237,6 +237,20 @@ namespace Cake.Common.Build.TeamCity
             WriteServiceMessage("buildNumber", buildNumber);
         }
 
+        /// <summary>
+        /// Tells TeamCity to set a named parameter with a given value
+        /// </summary>
+        /// <param name="parameterName">The name of the parameter to set.</param>
+        /// <param name="parameterValue">The value to set for the named parameter.</param>
+        public void SetParameter(string parameterName, string parameterValue)
+        {
+            WriteServiceMessage("setParameter", new Dictionary<string, string>
+            {
+                { "name", parameterName },
+                { "value", parameterValue }
+            });
+        }
+
         private void WriteServiceMessage(string messageName, string attributeValue)
         {
             WriteServiceMessage(messageName, new Dictionary<string, string> { { " ", attributeValue } });


### PR DESCRIPTION
In working with a legacy build process (converting to Cake), I noticed the absence of a method exposing the setParameter service message in TeamCity.

see: https://confluence.jetbrains.com/display/TCD9/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-AddingorChangingaBuildParameter

Given the current implementation of TeamCityProvider (WriteServiceMessage) this was a simple addition that seems like it would be useful to more fully support TeamCity interop.