### PR TITLE
GH1245: Added % to alphanumeric chars allowed in glob

### DIFF
--- a/src/Cake.Core.Tests/Fixtures/GlobberFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/GlobberFixture.cs
@@ -46,6 +46,7 @@ namespace Cake.Core.Tests.Fixtures
             FileSystem.CreateFile("C:/Working/Project.IntegrationTest.dll");
             FileSystem.CreateFile("C:/Tools & Services/MyTool.dll");
             FileSystem.CreateFile("C:/Tools + Services/MyTool.dll");
+            FileSystem.CreateFile("C:/Some %2F Directory/MyTool.dll");
         }
 
         private void PrepareUnixFixture()

--- a/src/Cake.Core.Tests/Unit/IO/GlobberTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/GlobberTests.cs
@@ -128,6 +128,20 @@ namespace Cake.Core.Tests.Unit.IO
                   Assert.Equal(1, result.Length);
                   Assert.ContainsFilePath(result, "C:/Tools + Services/MyTool.dll");
                 }
+
+                [WindowsFact]
+                public void Should_Parse_Glob_Expressions_With_Percent_In_Them()
+                {
+                  // Given
+                  var fixture = new GlobberFixture(windows: true);
+
+                  // When
+                  var result = fixture.Match("C:/Some %2F Directory/*.dll");
+
+                  // Then
+                  Assert.Equal(1, result.Length);
+                  Assert.ContainsFilePath(result, "C:/Some %2F Directory/MyTool.dll");
+                }
             }
 
             public sealed class WithPredicate

--- a/src/Cake.Core/IO/Globbing/GlobTokenizer.cs
+++ b/src/Cake.Core/IO/Globbing/GlobTokenizer.cs
@@ -27,7 +27,7 @@ namespace Cake.Core.IO.Globbing
             _sourceIndex = 0;
             _currentContent = string.Empty;
             _currentCharacter = _pattern[_sourceIndex];
-            _identifierRegex = new Regex("^[0-9a-zA-Z\\+&(). _-]$", RegexOptions.Compiled);
+            _identifierRegex = new Regex("^[0-9a-zA-Z\\+&%(). _-]$", RegexOptions.Compiled);
         }
 
         public GlobToken Scan()


### PR DESCRIPTION
Modified GlobTokenizer to allow % sign as an alphanumeric character. Fixes #1245 