### PR TITLE
[HOLD] GH1111: Fixed DotNetCoreRestore: dotnet restore no longer supports globbing

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/DotNetCore/Restore/DotNetCoreRestorerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/DotNetCore/Restore/DotNetCoreRestorerFixture.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Linq;
 using Cake.Common.Tools.DotNetCore.Restore;
+using Cake.Core.IO;
 using Cake.Testing;
 
 namespace Cake.Common.Tests.Fixtures.Tools.DotNetCore.Restore
@@ -10,11 +13,31 @@ namespace Cake.Common.Tests.Fixtures.Tools.DotNetCore.Restore
     internal sealed class DotNetCoreRestorerFixture : DotNetCoreFixture<DotNetCoreRestoreSettings>
     {
         public string Root { get; set; }
+        public List<FilePath> ProjectFiles { get; set; }
+        public List<DirectoryPath> DirectoryPaths { get; set; }
+
+        public DotNetCoreRestorerFixture()
+        {
+            ProjectFiles = new List<FilePath>();
+            DirectoryPaths = new List<DirectoryPath>();
+        }
 
         protected override void RunTool()
         {
             var tool = new DotNetCoreRestorer(FileSystem, Environment, ProcessRunner, Tools, new FakeLog());
-            tool.Restore(Root, Settings);
+
+            if (ProjectFiles.Any())
+            {
+                tool.Restore(ProjectFiles, Settings);
+            }
+            else if (DirectoryPaths.Any())
+            {
+                tool.Restore(DirectoryPaths, Settings);
+            }
+            else
+            {
+                tool.Restore(Root, Settings);
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Fixtures/Tools/DotNetCore/Test/DotNetCoreTesterFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/DotNetCore/Test/DotNetCoreTesterFixture.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Linq;
 using Cake.Common.Tools.DotNetCore.Test;
+using Cake.Core.IO;
 
 namespace Cake.Common.Tests.Fixtures.Tools.DotNetCore.Test
 {
@@ -10,10 +13,32 @@ namespace Cake.Common.Tests.Fixtures.Tools.DotNetCore.Test
     {
         public string Project { get; set; }
 
+        public List<FilePath> ProjectFiles { get; set; }
+
+        public List<DirectoryPath> DirectoryPaths { get; set; }
+
+        public DotNetCoreTesterFixture()
+        {
+            ProjectFiles = new List<FilePath>();
+            DirectoryPaths = new List<DirectoryPath>();
+        }
+
         protected override void RunTool()
         {
             var tool = new DotNetCoreTester(FileSystem, Environment, ProcessRunner, Tools);
-            tool.Test(Project, Settings);
+
+            if (ProjectFiles.Any())
+            {
+                tool.Test(ProjectFiles, Settings);
+            }
+            else if (DirectoryPaths.Any())
+            {
+                tool.Test(DirectoryPaths, Settings);
+            }
+            else
+            {
+                tool.Test(Project, Settings);
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Restore/DotNetCoreRestorerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Restore/DotNetCoreRestorerTests.cs
@@ -4,6 +4,7 @@
 
 using Cake.Common.Tests.Fixtures.Tools.DotNetCore.Restore;
 using Cake.Common.Tools.DotNetCore.Restore;
+using Cake.Core.IO;
 using Cake.Testing;
 using Xunit;
 
@@ -82,6 +83,40 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Restore
 
                 // Then
                 Assert.Equal("restore \"./src/*\"", result.Args);
+            }
+
+            [Theory]
+            [InlineData("./src/project.json", "restore \"src/project.json\"")]
+            [InlineData("./test/project.json", "restore \"test/project.json\"")]
+            [InlineData("./test/Unit Tests/project.json", "restore \"test/Unit Tests/project.json\"")]
+            public void Should_Add_Project_Files_If_Provided(string text, string expected)
+            {
+                // Given
+                var fixture = new DotNetCoreRestorerFixture();
+                fixture.ProjectFiles.Add(text);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./src", "restore \"src\"")]
+            [InlineData("./test", "restore \"test\"")]
+            [InlineData("./test/Unit Tests", "restore \"test/Unit Tests\"")]
+            public void Should_Add_Directory_Paths_If_Provided(string text, string expected)
+            {
+                // Given
+                var fixture = new DotNetCoreRestorerFixture();
+                fixture.DirectoryPaths.Add(text);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
             }
 
             [Theory]

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Test/DotNetCoreTesterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Test/DotNetCoreTesterTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Cake.Common.Tests.Fixtures.Tools.DotNetCore.Test;
+using Cake.Core.IO;
 using Cake.Testing;
 using Xunit;
 
@@ -94,6 +95,40 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Test
                 // Given
                 var fixture = new DotNetCoreTesterFixture();
                 fixture.Project = text;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./test/project.json", "test \"test/project.json\"")]
+            [InlineData("./test/cake unit tests/project.json", "test \"test/cake unit tests/project.json\"")]
+            [InlineData("./test/cake unit tests/cake core tests/project.json", "test \"test/cake unit tests/cake core tests/project.json\"")]
+            public void Should_Add_Project_Files_If_Provided(string text, string expected)
+            {
+                // Given
+                var fixture = new DotNetCoreTesterFixture();
+                fixture.ProjectFiles.Add(text);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./test", "test \"test\"")]
+            [InlineData("./test/cake unit tests/", "test \"test/cake unit tests\"")]
+            [InlineData("./test/cake unit tests/cake core tests", "test \"test/cake unit tests/cake core tests\"")]
+            public void Should_Add_Directory_Paths_If_Provided(string text, string expected)
+            {
+                // Given
+                var fixture = new DotNetCoreTesterFixture();
+                fixture.DirectoryPaths.Add(text);
 
                 // When
                 var result = fixture.Run();


### PR DESCRIPTION
This resolves #1111 and #1204

@patriksvensson based on the comments you seemed to think that either a `DirectoryPath` or a list of `project.json` would work.  I have implemented the later, and was checking to make sure this is the appropriate path before I change the `DotNetCoreTest` alias as well.  I have accounted for a string pattern and a single file.  Would the `DirectoryPath` route be more efficient?
- [x] List of `DirectoryPath`
- [x]  List of `FilePath`
- [x]  Specific `FilePath`
- [x]  Specific `DirectoryPath`
