### PR TITLE
GH702 GH473: Added logger switch to MSBuild runner

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -785,6 +785,23 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 // Then
                 Assert.IsCakeException(result, "Encountered unknown MSBuild build log verbosity.");
             }
+
+            [Fact]
+            public void Should_Append_Logger_To_Process_Arguments()
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false);
+                fixture.Settings.WithLogger("A", "B", "C");
+                fixture.Settings.WithLogger("D", "E");
+                fixture.Settings.WithLogger("F");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/v:normal /target:Build /logger:B,A;C /logger:E,D /logger:F " +
+                             "\"/Working/src/Solution.sln\"", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsExtensionsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsExtensionsTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using Cake.Common.Tools.MSBuild;
 using Cake.Core.Diagnostics;
 using Xunit;
@@ -256,6 +257,43 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
 
                 // When
                 var result = settings.SetVerbosity(Verbosity.Normal);
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheWithLoggersMethod
+        {
+            [Fact]
+            public void Should_Add_Logger()
+            {
+                // Given
+                var settings = new MSBuildSettings();
+
+                // When
+                settings.WithLogger("LoggerAssembly1", "LoggerClass1", "LoggerParameters1");
+                settings.WithLogger("LoggerAssembly2", "LoggerClass2", "LoggerParameters2");
+
+                // Then
+                var loggers = settings.Loggers.ToArray();
+                Assert.Equal(2, loggers.Length);
+                Assert.Equal("LoggerAssembly1", loggers[0].Assembly);
+                Assert.Equal("LoggerClass1", loggers[0].Class);
+                Assert.Equal("LoggerParameters1", loggers[0].Parameters);
+                Assert.Equal("LoggerAssembly2", loggers[1].Assembly);
+                Assert.Equal("LoggerClass2", loggers[1].Class);
+                Assert.Equal("LoggerParameters2", loggers[1].Parameters);
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new MSBuildSettings();
+
+                // When
+                var result = settings.WithLogger("Logger");
 
                 // Then
                 Assert.Equal(settings, result);

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsTests.cs
@@ -113,5 +113,18 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 Assert.Null(settings.MaxCpuCount);
             }
         }
+
+        public sealed class TheLoggersProperty
+        {
+            [Fact]
+            public void Should_Be_Empty_By_Default()
+            {
+                // Given
+                var settings = new MSBuildSettings();
+
+                // Then
+                Assert.Empty(settings.Loggers);
+            }
+        }
     }
 }

--- a/src/Cake.Common/Tools/MSBuild/MSBuildLogger.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildLogger.cs
@@ -1,0 +1,24 @@
+namespace Cake.Common.Tools.MSBuild
+{
+    /// <summary>
+    /// Contains settings for specifying a MSBuild logger.
+    /// </summary>
+    public sealed class MSBuildLogger
+    {
+        /// <summary>
+        /// Gets or sets the assembly containing the logger. Should match the format {AssemblyName[,StrongName] | AssemblyFile}
+        /// </summary>
+        public string Assembly { get; set; }
+
+        /// <summary>
+        /// Gets or sets the class implementing the logger. Should match the format [PartialOrFullNamespace.]LoggerClassName
+        /// If the assembly contains only one logger, class does not need to be specified.
+        /// </summary>
+        public string Class { get; set; }
+
+        /// <summary>
+        /// Gets or sets the parameters to be passed to the logger.
+        /// </summary>
+        public string Parameters { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
@@ -102,10 +102,37 @@ namespace Cake.Common.Tools.MSBuild
                 builder.Append("/target:Build");
             }
 
+            if (settings.Loggers.Count > 0)
+            {
+                foreach (var logger in settings.Loggers)
+                {
+                    var argument = GetLoggerArgument(logger);
+                    builder.Append(argument);
+                }
+            }
+
             // Add the solution as the last parameter.
             builder.AppendQuoted(solution.MakeAbsolute(_environment).FullPath);
 
             return builder;
+        }
+
+        private static string GetLoggerArgument(MSBuildLogger logger)
+        {
+            string argument = "/logger:";
+            if (!string.IsNullOrWhiteSpace(logger.Class))
+            {
+                argument += string.Format("{0},{1}", logger.Class, logger.Assembly);
+            }
+            else
+            {
+                argument += logger.Assembly;
+            }
+            if (!string.IsNullOrWhiteSpace(logger.Parameters))
+            {
+                argument += string.Concat(";", logger.Parameters);
+            }
+            return argument;
         }
 
         private static string GetPlatformName(PlatformTarget platform, bool isSolution)

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
@@ -16,6 +16,7 @@ namespace Cake.Common.Tools.MSBuild
     {
         private readonly HashSet<string> _targets;
         private readonly Dictionary<string, IList<string>> _properties;
+        private readonly List<MSBuildLogger> _loggers;
 
         /// <summary>
         /// Gets the targets.
@@ -76,12 +77,18 @@ namespace Cake.Common.Tools.MSBuild
         public Verbosity Verbosity { get; set; }
 
         /// <summary>
+        /// Gets the loggers.
+        /// </summary>
+        public ICollection<MSBuildLogger> Loggers => _loggers;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="MSBuildSettings"/> class.
         /// </summary>
         public MSBuildSettings()
         {
             _targets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             _properties = new Dictionary<string, IList<string>>(StringComparer.OrdinalIgnoreCase);
+            _loggers = new List<MSBuildLogger>();
 
             ToolVersion = MSBuildToolVersion.Default;
             Configuration = string.Empty;

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
@@ -173,5 +173,32 @@ namespace Cake.Common.Tools.MSBuild
             settings.Verbosity = verbosity;
             return settings;
         }
+
+        /// <summary>
+        /// Adds a custom logger.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="loggerAssembly">The assembly containing the logger. Should match the format {AssemblyName[,StrongName] | AssemblyFile}</param>
+        /// <param name="loggerClass">The class implementing the logger. Should match the format [PartialOrFullNamespace.]LoggerClassName. If the assembly contains only one logger, class does not need to be specified.</param>
+        /// <param name="loggerParameters">Parameters to be passed to the logger.</param>
+        /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static MSBuildSettings WithLogger(this MSBuildSettings settings, string loggerAssembly, string loggerClass = null, string loggerParameters = null)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            if (string.IsNullOrWhiteSpace(loggerAssembly))
+            {
+                throw new ArgumentException(nameof(loggerAssembly));
+            }
+            settings.Loggers.Add(new MSBuildLogger
+            {
+                Assembly = loggerAssembly,
+                Class = loggerClass,
+                Parameters = loggerParameters
+            });
+            return settings;
+        }
     }
 }


### PR DESCRIPTION
Relates to #702 and #473.

The gist of it is fairly simple. I've added an extension method for adding a logger switch to the MSBuildSettings class, similar to how property switches are added, like so:
```csharp
public static MSBuildSettings WithLogger(this MSBuildSettings settings, string loggerAssembly, string loggerClass = null, string loggerParameters = null)
```

Calling that method should append an argument to MSBuild, like so:
`/logger:loggerClass,loggerAssembly;loggerParameters`

In addition to this, I added a MSBuildLogger class to hold the above assembly, class and parameters values, and to the MSBuildSettings class I added a collection property to hold instances of those.