### PR TITLE
[DOC] Adds default CPU count behavior to MSBuild settings documentation

### DIFF
--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
@@ -57,7 +57,8 @@ namespace Cake.Common.Tools.MSBuild
         /// <summary>
         /// Gets or sets the maximum CPU count.
         /// If this value is zero, MSBuild will use as many processes as
-        /// there are available CPUs to build the project.
+        /// there are available CPUs to build the project. If not set
+        /// MSBuild compile projects in this solution one at a time.
         /// </summary>
         /// <value>The maximum CPU count.</value>
         public int? MaxCpuCount { get; set; }

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
@@ -120,7 +120,7 @@ namespace Cake.Common.Tools.MSBuild
         }
 
         /// <summary>
-        /// Sets the maximum CPU count.
+        /// Sets the maximum CPU count. Without this set MSBuild will compile projects in this solution one at a time.
         /// </summary>
         /// <param name="settings">The settings.</param>
         /// <param name="maxCpuCount">The maximum CPU count. Set this value to zero to use as many MSBuild processes as available CPUs.</param>


### PR DESCRIPTION
Default behavior without setting the MaxCpuCount will be to compile
projects one at a time. The documentation indicated how to set this to use
all your processors, but didn't indicate the behavior if you didn't.
Because the value of 0 means use all available CPUs I suspect many people
like myself would think that 0 is the default so no value was needed to be
explicitly specified.

See https://msdn.microsoft.com/en-us/library/bb651793.aspx