### PR TITLE
Expose TeamCityProvider.SetParameter method via the ITeamCityProvider interface

### DIFF
--- a/src/Cake.Common/Build/TeamCity/ITeamCityProvider.cs
+++ b/src/Cake.Common/Build/TeamCity/ITeamCityProvider.cs
@@ -53,6 +53,13 @@ namespace Cake.Common.Build.TeamCity
         void SetBuildNumber(string buildNumber);
 
         /// <summary>
+        /// Tells TeamCity to set a named parameter with a given value
+        /// </summary>
+        /// <param name="parameterName">The name of the parameter to set.</param>
+        /// <param name="parameterValue">The value to set for the named parameter.</param>
+        void SetParameter(string parameterName, string parameterValue);
+
+        /// <summary>
         /// Write the end of a message block to the TeamCity build log.
         /// </summary>
         /// <param name="blockName">Block name.</param>


### PR DESCRIPTION
<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over CONTRIBUTING - https://github.com/cake-build/cake/blob/develop/CONTRIBUTING.md. We provide VERY defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - You are not submitting a pull request from your MASTER branch.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
Support for TeamCity's "setParameter" service message was added in
https://github.com/cake-build/cake/pull/1114 but only the tests and implementor
were updated.

This change updates the interface to match, which is what is actually exposed to
Cake scripts.

Relates to https://github.com/cake-build/cake/issues/1121.