### PR TITLE
Updates System.ComponentModel.TypeConverter to 4.1.0 for .NET Core.

### DIFF
--- a/src/Cake.Common/project.json
+++ b/src/Cake.Common/project.json
@@ -58,7 +58,7 @@
         "System.Xml.XPath.XmlDocument": "4.0.1",
         "System.Runtime.Serialization.Json": "4.0.2",
         "System.Xml.ReaderWriter": "4.0.11",
-        "System.ComponentModel.TypeConverter": "4.0.0"
+        "System.ComponentModel.TypeConverter": "4.1.0"
       }
     },
     "net45": {


### PR DESCRIPTION
This PR updates `System.ComponentModel.TypeConverter` to 4.1.0 for .NET Core which solves some `dotnet restore` problems we've been seeing.