### PR TITLE
InferRuntimes does not require arguments

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Restore/DotNetCoreRestorerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Restore/DotNetCoreRestorerTests.cs
@@ -83,6 +83,22 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Restore
                 // Then
                 Assert.Equal("restore \"./src/*\"", result.Args);
             }
+            
+            [Theory]
+            [InlineData(null)]
+            [InlineData("")]
+            public void Should_Add_Infer_Runtimes_Without_Arguments(string value)
+            {
+                // Given
+                var fixture = new DotNetCoreRestorerFixture();
+                fixture.Settings.InferRuntimes = new[] { value };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("restore  --infer-runtimes", result.Args);
+            }
 
             [Theory]
             [InlineData("./src/*", "restore \"./src/*\"")]

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Restore/DotNetCoreRestorerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Restore/DotNetCoreRestorerTests.cs
@@ -83,7 +83,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Restore
                 // Then
                 Assert.Equal("restore \"./src/*\"", result.Args);
             }
-            
+
             [Theory]
             [InlineData(null)]
             [InlineData("")]

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Restore/DotNetCoreRestorerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Restore/DotNetCoreRestorerTests.cs
@@ -97,7 +97,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Restore
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("restore  --infer-runtimes", result.Args);
+                Assert.Equal("restore --infer-runtimes", result.Args);
             }
 
             [Theory]

--- a/src/Cake.Common/Tools/DotNetCore/Restore/DotNetCoreRestorer.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Restore/DotNetCoreRestorer.cs
@@ -101,10 +101,17 @@ namespace Cake.Common.Tools.DotNetCore.Restore
             // List of runtime identifiers
             if (settings.InferRuntimes != null)
             {
-                foreach (var runtime in settings.InferRuntimes)
+                if ((settings.InferRuntimes.Count == 1) && string.IsNullOrEmpty(settings.InferRuntimes[0]))
                 {
                     builder.Append("--infer-runtimes");
-                    builder.AppendQuoted(runtime);
+                }
+                else
+                {
+                    foreach (var runtime in settings.InferRuntimes)
+                    {
+                        builder.Append("--infer-runtimes");
+                        builder.AppendQuoted(runtime);
+                    }
                 }
             }
 #pragma warning disable 0618

--- a/src/Cake.Common/Tools/DotNetCore/Restore/DotNetCoreRestorer.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Restore/DotNetCoreRestorer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Linq;
 using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
@@ -101,7 +102,7 @@ namespace Cake.Common.Tools.DotNetCore.Restore
             // List of runtime identifiers
             if (settings.InferRuntimes != null)
             {
-                if ((settings.InferRuntimes.Count == 1) && string.IsNullOrEmpty(settings.InferRuntimes[0]))
+                if ((settings.InferRuntimes.Count == 1) && string.IsNullOrEmpty(settings.InferRuntimes.First()))
                 {
                     builder.Append("--infer-runtimes");
                 }


### PR DESCRIPTION
More details can be found [here](https://github.com/dotnet/cli/issues/2278) and [here](https://github.com/dotnet/cli/issues/2372). This is currently blocking us [here](https://github.com/RehanSaeed/Serilog.Exceptions/pull/7).