### PR TITLE
GH1227 GH1228: Deploy releases or deploy on release creation in Octopus Deploy

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/OctopusDeployReleaseDeployerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/OctopusDeployReleaseDeployerFixture.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Cake.Common.Tools.OctopusDeploy;
+using Cake.Testing.Fixtures;
+
+namespace Cake.Common.Tests.Fixtures.Tools
+{
+    public sealed class OctopusDeployReleaseDeployerFixture : ToolFixture<OctopusDeployReleaseDeploymentSettings>
+    {
+        internal string Server { get; set; }
+
+        internal string ApiKey { get; set; }
+
+        internal string Project { get; set; }
+
+        internal string DeployTo { get; set; }
+
+        internal string ReleaseNumber { get; set; }
+
+        public OctopusDeployReleaseDeployerFixture() : base("Octo.exe")
+        {
+            Server = "http://octopus";
+            ApiKey = "API-12345";
+            Project = "MyProject";
+            DeployTo = "Testing";
+            ReleaseNumber = "0.15.1";
+        }
+
+        protected override void RunTool()
+        {
+            var tool = new OctopusDeployReleaseDeployer(FileSystem, Environment, ProcessRunner, Tools);
+            tool.DeployRelease(Server, ApiKey, Project, DeployTo, ReleaseNumber, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctoCreateReleaseTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctoCreateReleaseTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using Cake.Common.Tests.Fixtures.Tools;
 using Cake.Testing;
@@ -189,7 +190,7 @@ namespace Cake.Common.Tests.Unit.Tools.OctopusDeploy
                 // Then
                 Assert.Equal("create-release --project \"testProject\" " +
                              "--server http://octopus --apiKey API-12345 " +
-                             "--username \"mike123\"", result.Args);
+                             "--user \"mike123\"", result.Args);
             }
 
             [Fact]
@@ -205,7 +206,7 @@ namespace Cake.Common.Tests.Unit.Tools.OctopusDeploy
                 // Then
                 Assert.Equal("create-release --project \"testProject\" " +
                              "--server http://octopus --apiKey API-12345 " +
-                             "--password \"secret\"", result.Args);
+                             "--pass \"secret\"", result.Args);
             }
 
             [Fact]
@@ -406,6 +407,389 @@ namespace Cake.Common.Tests.Unit.Tools.OctopusDeploy
                 Assert.Equal("create-release --project \"testProject\" " +
                              "--server http://octopus --apiKey API-12345 " +
                              "--ignoreexisting", result.Args);
+            }
+        }
+
+        public sealed class DeploymentAgrumentsBuilder
+        {
+            [Fact]
+            public void Should_Add_DeployTo_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseCreatorFixture();
+                fixture.Settings.DeployTo = "SomeEnvironment";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create-release --project \"testProject\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--deployto \"SomeEnvironment\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Progress_To_Arguments_If_Specified()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseCreatorFixture();
+                fixture.Settings.DeployTo = "SomeEnvironment";
+                fixture.Settings.ShowProgress = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create-release --project \"testProject\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--deployto \"SomeEnvironment\" " +
+                             "--progress", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_FocePackageDownload_To_Arguments_If_Specified()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseCreatorFixture();
+                fixture.Settings.DeployTo = "SomeEnvironment";
+                fixture.Settings.ForcePackageDownload = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create-release --project \"testProject\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--deployto \"SomeEnvironment\" " +
+                             "--forcepackagedownload", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_WaitForDeployment_To_Arguments_If_Specified()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseCreatorFixture();
+                fixture.Settings.DeployTo = "SomeEnvironment";
+                fixture.Settings.WaitForDeployment = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create-release --project \"testProject\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--deployto \"SomeEnvironment\" " +
+                             "--waitfordeployment", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_DeploymentTimeout_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseCreatorFixture();
+                fixture.Settings.DeployTo = "SomeEnvironment";
+                fixture.Settings.DeploymentTimeout = TimeSpan.FromMinutes(1);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create-release --project \"testProject\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--deployto \"SomeEnvironment\" " +
+                             "--deploymenttimeout=\"00:01:00\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_CancelTimeout_To_Arguments_If_Specified()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseCreatorFixture();
+                fixture.Settings.DeployTo = "SomeEnvironment";
+                fixture.Settings.CancelOnTimeout = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create-release --project \"testProject\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--deployto \"SomeEnvironment\" " +
+                             "--cancelontimeout", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_DeploymentChecksLeepCycle_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseCreatorFixture();
+                fixture.Settings.DeployTo = "SomeEnvironment";
+                fixture.Settings.DeploymentChecksLeepCycle = TimeSpan.FromMinutes(77);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create-release --project \"testProject\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--deployto \"SomeEnvironment\" " +
+                             "--deploymentchecksleepcycle=\"01:17:00\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_GuidedFailure_To_Arguments_If_True()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseCreatorFixture();
+                fixture.Settings.DeployTo = "SomeEnvironment";
+                fixture.Settings.GuidedFailure = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create-release --project \"testProject\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--deployto \"SomeEnvironment\" " +
+                             "--guidedfailure=True", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_GuidedFailure_To_Arguments_If_False()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseCreatorFixture();
+                fixture.Settings.DeployTo = "SomeEnvironment";
+                fixture.Settings.GuidedFailure = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create-release --project \"testProject\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--deployto \"SomeEnvironment\" " +
+                             "--guidedfailure=True", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_SpecificMachines_To_Arguments_If_NotNull()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseCreatorFixture();
+                fixture.Settings.DeployTo = "SomeEnvironment";
+                fixture.Settings.SpecificMachines = new string[] { "Machine1", "Machine2" };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create-release --project \"testProject\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--deployto \"SomeEnvironment\" " +
+                             "--specificmachines=\"Machine1,Machine2\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Force_To_Arguments_If_Specified()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseCreatorFixture();
+                fixture.Settings.DeployTo = "SomeEnvironment";
+                fixture.Settings.Force = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create-release --project \"testProject\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--deployto \"SomeEnvironment\" " +
+                             "--force", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_SkipSteps_To_Arguments_If_Specified()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseCreatorFixture();
+                fixture.Settings.DeployTo = "SomeEnvironment";
+                fixture.Settings.SkipSteps = new[] { "Step1", "Step2" };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create-release --project \"testProject\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--deployto \"SomeEnvironment\" " +
+                             "--skip=\"Step1\" " +
+                             "--skip=\"Step2\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_NoRawLog_To_Arguments_If_Specified()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseCreatorFixture();
+                fixture.Settings.DeployTo = "SomeEnvironment";
+                fixture.Settings.NoRawLog = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create-release --project \"testProject\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--deployto \"SomeEnvironment\" " +
+                             "--norawlog", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_RawLogFile_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseCreatorFixture();
+                fixture.Settings.DeployTo = "SomeEnvironment";
+                fixture.Settings.RawLogFile = "someFile.txt";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create-release --project \"testProject\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--deployto \"SomeEnvironment\" " +
+                             "--rawlogfile \"/Working/someFile.txt\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Variables_To_Arguments_If_Specified()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseCreatorFixture();
+                fixture.Settings.DeployTo = "SomeEnvironment";
+                fixture.Settings.Variables.Add(new KeyValuePair<string, string>("var1", "value1"));
+                fixture.Settings.Variables.Add(new KeyValuePair<string, string>("var2", "value2"));
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create-release --project \"testProject\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--deployto \"SomeEnvironment\" " +
+                             "--variable=\"var1:value1\" " +
+                             "--variable=\"var2:value2\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_DeployAt_To_Arguments_If_Specified()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseCreatorFixture();
+                fixture.Settings.DeployTo = "SomeEnvironment";
+                fixture.Settings.DeployAt = new DateTime(2010, 6, 15).AddMinutes(1);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create-release --project \"testProject\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--deployto \"SomeEnvironment\" " +
+                             "--deployat=\"2010-06-15 00:01\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Tenants_To_Arguments_If_Specified()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseCreatorFixture();
+                fixture.Settings.DeployTo = "SomeEnvironment";
+                fixture.Settings.Tenant = new[] { "Tenant1", "Tenant2" };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create-release --project \"testProject\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--deployto \"SomeEnvironment\" " +
+                             "--tenant=\"Tenant1\" " +
+                             "--tenant=\"Tenant2\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_TenantTags_To_Arguments_If_Specified()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseCreatorFixture();
+                fixture.Settings.DeployTo = "SomeEnvironment";
+                fixture.Settings.TenantTags = new[] { "Tag1", "Tag2" };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create-release --project \"testProject\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--deployto \"SomeEnvironment\" " +
+                             "--tenanttag=\"Tag1\" " +
+                             "--tenanttag=\"Tag2\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_All_Deploymnet_Arguments()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseCreatorFixture();
+                fixture.Settings.DeployTo = "SomeEnvironment";
+                fixture.Settings.ShowProgress = true;
+                fixture.Settings.ForcePackageDownload = true;
+                fixture.Settings.WaitForDeployment = true;
+                fixture.Settings.DeploymentTimeout = TimeSpan.FromMinutes(1);
+                fixture.Settings.CancelOnTimeout = true;
+                fixture.Settings.DeploymentChecksLeepCycle = TimeSpan.FromMinutes(77);
+                fixture.Settings.GuidedFailure = true;
+                fixture.Settings.SpecificMachines = new string[] { "Machine1", "Machine2" };
+                fixture.Settings.Force = true;
+                fixture.Settings.SkipSteps = new[] { "Step1", "Step2" };
+                fixture.Settings.NoRawLog = true;
+                fixture.Settings.RawLogFile = "someFile.txt";
+                fixture.Settings.Variables.Add(new KeyValuePair<string, string>("var1", "value1"));
+                fixture.Settings.Variables.Add(new KeyValuePair<string, string>("var2", "value2"));
+                fixture.Settings.DeployAt = new DateTime(2010, 6, 15).AddMinutes(1);
+                fixture.Settings.Tenant = new[] { "Tenant1", "Tenant2" };
+                fixture.Settings.TenantTags = new[] { "Tag1", "Tag2" };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create-release --project \"testProject\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--deployto \"SomeEnvironment\" " +
+                             "--progress " +
+                             "--forcepackagedownload " +
+                             "--waitfordeployment " +
+                             "--deploymenttimeout=\"00:01:00\" " +
+                             "--cancelontimeout " +
+                             "--deploymentchecksleepcycle=\"01:17:00\" " +
+                             "--guidedfailure=True " +
+                             "--specificmachines=\"Machine1,Machine2\" " +
+                             "--force " +
+                             "--skip=\"Step1\" " +
+                             "--skip=\"Step2\" " +
+                             "--norawlog " +
+                             "--rawlogfile \"/Working/someFile.txt\" " +
+                             "--variable=\"var1:value1\" " +
+                             "--variable=\"var2:value2\" " +
+                             "--deployat=\"2010-06-15 00:01\" " +
+                             "--tenant=\"Tenant1\" " +
+                             "--tenant=\"Tenant2\" " +
+                             "--tenanttag=\"Tag1\" " +
+                             "--tenanttag=\"Tag2\"", result.Args);
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctoDeployReleaseTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctoDeployReleaseTests.cs
@@ -1,0 +1,444 @@
+﻿using System;
+using System.Collections.Generic;
+using Cake.Common.Tests.Fixtures.Tools;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.OctopusDeploy
+{
+    public sealed class OctoDeployReleaseTests
+    {
+        private const string MinimalParameters = "deploy-release --project=\"MyProject\" --deployto=\"Testing\" --releasenumber=\"0.15.1\" --server http://octopus --apiKey API-12345";
+
+        public sealed class TheBaseArgumentBuilder
+        {
+            [Fact]
+            public void Should_Throw_If_Server_Is_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Server = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "server");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Api_Key_Is_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.ApiKey = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "apiKey");
+            }
+
+            [Fact]
+            public void Should_Throw_If_ProjectName_Is_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Project = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "projectName");
+            }
+
+            [Fact]
+            public void Should_Throw_If_DeployTo_Is_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.DeployTo = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "deployTo");
+            }
+
+            [Fact]
+            public void Should_Throw_If_ReleaseNumber_Is_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.ReleaseNumber = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "releaseNumber");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Is_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Give_Default_Minimal_Parameters()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters, result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Username_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings.Username = "mike123";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters + " --user \"mike123\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Password_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings.Password = "secret";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters + " --pass \"secret\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Configuration_File_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings.ConfigurationFile = "configFile.txt";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters + " --configFile \"/Working/configFile.txt\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Debug_Flag_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings.EnableDebugLogging = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters + " --debug", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Ignore_Ssl_Errors_Flag_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings.IgnoreSslErrors = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters + " --ignoreSslErrors", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Enable_Service_Messages_Flag_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings.EnableServiceMessages = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters + " --enableServiceMessages", result.Args);
+            }
+        }
+
+        public sealed class DeploymentArgumentBuilder
+        {
+            [Fact]
+            public void Should_Add_Progress_To_Arguments_If_Specified()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings.ShowProgress = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters + " --progress", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_FocePackageDownload_To_Arguments_If_Specified()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings.ForcePackageDownload = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters + " --forcepackagedownload", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_WaitForDeployment_To_Arguments_If_Specified()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings.WaitForDeployment = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters + " --waitfordeployment", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_DeploymentTimeout_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings.DeploymentTimeout = TimeSpan.FromMinutes(1);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters + " --deploymenttimeout=\"00:01:00\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_CancelTimeout_To_Arguments_If_Specified()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings.CancelOnTimeout = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters + " --cancelontimeout", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_DeploymentChecksLeepCycle_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings.DeploymentChecksLeepCycle = TimeSpan.FromMinutes(77);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters + " --deploymentchecksleepcycle=\"01:17:00\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_GuidedFailure_To_Arguments_If_True()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings.GuidedFailure = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters + " --guidedfailure=True", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_GuidedFailure_To_Arguments_If_False()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings.GuidedFailure = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters + " --guidedfailure=True", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_SpecificMachines_To_Arguments_If_NotNull()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings.SpecificMachines = new string[] { "Machine1", "Machine2" };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters + " --specificmachines=\"Machine1,Machine2\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Force_To_Arguments_If_Specified()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings.Force = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters + " --force", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_SkipSteps_To_Arguments_If_Specified()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings.SkipSteps = new[] { "Step1", "Step2" };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters + " --skip=\"Step1\" --skip=\"Step2\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_NoRawLog_To_Arguments_If_Specified()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings.NoRawLog = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters + " --norawlog", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_RawLogFile_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings.RawLogFile = "someFile.txt";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters + " --rawlogfile \"/Working/someFile.txt\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Variables_To_Arguments_If_Specified()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings.Variables.Add("var1", "value1");
+                fixture.Settings.Variables.Add("var2", "value2");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters +
+                             " --variable=\"var1:value1\"" +
+                             " --variable=\"var2:value2\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_DeployAt_To_Arguments_If_Specified()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings.DeployAt = new DateTime(2010, 6, 15).AddMinutes(1);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters + " --deployat=\"2010-06-15 00:01\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Tenants_To_Arguments_If_Specified()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings.Tenant = new[] { "Tenant1", "Tenant2" };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters +
+                             " --tenant=\"Tenant1\"" +
+                             " --tenant=\"Tenant2\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_TenantTags_To_Arguments_If_Specified()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings.TenantTags = new[] { "Tag1", "Tag2" };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters +
+                             " --tenanttag=\"Tag1\"" +
+                             " --tenanttag=\"Tag2\"", result.Args);
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Tools/OctopusDeploy/CreateReleaseArgumentBuilder.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/CreateReleaseArgumentBuilder.cs
@@ -7,108 +7,107 @@ using Cake.Core.IO;
 
 namespace Cake.Common.Tools.OctopusDeploy
 {
-    internal class CreateReleaseArgumentBuilder
+    internal sealed class CreateReleaseArgumentBuilder : OctopusDeployArgumentBuilder<CreateReleaseSettings>
     {
         private readonly string _projectName;
         private readonly CreateReleaseSettings _settings;
         private readonly ICakeEnvironment _environment;
 
-        private readonly ProcessArgumentBuilder _builder;
-
-        public CreateReleaseArgumentBuilder(string projectName, CreateReleaseSettings settings, ICakeEnvironment environment)
+        public CreateReleaseArgumentBuilder(string projectName, CreateReleaseSettings settings, ICakeEnvironment environment) : base(environment, settings)
         {
             _projectName = projectName;
             _settings = settings;
             _environment = environment;
-            _builder = new ProcessArgumentBuilder();
         }
 
         public ProcessArgumentBuilder Get()
         {
+            Builder.Append("create-release");
+            Builder.AppendSwitchQuoted("--project", _projectName);
+
             AppendCommonArguments();
 
             AppendArgumentIfNotNull("releaseNumber", _settings.ReleaseNumber);
             AppendArgumentIfNotNull("defaultpackageversion", _settings.DefaultPackageVersion);
-            AppendPackages(_settings, _builder);
+            AppendPackages(_settings, Builder);
             AppendArgumentIfNotNull("packagesFolder", _settings.PackagesFolder);
             AppendArgumentIfNotNull("releasenotes", _settings.ReleaseNotes);
             AppendArgumentIfNotNull("releasenotesfile", _settings.ReleaseNotesFile);
             AppendArgumentIfNotNull("channel", _settings.Channel);
-            AppendArgumentIfNotNull("deployto", _settings.DeployTo);
 
             if (_settings.IgnoreChannelRules)
             {
-                _builder.Append("--ignorechannelrules");
+                Builder.Append("--ignorechannelrules");
             }
 
             if (_settings.DeploymentProgress)
             {
-                _builder.Append("--progress");
+                Builder.Append("--progress");
             }
 
             if (_settings.IgnoreExisting)
             {
-                _builder.Append("--ignoreexisting");
+                Builder.Append("--ignoreexisting");
             }
 
-            return _builder;
+            AppendDeploymnetArguments();
+
+            return Builder;
         }
 
-        private void AppendCommonArguments()
+        private void AppendDeploymnetArguments()
         {
-            _builder.Append("create-release");
+            AppendArgumentIfNotNull("deployto", _settings.DeployTo);
+            AppendConditionalFlag(_settings.ShowProgress, "--progress");
+            AppendConditionalFlag(_settings.ForcePackageDownload, "--forcepackagedownload");
+            AppendConditionalFlag(_settings.WaitForDeployment, "--waitfordeployment");
 
-            _builder.Append("--project");
-            _builder.AppendQuoted(_projectName);
-
-            _builder.Append("--server");
-            _builder.Append(_settings.Server);
-
-            _builder.Append("--apiKey");
-            _builder.AppendSecret(_settings.ApiKey);
-
-            AppendArgumentIfNotNull("username", _settings.Username);
-
-            if (_settings.Password != null)
+            if (_settings.DeploymentTimeout.HasValue)
             {
-                _builder.Append("--password");
-                _builder.AppendQuotedSecret(_settings.Password);
+                Builder.AppendSwitchQuoted("--deploymenttimeout", "=", _settings.DeploymentTimeout.Value.ToString("hh\\:mm\\:ss"));
             }
 
-            AppendArgumentIfNotNull("configFile", _settings.ConfigurationFile);
+            AppendConditionalFlag(_settings.CancelOnTimeout, "--cancelontimeout");
 
-            if (_settings.EnableDebugLogging)
+            if (_settings.DeploymentChecksLeepCycle.HasValue)
             {
-                _builder.Append("--debug");
+                Builder.AppendSwitchQuoted("--deploymentchecksleepcycle", "=", _settings.DeploymentChecksLeepCycle.Value.ToString("hh\\:mm\\:ss"));
             }
 
-            if (_settings.IgnoreSslErrors)
+            if (_settings.GuidedFailure.HasValue)
             {
-                _builder.Append("--ignoreSslErrors");
+                Builder.AppendSwitch("--guidedfailure", "=", _settings.GuidedFailure.ToString());
             }
 
-            if (_settings.EnableServiceMessages)
+            if (_settings.SpecificMachines != null && _settings.SpecificMachines.Length > 0)
             {
-                _builder.Append("--enableServiceMessages");
+                Builder.AppendSwitchQuoted("--specificmachines", "=", string.Join(",", _settings.SpecificMachines));
             }
-        }
 
-        private void AppendArgumentIfNotNull(string argumentName, string value)
-        {
-            if (value != null)
-            {
-                _builder.Append("--" + argumentName);
-                _builder.AppendQuoted(value);
-            }
-        }
+            AppendConditionalFlag(_settings.Force, "--force");
 
-        private void AppendArgumentIfNotNull(string argumentName, FilePath value)
-        {
-            if (value != null)
+            AppendMultipleTimes("skip", _settings.SkipSteps);
+
+            AppendConditionalFlag(_settings.NoRawLog, "--norawlog");
+
+            AppendArgumentIfNotNull("rawlogfile", _settings.RawLogFile);
+
+            if (_settings.Variables != null && _settings.Variables.Count > 0)
             {
-                _builder.Append("--" + argumentName);
-                _builder.AppendQuoted(value.MakeAbsolute(_environment).FullPath);
+                foreach (var pair in _settings.Variables)
+                {
+                    Builder.AppendSwitchQuoted("--variable", "=", $"{pair.Key}:{pair.Value}");
+                }
             }
+
+            if (_settings.DeployAt.HasValue)
+            {
+                Builder.AppendSwitchQuoted("--deployat", "=", _settings.DeployAt.Value.ToString("yyyy-MM-dd HH:mm"));
+            }
+
+            AppendMultipleTimes("tenant", _settings.Tenant);
+
+            AppendMultipleTimes("tenanttag", _settings.TenantTags);
         }
 
         private static void AppendPackages(CreateReleaseSettings settings, ProcessArgumentBuilder builder)

--- a/src/Cake.Common/Tools/OctopusDeploy/CreateReleaseSettings.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/CreateReleaseSettings.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using Cake.Core.IO;
 
@@ -9,9 +10,18 @@ namespace Cake.Common.Tools.OctopusDeploy
 {
     /// <summary>
     /// Contains settings used by <see cref="OctopusDeployReleaseCreator.CreateRelease"/>.
+    /// See Octopus Deploy documentation <see href="http://docs.octopusdeploy.com/display/OD/Creating+releases">here</see>
     /// </summary>
     public sealed class CreateReleaseSettings : OctopusDeploySettings
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CreateReleaseSettings"/> class.
+        /// </summary>
+        public CreateReleaseSettings()
+        {
+            Variables = new List<KeyValuePair<string, string>>();
+        }
+
         /// <summary>
         /// Gets or sets the release number to use for the new release.
         /// </summary>
@@ -43,9 +53,95 @@ namespace Cake.Common.Tools.OctopusDeploy
         public FilePath ReleaseNotesFile { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the Ignore Existing flag.
+        /// Gets or sets a value indicating whether to Ignore Existing release flag.
         /// </summary>
         public bool IgnoreExisting { get; set; }
+
+        /// <summary>
+        /// Gets or sets environment to automatically deploy to, e.g., Production.
+        /// </summary>
+        public string DeployTo { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether progress of the deployment should be followed. (Sets --waitfordeployment and --norawlog to true.)
+        /// </summary>
+        public bool ShowProgress { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to force downloading of already installed packages. Default false.
+        /// </summary>
+        public bool ForcePackageDownload { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to wait synchronously for deployment to finish.
+        /// </summary>
+        public bool WaitForDeployment { get; set; }
+
+        /// <summary>
+        /// Gets or sets maximum time (timespan format) that the console session will wait for the deployment to finish (default 00:10:00).
+        /// This will not stop the deployment. Requires WaitForDeployment parameter set.
+        /// </summary>
+        public TimeSpan? DeploymentTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to cancel the deployment if the deployment timeout is reached(default false).
+        /// </summary>
+        public bool CancelOnTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets how much time should elapse between deployment status checks(default 00:00:10).
+        /// </summary>
+        public TimeSpan? DeploymentChecksLeepCycle { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use Guided Failure mode. If not specified, will use default setting from environment.
+        /// </summary>
+        public bool? GuidedFailure { get; set; }
+
+        /// <summary>
+        /// Gets or sets list of machines names to target in the deployed environment.If not specified all machines in the environment will be considered.
+        /// </summary>
+        public string[] SpecificMachines { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether a project is configured to skip packages with already-installed versions, override this setting to force re-deployment (flag, default false).
+        /// </summary>
+        public bool Force { get; set; }
+
+        /// <summary>
+        /// Gets or sets a list of steps to be skipped. Takes step names.
+        /// </summary>
+        public string[] SkipSteps { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether print the raw log of failed tasks or not.
+        /// </summary>
+        public bool NoRawLog { get; set; }
+
+        /// <summary>
+        /// Gets or sets a file where to redirect the raw log of failed tasks.
+        /// </summary>
+        public FilePath RawLogFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets values for any prompted variables.
+        /// </summary>
+        public List<KeyValuePair<string, string>> Variables { get; set; }
+
+        /// <summary>
+        /// Gets or sets time at which deployment should start (scheduled deployment), specified as any valid DateTimeOffset format, and assuming the time zone is the current local time zone.
+        /// </summary>
+        public DateTimeOffset? DeployAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets a tenant the deployment will be performed for; specify this argument multiple times to add multiple tenants or use `*` wildcard to deploy to tenants able to deploy.
+        /// </summary>
+        public string[] Tenant { get; set; }
+
+        /// <summary>
+        /// Gets or sets a tenant tags used to match tenants that the deployment will be performed for; specify this argument multiple times to add multiple tenant tags.
+        /// </summary>
+        public string[] TenantTags { get; set; }
 
         /// <summary>
         /// Gets or sets the octopus channel for the new release.
@@ -56,11 +152,6 @@ namespace Cake.Common.Tools.OctopusDeploy
         /// Gets or sets a value indicating whether octopus channel rules should be ignored.
         /// </summary>
         public bool IgnoreChannelRules { get; set; }
-
-        /// <summary>
-        /// Gets or sets the octopus deployment environment for the new release.
-        /// </summary>
-        public string DeployTo { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether progress of the deployment will be shown.

--- a/src/Cake.Common/Tools/OctopusDeploy/DeployReleaseArgumentBuilder.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/DeployReleaseArgumentBuilder.cs
@@ -1,0 +1,102 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.OctopusDeploy
+{
+    internal sealed class DeployReleaseArgumentBuilder : OctopusDeployArgumentBuilder<OctopusDeployReleaseDeploymentSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        private readonly string _projectName;
+        private readonly string _deployTo;
+        private readonly string _releaseNumber;
+        private readonly OctopusDeployReleaseDeploymentSettings _settings;
+
+        public DeployReleaseArgumentBuilder(string server, string apiKey, string projectName, string deployTo, string releaseNumber, OctopusDeployReleaseDeploymentSettings settings, ICakeEnvironment environment)
+            : base(server, apiKey, environment, settings)
+        {
+            _projectName = projectName;
+            _deployTo = deployTo;
+            _releaseNumber = releaseNumber;
+
+            _environment = environment;
+            _settings = settings;
+        }
+
+        public ProcessArgumentBuilder Get()
+        {
+            Builder.Append("deploy-release");
+
+            Builder.AppendSwitchQuoted("--project", "=", _projectName);
+            Builder.AppendSwitchQuoted("--deployto", "=", _deployTo);
+            Builder.AppendSwitchQuoted("--releasenumber", "=", _releaseNumber);
+
+            AppendCommonArguments();
+
+            AppendDeploymentParameters();
+
+            return Builder;
+        }
+
+        private void AppendDeploymentParameters()
+        {
+            AppendConditionalFlag(_settings.ShowProgress, "--progress");
+            AppendConditionalFlag(_settings.ForcePackageDownload, "--forcepackagedownload");
+            AppendConditionalFlag(_settings.WaitForDeployment, "--waitfordeployment");
+
+            if (_settings.DeploymentTimeout.HasValue)
+            {
+                Builder.AppendSwitchQuoted("--deploymenttimeout", "=",
+                    _settings.DeploymentTimeout.Value.ToString("hh\\:mm\\:ss"));
+            }
+
+            AppendConditionalFlag(_settings.CancelOnTimeout, "--cancelontimeout");
+
+            if (_settings.DeploymentChecksLeepCycle.HasValue)
+            {
+                Builder.AppendSwitchQuoted("--deploymentchecksleepcycle", "=",
+                    _settings.DeploymentChecksLeepCycle.Value.ToString("hh\\:mm\\:ss"));
+            }
+
+            if (_settings.GuidedFailure.HasValue)
+            {
+                Builder.AppendSwitch("--guidedfailure", "=", _settings.GuidedFailure.ToString());
+            }
+
+            if (_settings.SpecificMachines != null && _settings.SpecificMachines.Length > 0)
+            {
+                Builder.AppendSwitchQuoted("--specificmachines", "=", string.Join(",", _settings.SpecificMachines));
+            }
+
+            AppendConditionalFlag(_settings.Force, "--force");
+
+            AppendMultipleTimes("skip", _settings.SkipSteps);
+
+            AppendConditionalFlag(_settings.NoRawLog, "--norawlog");
+
+            AppendArgumentIfNotNull("rawlogfile", _settings.RawLogFile);
+
+            if (_settings.Variables != null && _settings.Variables.Count > 0)
+            {
+                foreach (var pair in _settings.Variables)
+                {
+                    Builder.AppendSwitchQuoted("--variable", "=", $"{pair.Key}:{pair.Value}");
+                }
+            }
+
+            if (_settings.DeployAt.HasValue)
+            {
+                Builder.AppendSwitchQuoted("--deployat", "=", _settings.DeployAt.Value.ToString("yyyy-MM-dd HH:mm"));
+            }
+
+            AppendMultipleTimes("tenant", _settings.Tenant);
+
+            AppendMultipleTimes("tenanttag", _settings.TenantTags);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployAliases.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployAliases.cs
@@ -88,7 +88,7 @@ namespace Cake.Common.Tools.OctopusDeploy
         /// Pushes the specified package to the Octopus Deploy repository
         /// </summary>
         /// <param name="context">The cake context</param>
-        /// /// <param name="server">The Octopus server URL</param>
+        /// <param name="server">The Octopus server URL</param>
         /// <param name="apiKey">The user's API key</param>
         /// <param name="packagePath">Path to the package</param>
         /// <param name="settings">The settings</param>
@@ -155,6 +155,54 @@ namespace Cake.Common.Tools.OctopusDeploy
 
             var packer = new OctopusDeployPacker(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             packer.Pack(id, settings);
+        }
+
+        /// <summary>
+        /// Deploys the specified already existing release into a specified environment
+        /// See <see href="http://docs.octopusdeploy.com/display/OD/Deploying+releases">Octopus Documentation</see> for more details.
+        /// </summary>
+        /// <param name="context">The cake context</param>
+        /// <param name="server">The Octopus server URL</param>
+        /// <param name="apiKey">The user's API key</param>
+        /// <param name="projectName">Name of the target project</param>
+        /// <param name="deployTo">Target environment name</param>
+        /// <param name="releaseNumber">Version number of the release to deploy. Specify "latest" for the latest release</param>
+        /// <param name="settings">Deployment settings</param>
+        /// <example>
+        /// <code>
+        ///     // bare minimum
+        ///     OctoDeployRelease("http://octopus-deploy.example", "API-XXXXXXXXXXXXXXXXXXXX", "MyGreatProject", "Testing", "2.1.15-RC" new OctopusDeployReleaseDeploymentSettings());
+        ///
+        ///     // All of deployment arguments
+        ///     OctoDeployRelease("http://octopus-deploy.example", "API-XXXXXXXXXXXXXXXXXXXX", "MyGreatProject", "Testing", "2.1.15-RC" new OctopusDeployReleaseDeploymentSettings {
+        ///         ShowProgress = true,
+        ///         ForcePackageDownload = true,
+        ///         WaitForDeployment = true,
+        ///         DeploymentTimeout = TimeSpan.FromMinutes(1),
+        ///         CancelOnTimeout = true,
+        ///         DeploymentChecksLeepCycle = TimeSpan.FromMinutes(77),
+        ///         GuidedFailure = true,
+        ///         SpecificMachines = new string[] { "Machine1", "Machine2" },
+        ///         Force = true,
+        ///         SkipSteps = new[] { "Step1", "Step2" },
+        ///         NoRawLog = true,
+        ///         RawLogFile = "someFile.txt",
+        ///         DeployAt = new DateTime(2010, 6, 15).AddMinutes(1),
+        ///         Tenant = new[] { "Tenant1", "Tenant2" },
+        ///         TenantTags = new[] { "Tag1", "Tag2" },
+        ///     });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static void OctoDeployRelease(this ICakeContext context, string server, string apiKey, string projectName, string deployTo, string releaseNumber, OctopusDeployReleaseDeploymentSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var releaseDeployer = new OctopusDeployReleaseDeployer(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            releaseDeployer.DeployRelease(server, apiKey, projectName, deployTo, releaseNumber, settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployArgumentBuilder.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployArgumentBuilder.cs
@@ -51,6 +51,26 @@ namespace Cake.Common.Tools.OctopusDeploy
             }
         }
 
+        protected void AppendMultipleTimes(string argumentName, string[] values)
+        {
+            if (values != null && values.Length > 0)
+            {
+                foreach (var value in values)
+                {
+                    Builder.AppendSwitchQuoted("--" + argumentName, "=", value);
+                }
+            }
+        }
+
+        protected ProcessArgumentBuilder AppendConditionalFlag(bool condition, string flag)
+        {
+            if (condition)
+            {
+                Builder.Append(flag);
+            }
+            return Builder;
+        }
+
         protected void AppendCommonArguments()
         {
             Builder.Append("--server");

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployReleaseDeployer.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployReleaseDeployer.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.OctopusDeploy
+{
+    /// <summary>
+    /// The Octopus Deploy Release Deploy runner. This class facilitates deploying existing releases in Octopus Deploy.
+    /// </summary>
+    public sealed class OctopusDeployReleaseDeployer : Tool<OctopusDeployReleaseDeploymentSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OctopusDeployReleaseDeployer"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="tools">The tool locator.</param>
+        public OctopusDeployReleaseDeployer(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IToolLocator tools)
+            : base(fileSystem, environment, processRunner, tools)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Requests a deployment of a specified release to an environment.
+        /// </summary>
+        /// <param name="server">Octopus Server URL</param>
+        /// <param name="apiKey">The user's API key</param>
+        /// <param name="projectName">Name of the target project</param>
+        /// <param name="deployTo">Environment to deploy to, e.g., Production</param>
+        /// <param name="releaseNumber">Release number to be deployed to</param>
+        /// <param name="settings">Settings for the deployment</param>
+        public void DeployRelease(string server, string apiKey, string projectName, string deployTo, string releaseNumber, OctopusDeployReleaseDeploymentSettings settings)
+        {
+            if (String.IsNullOrEmpty(server))
+            {
+                throw new ArgumentNullException(nameof(server));
+            }
+
+            if (String.IsNullOrEmpty(apiKey))
+            {
+                throw new ArgumentNullException(nameof(apiKey));
+            }
+
+            if (String.IsNullOrEmpty(projectName))
+            {
+                throw new ArgumentNullException(nameof(projectName));
+            }
+
+            if (String.IsNullOrEmpty(deployTo))
+            {
+                throw new ArgumentNullException(nameof(deployTo));
+            }
+
+            if (String.IsNullOrEmpty(releaseNumber))
+            {
+                throw new ArgumentNullException(nameof(releaseNumber));
+            }
+
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            var argumentBuilder = new DeployReleaseArgumentBuilder(server, apiKey, projectName, deployTo, releaseNumber, settings, _environment);
+            Run(settings, argumentBuilder.Get());
+        }
+
+        /// <summary>
+        /// Gets the name of the tool.
+        /// </summary>
+        /// <returns>The name of the tool.</returns>
+        protected override string GetToolName()
+        {
+            return "Octo";
+        }
+
+        /// <summary>
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return new[] { "Octo.exe" };
+        }
+    }
+}

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployReleaseDeploymentSettings.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployReleaseDeploymentSettings.cs
@@ -1,0 +1,105 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.OctopusDeploy
+{
+    /// <summary>
+    /// Possible arguments to pass to Octo.exe for deploying a release. See <see href="http://docs.octopusdeploy.com/display/OD/Deploying+releases">Octopus Deploy documentation</see>
+    /// </summary>
+    public sealed class OctopusDeployReleaseDeploymentSettings : OctopusDeploySettings
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OctopusDeployReleaseDeploymentSettings"/> class.
+        /// </summary>
+        public OctopusDeployReleaseDeploymentSettings()
+        {
+            Variables = new Dictionary<string, string>();
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether progress of the deployment should be followed. (Sets --waitfordeployment and --norawlog to true.)
+        /// </summary>
+        public bool ShowProgress { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to force downloading of already installed packages. Default false.
+        /// </summary>
+        public bool ForcePackageDownload { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to wait synchronously for deployment to finish.
+        /// </summary>
+        public bool WaitForDeployment { get; set; }
+
+        /// <summary>
+        /// Gets or sets maximum time (timespan format) that the console session will wait for the deployment to finish (default 00:10:00).
+        /// This will not stop the deployment. Requires WaitForDeployment parameter set.
+        /// </summary>
+        public TimeSpan? DeploymentTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to cancel the deployment if the deployment timeout is reached(default false).
+        /// </summary>
+        public bool CancelOnTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets how much time should elapse between deployment status checks(default 00:00:10).
+        /// </summary>
+        public TimeSpan? DeploymentChecksLeepCycle { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use Guided Failure mode. If not specified, will use default setting from environment.
+        /// </summary>
+        public bool? GuidedFailure { get; set; }
+
+        /// <summary>
+        /// Gets or sets list of machines names to target in the deployed environment.If not specified all machines in the environment will be considered.
+        /// </summary>
+        public string[] SpecificMachines { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether a project is configured to skip packages with already-installed versions, override this setting to force re-deployment (flag, default false).
+        /// </summary>
+        public bool Force { get; set; }
+
+        /// <summary>
+        /// Gets or sets a list of steps to be skipped. Takes step names.
+        /// </summary>
+        public string[] SkipSteps { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether print the raw log of failed tasks or not.
+        /// </summary>
+        public bool NoRawLog { get; set; }
+
+        /// <summary>
+        /// Gets or sets a file where to redirect the raw log of failed tasks.
+        /// </summary>
+        public FilePath RawLogFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets values for any prompted variables.
+        /// </summary>
+        public Dictionary<string, string> Variables { get; set; }
+
+        /// <summary>
+        /// Gets or sets time at which deployment should start (scheduled deployment), specified as any valid DateTimeOffset format, and assuming the time zone is the current local time zone.
+        /// </summary>
+        public DateTimeOffset? DeployAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets a tenant the deployment will be performed for; specify this argument multiple times to add multiple tenants or use `*` wildcard to deploy to tenants able to deploy.
+        /// </summary>
+        public string[] Tenant { get; set; }
+
+        /// <summary>
+        /// Gets or sets a tenant tags used to match tenants that the deployment will be performed for; specify this argument multiple times to add multiple tenant tags.
+        /// </summary>
+        public string[] TenantTags { get; set; }
+    }
+}


### PR DESCRIPTION
This PR is for issues #1227 and #1228.
One part adds an option to deploy a freshly created release - added more parameters to `CreateReleaseSettings` and modified argument builder around it.
Second part is to request a deployment of an already existing release to an environment: `OctopusDeployReleaseDeployer`.

Also refactored `CreateReleaseArgumentBuilder` to inherit from common argument builder and removed some duplicated code.

I'm not very happy that `OctopusDeployReleaseDeploymentSettings` has a lot of overlapping properties with `CreateReleaseSettings` and the argument builders for both of them contain a lot of identical code to create arguments related to deployment. However I don't see a way to reduce the duplication without adding more inheritance and doing some funky stuff. Suggestions are welcome.