### PR TITLE
GH899: Copy directory structure

### DIFF
--- a/src/Cake.Common.Tests/Unit/IO/FileAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/FileAliasesTests.cs
@@ -305,6 +305,20 @@ namespace Cake.Common.Tests.Unit.IO
                 }
 
                 [Fact]
+                public void Should_Keep_Folder_Structure()
+                {
+                    // Given
+                    var fixture = new FileCopyFixture();
+
+                    // When
+                    FileAliases.CopyFiles(fixture.Context, fixture.SourceFilePaths, "./target");
+
+                    // Then
+                    fixture.TargetFiles[0].Received(1).Copy(Arg.Any<FilePath>(), true);
+                    fixture.TargetFiles[1].Received(1).Copy(Arg.Any<FilePath>(), true);
+                }
+
+                [Fact]
                 public void Should_Copy_Files()
                 {
                     // Given
@@ -402,6 +416,21 @@ namespace Cake.Common.Tests.Unit.IO
                 }
 
                 [Fact]
+                public void Should_Keep_Folder_Structure()
+                {
+                    // Given
+                    var fixture = new FileCopyFixture();
+                    var filePaths = fixture.SourceFilePaths.Select(x => x.FullPath);
+
+                    // When
+                    FileAliases.CopyFiles(fixture.Context, filePaths, "./target");
+
+                    // Then
+                    fixture.TargetFiles[0].Received(1).Copy(Arg.Any<FilePath>(), true);
+                    fixture.TargetFiles[1].Received(1).Copy(Arg.Any<FilePath>(), true);
+                }
+
+                [Fact]
                 public void Should_Copy_Files()
                 {
                     // Given
@@ -490,6 +519,20 @@ namespace Cake.Common.Tests.Unit.IO
                     // Then
                     Assert.IsType<FileNotFoundException>(result);
                     Assert.Equal("The file '/Working/file2.txt' does not exist.", result?.Message);
+                }
+
+                [Fact]
+                public void Should_Keep_Folder_Structure()
+                {
+                    // Given
+                    var fixture = new FileCopyFixture();
+
+                    // When
+                    FileAliases.CopyFiles(fixture.Context, "*", "./target", true);
+
+                    // Then
+                    fixture.TargetFiles[0].Received(1).Copy(Arg.Any<FilePath>(), true);
+                    fixture.TargetFiles[1].Received(1).Copy(Arg.Any<FilePath>(), true);
                 }
 
                 [Fact]

--- a/src/Cake.Common/IO/FileAliases.cs
+++ b/src/Cake.Common/IO/FileAliases.cs
@@ -101,7 +101,7 @@ namespace Cake.Common.IO
         [CakeAliasCategory("Copy")]
         public static void CopyFiles(this ICakeContext context, string pattern, DirectoryPath targetDirectoryPath)
         {
-            FileCopier.CopyFiles(context, pattern, targetDirectoryPath);
+            FileCopier.CopyFiles(context, pattern, targetDirectoryPath, false);
         }
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace Cake.Common.IO
         [CakeAliasCategory("Copy")]
         public static void CopyFiles(this ICakeContext context, IEnumerable<FilePath> filePaths, DirectoryPath targetDirectoryPath)
         {
-            FileCopier.CopyFiles(context, filePaths, targetDirectoryPath);
+            FileCopier.CopyFiles(context, filePaths, targetDirectoryPath, false);
         }
 
         /// <summary>
@@ -148,7 +148,75 @@ namespace Cake.Common.IO
                 throw new ArgumentNullException(nameof(filePaths));
             }
             var paths = filePaths.Select(p => new FilePath(p));
-            FileCopier.CopyFiles(context, paths, targetDirectoryPath);
+            FileCopier.CopyFiles(context, paths, targetDirectoryPath, false);
+        }
+
+        /// <summary>
+        /// Copies all files matching the provided pattern to a new location.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="pattern">The pattern.</param>
+        /// <param name="targetDirectoryPath">The target directory path.</param>
+        /// <param name="preserveFolderStructure">Keep the folder structure.</param>
+        /// <example>
+        /// <code>
+        /// CopyFiles("Cake.*", "./publish");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Copy")]
+        public static void CopyFiles(this ICakeContext context, string pattern, DirectoryPath targetDirectoryPath, bool preserveFolderStructure)
+        {
+            FileCopier.CopyFiles(context, pattern, targetDirectoryPath, preserveFolderStructure);
+        }
+
+        /// <summary>
+        /// Copies existing files to a new location.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="filePaths">The file paths.</param>
+        /// <param name="targetDirectoryPath">The target directory path.</param>
+        /// <param name="preserveFolderStructure">Keep the folder structure.</param>
+        /// <example>
+        /// <code>
+        /// var files = GetFiles("./**/Cake.*");
+        /// CopyFiles(files, "destination");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Copy")]
+        public static void CopyFiles(this ICakeContext context, IEnumerable<FilePath> filePaths, DirectoryPath targetDirectoryPath, bool preserveFolderStructure)
+        {
+            FileCopier.CopyFiles(context, filePaths, targetDirectoryPath, preserveFolderStructure);
+        }
+
+        /// <summary>
+        /// Copies existing files to a new location.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="filePaths">The file paths.</param>
+        /// <param name="targetDirectoryPath">The target directory path.</param>
+        /// <param name="preserveFolderStructure">Keep the folder structure.</param>
+        /// <example>
+        /// <code>
+        /// CreateDirectory("destination");
+        /// var files = new [] {
+        ///     "Cake.exe",
+        ///     "Cake.pdb"
+        /// };
+        /// CopyFiles(files, "destination");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Copy")]
+        public static void CopyFiles(this ICakeContext context, IEnumerable<string> filePaths, DirectoryPath targetDirectoryPath, bool preserveFolderStructure)
+        {
+            if (filePaths == null)
+            {
+                throw new ArgumentNullException(nameof(filePaths));
+            }
+            var paths = filePaths.Select(p => new FilePath(p));
+            FileCopier.CopyFiles(context, paths, targetDirectoryPath, preserveFolderStructure);
         }
 
         /// <summary>

--- a/src/Cake.Common/IO/FileCopier.cs
+++ b/src/Cake.Common/IO/FileCopier.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
@@ -56,41 +57,42 @@ namespace Cake.Common.IO
                 throw new DirectoryNotFoundException(message);
             }
 
-            CopyFileCore(context, filePath, targetFilePath);
+            CopyFileCore(context, filePath, targetFilePath, null);
         }
 
-        public static void CopyFiles(ICakeContext context, string pattern, DirectoryPath targetDirectoryPath)
+        public static void CopyFiles(ICakeContext context, string pattern, DirectoryPath targetDirectoryPath, bool preserverFolderStructure)
         {
             if (context == null)
             {
-                throw new ArgumentNullException(nameof(context));
+                throw new ArgumentNullException("context");
             }
             if (pattern == null)
             {
-                throw new ArgumentNullException(nameof(pattern));
+                throw new ArgumentNullException("pattern");
             }
             var files = context.GetFiles(pattern);
+
             if (files.Count == 0)
             {
                 context.Log.Verbose("The provided pattern did not match any files.");
                 return;
             }
-            CopyFiles(context, files, targetDirectoryPath);
+            CopyFiles(context, files, targetDirectoryPath, preserverFolderStructure);
         }
 
-        public static void CopyFiles(ICakeContext context, IEnumerable<FilePath> filePaths, DirectoryPath targetDirectoryPath)
+        public static void CopyFiles(ICakeContext context, IEnumerable<FilePath> filePaths, DirectoryPath targetDirectoryPath, bool preserverFolderStructure)
         {
             if (context == null)
             {
-                throw new ArgumentNullException(nameof(context));
+                throw new ArgumentNullException("context");
             }
             if (filePaths == null)
             {
-                throw new ArgumentNullException(nameof(filePaths));
+                throw new ArgumentNullException("filePaths");
             }
             if (targetDirectoryPath == null)
             {
-                throw new ArgumentNullException(nameof(targetDirectoryPath));
+                throw new ArgumentNullException("targetDirectoryPath");
             }
 
             var absoluteTargetDirectoryPath = targetDirectoryPath.MakeAbsolute(context.Environment);
@@ -103,14 +105,47 @@ namespace Cake.Common.IO
                 throw new DirectoryNotFoundException(message);
             }
 
-            // Iterate all files and copy them.
-            foreach (var filePath in filePaths)
+            if (preserverFolderStructure)
             {
-                CopyFileCore(context, filePath, absoluteTargetDirectoryPath.GetFilePath(filePath));
+                var commonPath = string.Empty;
+                List<string> separatedPath = filePaths
+                .First(str => str.ToString().Length == filePaths.Max(st2 => st2.ToString().Length)).ToString()
+                .Split(new string[] { "/" }, StringSplitOptions.RemoveEmptyEntries)
+                .ToList();
+
+                foreach (string pathSegment in separatedPath)
+                {
+                    if (commonPath.Length == 0 && filePaths.All(str => str.ToString().StartsWith(pathSegment)))
+                    {
+                        commonPath = pathSegment;
+                    }
+                    else if (filePaths.All(str => str.ToString().StartsWith(commonPath + "/" + pathSegment)))
+                    {
+                        commonPath += "/" + pathSegment;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+
+                // Iterate all files and copy them.
+                foreach (var filePath in filePaths)
+                {
+                    CopyFileCore(context, filePath, absoluteTargetDirectoryPath.GetFilePath(filePath), context.DirectoryExists(commonPath) ? commonPath : null);
+                }
+            }
+            else
+            {
+                // Iterate all files and copy them.
+                foreach (var filePath in filePaths)
+                {
+                    CopyFileCore(context, filePath, absoluteTargetDirectoryPath.GetFilePath(filePath), null);
+                }
             }
         }
 
-        private static void CopyFileCore(ICakeContext context, FilePath filePath, FilePath targetFilePath)
+        private static void CopyFileCore(ICakeContext context, FilePath filePath, FilePath targetFilePath, string commonPath)
         {
             var absoluteFilePath = filePath.MakeAbsolute(context.Environment);
 
@@ -124,9 +159,28 @@ namespace Cake.Common.IO
 
             // Copy the file.
             var absoluteTargetPath = targetFilePath.MakeAbsolute(context.Environment);
-            context.Log.Verbose("Copying file {0} to {1}", absoluteFilePath.GetFilename(), absoluteTargetPath);
             var file = context.FileSystem.GetFile(absoluteFilePath);
-            file.Copy(absoluteTargetPath, true);
+
+            if (!string.IsNullOrEmpty(commonPath))
+            {
+                // Get the parent folder structure and create it.
+                var newRelativeFolderPath = context.Directory(commonPath).Path.GetRelativePath(filePath.GetDirectory());
+                var newTargetPath = targetFilePath.GetDirectory().Combine(newRelativeFolderPath);
+                var newAbsoluteTargetPath = newTargetPath.CombineWithFilePath(filePath.GetFilename());
+                context.Log.Verbose("Copying file {0} to {1}", absoluteFilePath.GetFilename(), newAbsoluteTargetPath);
+
+                if (!context.DirectoryExists(newTargetPath))
+                {
+                    context.CreateDirectory(newTargetPath);
+                }
+
+                file.Copy(newAbsoluteTargetPath, true);
+            }
+            else
+            {
+                context.Log.Verbose("Copying file {0} to {1}", absoluteFilePath.GetFilename(), absoluteTargetPath);
+                file.Copy(absoluteTargetPath, true);
+            }
         }
     }
 }


### PR DESCRIPTION
fix #899 

Here is an approach to keep the folder structure for `CopyFiles`. I add some new overloads. Yet only for patterns. 
