### PR TITLE
GH1112: Refactor AppVeyorProvider to be a Tool<TSettings>-based tool

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Build/AppVeyorFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/AppVeyorFixture.cs
@@ -5,6 +5,7 @@
 using Cake.Common.Build.AppVeyor;
 using Cake.Core;
 using Cake.Core.IO;
+using Cake.Core.Tooling;
 using NSubstitute;
 
 namespace Cake.Common.Tests.Fixtures.Build
@@ -13,6 +14,8 @@ namespace Cake.Common.Tests.Fixtures.Build
     {
         public ICakeEnvironment Environment { get; set; }
         public IProcessRunner ProcessRunner { get; set; }
+        public IFileSystem FileSystem { get; set; }
+        public IToolLocator ToolLocator { get; set; }
 
         public AppVeyorFixture()
         {
@@ -21,6 +24,8 @@ namespace Cake.Common.Tests.Fixtures.Build
             Environment.GetEnvironmentVariable("APPVEYOR").Returns((string)null);
 
             ProcessRunner = Substitute.For<IProcessRunner>();
+            FileSystem = Substitute.For<IFileSystem>();
+            ToolLocator = Substitute.For<IToolLocator>();
         }
 
         public void IsRunningOnAppVeyor()
@@ -30,7 +35,7 @@ namespace Cake.Common.Tests.Fixtures.Build
 
         public AppVeyorProvider CreateAppVeyorService()
         {
-            return new AppVeyorProvider(Environment, ProcessRunner);
+            return new AppVeyorProvider(FileSystem, Environment, ProcessRunner, ToolLocator);
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Build/AppVeyor/AppVeyorProviderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/AppVeyor/AppVeyorProviderTests.cs
@@ -14,31 +14,6 @@ namespace Cake.Common.Tests.Unit.Build.AppVeyor
 {
     public sealed class AppVeyorProviderTests
     {
-        public sealed class TheConstructor
-        {
-            [Fact]
-            public void Should_Throw_If_Environment_Is_Null()
-            {
-                // Given, When
-                var processRunner = Substitute.For<IProcessRunner>();
-                var result = Record.Exception(() => new AppVeyorProvider(null, processRunner));
-
-                // Then
-                Assert.IsArgumentNullException(result, "environment");
-            }
-
-            [Fact]
-            public void Should_Throw_If_Process_Runner_Is_Null()
-            {
-                // Given, When
-                var environment = Substitute.For<ICakeEnvironment>();
-                var result = Record.Exception(() => new AppVeyorProvider(environment, null));
-
-                // Then
-                Assert.IsArgumentNullException(result, "processRunner");
-            }
-        }
-
         public sealed class TheIsRunningOnAppVeyorProperty
         {
             [Fact]

--- a/src/Cake.Common/Build/AppVeyor/AppVeyorToolSettings.cs
+++ b/src/Cake.Common/Build/AppVeyor/AppVeyorToolSettings.cs
@@ -1,0 +1,11 @@
+﻿using Cake.Core.Tooling;
+
+namespace Cake.Common.Build.AppVeyor
+{
+    /// <summary>
+    /// Settings for the AppVeyor.exe tool
+    /// </summary>
+    public class AppVeyorToolSettings : ToolSettings
+    {
+    }
+}

--- a/src/Cake.Common/Build/BuildSystemAliases.cs
+++ b/src/Cake.Common/Build/BuildSystemAliases.cs
@@ -41,7 +41,7 @@ namespace Cake.Common.Build
             {
                 throw new ArgumentNullException("context");
             }
-            var appVeyorProvider = new AppVeyorProvider(context.Environment, context.ProcessRunner);
+            var appVeyorProvider = new AppVeyorProvider(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             var teamCityProvider = new TeamCityProvider(context.Environment, context.Log);
             var myGetProvider = new MyGetProvider(context.Environment);
             var bambooProvider = new BambooProvider(context.Environment);

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Build\AppVeyor\AppVeyorMessageCategoryType.cs" />
     <Compile Include="Build\AppVeyor\AppVeyorProviderAddMessageExtensions.cs" />
     <Compile Include="Build\AppVeyor\AppVeyorTestResultsType.cs" />
+    <Compile Include="Build\AppVeyor\AppVeyorToolSettings.cs" />
     <Compile Include="Build\AppVeyor\AppVeyorUploadArtifactsSettings.cs" />
     <Compile Include="Build\AppVeyor\AppVeyorUploadArtifactType.cs" />
     <Compile Include="Build\AppVeyor\Data\AppVeyorEnvironmentInfo.cs" />


### PR DESCRIPTION
This resolves #1112 which was raised in response to #1097 .

This is "minimum required" refactoring of `AppVeyorProvider` to correctly inherit from `Tool<TSettings>` mostly to enable correct exit code handling etc.

I have also removed the constructor tests since those null checks are now happening in the base class.

Let me know if any changes need to be made, or if you'd prefer to wait and do a more holistic refactoring.
