### PR TITLE
GH-918: Adds Atlassian Bitbucket Pipelines support

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,0 +1,8 @@
+# Cake Bitbucket Pipeline
+image: devlead/pipeline-mono
+
+pipelines:
+  default:
+    - step:
+        script:
+          - ./build.sh

--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -58,6 +58,7 @@
   <ItemGroup>
     <Compile Include="Fixtures\Build\AppVeyorFixture.cs" />
     <Compile Include="Fixtures\Build\AppVeyorInfoFixture.cs" />
+    <Compile Include="Fixtures\Build\BitbucketPipelinesInfoFixture.cs" />
     <Compile Include="Fixtures\Build\BitriseFixture.cs" />
     <Compile Include="Fixtures\Build\BitriseInfoFixture.cs" />
     <Compile Include="Fixtures\Build\ContinuaCIFixture.cs" />
@@ -189,6 +190,7 @@
     <Compile Include="Unit\Build\AppVeyor\Data\AppVeyorPullRequestInfoTests.cs" />
     <Compile Include="Unit\Build\AppVeyor\Data\AppVeyorTagInfoTests.cs" />
     <Compile Include="Unit\Build\AppVeyor\Data\AppVeyorRepositoryInfoTests.cs" />
+    <Compile Include="Unit\Build\BitbucketPipelines\Data\BitriseRepositoryInfoTests.cs" />
     <Compile Include="Unit\Build\Bitrise\Data\BitriseApplicationInfoTests.cs" />
     <Compile Include="Unit\Build\Bitrise\Data\BitriseBuildInfoTests.cs" />
     <Compile Include="Unit\Build\Bitrise\Data\BitriseDirectoryInfoTests.cs" />

--- a/src/Cake.Common.Tests/Fixtures/Build/BitbucketPipelinesInfoFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/BitbucketPipelinesInfoFixture.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using Cake.Common.Build.BitbucketPipelines.Data;
+using Cake.Core;
+using NSubstitute;
+
+namespace Cake.Common.Tests.Fixtures.Build
+{
+    public class BitbucketPiplinesInfoFixture
+    {
+        public ICakeEnvironment Environment { get; set; }
+
+        public BitbucketPiplinesInfoFixture()
+        {
+            Environment = Substitute.For<ICakeEnvironment>();
+
+            // BitbucketPiplines RepositoryInfo
+            Environment.GetEnvironmentVariable("BITBUCKET_COMMIT").Returns("4efbc1ffb993dfbcf024e6a9202865cc0b6d9c50");
+            Environment.GetEnvironmentVariable("BITBUCKET_REPO_SLUG").Returns("cake");
+            Environment.GetEnvironmentVariable("BITBUCKET_REPO_OWNER").Returns("cakebuild");
+            Environment.GetEnvironmentVariable("BITBUCKET_BRANCH").Returns("develop");
+            Environment.GetEnvironmentVariable("BITBUCKET_TAG").Returns("BitbucketPiplines");
+        }
+
+        public BitbucketPipelinesEnvironmentInfo CreateEnvironmentInfo()
+        {
+            return new BitbucketPipelinesEnvironmentInfo(Environment);
+        }
+
+        public BitbucketPipelinesRepositoryInfo CreateRepositoryInfo()
+        {
+            return new BitbucketPipelinesRepositoryInfo(Environment);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Build/BitbucketPipelines/Data/BitriseRepositoryInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/BitbucketPipelines/Data/BitriseRepositoryInfoTests.cs
@@ -1,0 +1,91 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using Cake.Common.Tests.Fixtures.Build;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Build.BitbucketPipelines.Data
+{
+    public sealed class BitriseRepositoryInfoTests
+    {
+        public sealed class TheCommitProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new BitbucketPiplinesInfoFixture().CreateRepositoryInfo();
+
+                // When
+                var result = info.Commit;
+
+                //Then
+                Assert.Equal("4efbc1ffb993dfbcf024e6a9202865cc0b6d9c50", result);
+            }
+        }
+
+        public sealed class TheRepoSlugProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new BitbucketPiplinesInfoFixture().CreateRepositoryInfo();
+
+                // When
+                var result = info.RepoSlug;
+
+                //Then
+                Assert.Equal("cake", result);
+            }
+        }
+
+        public sealed class TheRepoOwnerProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new BitbucketPiplinesInfoFixture().CreateRepositoryInfo();
+
+                // When
+                var result = info.RepoOwner;
+
+                //Then
+                Assert.Equal("cakebuild", result);
+            }
+        }
+
+        public sealed class TheBranchProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new BitbucketPiplinesInfoFixture().CreateRepositoryInfo();
+
+                // When
+                var result = info.Branch;
+
+                //Then
+                Assert.Equal("develop", result);
+            }
+        }
+
+        public sealed class TheTagProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new BitbucketPiplinesInfoFixture().CreateRepositoryInfo();
+
+                // When
+                var result = info.Tag;
+
+                //Then
+                Assert.Equal("BitbucketPiplines", result);
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Build/BuildSystemAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/BuildSystemAliasesTests.cs
@@ -95,5 +95,18 @@ namespace Cake.Common.Tests.Unit.Build
                 Assert.IsArgumentNullException(result, "context");
             }
         }
+
+        public sealed class TheBitbucketPipelinesMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Context_Is_Null()
+            {
+                // Given, When
+                var result = Record.Exception(() => BuildSystemAliases.BitbucketPipelines(null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "context");
+            }
+        }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Build/BuildSystemTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/BuildSystemTests.cs
@@ -12,6 +12,7 @@ using Xunit;
 using Cake.Common.Build.ContinuaCI;
 using Cake.Common.Build.Jenkins;
 using Cake.Common.Build.TravisCI;
+using Cake.Common.Build.BitbucketPipelines;
 
 namespace Cake.Common.Tests.Unit.Build
 {
@@ -30,9 +31,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var jenkinsProvider = Substitute.For<IJenkinsProvider>();
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(null, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider));
+                var result = Record.Exception(() => new BuildSystem(null, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "appVeyorProvider");
@@ -49,9 +51,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var jenkinsProvider = Substitute.For<IJenkinsProvider>();
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, null, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, null, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "teamCityProvider");
@@ -68,9 +71,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var jenkinsProvider = Substitute.For<IJenkinsProvider>();
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, null, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, null, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "myGetProvider");
@@ -87,9 +91,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var jenkinsProvider = Substitute.For<IJenkinsProvider>();
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, null, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, null, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "bambooProvider");
@@ -106,9 +111,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var jenkinsProvider = Substitute.For<IJenkinsProvider>();
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, null,  jenkinsProvider, bitriseProvider, travisCIProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, null,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "continuaCIProvider");
@@ -125,9 +131,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, null, bitriseProvider, travisCIProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, null, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "jenkinsProvider");
@@ -144,9 +151,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
                 var jenkinsProvider = Substitute.For<IJenkinsProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, null, travisCIProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, null, travisCIProvider, bitbucketPipelinesProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "bitriseProvider");
@@ -163,12 +171,33 @@ namespace Cake.Common.Tests.Unit.Build
                 var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
                 var jenkinsProvider = Substitute.For<IJenkinsProvider>();
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, null));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, null, bitbucketPipelinesProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "travisCIProvider");
+            }
+
+            [Fact]
+            public void Should_Throw_If_BitbucketPipelines_Is_Null()
+            {
+                // Given
+                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
+                var teamCityProvider = Substitute.For<ITeamCityProvider>();
+                var myGetProvider = Substitute.For<IMyGetProvider>();
+                var bambooProvider = Substitute.For<IBambooProvider>();
+                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
+                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
+                var bitriseProvider = Substitute.For<IBitriseProvider>();
+                var travisCIProvider = Substitute.For<ITravisCIProvider>();
+
+                // When
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "bitbucketPipelinesProvider");
             }
         }
 
@@ -186,9 +215,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var jenkinsProvider = Substitute.For<IJenkinsProvider>();
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnAppVeyor;
@@ -212,9 +242,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var jenkinsProvider = Substitute.For<IJenkinsProvider>();
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 teamCityProvider.IsRunningOnTeamCity.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnTeamCity;
@@ -238,9 +269,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var jenkinsProvider = Substitute.For<IJenkinsProvider>();
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 myGetProvider.IsRunningOnMyGet.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnMyGet;
@@ -264,9 +296,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var jenkinsProvider = Substitute.For<IJenkinsProvider>();
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 bambooProvider.IsRunningOnBamboo.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnBamboo;
@@ -290,9 +323,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var jenkinsProvider = Substitute.For<IJenkinsProvider>();
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 continuaCIProvider.IsRunningOnContinuaCI.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnContinuaCI;
@@ -316,9 +350,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var jenkinsProvider = Substitute.For<IJenkinsProvider>();
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 jenkinsProvider.IsRunningOnJenkins.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnJenkins;
@@ -342,9 +377,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var jenkinsProvider = Substitute.For<IJenkinsProvider>();
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 bitriseProvider.IsRunningOnBitrise.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnBitrise;
@@ -368,12 +404,40 @@ namespace Cake.Common.Tests.Unit.Build
                 var jenkinsProvider = Substitute.For<IJenkinsProvider>();
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 travisCIProvider.IsRunningOnTravisCI.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnTravisCI;
+
+                // Then
+                Assert.True(result);
+            }
+        }
+
+        public sealed class TheIsRunningOnBitbucketPipelinesProperty
+        {
+            [Fact]
+            public void Should_Return_True_If_Running_On_TravisCI()
+            {
+                // Given
+                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
+                var teamCityProvider = Substitute.For<ITeamCityProvider>();
+                var myGetProvider = Substitute.For<IMyGetProvider>();
+                var bambooProvider = Substitute.For<IBambooProvider>();
+                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
+                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
+                var bitriseProvider = Substitute.For<IBitriseProvider>();
+                var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
+
+                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(true);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider);
+
+                // When
+                var result = buildSystem.IsRunningOnBitbucketPipelines;
 
                 // Then
                 Assert.True(result);
@@ -394,6 +458,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var jenkinsProvider = Substitute.For<IJenkinsProvider>();
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(true);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -403,7 +468,8 @@ namespace Cake.Common.Tests.Unit.Build
                 jenkinsProvider.IsRunningOnJenkins.Returns(false);
                 bitriseProvider.IsRunningOnBitrise.Returns(false);
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider);
+                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -424,6 +490,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var jenkinsProvider = Substitute.For<IJenkinsProvider>();
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(true);
@@ -433,7 +500,8 @@ namespace Cake.Common.Tests.Unit.Build
                 jenkinsProvider.IsRunningOnJenkins.Returns(false);
                 bitriseProvider.IsRunningOnBitrise.Returns(false);
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider);
+                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -454,6 +522,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var jenkinsProvider = Substitute.For<IJenkinsProvider>();
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -463,7 +532,8 @@ namespace Cake.Common.Tests.Unit.Build
                 jenkinsProvider.IsRunningOnJenkins.Returns(false);
                 bitriseProvider.IsRunningOnBitrise.Returns(false);
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider);
+                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -484,6 +554,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var jenkinsProvider = Substitute.For<IJenkinsProvider>();
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -493,7 +564,8 @@ namespace Cake.Common.Tests.Unit.Build
                 jenkinsProvider.IsRunningOnJenkins.Returns(false);
                 bitriseProvider.IsRunningOnBitrise.Returns(false);
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider);
+                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -514,6 +586,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var jenkinsProvider = Substitute.For<IJenkinsProvider>();
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -523,7 +596,8 @@ namespace Cake.Common.Tests.Unit.Build
                 jenkinsProvider.IsRunningOnJenkins.Returns(false);
                 bitriseProvider.IsRunningOnBitrise.Returns(false);
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider);
+                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -544,6 +618,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var jenkinsProvider = Substitute.For<IJenkinsProvider>();
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -553,7 +628,8 @@ namespace Cake.Common.Tests.Unit.Build
                 jenkinsProvider.IsRunningOnJenkins.Returns(true);
                 bitriseProvider.IsRunningOnBitrise.Returns(false);
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider);
+                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -574,6 +650,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var jenkinsProvider = Substitute.For<IJenkinsProvider>();
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -583,7 +660,8 @@ namespace Cake.Common.Tests.Unit.Build
                 jenkinsProvider.IsRunningOnJenkins.Returns(false);
                 bitriseProvider.IsRunningOnBitrise.Returns(true);
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider);
+                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -604,6 +682,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var jenkinsProvider = Substitute.For<IJenkinsProvider>();
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -613,7 +692,40 @@ namespace Cake.Common.Tests.Unit.Build
                 jenkinsProvider.IsRunningOnJenkins.Returns(false);
                 bitriseProvider.IsRunningOnBitrise.Returns(false);
                 travisCIProvider.IsRunningOnTravisCI.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider);
+                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider);
+
+                // When
+                var result = buildSystem.IsLocalBuild;
+
+                // Then
+                Assert.False(result);
+            }
+
+            [Fact]
+            public void Should_Return_False_If_Running_On_BitbucketPipelines()
+            {
+                // Given
+                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
+                var teamCityProvider = Substitute.For<ITeamCityProvider>();
+                var myGetProvider = Substitute.For<IMyGetProvider>();
+                var bambooProvider = Substitute.For<IBambooProvider>();
+                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
+                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
+                var bitriseProvider = Substitute.For<IBitriseProvider>();
+                var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
+
+                appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
+                teamCityProvider.IsRunningOnTeamCity.Returns(false);
+                myGetProvider.IsRunningOnMyGet.Returns(false);
+                bambooProvider.IsRunningOnBamboo.Returns(false);
+                continuaCIProvider.IsRunningOnContinuaCI.Returns(false);
+                jenkinsProvider.IsRunningOnJenkins.Returns(false);
+                bitriseProvider.IsRunningOnBitrise.Returns(false);
+                travisCIProvider.IsRunningOnTravisCI.Returns(false);
+                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(true);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -634,6 +746,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var jenkinsProvider = Substitute.For<IJenkinsProvider>();
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -642,7 +755,8 @@ namespace Cake.Common.Tests.Unit.Build
                 continuaCIProvider.IsRunningOnContinuaCI.Returns(false);
                 bitriseProvider.IsRunningOnBitrise.Returns(false);
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider);
+                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;

--- a/src/Cake.Common/Build/BitbucketPipelines/BitbucketPipelinesInfo.cs
+++ b/src/Cake.Common/Build/BitbucketPipelines/BitbucketPipelinesInfo.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+using Cake.Core;
+
+namespace Cake.Common.Build.BitbucketPipelines
+{
+    /// <summary>
+    /// Base class used to provide information about the Bitbucket Pipelines environment.
+    /// </summary>
+    public abstract class BitbucketPipelinesInfo
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BitbucketPipelinesInfo"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        protected BitbucketPipelinesInfo(ICakeEnvironment environment)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Gets an environment variable as a <see cref="System.String"/>.
+        /// </summary>
+        /// <param name="variable">The environment variable name.</param>
+        /// <returns>The environment variable.</returns>
+        protected string GetEnvironmentString(string variable)
+        {
+            return _environment.GetEnvironmentVariable(variable) ?? string.Empty;
+        }
+    }
+}

--- a/src/Cake.Common/Build/BitbucketPipelines/BitbucketPipelinesProvider.cs
+++ b/src/Cake.Common/Build/BitbucketPipelines/BitbucketPipelinesProvider.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using Cake.Common.Build.BitbucketPipelines.Data;
+using Cake.Core;
+
+namespace Cake.Common.Build.BitbucketPipelines
+{
+    /// <summary>
+    /// Responsible for communicating with Pipelibes.
+    /// </summary>
+    public sealed class BitbucketPipelinesProvider : IBitbucketPipelinesProvider
+    {
+        private readonly BitbucketPipelinesEnvironmentInfo _bitbucketPipelinesEnvironment;
+
+        /// <summary>
+        /// Gets a value indicating whether the current build is running on Pipelines.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the current build is running on Pipelines; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsRunningOnBitbucketPipelines
+        {
+            get
+            {
+                return !string.IsNullOrWhiteSpace(Environment.Repository.RepoOwner) &&
+                       !string.IsNullOrWhiteSpace(Environment.Repository.RepoSlug) &&
+                       !string.IsNullOrWhiteSpace(Environment.Repository.Commit);
+            }
+        }
+
+        /// <summary>
+        /// Gets the Pipelines environment.
+        /// </summary>
+        /// <value>
+        /// The Pipelines environment.
+        /// </value>
+        public BitbucketPipelinesEnvironmentInfo Environment
+        {
+            get { return _bitbucketPipelinesEnvironment; }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BitbucketPipelinesProvider"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        public BitbucketPipelinesProvider(ICakeEnvironment environment)
+        {
+            _bitbucketPipelinesEnvironment = new BitbucketPipelinesEnvironmentInfo(environment);
+        }
+    }
+}

--- a/src/Cake.Common/Build/BitbucketPipelines/Data/BitbucketPipelinesEnvironmentInfo.cs
+++ b/src/Cake.Common/Build/BitbucketPipelines/Data/BitbucketPipelinesEnvironmentInfo.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using Cake.Core;
+
+namespace Cake.Common.Build.BitbucketPipelines.Data
+{
+    /// <summary>
+    /// Provides Bitbucket Pipelines environment information for the current build.
+    /// </summary>
+    public class BitbucketPipelinesEnvironmentInfo : BitbucketPipelinesInfo
+    {
+         private readonly BitbucketPipelinesRepositoryInfo _repositoryProvider;
+
+        /// <summary>
+        /// Gets Bitbucket Pipelines repository information.
+        /// </summary>
+        /// <value>
+        /// The repository.
+        /// </value>
+        public BitbucketPipelinesRepositoryInfo Repository
+        {
+            get { return _repositoryProvider; }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BitbucketPipelinesEnvironmentInfo"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        public BitbucketPipelinesEnvironmentInfo(ICakeEnvironment environment) : base(environment)
+        {
+            _repositoryProvider = new BitbucketPipelinesRepositoryInfo(environment);
+        }
+    }
+}

--- a/src/Cake.Common/Build/BitbucketPipelines/Data/BitbucketPipelinesRepositoryInfo.cs
+++ b/src/Cake.Common/Build/BitbucketPipelines/Data/BitbucketPipelinesRepositoryInfo.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using Cake.Core;
+
+namespace Cake.Common.Build.BitbucketPipelines.Data
+{
+    /// <summary>
+    /// Provides Bitbucket Pipelines repository information for the current build.
+    /// </summary>
+    public class BitbucketPipelinesRepositoryInfo : BitbucketPipelinesInfo
+    {
+        /// <summary>
+        /// Gets the branch on which the build was kicked off. This value is only available on branches.
+        /// </summary>
+        /// <remarks>Note: <see cref="Branch"/> and <see cref="Tag"/> are mutually exclusive. If you use both, only one will have a value.</remarks>
+        /// <value>
+        /// The SCM branch.
+        /// </value>
+        public string Branch
+        {
+            get { return GetEnvironmentString("BITBUCKET_BRANCH"); }
+        }
+
+        /// <summary>
+        /// Gets the tag on which the build was kicked off. This value is only available when tagged.
+        /// </summary>
+        /// <remarks>Note: <see cref="Branch"/> and <see cref="Tag"/> are mutually exclusive. If you use both, only one will have a value.</remarks>
+        /// <value>
+        /// The SCM tag.
+        /// </value>
+        public string Tag
+        {
+            get { return GetEnvironmentString("BITBUCKET_TAG"); }
+        }
+
+        /// <summary>
+        /// Gets the commit hash of a commit that kicked off the build.
+        /// </summary>
+        /// <value>
+        /// The SCM commit.
+        /// </value>
+        public string Commit
+        {
+            get { return GetEnvironmentString("BITBUCKET_COMMIT"); }
+        }
+
+        /// <summary>
+        /// Gets the name of the account in which the repository lives.
+        /// </summary>
+        /// <value>
+        /// The repository owner account.
+        /// </value>
+        public string RepoOwner
+        {
+            get { return GetEnvironmentString("BITBUCKET_REPO_OWNER"); }
+        }
+
+        /// <summary>
+        /// Gets the URL-friendly version of a repository name.
+        /// </summary>
+        /// <value>
+        /// The URL-friendly repository name.
+        /// </value>
+        public string RepoSlug
+        {
+            get { return GetEnvironmentString("BITBUCKET_REPO_SLUG"); }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BitbucketPipelinesRepositoryInfo"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        public BitbucketPipelinesRepositoryInfo(ICakeEnvironment environment) : base(environment)
+        {
+        }
+    }
+}

--- a/src/Cake.Common/Build/BitbucketPipelines/IBitbucketPipelinesProvider.cs
+++ b/src/Cake.Common/Build/BitbucketPipelines/IBitbucketPipelinesProvider.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using Cake.Common.Build.BitbucketPipelines.Data;
+
+namespace Cake.Common.Build.BitbucketPipelines
+{
+    /// <summary>
+    /// Represents a Bitrise provider.
+    /// </summary>
+    public interface IBitbucketPipelinesProvider
+    {
+        /// <summary>
+        /// Gets a value indicating whether the current build is running on Bitbucket Pipelines.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the current build is running on Bitbucket Pipelines; otherwise, <c>false</c>.
+        /// </value>
+        bool IsRunningOnBitbucketPipelines { get; }
+
+        /// <summary>
+        /// Gets the Bitbucket Pipelines environment.
+        /// </summary>
+        /// <value>
+        /// The Bitbucket Pipelines environment.
+        /// </value>
+        BitbucketPipelinesEnvironmentInfo Environment { get; }
+    }
+}

--- a/src/Cake.Common/Build/BuildSystem.cs
+++ b/src/Cake.Common/Build/BuildSystem.cs
@@ -4,6 +4,7 @@
 using System;
 using Cake.Common.Build.AppVeyor;
 using Cake.Common.Build.Bamboo;
+using Cake.Common.Build.BitbucketPipelines;
 using Cake.Common.Build.Bitrise;
 using Cake.Common.Build.ContinuaCI;
 using Cake.Common.Build.Jenkins;
@@ -27,6 +28,7 @@ namespace Cake.Common.Build
         private readonly IJenkinsProvider _jenkinsProvider;
         private readonly IBitriseProvider _bitriseProvider;
         private readonly ITravisCIProvider _travisCIProvider;
+        private readonly IBitbucketPipelinesProvider _bitbucketPipelinesProvider;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BuildSystem" /> class.
@@ -39,7 +41,8 @@ namespace Cake.Common.Build
         /// <param name="jenkinsProvider">The Jenkins Provider.</param>
         /// <param name="bitriseProvider">The Bitrise Provider.</param>
         /// <param name="travisCIProvider">The Travis CI provider.</param>
-        public BuildSystem(IAppVeyorProvider appVeyorProvider, ITeamCityProvider teamCityProvider, IMyGetProvider myGetProvider, IBambooProvider bambooProvider, IContinuaCIProvider continuaCIProvider, IJenkinsProvider jenkinsProvider, IBitriseProvider bitriseProvider, ITravisCIProvider travisCIProvider)
+        /// <param name="bitbucketPipelinesProvider">The Bitbucket Pipelines provider.</param>
+        public BuildSystem(IAppVeyorProvider appVeyorProvider, ITeamCityProvider teamCityProvider, IMyGetProvider myGetProvider, IBambooProvider bambooProvider, IContinuaCIProvider continuaCIProvider, IJenkinsProvider jenkinsProvider, IBitriseProvider bitriseProvider, ITravisCIProvider travisCIProvider, IBitbucketPipelinesProvider bitbucketPipelinesProvider)
         {
             if (appVeyorProvider == null)
             {
@@ -73,6 +76,10 @@ namespace Cake.Common.Build
             {
                 throw new ArgumentNullException("travisCIProvider");
             }
+            if (bitbucketPipelinesProvider == null)
+            {
+                throw new ArgumentNullException("bitbucketPipelinesProvider");
+            }
 
             _appVeyorProvider = appVeyorProvider;
             _teamCityProvider = teamCityProvider;
@@ -82,6 +89,7 @@ namespace Cake.Common.Build
             _jenkinsProvider = jenkinsProvider;
             _bitriseProvider = bitriseProvider;
             _travisCIProvider = travisCIProvider;
+            _bitbucketPipelinesProvider = bitbucketPipelinesProvider;
         }
 
         /// <summary>
@@ -387,6 +395,43 @@ namespace Cake.Common.Build
         }
 
         /// <summary>
+        /// Gets a value indicating whether this instance is running on Bitbucket Pipelines.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// if(BuildSystem.IsRunningOnBitbucketPipelines)
+        /// {
+        ///     // Get the build commit hash.
+        ///     var commitHash = BuildSystem.BitbucketPipelines.Environment.Repository.Commit;
+        /// }
+        /// </code>
+        /// </example>
+        /// <value>
+        /// <c>true</c> if this instance is running on Bitbucket Pipelines; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsRunningOnBitbucketPipelines
+        {
+            get { return _bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines; }
+        }
+
+        /// <summary>
+        /// Gets the Bitbucket Pipelines Provider.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// if(BuildSystem.IsRunningOnBitbucketPipelines)
+        /// {
+        ///     // Get the URL friendly repo name.
+        ///     var repoSlug = BuildSystem.BitbucketPipelines.Environment.Repository.RepoSlug;
+        /// }
+        /// </code>
+        /// </example>
+        public IBitbucketPipelinesProvider BitbucketPipelines
+        {
+            get { return _bitbucketPipelinesProvider; }
+        }
+
+        /// <summary>
         /// Gets a value indicating whether the current build is local build.
         /// </summary>
         /// <example>
@@ -407,7 +452,7 @@ namespace Cake.Common.Build
         /// </value>
         public bool IsLocalBuild
         {
-            get { return !(IsRunningOnAppVeyor || IsRunningOnTeamCity || IsRunningOnMyGet || IsRunningOnBamboo || IsRunningOnContinuaCI || IsRunningOnJenkins || IsRunningOnBitrise || IsRunningOnTravisCI); }
+            get { return !(IsRunningOnAppVeyor || IsRunningOnTeamCity || IsRunningOnMyGet || IsRunningOnBamboo || IsRunningOnContinuaCI || IsRunningOnJenkins || IsRunningOnBitrise || IsRunningOnTravisCI || IsRunningOnBitbucketPipelines); }
         }
     }
 }

--- a/src/Cake.Common/Build/BuildSystemAliases.cs
+++ b/src/Cake.Common/Build/BuildSystemAliases.cs
@@ -4,6 +4,7 @@
 using System;
 using Cake.Common.Build.AppVeyor;
 using Cake.Common.Build.Bamboo;
+using Cake.Common.Build.BitbucketPipelines;
 using Cake.Common.Build.Bitrise;
 using Cake.Common.Build.ContinuaCI;
 using Cake.Common.Build.Jenkins;
@@ -47,8 +48,9 @@ namespace Cake.Common.Build
             var jenkinsProvider = new JenkinsProvider(context.Environment);
             var bitriseProvider = new BitriseProvider(context.Environment);
             var travisCIProvider = new TravisCIProvider(context.Environment, context.Log);
+            var bitbucketPipelinesProvider = new BitbucketPipelinesProvider(context.Environment);
 
-            return new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider);
+            return new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider);
         }
 
         /// <summary>
@@ -235,6 +237,30 @@ namespace Cake.Common.Build
             }
             var buildSystem = context.BuildSystem();
             return buildSystem.TravisCI;
+        }
+
+        /// <summary>
+        /// Get a <see cref="BitbucketPipelinesProvider"/> instance that can be user to
+        /// obtain information from the Bitbucket Pipelines environment.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var isBitbucketPipelinesBuild = BitbucketPipelines.IsRunningOnBitbucketPipelines;
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <returns>A <see cref="Build.BitbucketPipelines"/> instance.</returns>
+        [CakePropertyAlias(Cache = true)]
+        [CakeNamespaceImport("Cake.Common.Build.BitbucketPipelines")]
+        [CakeNamespaceImport("Cake.Common.Build.BitbucketPipelines.Data")]
+        public static IBitbucketPipelinesProvider BitbucketPipelines(this ICakeContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            var buildSystem = context.BuildSystem();
+            return buildSystem.BitbucketPipelines;
         }
     }
 }

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -100,6 +100,11 @@
     <Compile Include="Build\MyGet\IMyGetProvider.cs" />
     <Compile Include="Build\MyGet\MyGetProvider.cs" />
     <Compile Include="Build\MyGet\MyGetBuildStatus.cs" />
+    <Compile Include="Build\BitbucketPipelines\Data\BitbucketPipelinesEnvironmentInfo.cs" />
+    <Compile Include="Build\BitbucketPipelines\Data\BitbucketPipelinesRepositoryInfo.cs" />
+    <Compile Include="Build\BitbucketPipelines\BitbucketPipelinesInfo.cs" />
+    <Compile Include="Build\BitbucketPipelines\BitbucketPipelinesProvider.cs" />
+    <Compile Include="Build\BitbucketPipelines\IBitbucketPipelinesProvider.cs" />
     <Compile Include="Build\TeamCity\ITeamCityProvider.cs" />
     <Compile Include="Build\TeamCity\TeamCityDisposableExtensions.cs" />
     <Compile Include="Build\TeamCity\TeamCityProvider.cs" />


### PR DESCRIPTION
* Fixes #918

This adds Bitbucket Pipelines builsystem support to Cake.

### Example usage:
```cake
var isBitbucketPipelinesBuild = BitbucketPipelines.IsRunningOnBitbucketPipelines;

Information("isBitbucketPipelinesBuild: {0}", isBitbucketPipelinesBuild);

if(BuildSystem.IsRunningOnBitbucketPipelines)
{
    // Get the build commit hash.
    var commitHash = BuildSystem.BitbucketPipelines.Environment.Repository.Commit;
}

if(BuildSystem.IsRunningOnBitbucketPipelines)
{
    // Get the URL friendly repo name.
    var repoSlug = BuildSystem.BitbucketPipelines.Environment.Repository.RepoSlug;
}
```

### Example values of `BitbucketPipelines`
```json
BitbucketPipelines: {
  "IsRunningOnBitbucketPipelines": true,
  "Environment": {
    "Repository": {
      "Branch": "develop",
      "Tag": "Bitbucket Pipelines",
      "Commit": "4efbc1ffb993dfbcf024e6a9202865cc0b6d9c50",
      "RepoOwner": "cakebuild",
      "RepoSlug": "cake"
    }
  }
```

### Example output Building Cake on Bitbucket Pipelines
![Cake on Bitbucket Pipelines](https://cloud.githubusercontent.com/assets/1647294/17108384/7f980826-5293-11e6-91b5-c1d3deb5b565.png)

### Example build system aware execution on Bitbucket Pipelines
![Execute Cake result on Bitbucket Pipelines](https://cloud.githubusercontent.com/assets/1647294/17108705/f748b298-5294-11e6-84ed-b7dd451413ec.png)

### bitbucket-pipelines.yml used for testing
```yml
# Cake Bitbucket Pipeline
image: devlead/pipeline-mono

pipelines:
  default:
    - step:
        script:
          - ./build.sh
          - mono ./src/Cake/bin/Release/Cake.exe ./bitbucket-pipelines.cake
```

