### PR TITLE
GH1055: Fixed WixHeat: HarvestType Out parameter issue

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/WiX/HeatFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/WiX/HeatFixture.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-using System;
 using System.Collections.Generic;
 using Cake.Common.Tools.WiX.Heat;
 using Cake.Core.IO;
@@ -18,7 +16,9 @@ namespace Cake.Common.Tests.Fixtures.Tools.WiX
 
         public FilePath OutputFile { get; set; }
 
-        public string HarvestType { get; set; }
+        public string HarvestTarget { get; set; }
+
+        public WiXHarvestType HarvestType { get; set; } 
 
         public HeatFixture()
             : base("heat.exe")
@@ -28,32 +28,31 @@ namespace Cake.Common.Tests.Fixtures.Tools.WiX
             ObjectFiles.Add(new FilePath("Cake.dll"));
             OutputFile = new FilePath("cake.wxs");
             Settings = new HeatSettings();
-            Settings.HarvestType = WiXHarvestType.Dir;
-            HarvestType = "Default Web Site";
+            HarvestType = WiXHarvestType.Dir;
+            HarvestTarget = "Default Web Site";
         }
 
         protected override void RunTool()
         {
             var tool = new HeatRunner(FileSystem, Environment, ProcessRunner, Tools);
 
-            switch (Settings.HarvestType)
+            switch (HarvestType)
             {
                 case WiXHarvestType.Dir:
-                    tool.Run(DirectoryPath, OutputFile, Settings);
+                    tool.Run(DirectoryPath, OutputFile, HarvestType, Settings);
                     break;
                 case WiXHarvestType.File:
                 case WiXHarvestType.Project:
                 case WiXHarvestType.Reg:
-                    tool.Run(ObjectFiles, OutputFile, Settings);
+                    tool.Run(ObjectFiles, OutputFile, HarvestType, Settings);
                     break;
                 case WiXHarvestType.Website:
                 case WiXHarvestType.Perf:
-                    tool.Run(HarvestType, OutputFile, Settings);
-                    break;
-                case null:
+                    tool.Run(HarvestTarget, OutputFile, HarvestType, Settings);
                     break;
                 default:
-                    throw new ArgumentOutOfRangeException();
+                    tool.Run(DirectoryPath, OutputFile, HarvestType, Settings);
+                    break;
             }
         }
     }

--- a/src/Cake.Common.Tests/Unit/Tools/WiX/HeatRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/WiX/HeatRunnerTests.cs
@@ -1,12 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
 using System;
 using Cake.Common.Tests.Fixtures.Tools.WiX;
 using Cake.Common.Tools.WiX.Heat;
 using Cake.Core;
-using Cake.Core.IO;
 using Cake.Testing;
 using Cake.Testing.Xunit;
 using Xunit;
@@ -187,7 +185,7 @@ namespace Cake.Common.Tests.Unit.Tools.WiX
             {
                 // Given
                 var fixture = new HeatFixture();
-                fixture.Settings.HarvestType = WiXHarvestType.File;
+                fixture.HarvestType = WiXHarvestType.File;
 
                 // When
                 var result = fixture.Run();
@@ -201,7 +199,7 @@ namespace Cake.Common.Tests.Unit.Tools.WiX
             {
                 // Given
                 var fixture = new HeatFixture();
-                fixture.Settings.HarvestType = WiXHarvestType.Website;
+                fixture.HarvestType = WiXHarvestType.Website;
 
                 // When
                 var result = fixture.Run();
@@ -215,8 +213,8 @@ namespace Cake.Common.Tests.Unit.Tools.WiX
             {
                 // Given
                 var fixture = new HeatFixture();
-                fixture.Settings.HarvestType = WiXHarvestType.Perf;
-                fixture.HarvestType = "Cake Category";
+                fixture.HarvestType = WiXHarvestType.Perf;
+                fixture.HarvestTarget = "Cake Category";
 
                 // When
                 var result = fixture.Run();
@@ -713,6 +711,20 @@ namespace Cake.Common.Tests.Unit.Tools.WiX
 
                 // Then
                 Assert.Equal("dir \"/Working/src/Cake\" -wixvar -out \"/Working/cake.wxs\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Default_To_Directory_Harvest_Type()
+            {
+                // Given
+                var fixture = new HeatFixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("dir \"/Working/src/Cake\" -out \"/Working/cake.wxs\"", result.Args);
+
             }
         }
     }

--- a/src/Cake.Common.Tests/Unit/Tools/WiX/WiXAliasTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/WiX/WiXAliasTests.cs
@@ -4,8 +4,6 @@
 
 using Cake.Common.Tests.Fixtures.Tools.WiX;
 using Cake.Common.Tools.WiX;
-using Cake.Core;
-using NSubstitute;
 using Xunit;
 
 namespace Cake.Common.Tests.Unit.Tools.WiX
@@ -21,24 +19,10 @@ namespace Cake.Common.Tests.Unit.Tools.WiX
                 var fixture = new HeatFixture();
 
                 // When
-                var result = Record.Exception(() => WiXAliases.WiXHeat(null, fixture.DirectoryPath, fixture.OutputFile));
+                var result = Record.Exception(() => WiXAliases.WiXHeat(null, fixture.DirectoryPath, fixture.OutputFile, fixture.HarvestType));
 
                 // Then
                 Assert.IsArgumentNullException(result, "context");
-            }
-
-            [Fact]
-            public void Should_Throw_If_Directory_Path_Is_Null()
-            {
-                // Given
-                var fixture = new HeatFixture();
-                var context = Substitute.For<ICakeContext>();
-
-                // When
-                var result = Record.Exception(() => WiXAliases.WiXHeat(context, null, fixture.OutputFile));
-
-                // Then
-                Assert.IsArgumentNullException(result, "directoryPath");
             }
         }
     }

--- a/src/Cake.Common/Tools/WiX/Heat/HeatRunner.cs
+++ b/src/Cake.Common/Tools/WiX/Heat/HeatRunner.cs
@@ -42,8 +42,9 @@ namespace Cake.Common.Tools.WiX.Heat
         /// </summary>
         /// <param name="directoryPath">The directory path.</param>
         /// <param name="outputFile">The output file.</param>
+        /// <param name="harvestType">The WiX harvest type.</param>
         /// <param name="settings">The settings.</param>
-        public void Run(DirectoryPath directoryPath, FilePath outputFile, HeatSettings settings)
+        public void Run(DirectoryPath directoryPath, FilePath outputFile, WiXHarvestType harvestType, HeatSettings settings)
         {
             if (directoryPath == null)
             {
@@ -60,7 +61,7 @@ namespace Cake.Common.Tools.WiX.Heat
                 throw new ArgumentNullException("settings");
             }
 
-            Run(settings, GetArguments(directoryPath, outputFile, settings));
+            Run(settings, GetArguments(directoryPath, outputFile, harvestType, settings));
         }
 
         /// <summary>
@@ -68,8 +69,9 @@ namespace Cake.Common.Tools.WiX.Heat
         /// </summary>
         /// <param name="objectFiles">The object files.</param>
         /// <param name="outputFile">The output file.</param>
+        /// <param name="harvestType">The WiX harvest type.</param>
         /// <param name="settings">The settings.</param>
-        public void Run(IEnumerable<FilePath> objectFiles, FilePath outputFile, HeatSettings settings)
+        public void Run(IEnumerable<FilePath> objectFiles, FilePath outputFile, WiXHarvestType harvestType, HeatSettings settings)
         {
             if (objectFiles == null)
             {
@@ -92,7 +94,7 @@ namespace Cake.Common.Tools.WiX.Heat
                 throw new ArgumentException("No object files provided.", "objectFiles");
             }
 
-            Run(settings, GetArguments(objectFilesArray, outputFile, settings));
+            Run(settings, GetArguments(objectFilesArray, outputFile, harvestType, settings));
         }
 
         /// <summary>
@@ -100,8 +102,9 @@ namespace Cake.Common.Tools.WiX.Heat
         /// </summary>
         /// <param name="harvestTarget">The harvest target.</param>
         /// <param name="outputFile">The output file.</param>
+        /// <param name="harvestType">The WiX harvest type.</param>
         /// <param name="settings">The settings.</param>
-        public void Run(string harvestTarget, FilePath outputFile, HeatSettings settings)
+        public void Run(string harvestTarget, FilePath outputFile, WiXHarvestType harvestType, HeatSettings settings)
         {
             if (harvestTarget == null)
             {
@@ -118,30 +121,14 @@ namespace Cake.Common.Tools.WiX.Heat
                 throw new ArgumentNullException("settings");
             }
 
-            Run(settings, GetArguments(harvestTarget, outputFile, settings));
+            Run(settings, GetArguments(harvestTarget, outputFile, harvestType, settings));
         }
 
-        private ProcessArgumentBuilder GetArguments(IEnumerable<FilePath> objectFiles, FilePath outputFile, HeatSettings settings)
+        private ProcessArgumentBuilder GetArguments(IEnumerable<FilePath> objectFiles, FilePath outputFile, WiXHarvestType harvestType, HeatSettings settings)
         {
             var builder = new ProcessArgumentBuilder();
 
-            if (settings.HarvestType != null)
-            {
-                switch (settings.HarvestType)
-                {
-                    case WiXHarvestType.File:
-                        builder.Append("file");
-                        break;
-                    case WiXHarvestType.Project:
-                        builder.Append("project");
-                        break;
-                    case WiXHarvestType.Reg:
-                        builder.Append("reg");
-                        break;
-                    default:
-                        throw new ArgumentException("Incorrect harvest type for input.", "objectFiles");
-                }
-            }
+            builder.Append(GetHarvestType(harvestType));
 
             // Object files
             foreach (var objectFile in objectFiles.Select(file => file.MakeAbsolute(_environment).FullPath))
@@ -156,22 +143,11 @@ namespace Cake.Common.Tools.WiX.Heat
             return builder;
         }
 
-        private ProcessArgumentBuilder GetArguments(DirectoryPath directoryPath, FilePath outputFile, HeatSettings settings)
+        private ProcessArgumentBuilder GetArguments(DirectoryPath directoryPath, FilePath outputFile, WiXHarvestType harvestType, HeatSettings settings)
         {
             var builder = new ProcessArgumentBuilder();
 
-            if (settings.HarvestType != null)
-            {
-                switch (settings.HarvestType)
-                {
-                    case WiXHarvestType.Dir:
-                        builder.Append("dir");
-                        break;
-                    default:
-                        throw new ArgumentException("Incorrect harvest type for input.", "directoryPath");
-                }
-            }
-
+            builder.Append(GetHarvestType(harvestType));
             builder.AppendQuoted(directoryPath.MakeAbsolute(_environment).FullPath);
 
             var args = GetArguments(outputFile, settings);
@@ -181,24 +157,11 @@ namespace Cake.Common.Tools.WiX.Heat
             return builder;
         }
 
-        private ProcessArgumentBuilder GetArguments(string harvestTarget, FilePath outputFile, HeatSettings settings)
+        private ProcessArgumentBuilder GetArguments(string harvestTarget, FilePath outputFile, WiXHarvestType harvestType, HeatSettings settings)
         {
             var builder = new ProcessArgumentBuilder();
 
-            if (settings.HarvestType != null)
-            {
-                switch (settings.HarvestType)
-                {
-                    case WiXHarvestType.Perf:
-                        builder.Append("perf");
-                        break;
-                    case WiXHarvestType.Website:
-                        builder.Append("website");
-                        break;
-                    default:
-                        throw new ArgumentException("Incorrect harvest type for input.", "harvestTarget");
-                }
-            }
+            builder.Append(GetHarvestType(harvestType));
 
             builder.AppendQuoted(harvestTarget);
 
@@ -430,6 +393,27 @@ namespace Cake.Common.Tools.WiX.Heat
             builder.AppendQuoted(outputFile.MakeAbsolute(_environment).FullPath);
 
             return builder;
+        }
+
+        private string GetHarvestType(WiXHarvestType harvestType)
+        {
+            switch (harvestType)
+            {
+                case WiXHarvestType.Dir:
+                    return "dir";
+                case WiXHarvestType.File:
+                    return "file";
+                case WiXHarvestType.Project:
+                    return "project";
+                case WiXHarvestType.Reg:
+                    return "reg";
+                case WiXHarvestType.Perf:
+                    return "perf";
+                case WiXHarvestType.Website:
+                    return "website";
+                default:
+                    return "dir";
+            }
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/WiX/Heat/HeatSettings.cs
+++ b/src/Cake.Common/Tools/WiX/Heat/HeatSettings.cs
@@ -14,15 +14,6 @@ namespace Cake.Common.Tools.WiX.Heat
     public sealed class HeatSettings : ToolSettings
     {
         /// <summary>
-        /// Gets or sets the type for WiX harvest.
-        /// Default is dir.
-        /// </summary>
-        /// <value>
-        /// The type of the harvest.
-        /// </value>
-        public WiXHarvestType? HarvestType { get; set; }
-
-        /// <summary>
         /// Gets or sets the WiX extensions to use.
         /// </summary>
         public IEnumerable<string> Extensions { get; set; }

--- a/src/Cake.Common/Tools/WiX/WiXAliases.cs
+++ b/src/Cake.Common/Tools/WiX/WiXAliases.cs
@@ -155,18 +155,19 @@ namespace Cake.Common.Tools.WiX
         /// </summary>
         /// <example>
         /// <code>
-        /// var harvestDirectory = Directory("./src");
-        /// var filePath = new FilePath("cake.wxs");
-        /// WiXHeat(harvestDirectory, filePath);
+        /// DirectoryPath harvestDirectory = Directory("./src");
+        /// var filePath = new FilePath("Wix.Directory.wxs");
+        /// WiXHeat(harvestDirectory, filePath, WiXHarvestType.Dir);
         /// </code>
         /// </example>
         /// <param name="context">The context.</param>
         /// <param name="directoryPath">The object files.</param>
         /// <param name="outputFile">The output file.</param>
+        /// <param name="harvestType">The WiX harvest type.</param>
         [CakeMethodAlias]
         [CakeAliasCategory("Heat")]
         [CakeNamespaceImport("Cake.Common.Tools.WiX.Heat")]
-        public static void WiXHeat(this ICakeContext context, DirectoryPath directoryPath, FilePath outputFile)
+        public static void WiXHeat(this ICakeContext context, DirectoryPath directoryPath, FilePath outputFile, WiXHarvestType harvestType)
         {
             if (context == null)
             {
@@ -174,7 +175,7 @@ namespace Cake.Common.Tools.WiX
             }
 
             var runner = new HeatRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Run(directoryPath, outputFile, new HeatSettings());
+            runner.Run(directoryPath, outputFile, harvestType, new HeatSettings());
         }
 
         /// <summary>
@@ -182,19 +183,21 @@ namespace Cake.Common.Tools.WiX
         /// </summary>
         /// <example>
         /// <code>
-        /// var harvestDirectory = Directory("./src");
-        /// var filePath = new FilePath("cake.wxs");
-        /// WiXHeat(harvestDirectory, filePath, new HeatSettings { HarvestType = WiXHarvestType.Dir });
+        /// DirectoryPath harvestDirectory = Directory("./src");
+        /// var filePath = File("Wix.Directory.wxs");
+        /// Information(MakeAbsolute(harvestDirectory).FullPath);
+        /// WiXHeat(harvestDirectory, filePath, WiXHarvestType.Dir, new HeatSettings { NoLogo = true });
         /// </code>
         /// </example>
         /// <param name="context">The context.</param>
         /// <param name="directoryPath">The directory path.</param>
         /// <param name="outputFile">The output file.</param>
+        /// <param name="harvestType">The WiX harvest type.</param>
         /// <param name="settings">The settings.</param>
         [CakeMethodAlias]
         [CakeAliasCategory("Heat")]
         [CakeNamespaceImport("Cake.Common.Tools.WiX.Heat")]
-        public static void WiXHeat(this ICakeContext context, DirectoryPath directoryPath, FilePath outputFile, HeatSettings settings)
+        public static void WiXHeat(this ICakeContext context, DirectoryPath directoryPath, FilePath outputFile, WiXHarvestType harvestType, HeatSettings settings)
         {
             if (context == null)
             {
@@ -202,7 +205,7 @@ namespace Cake.Common.Tools.WiX
             }
 
             var runner = new HeatRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Run(directoryPath, outputFile, settings ?? new HeatSettings());
+            runner.Run(directoryPath, outputFile, harvestType, settings ?? new HeatSettings());
         }
 
         /// <summary>
@@ -210,19 +213,19 @@ namespace Cake.Common.Tools.WiX
         /// </summary>
         /// <example>
         /// <code>
-        /// var harvestFiles = GetFiles(".src/website/bin/website.dll");
-        /// var filePath = File("cake.wxs");
-        /// WiXHeat(harvestFiles, filePath, new HeatSettings { HarvestType = WiXHarvestType.File });
+        /// var harvestFile = File("./tools/Cake/Cake.Core.dll");
+        /// var filePath = File("Wix.File.wxs");
+        /// WiXHeat(harvestFile, filePath, WiXHarvestType.File);
         /// </code>
         /// </example>
         /// <param name="context">The context.</param>
         /// <param name="objectFiles">The object files.</param>
         /// <param name="outputFile">The output file.</param>
-        /// <param name="settings">The settings.</param>
+        /// <param name="harvestType">The WiX harvest type.</param>
         [CakeMethodAlias]
         [CakeAliasCategory("Heat")]
         [CakeNamespaceImport("Cake.Common.Tools.WiX.Heat")]
-        public static void WiXHeat(this ICakeContext context, IEnumerable<FilePath> objectFiles, FilePath outputFile, HeatSettings settings)
+        public static void WiXHeat(this ICakeContext context, IEnumerable<FilePath> objectFiles, FilePath outputFile, WiXHarvestType harvestType)
         {
             if (context == null)
             {
@@ -230,7 +233,36 @@ namespace Cake.Common.Tools.WiX
             }
 
             var runner = new HeatRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Run(objectFiles, outputFile, settings ?? new HeatSettings());
+            runner.Run(objectFiles, outputFile, harvestType, new HeatSettings());
+        }
+
+        /// <summary>
+        /// Harvests from the desired files.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var harvestFiles = File("./tools/Cake/*.dll");
+        /// var filePath = File("Wix.File.wxs");
+        /// WiXHeat(harvestFiles, filePath, WiXHarvestType.File, new HeatSettings { NoLogo = true });
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="objectFiles">The object files.</param>
+        /// <param name="outputFile">The output file.</param>
+        /// <param name="harvestType">The WiX harvest type.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Heat")]
+        [CakeNamespaceImport("Cake.Common.Tools.WiX.Heat")]
+        public static void WiXHeat(this ICakeContext context, IEnumerable<FilePath> objectFiles, FilePath outputFile, WiXHarvestType harvestType, HeatSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var runner = new HeatRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            runner.Run(objectFiles, outputFile, harvestType, settings ?? new HeatSettings());
         }
 
         /// <summary>
@@ -238,18 +270,18 @@ namespace Cake.Common.Tools.WiX
         /// </summary>
         /// <example>
         /// <code>
-        /// var filePath = File("cake.wxs");
-        /// WiXHeat("Default Web Site", filePath, new HeatSettings { HarvestType = WiXHarvestType.Website });
+        /// var filePath = File("Wix.Website.wxs");
+        /// WiXHeat("Default Web Site", filePath, WiXHarvestType.Website);
         /// </code>
         /// </example>
         /// <param name="context">The context.</param>
         /// <param name="harvestTarget">The harvest target.</param>
         /// <param name="outputFile">The output file.</param>
-        /// <param name="settings">The settings.</param>
+        /// <param name="harvestType">The WiX harvest type.</param>
         [CakeMethodAlias]
         [CakeAliasCategory("Heat")]
         [CakeNamespaceImport("Cake.Common.Tools.WiX.Heat")]
-        public static void WiXHeat(this ICakeContext context, string harvestTarget, FilePath outputFile, HeatSettings settings)
+        public static void WiXHeat(this ICakeContext context, string harvestTarget, FilePath outputFile, WiXHarvestType harvestType)
         {
             if (context == null)
             {
@@ -257,7 +289,35 @@ namespace Cake.Common.Tools.WiX
             }
 
             var runner = new HeatRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Run(harvestTarget, outputFile, settings ?? new HeatSettings());
+            runner.Run(harvestTarget, outputFile, harvestType, new HeatSettings());
+        }
+
+        /// <summary>
+        /// Harvests files for a website or performance.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var filePath = File("Wix.Website.wxs");
+        /// WiXHeat("Default Web Site", filePath, WiXHarvestType.Website, new HeatSettings { NoLogo = true });
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="harvestTarget">The harvest target.</param>
+        /// <param name="outputFile">The output file.</param>
+        /// <param name="harvestType">The WiX harvest type.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Heat")]
+        [CakeNamespaceImport("Cake.Common.Tools.WiX.Heat")]
+        public static void WiXHeat(this ICakeContext context, string harvestTarget, FilePath outputFile, WiXHarvestType harvestType, HeatSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var runner = new HeatRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            runner.Run(harvestTarget, outputFile, harvestType, settings ?? new HeatSettings());
         }
     }
 }


### PR DESCRIPTION
This pull request is to resolve #1055.

Because the `WiXHarvestType` is required, I change the code to allow the alias to accept the `WiXHarvestType` instead of trying to default it from the `HeatSettings`.

Please let me know if there are recommended changes.