### PR TITLE
GH1250: Add support for VSTS and TFS build system

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Build/TFBuildFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/TFBuildFixture.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Cake.Common.Build.TFBuild;
+using Cake.Core;
+using NSubstitute;
+
+namespace Cake.Common.Tests.Fixtures.Build
+{
+    internal sealed class TFBuildFixture
+    {
+        public ICakeEnvironment Environment { get; set; }
+
+        public TFBuildFixture()
+        {
+            Environment = Substitute.For<ICakeEnvironment>();
+            Environment.WorkingDirectory.Returns("C:\\build\\CAKE-CAKE-JOB1");
+            Environment.GetEnvironmentVariable("TF_BUILD").Returns((string)null);
+        }
+
+        public void IsRunningOnVSTS()
+        {
+            Environment.GetEnvironmentVariable("TF_BUILD").Returns("True");
+            Environment.GetEnvironmentVariable("AGENT_NAME").Returns("Hosted Agent");
+        }
+
+        public void IsRunningOnTFS()
+        {
+            Environment.GetEnvironmentVariable("TF_BUILD").Returns("True");
+            Environment.GetEnvironmentVariable("AGENT_NAME").Returns("On Premises");
+        }
+
+        public TFBuildProvider CreateTFBuildService()
+        {
+            return new TFBuildProvider(Environment);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Fixtures/Build/TFBuildInfoFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/TFBuildInfoFixture.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Cake.Common.Build.TFBuild.Data;
+using Cake.Core;
+using NSubstitute;
+
+namespace Cake.Common.Tests.Fixtures.Build
+{
+    public sealed class TFBuildInfoFixture
+    {
+        public ICakeEnvironment Environment { get; set; }
+
+        public TFBuildInfoFixture()
+        {
+            Environment = Substitute.For<ICakeEnvironment>();
+
+            // VSTS RepositoryInfo
+            Environment.GetEnvironmentVariable("BUILD_SOURCEVERSION").Returns("4efbc1ffb993dfbcf024e6a9202865cc0b6d9c50");
+            Environment.GetEnvironmentVariable("BUILD_SOURCETFVCSHELVESET").Returns("Shelveset1");
+            Environment.GetEnvironmentVariable("BUILD_REPOSITORY_NAME").Returns("cake");
+            Environment.GetEnvironmentVariable("BUILD_REPOSITORY_PROVIDER").Returns("GitHub");
+            Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCHNAME").Returns("develop");
+
+            // VSTS AgentInfo
+            Environment.GetEnvironmentVariable("AGENT_BUILDDIRECTORY").Returns(@"c:\agent\_work\1");
+            Environment.GetEnvironmentVariable("AGENT_HOMEDIRECTORY").Returns(@"c:\agent");
+            Environment.GetEnvironmentVariable("AGENT_WORKFOLDER").Returns(@"c:\agent\_work");
+            Environment.GetEnvironmentVariable("AGENT_ID").Returns("71");
+            Environment.GetEnvironmentVariable("AGENT_NAME").Returns("Agent-1");
+            Environment.GetEnvironmentVariable("AGENT_MACHINE_NAME").Returns("BuildServer");
+
+            // VSTS BuildInfo
+            Environment.GetEnvironmentVariable("BUILD_BUILDID").Returns("100234");
+            Environment.GetEnvironmentVariable("BUILD_BUILDNUMBER").Returns("Build-20160927.1");
+            Environment.GetEnvironmentVariable("BUILD_BUILDURI").Returns("vstfs:///Build/Build/1430");
+            Environment.GetEnvironmentVariable("BUILD_QUEUEDBY")
+                .Returns(@"[DefaultCollection]\Project Collection Service Accounts");
+            Environment.GetEnvironmentVariable("BUILD_REQUESTEDFOR").Returns("Alistair Chapman");
+            Environment.GetEnvironmentVariable("BUILD_REQUESTEDFOREMAIL").Returns("author@mail.com");
+
+            // VSTS DefinitionInfo
+            Environment.GetEnvironmentVariable("SYSTEM_DEFINITIONID").Returns("1855");
+            Environment.GetEnvironmentVariable("BUILD_DEFINITIONNAME").Returns("Cake-CI");
+            Environment.GetEnvironmentVariable("BUILD_DEFINITIONVERSION").Returns("47");
+
+            // VSTS TeamProjectInfo
+            Environment.GetEnvironmentVariable("SYSTEM_TEAMPROJECT").Returns("TeamProject");
+            Environment.GetEnvironmentVariable("SYSTEM_TEAMPROJECTID").Returns("D0A3B6B8-499B-4D4B-BD46-DB70C19E6D33");
+            Environment.GetEnvironmentVariable("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI")
+                .Returns("https://fabrikamfiber.visualstudio.com/");
+        }
+
+        public TFBuildEnvironmentInfo CreateEnvironmentInfo()
+        {
+            return new TFBuildEnvironmentInfo(Environment);
+        }
+
+        public TFBuildRepositoryInfo CreateRepositoryInfo()
+        {
+            return new TFBuildRepositoryInfo(Environment);
+        }
+
+        public TFBuildRepositoryInfo CreateRepositoryInfo(string repoType)
+        {
+            Environment.GetEnvironmentVariable("BUILD_REPOSITORY_PROVIDER").Returns(repoType);
+            return CreateRepositoryInfo();
+        }
+
+        public TFBuildAgentInfo CreateAgentInfo()
+        {
+            return new TFBuildAgentInfo(Environment);
+        }
+
+        public TFBuildAgentInfo CreateHostedAgentInfo()
+        {
+            Environment.GetEnvironmentVariable("AGENT_NAME").Returns("Hosted Agent");
+            return new TFBuildAgentInfo(Environment);
+        }
+
+        public TFBuildInfo CreateBuildInfo()
+        {
+            return new TFBuildInfo(Environment);
+        }
+
+        public TFBuildDefinitionInfo CreateDefinitionInfo()
+        {
+            return new TFBuildDefinitionInfo(Environment);
+        }
+
+        public TFBuildTeamProjectInfo CreateTeamProjectInfo()
+        {
+            return new TFBuildTeamProjectInfo(Environment);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Build/BuildSystemAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/BuildSystemAliasesTests.cs
@@ -122,5 +122,18 @@ namespace Cake.Common.Tests.Unit.Build
                 Assert.IsArgumentNullException(result, "context");
             }
         }
+
+        public sealed class TheTFBuildMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Context_Is_Null()
+            {
+                // Given, When
+                var result = Record.Exception(() => BuildSystemAliases.TFBuild(null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "context");
+            }
+        }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Build/BuildSystemTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/BuildSystemTests.cs
@@ -13,6 +13,7 @@ using Cake.Common.Build.GoCD;
 using Cake.Common.Build.Jenkins;
 using Cake.Common.Build.MyGet;
 using Cake.Common.Build.TeamCity;
+using Cake.Common.Build.TFBuild;
 using Cake.Common.Build.TravisCI;
 using NSubstitute;
 using Xunit;
@@ -37,9 +38,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(null, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider));
+                var result = Record.Exception(() => new BuildSystem(null, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "appVeyorProvider");
@@ -59,9 +61,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, null, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, null, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "teamCityProvider");
@@ -81,9 +84,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, null, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, null, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "myGetProvider");
@@ -103,9 +107,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, null, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, null, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "bambooProvider");
@@ -125,9 +130,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, null,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, null,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "continuaCIProvider");
@@ -147,9 +153,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, null, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, null, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "jenkinsProvider");
@@ -169,9 +176,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, null, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, null, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "bitriseProvider");
@@ -191,9 +199,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, null, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, null, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "travisCIProvider");
@@ -213,9 +222,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, null, goCDProvider, gitlabCIProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, null, goCDProvider, gitlabCIProvider, tfBuildProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "bitbucketPipelinesProvider");
@@ -235,9 +245,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, null, gitlabCIProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, null, gitlabCIProvider, tfBuildProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "goCDProvider");
@@ -257,12 +268,36 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, null));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, null, tfBuildProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "gitlabCIProvider");
+            }
+
+            [Fact]
+            public void Should_Throw_If_TFBuild_Is_Null()
+            {
+                // Given
+                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
+                var teamCityProvider = Substitute.For<ITeamCityProvider>();
+                var myGetProvider = Substitute.For<IMyGetProvider>();
+                var bambooProvider = Substitute.For<IBambooProvider>();
+                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
+                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
+                var bitriseProvider = Substitute.For<IBitriseProvider>();
+                var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
+                var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+
+                // When
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "tfBuildProvider");
             }
         }
 
@@ -283,9 +318,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnAppVeyor;
@@ -312,9 +348,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 teamCityProvider.IsRunningOnTeamCity.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnTeamCity;
@@ -341,9 +378,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 myGetProvider.IsRunningOnMyGet.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnMyGet;
@@ -370,9 +408,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 bambooProvider.IsRunningOnBamboo.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnBamboo;
@@ -399,9 +438,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 continuaCIProvider.IsRunningOnContinuaCI.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnContinuaCI;
@@ -428,9 +468,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 jenkinsProvider.IsRunningOnJenkins.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnJenkins;
@@ -457,9 +498,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 bitriseProvider.IsRunningOnBitrise.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnBitrise;
@@ -486,9 +528,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 travisCIProvider.IsRunningOnTravisCI.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnTravisCI;
@@ -515,9 +558,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnBitbucketPipelines;
@@ -544,9 +588,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 goCDProvider.IsRunningOnGoCD.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnGoCD;
@@ -573,12 +618,73 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 gitlabCIProvider.IsRunningOnGitLabCI.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnGitLabCI;
+
+                // Then
+                Assert.True(result);
+            }
+        }
+
+        public sealed class TheIsRunningOnVSTSProperty
+        {
+            [Fact]
+            public void Should_Return_True_If_Running_On_VSTS()
+            {
+                // Given
+                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
+                var teamCityProvider = Substitute.For<ITeamCityProvider>();
+                var myGetProvider = Substitute.For<IMyGetProvider>();
+                var bambooProvider = Substitute.For<IBambooProvider>();
+                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
+                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
+                var bitriseProvider = Substitute.For<IBitriseProvider>();
+                var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
+                var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
+
+                tfBuildProvider.IsRunningOnVSTS.Returns(true);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
+
+                // When
+                var result = buildSystem.IsRunningOnVSTS;
+
+                // Then
+                Assert.True(result);
+            }
+        }
+
+        public sealed class TheIsRunningOnTFSProperty
+        {
+            [Fact]
+            public void Should_Return_True_If_Running_On_TFS()
+            {
+                // Given
+                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
+                var teamCityProvider = Substitute.For<ITeamCityProvider>();
+                var myGetProvider = Substitute.For<IMyGetProvider>();
+                var bambooProvider = Substitute.For<IBambooProvider>();
+                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
+                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
+                var bitriseProvider = Substitute.For<IBitriseProvider>();
+                var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
+                var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
+
+                tfBuildProvider.IsRunningOnTFS.Returns(true);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
+
+                // When
+                var result = buildSystem.IsRunningOnTFS;
 
                 // Then
                 Assert.True(result);
@@ -602,6 +708,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(true);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -613,7 +720,9 @@ namespace Cake.Common.Tests.Unit.Build
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
                 gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+                tfBuildProvider.IsRunningOnVSTS.Returns(false);
+                tfBuildProvider.IsRunningOnTFS.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -637,6 +746,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(true);
@@ -648,7 +758,9 @@ namespace Cake.Common.Tests.Unit.Build
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
                 gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+                tfBuildProvider.IsRunningOnVSTS.Returns(false);
+                tfBuildProvider.IsRunningOnTFS.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -672,6 +784,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -683,7 +796,9 @@ namespace Cake.Common.Tests.Unit.Build
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
                 gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+                tfBuildProvider.IsRunningOnVSTS.Returns(false);
+                tfBuildProvider.IsRunningOnTFS.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -707,6 +822,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -718,7 +834,9 @@ namespace Cake.Common.Tests.Unit.Build
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
                 gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+                tfBuildProvider.IsRunningOnVSTS.Returns(false);
+                tfBuildProvider.IsRunningOnTFS.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -742,6 +860,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -753,7 +872,9 @@ namespace Cake.Common.Tests.Unit.Build
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
                 gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+                tfBuildProvider.IsRunningOnVSTS.Returns(false);
+                tfBuildProvider.IsRunningOnTFS.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -777,6 +898,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -788,7 +910,9 @@ namespace Cake.Common.Tests.Unit.Build
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
                 gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+                tfBuildProvider.IsRunningOnVSTS.Returns(false);
+                tfBuildProvider.IsRunningOnTFS.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -812,6 +936,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -823,7 +948,9 @@ namespace Cake.Common.Tests.Unit.Build
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
                 gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+                tfBuildProvider.IsRunningOnVSTS.Returns(false);
+                tfBuildProvider.IsRunningOnTFS.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -847,6 +974,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -858,7 +986,9 @@ namespace Cake.Common.Tests.Unit.Build
                 travisCIProvider.IsRunningOnTravisCI.Returns(true);
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
                 gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+                tfBuildProvider.IsRunningOnVSTS.Returns(false);
+                tfBuildProvider.IsRunningOnTFS.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -882,6 +1012,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -893,7 +1024,9 @@ namespace Cake.Common.Tests.Unit.Build
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(true);
                 gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+                tfBuildProvider.IsRunningOnVSTS.Returns(false);
+                tfBuildProvider.IsRunningOnTFS.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -917,6 +1050,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -929,7 +1063,9 @@ namespace Cake.Common.Tests.Unit.Build
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
                 goCDProvider.IsRunningOnGoCD.Returns(true);
                 gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+                tfBuildProvider.IsRunningOnVSTS.Returns(false);
+                tfBuildProvider.IsRunningOnTFS.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -953,6 +1089,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -965,7 +1102,87 @@ namespace Cake.Common.Tests.Unit.Build
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
                 goCDProvider.IsRunningOnGoCD.Returns(false);
                 gitlabCIProvider.IsRunningOnGitLabCI.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+                tfBuildProvider.IsRunningOnVSTS.Returns(false);
+                tfBuildProvider.IsRunningOnTFS.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
+
+                // When
+                var result = buildSystem.IsLocalBuild;
+
+                // Then
+                Assert.False(result);
+            }
+
+            [Fact]
+            public void Should_Return_False_If_Running_On_VSTS()
+            {
+                // Given
+                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
+                var teamCityProvider = Substitute.For<ITeamCityProvider>();
+                var myGetProvider = Substitute.For<IMyGetProvider>();
+                var bambooProvider = Substitute.For<IBambooProvider>();
+                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
+                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
+                var bitriseProvider = Substitute.For<IBitriseProvider>();
+                var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
+                var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
+
+                appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
+                teamCityProvider.IsRunningOnTeamCity.Returns(false);
+                myGetProvider.IsRunningOnMyGet.Returns(false);
+                bambooProvider.IsRunningOnBamboo.Returns(false);
+                continuaCIProvider.IsRunningOnContinuaCI.Returns(false);
+                jenkinsProvider.IsRunningOnJenkins.Returns(false);
+                bitriseProvider.IsRunningOnBitrise.Returns(false);
+                travisCIProvider.IsRunningOnTravisCI.Returns(false);
+                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
+                goCDProvider.IsRunningOnGoCD.Returns(false);
+                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
+                tfBuildProvider.IsRunningOnVSTS.Returns(true);
+                tfBuildProvider.IsRunningOnTFS.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
+
+                // When
+                var result = buildSystem.IsLocalBuild;
+
+                // Then
+                Assert.False(result);
+            }
+
+            [Fact]
+            public void Should_Return_False_If_Running_On_TFS()
+            {
+                // Given
+                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
+                var teamCityProvider = Substitute.For<ITeamCityProvider>();
+                var myGetProvider = Substitute.For<IMyGetProvider>();
+                var bambooProvider = Substitute.For<IBambooProvider>();
+                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
+                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
+                var bitriseProvider = Substitute.For<IBitriseProvider>();
+                var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
+                var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
+
+                appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
+                teamCityProvider.IsRunningOnTeamCity.Returns(false);
+                myGetProvider.IsRunningOnMyGet.Returns(false);
+                bambooProvider.IsRunningOnBamboo.Returns(false);
+                continuaCIProvider.IsRunningOnContinuaCI.Returns(false);
+                jenkinsProvider.IsRunningOnJenkins.Returns(false);
+                bitriseProvider.IsRunningOnBitrise.Returns(false);
+                travisCIProvider.IsRunningOnTravisCI.Returns(false);
+                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
+                goCDProvider.IsRunningOnGoCD.Returns(false);
+                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
+                tfBuildProvider.IsRunningOnVSTS.Returns(false);
+                tfBuildProvider.IsRunningOnTFS.Returns(true);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -989,6 +1206,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -1000,7 +1218,9 @@ namespace Cake.Common.Tests.Unit.Build
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
                 goCDProvider.IsRunningOnGoCD.Returns(false);
                 gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+                tfBuildProvider.IsRunningOnVSTS.Returns(false);
+                tfBuildProvider.IsRunningOnTFS.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;

--- a/src/Cake.Common.Tests/Unit/Build/TFBuild/Data/TFBuildAgentInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TFBuild/Data/TFBuildAgentInfoTests.cs
@@ -1,0 +1,137 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tests.Fixtures.Build;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Build.TFBuild.Data
+{
+    public sealed class TFBuildAgentInfoTests
+    {
+        public sealed class TheBuildDirectoryProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateAgentInfo();
+
+                // When
+                var result = info.BuildDirectory;
+
+                // Then
+                Assert.Equal("c:/agent/_work/1", result.FullPath);
+            }
+        }
+
+        public sealed class TheHomeDirectoryProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateAgentInfo();
+
+                // When
+                var result = info.HomeDirectory;
+
+                // Then
+                Assert.Equal("c:/agent", result.FullPath);
+            }
+        }
+
+        public sealed class TheWorkingDirectoryProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateAgentInfo();
+
+                // When
+                var result = info.WorkingDirectory;
+
+                // Then
+                Assert.Equal("c:/agent/_work", result.FullPath);
+            }
+        }
+
+        public sealed class TheIdProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateAgentInfo();
+
+                // When
+                var result = info.Id;
+
+                // Then
+                Assert.Equal(71, result);
+            }
+        }
+
+        public sealed class TheNameProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateAgentInfo();
+
+                // When
+                var result = info.Name;
+
+                // Then
+                Assert.Equal("Agent-1", result);
+            }
+        }
+
+        public sealed class TheMachineNameProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateAgentInfo();
+
+                // When
+                var result = info.MachineName;
+
+                // Then
+                Assert.Equal("BuildServer", result);
+            }
+        }
+
+        public sealed class TheIsHostedProperty
+        {
+            [Fact]
+            public void Should_Return_True_On_Hosted_Agent()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateHostedAgentInfo();
+
+                // When
+                var result = info.IsHosted;
+
+                // Then
+                Assert.True(result);
+            }
+
+            [Fact]
+            public void Should_Return_False_On_Other_Agent()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateAgentInfo();
+
+                // When
+                var result = info.IsHosted;
+
+                // Then
+                Assert.False(result);
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Build/TFBuild/Data/TFBuildDefinitionInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TFBuild/Data/TFBuildDefinitionInfoTests.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tests.Fixtures.Build;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Build.TFBuild.Data
+{
+    public sealed class TFBuildDefinitionInfoTests
+    {
+        public sealed class TheIdProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateDefinitionInfo();
+
+                // When
+                var result = info.Id;
+
+                // Then
+                Assert.Equal(1855, result);
+            }
+        }
+
+        public sealed class TheNameProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateDefinitionInfo();
+
+                // When
+                var result = info.Name;
+
+                // Then
+                Assert.Equal("Cake-CI", result);
+            }
+        }
+
+        public sealed class TheVersionProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateDefinitionInfo();
+
+                // When
+                var result = info.Version;
+
+                // Then
+                Assert.Equal(47, result);
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Build/TFBuild/Data/TFBuildInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TFBuild/Data/TFBuildInfoTests.cs
@@ -1,0 +1,110 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Common.Tests.Fixtures.Build;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Build.TFBuild.Data
+{
+    public sealed class TFBuildInfoTests
+    {
+        public sealed class TheIdProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.Id;
+
+                // Then
+                Assert.Equal(100234, result);
+            }
+        }
+
+        public sealed class TheNumberProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.Number;
+
+                // Then
+                Assert.Equal("Build-20160927.1", result);
+            }
+        }
+
+        public sealed class TheUriProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.Uri;
+
+                // Then
+                var uri = new Uri("vstfs:///Build/Build/1430");
+                Assert.Equal(uri, result);
+            }
+        }
+
+        public sealed class TheQueuedByProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.QueuedBy;
+
+                // Then
+                Assert.Equal(@"[DefaultCollection]\Project Collection Service Accounts", result);
+            }
+        }
+
+        public sealed class TheRequestedForProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.RequestedFor;
+
+                // Then
+                Assert.Equal("Alistair Chapman", result);
+            }
+        }
+
+        public sealed class TheRequestedForEmailProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.RequestedForEmail;
+
+                // Then
+                Assert.Equal("author@mail.com", result);
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Build/TFBuild/Data/TFBuildRepositoryInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TFBuild/Data/TFBuildRepositoryInfoTests.cs
@@ -1,0 +1,98 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Build.TFBuild.Data;
+using Cake.Common.Tests.Fixtures.Build;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Build.TFBuild.Data
+{
+    public sealed class TFBuildRepositoryInfoTests
+    {
+        public sealed class TheBranchProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateRepositoryInfo();
+
+                // When
+                var result = info.Branch;
+
+                // Then
+                Assert.Equal("develop", result);
+            }
+        }
+
+        public sealed class TheSourceVersionProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateRepositoryInfo();
+
+                // When
+                var result = info.SourceVersion;
+
+                // Then
+                Assert.Equal("4efbc1ffb993dfbcf024e6a9202865cc0b6d9c50", result);
+            }
+        }
+
+        public sealed class TheShelvesetProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateRepositoryInfo();
+
+                // When
+                var result = info.Shelveset;
+
+                // Then
+                Assert.Equal("Shelveset1", result);
+            }
+        }
+
+        public sealed class TheRepoNameProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateRepositoryInfo();
+
+                // When
+                var result = info.RepoName;
+
+                // Then
+                Assert.Equal("cake", result);
+            }
+        }
+
+        public sealed class TheProviderProperty
+        {
+            [Theory]
+            [InlineData("Git", TFRepositoryType.Git)]
+            [InlineData("GitHub", TFRepositoryType.GitHub)]
+            [InlineData("Svn", TFRepositoryType.Svn)]
+            [InlineData("TfsGit", TFRepositoryType.TfsGit)]
+            [InlineData("TfsVersionControl", TFRepositoryType.TfsVersionControl)]
+            public void Should_Return_Correct_Value(string type, TFRepositoryType provider)
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateRepositoryInfo(type);
+
+                // When
+                var result = info.Provider;
+
+                // Then
+                Assert.Equal(provider, result);
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Build/TFBuild/Data/TFBuildTeamProjectInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TFBuild/Data/TFBuildTeamProjectInfoTests.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Common.Tests.Fixtures.Build;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Build.TFBuild.Data
+{
+    public sealed class TFBuildTeamProjectInfoTests
+    {
+        public sealed class TheNameProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateTeamProjectInfo();
+
+                // When
+                var result = info.Name;
+
+                // Then
+                Assert.Equal("TeamProject", result);
+            }
+        }
+
+        public sealed class TheIdProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateTeamProjectInfo();
+
+                // When
+                var result = info.Id;
+
+                // Then
+                Assert.Equal("D0A3B6B8-499B-4D4B-BD46-DB70C19E6D33", result);
+            }
+        }
+
+        public sealed class TheCollectionUriProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateTeamProjectInfo();
+
+                // When
+                var result = info.CollectionUri;
+
+                // Then
+                var uri = new Uri("https://fabrikamfiber.visualstudio.com/");
+                Assert.Equal(uri, result);
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Build/TFBuild/TFBuildProviderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TFBuild/TFBuildProviderTests.cs
@@ -1,0 +1,107 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Build.TFBuild;
+using Cake.Common.Tests.Fixtures.Build;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Build.TFBuild
+{
+    public sealed class TFBuildProviderTests
+    {
+        public sealed class TheConstructor
+        {
+            [Fact]
+            public void Should_Throw_If_Environment_Is_Null()
+            {
+                // Given, When
+                var result = Record.Exception(() => new TFBuildProvider(null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "environment");
+            }
+        }
+
+        public sealed class TheIsRunningOnVSTSProperty
+        {
+            [Fact]
+            public void Should_Return_True_If_Running_On_VSTS()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                fixture.IsRunningOnVSTS();
+                var vsts = fixture.CreateTFBuildService();
+
+                // When
+                var result = vsts.IsRunningOnVSTS;
+
+                // Then
+                Assert.True(result);
+            }
+
+            [Fact]
+            public void Should_Return_False_If_Not_Running_On_VSTS()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var vsts = fixture.CreateTFBuildService();
+
+                // When
+                var result = vsts.IsRunningOnVSTS;
+
+                // Then
+                Assert.False(result);
+            }
+        }
+
+        public sealed class TheIsRunningOnTFSProperty
+        {
+            [Fact]
+            public void Should_Return_True_If_Running_On_TFS()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                fixture.IsRunningOnTFS();
+                var vsts = fixture.CreateTFBuildService();
+
+                // When
+                var result = vsts.IsRunningOnTFS;
+
+                // Then
+                Assert.True(result);
+            }
+
+            [Fact]
+            public void Should_Return_False_If_Not_Running_On_TFS()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var vsts = fixture.CreateTFBuildService();
+
+                // When
+                var result = vsts.IsRunningOnTFS;
+
+                // Then
+                Assert.False(result);
+            }
+        }
+
+        public sealed class TheEnvironmentProperty
+        {
+            [Fact]
+            public void Should_Return_Non_Null_Reference()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var vsts = fixture.CreateTFBuildService();
+
+                // When
+                var result = vsts.Environment;
+
+                // Then
+                Assert.NotNull(result);
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Build/BuildSystem.cs
+++ b/src/Cake.Common/Build/BuildSystem.cs
@@ -13,6 +13,7 @@ using Cake.Common.Build.GoCD;
 using Cake.Common.Build.Jenkins;
 using Cake.Common.Build.MyGet;
 using Cake.Common.Build.TeamCity;
+using Cake.Common.Build.TFBuild;
 using Cake.Common.Build.TravisCI;
 
 namespace Cake.Common.Build
@@ -37,6 +38,7 @@ namespace Cake.Common.Build
         /// <param name="bitbucketPipelinesProvider">The Bitbucket Pipelines provider.</param>
         /// <param name="goCDProvider">The Go.CD provider.</param>
         /// <param name="gitlabCIProvider">The GitLab CI provider.</param>
+        /// <param name="tfBuildProvider">The TF Build provider.</param>
         public BuildSystem(
             IAppVeyorProvider appVeyorProvider,
             ITeamCityProvider teamCityProvider,
@@ -48,7 +50,8 @@ namespace Cake.Common.Build
             ITravisCIProvider travisCIProvider,
             IBitbucketPipelinesProvider bitbucketPipelinesProvider,
             IGoCDProvider goCDProvider,
-            IGitLabCIProvider gitlabCIProvider)
+            IGitLabCIProvider gitlabCIProvider,
+            ITFBuildProvider tfBuildProvider)
         {
             if (appVeyorProvider == null)
             {
@@ -94,6 +97,10 @@ namespace Cake.Common.Build
             {
                 throw new ArgumentNullException(nameof(gitlabCIProvider));
             }
+            if (tfBuildProvider == null)
+            {
+                throw new ArgumentNullException(nameof(tfBuildProvider));
+            }
 
             AppVeyor = appVeyorProvider;
             TeamCity = teamCityProvider;
@@ -106,6 +113,7 @@ namespace Cake.Common.Build
             BitbucketPipelines = bitbucketPipelinesProvider;
             GoCD = goCDProvider;
             GitLabCI = gitlabCIProvider;
+            TFBuild = tfBuildProvider;
         }
 
         /// <summary>
@@ -456,6 +464,54 @@ namespace Cake.Common.Build
         public bool IsRunningOnGitLabCI => GitLabCI.IsRunningOnGitLabCI;
 
         /// <summary>
+        /// Gets a value indicating whether this instance is running on VSTS.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// if(BuildSystem.IsRunningOnVSTS)
+        /// {
+        ///     // Get the build commit hash.
+        ///     var commitHash = BuildSystem.TFBuild.Environment.Repository.SourceVersion;
+        /// }
+        /// </code>
+        /// </example>
+        /// <value>
+        /// <c>true</c> if this instance is running on VSTS; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsRunningOnVSTS => TFBuild.IsRunningOnVSTS;
+
+        /// <summary>
+        /// Gets a value indicating whether this instance is running on TFS.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// if(BuildSystem.IsRunningOnTFS)
+        /// {
+        ///     // Get the build commit hash.
+        ///     var commitHash = BuildSystem.TFBuild.Environment.Repository.SourceVersion;
+        /// }
+        /// </code>
+        /// </example>
+        /// <value>
+        /// <c>true</c> if this instance is running on TFS; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsRunningOnTFS => TFBuild.IsRunningOnTFS;
+
+        /// <summary>
+        /// Gets the TF Build Provider.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// if(BuildSystem.IsRunningOnVSTS)
+        /// {
+        ///     // Get the build definition name.
+        ///     var definitionName = BuildSystem.TFBuild.Environment.BuildDefinition.Name;
+        /// }
+        /// </code>
+        /// </example>
+        public ITFBuildProvider TFBuild { get; }
+
+        /// <summary>
         /// Gets a value indicating whether the current build is local build.
         /// </summary>
         /// <example>
@@ -474,6 +530,6 @@ namespace Cake.Common.Build
         /// <value>
         ///   <c>true</c> if the current build is local build; otherwise, <c>false</c>.
         /// </value>
-        public bool IsLocalBuild => !(IsRunningOnAppVeyor || IsRunningOnTeamCity || IsRunningOnMyGet || IsRunningOnBamboo || IsRunningOnContinuaCI || IsRunningOnJenkins || IsRunningOnBitrise || IsRunningOnTravisCI || IsRunningOnBitbucketPipelines || IsRunningOnGoCD || IsRunningOnGitLabCI);
+        public bool IsLocalBuild => !(IsRunningOnAppVeyor || IsRunningOnTeamCity || IsRunningOnMyGet || IsRunningOnBamboo || IsRunningOnContinuaCI || IsRunningOnJenkins || IsRunningOnBitrise || IsRunningOnTravisCI || IsRunningOnBitbucketPipelines || IsRunningOnGoCD || IsRunningOnGitLabCI || IsRunningOnTFS || IsRunningOnVSTS);
     }
 }

--- a/src/Cake.Common/Build/BuildSystemAliases.cs
+++ b/src/Cake.Common/Build/BuildSystemAliases.cs
@@ -13,6 +13,7 @@ using Cake.Common.Build.GoCD;
 using Cake.Common.Build.Jenkins;
 using Cake.Common.Build.MyGet;
 using Cake.Common.Build.TeamCity;
+using Cake.Common.Build.TFBuild;
 using Cake.Common.Build.TravisCI;
 using Cake.Core;
 using Cake.Core.Annotations;
@@ -54,7 +55,8 @@ namespace Cake.Common.Build
             var bitbucketPipelinesProvider = new BitbucketPipelinesProvider(context.Environment);
             var goCDProvider = new GoCDProvider(context.Environment);
             var gitlabCIProvider = new GitLabCIProvider(context.Environment);
-            return new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+            var tfBuildProvider = new TFBuildProvider(context.Environment);
+            return new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
         }
 
         /// <summary>
@@ -177,7 +179,7 @@ namespace Cake.Common.Build
         }
 
         /// <summary>
-        /// Gets a <see cref="JenkinsProvider"/> instance that can be user to
+        /// Gets a <see cref="JenkinsProvider"/> instance that can be used to
         /// obtain information from the Jenkins environment.
         /// </summary>
         /// <example>
@@ -202,7 +204,7 @@ namespace Cake.Common.Build
         }
 
         /// <summary>
-        /// Gets a <see cref="BitriseProvider"/> instance that can be user to
+        /// Gets a <see cref="BitriseProvider"/> instance that can be used to
         /// obtain information from the Bitrise environment.
         /// </summary>
         /// <example>
@@ -227,7 +229,7 @@ namespace Cake.Common.Build
         }
 
         /// <summary>
-        /// Gets a <see cref="TravisCIProvider"/> instance that can be user to
+        /// Gets a <see cref="TravisCIProvider"/> instance that can be used to
         /// obtain information from the Travis CI environment.
         /// </summary>
         /// <example>
@@ -252,7 +254,7 @@ namespace Cake.Common.Build
         }
 
         /// <summary>
-        /// Gets a <see cref="BitbucketPipelinesProvider"/> instance that can be user to
+        /// Gets a <see cref="BitbucketPipelinesProvider"/> instance that can be used to
         /// obtain information from the Bitbucket Pipelines environment.
         /// </summary>
         /// <example>
@@ -277,7 +279,7 @@ namespace Cake.Common.Build
         }
 
         /// <summary>
-        /// Gets a <see cref="GoCDProvider"/> instance that can be user to
+        /// Gets a <see cref="GoCDProvider"/> instance that can be used to
         /// obtain information from the Go.CD environment.
         /// </summary>
         /// <example>
@@ -302,7 +304,7 @@ namespace Cake.Common.Build
         }
 
         /// <summary>
-        /// Gets a <see cref="GitLabCIProvider"/> instance that can be user to
+        /// Gets a <see cref="GitLabCIProvider"/> instance that can be used to
         /// obtain information from the GitLab CI environment.
         /// </summary>
         /// <example>
@@ -311,7 +313,7 @@ namespace Cake.Common.Build
         /// </code>
         /// </example>
         /// <param name="context">The context.</param>
-        /// <returns>A <see cref="Build.GitLabCI"/> instance.</returns>
+        /// <returns>A <see cref="Cake.Common.Build.GitLabCI"/> instance.</returns>
         [CakePropertyAlias(Cache = true)]
         [CakeNamespaceImport("Cake.Common.Build.GitLabCI")]
         [CakeNamespaceImport("Cake.Common.Build.GitLabCI.Data")]
@@ -324,6 +326,31 @@ namespace Cake.Common.Build
 
             var buildSystem = context.BuildSystem();
             return buildSystem.GitLabCI;
+        }
+
+        /// <summary>
+        /// Gets a <see cref="TFBuildProvider"/> instance that can be used to
+        /// obtain information from the Team Foundation Build environment.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var isTFSBuild = TFBuild.IsRunningOnTFS;
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <returns>A <see cref="Build.TFBuild"/> instance.</returns>
+        [CakePropertyAlias(Cache = true)]
+        [CakeNamespaceImport("Cake.Common.Build.TFBuild")]
+        [CakeNamespaceImport("Cake.Common.Build.TFBuild.Data")]
+        public static ITFBuildProvider TFBuild(this ICakeContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var buildSystem = context.BuildSystem();
+            return buildSystem.TFBuild;
         }
     }
 }

--- a/src/Cake.Common/Build/TFBuild/Data/TFBuildAgentInfo.cs
+++ b/src/Cake.Common/Build/TFBuild/Data/TFBuildAgentInfo.cs
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Build.TFBuild.Data
+{
+    /// <summary>
+    /// Provides TF Build agent info for the current build and build agent
+    /// </summary>
+    public sealed class TFBuildAgentInfo : TFInfo
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TFBuildAgentInfo"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        public TFBuildAgentInfo(ICakeEnvironment environment)
+            : base(environment)
+        {
+        }
+
+        /// <summary>
+        /// Gets the local path on the agent where all folders for a given build definition are created.
+        /// </summary>
+        /// <value>
+        /// The local path on the agent where all folders for a given build definition are created.
+        /// </value>
+        /// <example><c>c:\agent\_work\1</c></example>
+        public FilePath BuildDirectory => GetEnvironmentString("AGENT_BUILDDIRECTORY");
+
+        /// <summary>
+        /// Gets the directory the agent is installed into. This contains the agent software.
+        /// </summary>
+        /// <remarks>If you are using an on-premises agent, this directory is specified by you.</remarks>
+        /// <value>
+        /// The directory the agent is installed into.
+        /// </value>
+        /// <example><c>c:\agent\</c></example>
+        public FilePath HomeDirectory => GetEnvironmentString("AGENT_HOMEDIRECTORY");
+
+        /// <summary>
+        /// Gets the working directory for this agent.
+        /// </summary>
+        /// <value>
+        /// The working directory for this agent.
+        /// </value>
+        public FilePath WorkingDirectory => GetEnvironmentString("AGENT_WORKFOLDER");
+
+        /// <summary>
+        /// Gets the ID of the agent.
+        /// </summary>
+        /// <value>
+        /// The ID of the agent.
+        /// </value>
+        public int Id => GetEnvironmentInteger("AGENT_ID");
+
+        /// <summary>
+        /// Gets the name of the agent that is registered with the pool.
+        /// </summary>
+        /// <remarks>If you are using an on-premises agent, this is specified by you.</remarks>
+        /// <value>
+        /// The name of the agent that is registered with the pool.
+        /// </value>
+        public string Name => GetEnvironmentString("AGENT_NAME");
+
+        /// <summary>
+        /// Gets the name of the machine on which the agent is installed.
+        /// </summary>
+        /// <value>
+        /// The name of the machine on which the agent is installed.
+        /// </value>
+        public string MachineName => GetEnvironmentString("AGENT_MACHINE_NAME");
+
+        /// <summary>
+        /// Gets a value indicating whether the current agent is a hosted agent.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the current agent is a hosted agent; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsHosted => Name == "Hosted Agent";
+    }
+}

--- a/src/Cake.Common/Build/TFBuild/Data/TFBuildDefinitionInfo.cs
+++ b/src/Cake.Common/Build/TFBuild/Data/TFBuildDefinitionInfo.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core;
+
+namespace Cake.Common.Build.TFBuild.Data
+{
+    /// <summary>
+    /// Provides TF Build Definition information for the current build
+    /// </summary>
+    public sealed class TFBuildDefinitionInfo : TFInfo
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TFBuildDefinitionInfo"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        public TFBuildDefinitionInfo(ICakeEnvironment environment)
+            : base(environment)
+        {
+        }
+
+        /// <summary>
+        /// Gets the build definition ID.
+        /// </summary>
+        /// <value>
+        /// The build definition ID.
+        /// </value>
+        public int Id => GetEnvironmentInteger("SYSTEM_DEFINITIONID");
+
+        /// <summary>
+        /// Gets the build definition name.
+        /// </summary>
+        /// <value>
+        /// The build definition name.
+        /// </value>
+        public string Name => GetEnvironmentString("BUILD_DEFINITIONNAME");
+
+        /// <summary>
+        /// Gets the build definition version.
+        /// </summary>
+        /// <value>
+        /// The build definition version.
+        /// </value>
+        public int Version => GetEnvironmentInteger("BUILD_DEFINITIONVERSION");
+    }
+}

--- a/src/Cake.Common/Build/TFBuild/Data/TFBuildEnvironmentInfo.cs
+++ b/src/Cake.Common/Build/TFBuild/Data/TFBuildEnvironmentInfo.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core;
+
+namespace Cake.Common.Build.TFBuild.Data
+{
+    /// <summary>
+    /// Provides TF Build Environment information for the current build.
+    /// </summary>
+    public sealed class TFBuildEnvironmentInfo : TFInfo
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TFBuildEnvironmentInfo"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        public TFBuildEnvironmentInfo(ICakeEnvironment environment)
+            : base(environment)
+        {
+            Repository = new TFBuildRepositoryInfo(environment);
+            BuildDefinition = new TFBuildDefinitionInfo(environment);
+            Build = new TFBuildInfo(environment);
+            Agent = new TFBuildAgentInfo(environment);
+            TeamProject = new TFBuildTeamProjectInfo(environment);
+        }
+
+        /// <summary>
+        /// Gets TF Build repository information
+        /// </summary>
+        /// <value>
+        /// The TF Build repository information.
+        /// </value>
+        public TFBuildRepositoryInfo Repository { get; }
+
+        /// <summary>
+        /// Gets TF Build Definition information.
+        /// </summary>
+        /// <value>
+        /// The TF Build Definition.
+        /// </value>
+        public TFBuildDefinitionInfo BuildDefinition { get; }
+
+        /// <summary>
+        /// Gets TF Build information.
+        /// </summary>
+        /// <value>
+        /// The TF Build.
+        /// </value>
+        public TFBuildInfo Build { get; }
+
+        /// <summary>
+        /// Gets TF Team Project information.
+        /// </summary>
+        /// <value>
+        /// The TF Team Project.
+        /// </value>
+        public TFBuildTeamProjectInfo TeamProject { get; }
+
+        /// <summary>
+        /// Gets TF Build agent information.
+        /// </summary>
+        /// <value>
+        /// The TF Build agent.
+        /// </value>
+        public TFBuildAgentInfo Agent { get; }
+    }
+}

--- a/src/Cake.Common/Build/TFBuild/Data/TFBuildInfo.cs
+++ b/src/Cake.Common/Build/TFBuild/Data/TFBuildInfo.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Core;
+
+namespace Cake.Common.Build.TFBuild.Data
+{
+    /// <summary>
+    /// Provides TF Build info for the current build.
+    /// </summary>
+    public sealed class TFBuildInfo : TFInfo
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TFBuildInfo"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        public TFBuildInfo(ICakeEnvironment environment)
+            : base(environment)
+        {
+        }
+
+        /// <summary>
+        /// Gets the ID of the record for the completed build.
+        /// </summary>
+        /// <value>
+        /// The ID of the record for the completed build.
+        /// </value>
+        public int Id => GetEnvironmentInteger("BUILD_BUILDID");
+
+        /// <summary>
+        /// Gets the name of the completed build.
+        /// </summary>
+        /// <remarks>You can specify the build number format that generates this value in the build definition.</remarks>
+        /// <value>
+        /// The name of the completed build.
+        /// </value>
+        public string Number => GetEnvironmentString("BUILD_BUILDNUMBER");
+
+        /// <summary>
+        /// Gets the URI for the build.
+        /// </summary>
+        /// <example><c>vstfs:///Build/Build/1430</c></example>
+        /// <value>
+        /// The URI for the build.
+        /// </value>
+        public Uri Uri => new Uri(GetEnvironmentString("BUILD_BUILDURI"));
+
+        /// <summary>
+        /// Gets the user who queued the build.
+        /// </summary>
+        /// <value>
+        /// The user who queued the build.
+        /// </value>
+        public string QueuedBy => GetEnvironmentString("BUILD_QUEUEDBY");
+
+        /// <summary>
+        /// Gets the user the build was requested for.
+        /// </summary>
+        /// <value>
+        /// The user the build was requested for.
+        /// </value>
+        public string RequestedFor => GetEnvironmentString("BUILD_REQUESTEDFOR");
+
+        /// <summary>
+        /// Gets the email of the user the build was requested for.
+        /// </summary>
+        /// <value>
+        /// The email of the user the build was requested for.
+        /// </value>
+        public string RequestedForEmail => GetEnvironmentString("BUILD_REQUESTEDFOREMAIL");
+    }
+}

--- a/src/Cake.Common/Build/TFBuild/Data/TFBuildRepositoryInfo.cs
+++ b/src/Cake.Common/Build/TFBuild/Data/TFBuildRepositoryInfo.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core;
+
+namespace Cake.Common.Build.TFBuild.Data
+{
+    /// <summary>
+    /// Provides TF Build Repository information for the current build
+    /// </summary>
+    public sealed class TFBuildRepositoryInfo : TFInfo
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TFBuildRepositoryInfo"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        public TFBuildRepositoryInfo(ICakeEnvironment environment)
+            : base(environment)
+        {
+        }
+
+        /// <summary>
+        /// Gets name of the branch the build was queued for.
+        /// </summary>
+        /// <value>
+        /// The SCM branch
+        /// </value>
+        public string Branch => GetEnvironmentString("BUILD_SOURCEBRANCHNAME");
+
+        /// <summary>
+        /// Gets the latest version control change that is included in this build.
+        /// </summary>
+        /// <remarks>Note: for Git this is the commit ID. For TFVC this is the changeset.</remarks>
+        /// <value>
+        /// The SCM source version
+        /// </value>
+        public string SourceVersion => GetEnvironmentString("BUILD_SOURCEVERSION");
+
+        /// <summary>
+        /// Gets the name of the shelveset you are building, if you are running a gated build or a shelveset build.
+        /// </summary>
+        /// <remarks>Defined only if your repository is Team Foundation Version Control.</remarks>
+        /// <value>
+        /// The shelveset name
+        /// </value>
+        public string Shelveset => GetEnvironmentString("BUILD_SOURCETFVCSHELVESET");
+
+        /// <summary>
+        /// Gets the name of the repository
+        /// </summary>
+        /// <value>
+        /// The name of the repository
+        /// </value>
+        public string RepoName => GetEnvironmentString("BUILD_REPOSITORY_NAME");
+
+        /// <summary>
+        /// Gets the type of the current repository.
+        /// </summary>
+        /// <value>
+        /// The type of the current repository.
+        /// </value>
+        public TFRepositoryType? Provider => GetRepositoryType("BUILD_REPOSITORY_PROVIDER");
+    }
+}

--- a/src/Cake.Common/Build/TFBuild/Data/TFBuildTeamProjectInfo.cs
+++ b/src/Cake.Common/Build/TFBuild/Data/TFBuildTeamProjectInfo.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Core;
+
+namespace Cake.Common.Build.TFBuild.Data
+{
+    /// <summary>
+    /// Provides Team Foundation Team Project information for the current build
+    /// </summary>
+    public sealed class TFBuildTeamProjectInfo : TFInfo
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TFBuildTeamProjectInfo"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        public TFBuildTeamProjectInfo(ICakeEnvironment environment) : base(environment)
+        {
+        }
+
+        /// <summary>
+        /// Gets the name of the team project that contains this build.
+        /// </summary>
+        /// <value>
+        /// The name of the team project that contains this build.
+        /// </value>
+        public string Name => GetEnvironmentString("SYSTEM_TEAMPROJECT");
+
+        /// <summary>
+        /// Gets the ID of the team project that contains this build.
+        /// </summary>
+        /// <value>
+        /// The ID of the team project that contains this build.
+        /// </value>
+        public string Id => GetEnvironmentString("SYSTEM_TEAMPROJECTID");
+
+        /// <summary>
+        /// Gets the URI of the team foundation collection.
+        /// </summary>
+        /// <value>
+        /// The URI of the team foundation collection.
+        /// </value>
+        public Uri CollectionUri => GetEnvironmentUri("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI");
+    }
+}

--- a/src/Cake.Common/Build/TFBuild/Data/TFRepositoryType.cs
+++ b/src/Cake.Common/Build/TFBuild/Data/TFRepositoryType.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Build.TFBuild.Data
+{
+    /// <summary>
+    /// Provides the known values for the TF Build Repository types.
+    /// </summary>
+    public enum TFRepositoryType
+    {
+        /// <summary>
+        /// TFS Git repository.
+        /// </summary>
+        TfsGit,
+
+        /// <summary>
+        /// Team Foundation Version Control repository.
+        /// </summary>
+        TfsVersionControl,
+
+        /// <summary>
+        /// Git repository hosted on an external server.
+        /// </summary>
+        Git,
+
+        /// <summary>
+        /// GitHub repository.
+        /// </summary>
+        GitHub,
+
+        /// <summary>
+        /// Subversion repository.
+        /// </summary>
+        Svn
+    }
+}

--- a/src/Cake.Common/Build/TFBuild/ITFBuildProvider.cs
+++ b/src/Cake.Common/Build/TFBuild/ITFBuildProvider.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Build.TFBuild.Data;
+
+namespace Cake.Common.Build.TFBuild
+{
+    /// <summary>
+    /// Represents a TF Build provider.
+    /// </summary>
+    public interface ITFBuildProvider
+    {
+        /// <summary>
+        /// Gets a value indicating whether the current build is running on VSTS.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the current build is running on VSTS; otherwise, <c>false</c>.
+        /// </value>
+        bool IsRunningOnVSTS { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the current build is running on TFS.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the current build is running on TFS; otherwise, <c>false</c>.
+        /// </value>
+        bool IsRunningOnTFS { get; }
+
+        /// <summary>
+        /// Gets the TF Build environment.
+        /// </summary>
+        /// <value>
+        /// The TF Build environment.
+        /// </value>
+        TFBuildEnvironmentInfo Environment { get; }
+    }
+}

--- a/src/Cake.Common/Build/TFBuild/TFBuildProvider.cs
+++ b/src/Cake.Common/Build/TFBuild/TFBuildProvider.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Common.Build.TFBuild.Data;
+using Cake.Core;
+
+namespace Cake.Common.Build.TFBuild
+{
+    /// <summary>
+    /// Responsible for communicating with Team Foundation Build (VSTS or TFS).
+    /// </summary>
+    public sealed class TFBuildProvider : ITFBuildProvider
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TFBuildProvider"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        public TFBuildProvider(ICakeEnvironment environment)
+        {
+            if (environment == null)
+            {
+                throw new ArgumentNullException(nameof(environment));
+            }
+            _environment = environment;
+            Environment = new TFBuildEnvironmentInfo(environment);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the current build is running on VSTS.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the current build is running on VSTS; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsRunningOnVSTS
+            => !string.IsNullOrWhiteSpace(_environment.GetEnvironmentVariable("TF_BUILD")) && IsHostedAgent;
+
+        /// <summary>
+        /// Gets a value indicating whether the current build is running on TFS.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the current build is running on TFS; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsRunningOnTFS
+            => !string.IsNullOrWhiteSpace(_environment.GetEnvironmentVariable("TF_BUILD")) && !IsHostedAgent;
+
+        /// <summary>
+        /// Gets the TF Build environment.
+        /// </summary>
+        /// <value>
+        /// The TF Build environment.
+        /// </value>
+        public TFBuildEnvironmentInfo Environment { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the current build is running on a hosted build agent.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the current build is running on a hosted agent; otherwise, <c>false</c>.
+        /// </value>
+        private bool IsHostedAgent
+            =>
+                !string.IsNullOrWhiteSpace(_environment.GetEnvironmentVariable("AGENT_NAME")) &&
+                _environment.GetEnvironmentVariable("AGENT_NAME") == "Hosted Agent";
+    }
+}

--- a/src/Cake.Common/Build/TFBuild/TFInfo.cs
+++ b/src/Cake.Common/Build/TFBuild/TFInfo.cs
@@ -1,0 +1,103 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Common.Build.TFBuild.Data;
+using Cake.Core;
+
+namespace Cake.Common.Build.TFBuild
+{
+    /// <summary>
+    /// Base class used to provide information about the TF Build environment.
+    /// </summary>
+    public abstract class TFInfo
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TFInfo"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        protected TFInfo(ICakeEnvironment environment)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Gets an environment variable as a <see cref="System.String"/>.
+        /// </summary>
+        /// <param name="variable">The environment variable name.</param>
+        /// <returns>The environment variable.</returns>
+        protected string GetEnvironmentString(string variable)
+        {
+            return _environment.GetEnvironmentVariable(variable) ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Gets an environment variable as a <see cref="System.Int32"/>.
+        /// </summary>
+        /// <param name="variable">The environment variable name.</param>
+        /// <returns>The environment variable.</returns>
+        protected int GetEnvironmentInteger(string variable)
+        {
+            var value = GetEnvironmentString(variable);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                int result;
+                if (int.TryParse(value, out result))
+                {
+                    return result;
+                }
+            }
+            return 0;
+        }
+
+        /// <summary>
+        /// Gets an environment variable as a <see cref="System.Boolean"/>.
+        /// </summary>
+        /// <param name="variable">The environment variable name.</param>
+        /// <returns>The environment variable.</returns>
+        protected bool GetEnvironmentBoolean(string variable)
+        {
+            var value = GetEnvironmentString(variable);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value.Equals("true", StringComparison.OrdinalIgnoreCase);
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Gets an environment variable as a <see cref="System.Uri"/>.
+        /// </summary>
+        /// <param name="variable">The environment variable name.</param>
+        /// <returns>The environment variable.</returns>
+        protected Uri GetEnvironmentUri(string variable)
+        {
+            var value = GetEnvironmentString(variable);
+            Uri uri;
+            if (Uri.TryCreate(value, UriKind.Absolute, out uri))
+            {
+                return uri;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the current repository type as a <see cref="TFRepositoryType"/> from an environment variable.
+        /// </summary>
+        /// <param name="variable">The environment variable name.</param>
+        /// <returns>The current repository type.</returns>
+        protected TFRepositoryType? GetRepositoryType(string variable)
+        {
+            var value = GetEnvironmentString(variable);
+            TFRepositoryType type;
+            if (Enum.TryParse(value, true, out type))
+            {
+                return type;
+            }
+            return null;
+        }
+    }
+}

--- a/src/Cake.sln.DotSettings
+++ b/src/Cake.sln.DotSettings
@@ -28,7 +28,10 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MSIL/@EntryIndexedValue">MSIL</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NET/@EntryIndexedValue">NET</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NSIS/@EntryIndexedValue">NSIS</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=TF/@EntryIndexedValue">TF</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=TFS/@EntryIndexedValue">TFS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=VS/@EntryIndexedValue">VS</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=VSTS/@EntryIndexedValue">VSTS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
Adds basic support for VSTS as a build system, encapsulating the majority of the pre-defined build variables.

Note that this will need to be rebased/merged after #1222 is merged, given that the `BuildSystemTests.cs` has so many changes.

Let me know if anything looks off or if is missing.

