### PR TITLE
GH1154: NuGetPacker, making Files collection optional when Dependencies collection specified

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/NuGet/Pack/NuGetPackerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NuGet/Pack/NuGetPackerTests.cs
@@ -854,6 +854,30 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Pack
                 }
 
                 [Fact]
+                public void Should_Pack_If_Sufficient_Settings_For_MetaPackage_Specified()
+                {
+                    // Given
+                    var fixture = new NuGetPackerWithoutNuSpecFixture();
+                    fixture.Settings.OutputDirectory = "/Working/";
+                    fixture.Settings.Id = "nonexisting";
+                    fixture.Settings.Version = "1.0.0";
+                    fixture.Settings.Description = "The description";
+                    fixture.Settings.Authors = new[] { "Author #1", "Author #2" };
+                    fixture.Settings.Files = null;
+                    fixture.Settings.Dependencies = new List<NuSpecDependency>
+                    {
+                        new NuSpecDependency { Id = "Test1", Version = "1.0.0" }
+                    };
+
+                    // When
+                    var result = fixture.Run();
+
+                    // Then
+                    Assert.Equal("pack -Version \"1.0.0\" -OutputDirectory \"/Working\" " +
+                                 "\"/Working/nonexisting.temp.nuspec\"", result.Args);
+                }
+
+                [Fact]
                 public void Should_Throw_If_OutputDirectory_Setting_Not_Specified()
                 {
                     // Given
@@ -929,7 +953,7 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Pack
                 }
 
                 [Fact]
-                public void Should_Throw_If_Files_Setting_Not_Specified()
+                public void Should_Throw_If_Files_Setting_And_Dependencies_Not_Specified()
                 {
                     // Given
                     var fixture = new NuGetPackerWithoutNuSpecFixture();
@@ -938,7 +962,8 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Pack
                     fixture.Settings.Version = "1.0.0";
                     fixture.Settings.Authors = new[] { "Author #1", "Author #2" };
                     fixture.Settings.Description = "The description";
-
+                    fixture.Settings.Dependencies = null;
+                    fixture.Settings.Files = null;
                     // When
                     var result = Record.Exception(() => fixture.Run());
 

--- a/src/Cake.Common/Tools/NuGet/Pack/NuGetPacker.cs
+++ b/src/Cake.Common/Tools/NuGet/Pack/NuGetPacker.cs
@@ -73,7 +73,7 @@ namespace Cake.Common.Tools.NuGet.Pack
             {
                 throw new CakeException("Required setting Description not specified.");
             }
-            if (settings.Files == null || settings.Files.Count == 0)
+            if ((settings.Files == null || settings.Files.Count == 0) && (settings.Dependencies == null || settings.Dependencies.Count == 0))
             {
                 throw new CakeException("Required setting Files not specified.");
             }


### PR DESCRIPTION
#1154 
As mentioned in here https://github.com/cake-build/cake/issues/1154#issuecomment-239369383 ``Files`` collection is not required in ``NuGetPackSettings`` when ``Dependencies`` are specified