### PR TITLE
GH1231: GetEntryAssembly can return null, leading to NullReferenceException

### DIFF
--- a/src/Cake.Common/Tools/Cake/CakeRunner.cs
+++ b/src/Cake.Common/Tools/Cake/CakeRunner.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Text;
 using Cake.Core;
 using Cake.Core.IO;
+using Cake.Core.Polyfill;
 using Cake.Core.Tooling;
 
 namespace Cake.Common.Tools.Cake
@@ -23,7 +24,17 @@ namespace Cake.Common.Tools.Cake
         private readonly ICakeEnvironment _environment;
         private readonly IFileSystem _fileSystem;
         private readonly IGlobber _globber;
-        private static readonly IEnumerable<FilePath> _executingAssemblyToolPaths = new FilePath[] { System.Reflection.Assembly.GetEntryAssembly().Location };
+        private static readonly IEnumerable<FilePath> _executingAssemblyToolPaths;
+
+        /// <summary>
+        /// Initializes static members of the <see cref="CakeRunner"/> class.
+        /// </summary>
+        static CakeRunner()
+        {
+            var entryAssembly = AssemblyHelper.GetExecutingAssembly();
+            var executingAssemblyToolPath = entryAssembly.Location;
+            _executingAssemblyToolPaths = new FilePath[] { executingAssemblyToolPath };
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CakeRunner"/> class.

--- a/src/Cake.Core/Properties/AssemblyInfo.cs
+++ b/src/Cake.Core/Properties/AssemblyInfo.cs
@@ -21,6 +21,7 @@ using System.Runtime.InteropServices;
 // We're CLS compliant.
 [assembly: CLSCompliant(true)]
 
-// Make internals visible to unit test assembly.
+// Make internals visible to other Cake assemblies.
+[assembly: InternalsVisibleTo("Cake.Common")]
 [assembly: InternalsVisibleTo("Cake.Core.Tests")]
 [assembly: InternalsVisibleTo("Cake.Testing.Xunit")]


### PR DESCRIPTION
This PR makes the call to `GetEntryAssembly()` fallback to `GetExecutingAssembly()` since the former can return null, leading to an unhandled `NullReferenceException`.