### PR TITLE
GH1318: Add the ability to use default credentials for HttpClient when downlo…

### DIFF
--- a/src/Cake.Common/Net/DownloadFileSettings.cs
+++ b/src/Cake.Common/Net/DownloadFileSettings.cs
@@ -18,5 +18,10 @@ namespace Cake.Common.Net
         /// Gets or sets the Password to use when downloading the file
         /// </summary>
         public string Password { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that controls whether default credentials are sent when downloading the file
+        /// </summary>
+        public bool UseDefaultCredentials { get; set; }
     }
 }

--- a/src/Cake.Common/Net/HttpAliases.cs
+++ b/src/Cake.Common/Net/HttpAliases.cs
@@ -197,7 +197,7 @@ namespace Cake.Common.Net
             // We track the last posted value since the event seems to fire many times for the same value.
             var percentComplete = 0;
 
-            using (var http = new HttpClient())
+            using (var http = new HttpClient(new HttpClientHandler { UseDefaultCredentials = settings.UseDefaultCredentials }))
             {
                 if (!string.IsNullOrWhiteSpace(settings.Username) && !string.IsNullOrWhiteSpace(settings.Password))
                 {


### PR DESCRIPTION
We should be able to authenticate against any web service using by UseDefaultCredentials.
DownloadFileSettings will need a new property UseDefaultCredentials that will be used for HttpClientHandler to set UseDefaultCredentials.
We need this, when we download documents from a Sharepoint website.