### PR TITLE
Add the ability to get a list of all packages from a Nuget feed source

### DIFF
--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Fixtures\Tools\DNU\DNUFixture.cs" />
     <Compile Include="Fixtures\Tools\DNU\Pack\DNUPackerFixture.cs" />
     <Compile Include="Fixtures\Tools\DNU\Restorer\DNURestorerFixture.cs" />
+    <Compile Include="Fixtures\Tools\NuGet\Sources\NuGetListFixture.cs" />
     <Compile Include="Fixtures\Tools\OctopusDeployPusherFixture.cs" />
     <Compile Include="Fixtures\Tools\VSTestRunnerFixture.cs" />
     <Compile Include="Fixtures\Tools\SpecFlow\StepDefinitionReport\SpecFlowStepDefinitionReporterFixture.cs" />

--- a/src/Cake.Common.Tests/Fixtures/Tools/NuGet/Sources/NuGetListFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/NuGet/Sources/NuGetListFixture.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.NuGet.Sources;
+
+namespace Cake.Common.Tests.Fixtures.Tools.NuGet.Sources
+{
+    internal sealed class NuGetListFixture : NuGetSourcesFixture
+    {
+        protected override void RunTool()
+        {
+            var tool = new NuGetList(FileSystem, Environment, ProcessRunner, Tools, Resolver);
+            tool.List(Source, Settings);
+        }
+    }
+}

--- a/src/Cake.Common/Cake.Common.csproj
+++ b/src/Cake.Common/Cake.Common.csproj
@@ -309,6 +309,7 @@
     <Compile Include="Tools\NuGet\SetApiKey\NuGetSetApiKeySettings.cs" />
     <Compile Include="Tools\NuGet\SetProxy\NuGetSetProxy.cs" />
     <Compile Include="Tools\NuGet\SetProxy\NuGetSetProxySettings.cs" />
+    <Compile Include="Tools\NuGet\Sources\NuGetList.cs" />
     <Compile Include="Tools\NuGet\Sources\NuGetSources.cs" />
     <Compile Include="Tools\NuGet\Sources\NuGetSourcesSettings.cs" />
     <Compile Include="Tools\NuGet\NuGetAliases.cs" />

--- a/src/Cake.Common/Tools/NuGet/NuGetAliases.cs
+++ b/src/Cake.Common/Tools/NuGet/NuGetAliases.cs
@@ -977,5 +977,58 @@ namespace Cake.Common.Tools.NuGet
                 NuGetUpdate(context, targetFile, settings);
             }
         }
+
+        /// <summary>
+        /// Lists the packages of a NuGet package source using the specified source
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="source">Path to the package(s) source.</param>
+        /// <returns>A list of package names and versions</returns>
+        /// <example>
+        /// <code>
+        /// var packages = NuGetList(EnvironmentVariable("PRIVATE_FEED_SOURCE"));
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("List")]
+        [CakeNamespaceImport("Cake.Common.Tools.NuGet.Sources")]
+        public static IEnumerable<string> NuGetList(this ICakeContext context, string source)
+        {
+            return context.NuGetList(source, new NuGetSourcesSettings());
+        }
+
+        /// <summary>
+        /// Lists the packages of a NuGet package source using the specified source
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="source">Path to the package(s) source.</param>
+        /// <param name="settings">The settings.</param>
+        /// <returns>A list of package names and versions</returns>
+        /// <example>
+        /// <code>
+        /// var nugetSourceSettings = new NuGetSourcesSettings
+        ///                             {
+        ///                                 UserName = EnvironmentVariable("PRIVATE_FEED_USERNAME"),
+        ///                                 Password = EnvironmentVariable("PRIVATE_FEED_PASSWORD"),
+        ///                                 IsSensitiveSource = true,
+        ///                                 Verbosity = NuGetVerbosity.Detailed
+        ///                             };
+        /// var packages = NuGetList(EnvironmentVariable("PRIVATE_FEED_SOURCE"), nugetSourceSettings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("List")]
+        [CakeNamespaceImport("Cake.Common.Tools.NuGet.Sources")]
+        public static IEnumerable<string> NuGetList(this ICakeContext context, string source, NuGetSourcesSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var resolver = new NuGetToolResolver(context.FileSystem, context.Environment, context.Tools);
+            var runner = new NuGetList(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools, resolver);
+            return runner.List(source, settings);
+        }
     }
 }

--- a/src/Cake.Common/Tools/NuGet/Sources/NuGetList.cs
+++ b/src/Cake.Common/Tools/NuGet/Sources/NuGetList.cs
@@ -1,0 +1,126 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.IO.NuGet;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.NuGet.Sources
+{
+    /// <summary>
+    /// The NuGet list is used to list the contents of a source
+    /// </summary>
+    public sealed class NuGetList : NuGetTool<NuGetSourcesSettings>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NuGetList"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="tools">The tool locator.</param>
+        /// <param name="resolver">The NuGet tool resolver.</param>
+        public NuGetList(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IToolLocator tools,
+            INuGetToolResolver resolver) : base(fileSystem, environment, processRunner, tools, resolver)
+        {
+        }
+
+        /// <summary>
+        /// List NuGet packages for a source using the specified settings to global user config
+        /// </summary>
+        /// <param name="source">Path to the package(s) source.</param>
+        /// <param name="settings">The settings.</param>
+        /// <returns>A list of package names and versions</returns>
+        public IEnumerable<string> List(string source, NuGetSourcesSettings settings)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException("source");
+            }
+            if (string.IsNullOrWhiteSpace(source))
+            {
+                throw new ArgumentException("Source cannot be empty.", "source");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            var processSettings = new ProcessSettings
+            {
+                Arguments = GetListArguments(source, settings),
+                RedirectStandardOutput = true
+            };
+
+            IEnumerable<string> result = null;
+            Run(settings, null, processSettings,
+                process => result = process.GetStandardOutput().ToList());
+
+            return result;
+        }
+ 
+        private static ProcessArgumentBuilder GetListArguments(string source, NuGetSourcesSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("list");
+
+            AddCommonParameters(source, settings, builder);
+
+            // User name specified?
+            if (!string.IsNullOrWhiteSpace(settings.UserName))
+            {
+                builder.Append("-UserName");
+                builder.AppendQuoted(settings.UserName);
+            }
+
+            // Password specified?
+            if (!string.IsNullOrWhiteSpace(settings.Password))
+            {
+                builder.Append("-Password");
+                builder.AppendQuotedSecret(settings.Password);
+            }
+
+            // Store password in plain text?
+            if (settings.StorePasswordInClearText)
+            {
+                builder.Append("-StorePasswordInClearText");
+            }
+
+            return builder;
+        }
+
+        private static void AddCommonParameters(string source, NuGetSourcesSettings settings, ProcessArgumentBuilder builder)
+        {
+            builder.Append("-Source");
+            if (settings.IsSensitiveSource)
+            {
+                // Sensitive information in source.
+                builder.AppendQuotedSecret(source);
+            }
+            else
+            {
+                builder.AppendQuoted(source);
+            }
+
+            // Verbosity?
+            if (settings.Verbosity.HasValue)
+            {
+                builder.Append("-Verbosity");
+                builder.Append(settings.Verbosity.Value.ToString().ToLowerInvariant());
+            }
+
+            builder.Append("-NonInteractive");
+        }
+    }
+}


### PR DESCRIPTION
One NuGet command that is missing from the implementation in cake.common is a way to list the packages currently on a Source. This could be useful for instance in deciding not to push packages that have the same version number as one that is already there.

This PR adds a script aliases for getting a list of packages form a source.

e.g.
            var packages = NuGetList(EnvironmentVariable("PRIVATE_FEED_SOURCE"));

_One concern: should this just be part of the `NugetSources` class?_ 