### PR TITLE
GH1126: corrects issues with UploadArtifact and UploadTestResults

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Build/AppVeyorFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/AppVeyorFixture.cs
@@ -4,7 +4,9 @@
 
 using Cake.Common.Build.AppVeyor;
 using Cake.Core;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
+using Cake.Testing;
 using NSubstitute;
 
 namespace Cake.Common.Tests.Fixtures.Build
@@ -14,6 +16,8 @@ namespace Cake.Common.Tests.Fixtures.Build
         public ICakeEnvironment Environment { get; set; }
         public IProcessRunner ProcessRunner { get; set; }
 
+        public FakeLog CakeLog { get; set; }
+
         public AppVeyorFixture()
         {
             Environment = Substitute.For<ICakeEnvironment>();
@@ -21,6 +25,7 @@ namespace Cake.Common.Tests.Fixtures.Build
             Environment.GetEnvironmentVariable("APPVEYOR").Returns((string)null);
 
             ProcessRunner = Substitute.For<IProcessRunner>();
+            CakeLog = new FakeLog();
         }
 
         public void IsRunningOnAppVeyor()
@@ -30,7 +35,7 @@ namespace Cake.Common.Tests.Fixtures.Build
 
         public AppVeyorProvider CreateAppVeyorService()
         {
-            return new AppVeyorProvider(Environment, ProcessRunner);
+            return new AppVeyorProvider(Environment, ProcessRunner, CakeLog);
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Build/AppVeyor/AppVeyorProviderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/AppVeyor/AppVeyorProviderTests.cs
@@ -6,6 +6,7 @@ using System;
 using Cake.Common.Build.AppVeyor;
 using Cake.Common.Tests.Fixtures.Build;
 using Cake.Core;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using NSubstitute;
 using Xunit;
@@ -20,8 +21,9 @@ namespace Cake.Common.Tests.Unit.Build.AppVeyor
             public void Should_Throw_If_Environment_Is_Null()
             {
                 // Given, When
+                var cakeLog = Substitute.For<ICakeLog>();
                 var processRunner = Substitute.For<IProcessRunner>();
-                var result = Record.Exception(() => new AppVeyorProvider(null, processRunner));
+                var result = Record.Exception(() => new AppVeyorProvider(null, processRunner, cakeLog));
 
                 // Then
                 Assert.IsArgumentNullException(result, "environment");
@@ -31,11 +33,24 @@ namespace Cake.Common.Tests.Unit.Build.AppVeyor
             public void Should_Throw_If_Process_Runner_Is_Null()
             {
                 // Given, When
+                var cakeLog = Substitute.For<ICakeLog>();
                 var environment = Substitute.For<ICakeEnvironment>();
-                var result = Record.Exception(() => new AppVeyorProvider(environment, null));
+                var result = Record.Exception(() => new AppVeyorProvider(environment, null, cakeLog));
 
                 // Then
                 Assert.IsArgumentNullException(result, "processRunner");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Log_Is_Null()
+            {
+                // Given, When
+                var processRunner = Substitute.For<IProcessRunner>();
+                var environment = Substitute.For<ICakeEnvironment>();
+                var result = Record.Exception(() => new AppVeyorProvider(environment, processRunner, null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "cakeLog");
             }
         }
 
@@ -148,7 +163,7 @@ namespace Cake.Common.Tests.Unit.Build.AppVeyor
                 fixture.ProcessRunner.Received(1).Start(
                     Arg.Is<FilePath>(p => p.FullPath == "appveyor"),
                     Arg.Is<ProcessSettings>(p => p.Arguments.Render()
-                        == "PushArtifact -Path \"/Working/file.zip\" -FileName \"file.zip\" -ArtifactType \"Auto\""));
+                        == "PushArtifact \"/Working/file.zip\" -Type Auto"));
             }
 
             [Theory]
@@ -169,7 +184,7 @@ namespace Cake.Common.Tests.Unit.Build.AppVeyor
                 fixture.ProcessRunner.Received(1).Start(
                     Arg.Is<FilePath>(p => p.FullPath == "appveyor"),
                     Arg.Is<ProcessSettings>(p => p.Arguments.Render()
-                        == string.Format("PushArtifact -Path \"/Working/file.zip\" -FileName \"file.zip\" -ArtifactType \"{0}\"", arg)));
+                        == string.Format("PushArtifact \"/Working/file.zip\" -Type {0}", arg)));
             }
 
             [Fact]
@@ -187,7 +202,7 @@ namespace Cake.Common.Tests.Unit.Build.AppVeyor
                 fixture.ProcessRunner.Received(1).Start(
                     Arg.Is<FilePath>(p => p.FullPath == "appveyor"),
                     Arg.Is<ProcessSettings>(p => p.Arguments.Render()
-                        == "PushArtifact -Path \"/Working/file.zip\" -FileName \"file.zip\" -ArtifactType \"Auto\" -DeploymentName \"MyApp.Web\""));
+                        == "PushArtifact \"/Working/file.zip\" -Type Auto -DeploymentName \"MyApp.Web\""));
             }
 
             [Fact]

--- a/src/Cake.Common/Build/BuildSystemAliases.cs
+++ b/src/Cake.Common/Build/BuildSystemAliases.cs
@@ -41,7 +41,7 @@ namespace Cake.Common.Build
             {
                 throw new ArgumentNullException("context");
             }
-            var appVeyorProvider = new AppVeyorProvider(context.Environment, context.ProcessRunner);
+            var appVeyorProvider = new AppVeyorProvider(context.Environment, context.ProcessRunner, context.Log);
             var teamCityProvider = new TeamCityProvider(context.Environment, context.Log);
             var myGetProvider = new MyGetProvider(context.Environment);
             var bambooProvider = new BambooProvider(context.Environment);


### PR DESCRIPTION
* ```UploadArtifact``` now sends ```-Type``` instead of ```-ArtifactType``` to define the type of artifact uploaded, I blame resharper for this one!

* ```UploadTestResults``` - the ```Content-Disposition``` header on the form-data content needs to specify at least a name.  Now generates a header similar to:

```
Content-Disposition: form-data; name=test-results.xml; filename=test-results.xml
```