### PR TITLE
Corrects the grammar "do/does" in exception messages and tests

### DIFF
--- a/src/Cake.Common.Tests/Unit/IO/DirectoryAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/DirectoryAliasesTests.cs
@@ -638,7 +638,7 @@ namespace Cake.Common.Tests.Unit.IO
 
                 // Then
                 Assert.IsType<IOException>(result);
-                Assert.Equal("The directory '/Temp/DoNotExist' do not exist.", result?.Message);
+                Assert.Equal("The directory '/Temp/DoNotExist' does not exist.", result?.Message);
             }
 
             [Fact]
@@ -751,7 +751,7 @@ namespace Cake.Common.Tests.Unit.IO
 
                     // Then
                     Assert.IsType<IOException>(result);
-                    Assert.Equal("The directory '/Temp/DoNotExist' do not exist.", result?.Message);
+                    Assert.Equal("The directory '/Temp/DoNotExist' does not exist.", result?.Message);
                 }
 
                 [Fact]
@@ -875,7 +875,7 @@ namespace Cake.Common.Tests.Unit.IO
 
                     // Then
                     Assert.IsType<IOException>(result);
-                    Assert.Equal("The directory '/Temp/DoNotExist' do not exist.", result?.Message);
+                    Assert.Equal("The directory '/Temp/DoNotExist' does not exist.", result?.Message);
                 }
 
                 [Fact]

--- a/src/Cake.Common.Tests/Unit/IO/FileAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/FileAliasesTests.cs
@@ -173,7 +173,7 @@ namespace Cake.Common.Tests.Unit.IO
 
                 // Then
                 Assert.IsType<DirectoryNotFoundException>(result);
-                Assert.Equal("The directory '/Working/target' do not exist.", result?.Message);
+                Assert.Equal("The directory '/Working/target' does not exist.", result?.Message);
             }
 
             [Fact]
@@ -190,7 +190,7 @@ namespace Cake.Common.Tests.Unit.IO
 
                 // Then
                 Assert.IsType<FileNotFoundException>(result);
-                Assert.Equal("The file '/Working/file1.txt' do not exist.", result?.Message);
+                Assert.Equal("The file '/Working/file1.txt' does not exist.", result?.Message);
             }
 
             [Fact]
@@ -284,7 +284,7 @@ namespace Cake.Common.Tests.Unit.IO
 
                     // Then
                     Assert.IsType<DirectoryNotFoundException>(result);
-                    Assert.Equal("The directory '/Working/target' do not exist.", result?.Message);
+                    Assert.Equal("The directory '/Working/target' does not exist.", result?.Message);
                 }
 
                 [Fact]
@@ -301,7 +301,7 @@ namespace Cake.Common.Tests.Unit.IO
 
                     // Then
                     Assert.IsType<FileNotFoundException>(result);
-                    Assert.Equal("The file '/Working/file2.txt' do not exist.", result?.Message);
+                    Assert.Equal("The file '/Working/file2.txt' does not exist.", result?.Message);
                 }
 
                 [Fact]
@@ -380,7 +380,7 @@ namespace Cake.Common.Tests.Unit.IO
 
                     // Then
                     Assert.IsType<DirectoryNotFoundException>(result);
-                    Assert.Equal("The directory '/Working/target' do not exist.", result?.Message);
+                    Assert.Equal("The directory '/Working/target' does not exist.", result?.Message);
                 }
 
                 [Fact]
@@ -398,7 +398,7 @@ namespace Cake.Common.Tests.Unit.IO
 
                     // Then
                     Assert.IsType<FileNotFoundException>(result);
-                    Assert.Equal("The file '/Working/file2.txt' do not exist.", result?.Message);
+                    Assert.Equal("The file '/Working/file2.txt' does not exist.", result?.Message);
                 }
 
                 [Fact]
@@ -472,7 +472,7 @@ namespace Cake.Common.Tests.Unit.IO
 
                     // Then
                     Assert.IsType<DirectoryNotFoundException>(result);
-                    Assert.Equal("The directory '/Working/target' do not exist.", result?.Message);
+                    Assert.Equal("The directory '/Working/target' does not exist.", result?.Message);
                 }
 
                 [Fact]
@@ -489,7 +489,7 @@ namespace Cake.Common.Tests.Unit.IO
 
                     // Then
                     Assert.IsType<FileNotFoundException>(result);
-                    Assert.Equal("The file '/Working/file2.txt' do not exist.", result?.Message);
+                    Assert.Equal("The file '/Working/file2.txt' does not exist.", result?.Message);
                 }
 
                 [Fact]
@@ -550,7 +550,7 @@ namespace Cake.Common.Tests.Unit.IO
 
                 // Then
                 Assert.IsType<FileNotFoundException>(result);
-                Assert.Equal("The file '/file.txt' do not exist.", result?.Message);
+                Assert.Equal("The file '/file.txt' does not exist.", result?.Message);
             }
 
             [Fact]
@@ -792,7 +792,7 @@ namespace Cake.Common.Tests.Unit.IO
 
                     // Then
                     Assert.IsType<DirectoryNotFoundException>(result);
-                    Assert.Equal("The directory '/Working/target' do not exist.", result?.Message);
+                    Assert.Equal("The directory '/Working/target' does not exist.", result?.Message);
                 }
 
                 [Fact]
@@ -809,7 +809,7 @@ namespace Cake.Common.Tests.Unit.IO
 
                     // Then
                     Assert.IsType<FileNotFoundException>(result);
-                    Assert.Equal("The file '/Working/file2.txt' do not exist.", result?.Message);
+                    Assert.Equal("The file '/Working/file2.txt' does not exist.", result?.Message);
                 }
 
                 [Fact]
@@ -882,7 +882,7 @@ namespace Cake.Common.Tests.Unit.IO
 
                     // Then
                     Assert.IsType<DirectoryNotFoundException>(result);
-                    Assert.Equal("The directory '/Working/target' do not exist.", result?.Message);
+                    Assert.Equal("The directory '/Working/target' does not exist.", result?.Message);
                 }
 
                 [Fact]
@@ -899,7 +899,7 @@ namespace Cake.Common.Tests.Unit.IO
 
                     // Then
                     Assert.IsType<FileNotFoundException>(result);
-                    Assert.Equal("The file '/Working/file2.txt' do not exist.", result?.Message);
+                    Assert.Equal("The file '/Working/file2.txt' does not exist.", result?.Message);
                 }
 
                 [Fact]
@@ -978,7 +978,7 @@ namespace Cake.Common.Tests.Unit.IO
 
                 // Then
                 Assert.IsType<DirectoryNotFoundException>(result);
-                Assert.Equal("The directory '/Working/target' do not exist.", result?.Message);
+                Assert.Equal("The directory '/Working/target' does not exist.", result?.Message);
             }
 
             [Fact]
@@ -995,7 +995,7 @@ namespace Cake.Common.Tests.Unit.IO
 
                 // Then
                 Assert.IsType<FileNotFoundException>(result);
-                Assert.Equal("The file '/Working/file1.txt' do not exist.", result?.Message);
+                Assert.Equal("The file '/Working/file1.txt' does not exist.", result?.Message);
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/ReleaseNotesAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/ReleaseNotesAliasesTests.cs
@@ -42,7 +42,7 @@ namespace Cake.Common.Tests.Unit
 
                 // Then
                 Assert.IsType<CakeException>(result);
-                Assert.Equal("Release notes file '/Working/ReleaseNotes.md' do not exist.", result?.Message);
+                Assert.Equal("Release notes file '/Working/ReleaseNotes.md' does not exist.", result?.Message);
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/SignTool/SignToolSignRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/SignTool/SignToolSignRunnerTests.cs
@@ -99,7 +99,7 @@ namespace Cake.Common.Tests.Unit.Tools.SignTool
 
                 // Then
                 Assert.IsType<CakeException>(result);
-                Assert.Equal("SignTool SIGN: The assembly '/Working/a.dll' do not exist.", result?.Message);
+                Assert.Equal("SignTool SIGN: The assembly '/Working/a.dll' does not exist.", result?.Message);
             }
 
             [Fact]
@@ -177,7 +177,7 @@ namespace Cake.Common.Tests.Unit.Tools.SignTool
 
                 // Then
                 Assert.IsType<CakeException>(result);
-                Assert.Equal("SignTool SIGN: The certificate '/Working/cert.pfx' do not exist.", result?.Message);
+                Assert.Equal("SignTool SIGN: The certificate '/Working/cert.pfx' does not exist.", result?.Message);
             }
 
             [Fact]

--- a/src/Cake.Common/EnviromentAliases.cs
+++ b/src/Cake.Common/EnviromentAliases.cs
@@ -16,7 +16,7 @@ namespace Cake.Common
     public static class EnvironmentAliases
     {
         /// <summary>
-        /// Retrieves the value of the environment variable or <c>null</c> if the environment variable do not exist.
+        /// Retrieves the value of the environment variable or <c>null</c> if the environment variable does not exist.
         /// </summary>
         /// <example>
         /// <code>
@@ -25,7 +25,7 @@ namespace Cake.Common
         /// </example>
         /// <param name="context">The context.</param>
         /// <param name="variable">The environment variable.</param>
-        /// <returns>The environment variable or <c>null</c> if the environment variable do not exist.</returns>
+        /// <returns>The environment variable or <c>null</c> if the environment variable does not exist.</returns>
         [CakeMethodAlias]
         [CakeAliasCategory("Environment Variables")]
         public static string EnvironmentVariable(this ICakeContext context, string variable)

--- a/src/Cake.Common/IO/DirectoryDeleter.cs
+++ b/src/Cake.Common/IO/DirectoryDeleter.cs
@@ -33,7 +33,7 @@ namespace Cake.Common.IO
             var directory = context.FileSystem.GetDirectory(path);
             if (!directory.Exists)
             {
-                const string format = "The directory '{0}' do not exist.";
+                const string format = "The directory '{0}' does not exist.";
                 throw new IOException(string.Format(CultureInfo.InvariantCulture, format, path.FullPath));
             }
 

--- a/src/Cake.Common/IO/FileCopier.cs
+++ b/src/Cake.Common/IO/FileCopier.cs
@@ -51,7 +51,7 @@ namespace Cake.Common.IO
             // Make sure the target directory exist.
             if (!context.FileSystem.Exist(targetDirectoryPath))
             {
-                const string format = "The directory '{0}' do not exist.";
+                const string format = "The directory '{0}' does not exist.";
                 var message = string.Format(CultureInfo.InvariantCulture, format, targetDirectoryPath.FullPath);
                 throw new DirectoryNotFoundException(message);
             }
@@ -98,7 +98,7 @@ namespace Cake.Common.IO
             // Make sure the target directory exist.
             if (!context.FileSystem.Exist(absoluteTargetDirectoryPath))
             {
-                const string format = "The directory '{0}' do not exist.";
+                const string format = "The directory '{0}' does not exist.";
                 var message = string.Format(CultureInfo.InvariantCulture, format, absoluteTargetDirectoryPath.FullPath);
                 throw new DirectoryNotFoundException(message);
             }
@@ -117,7 +117,7 @@ namespace Cake.Common.IO
             // Get the file.
             if (!context.FileSystem.Exist(absoluteFilePath))
             {
-                const string format = "The file '{0}' do not exist.";
+                const string format = "The file '{0}' does not exist.";
                 var message = string.Format(CultureInfo.InvariantCulture, format, absoluteFilePath.FullPath);
                 throw new FileNotFoundException(message, absoluteFilePath.FullPath);
             }

--- a/src/Cake.Common/IO/FileDeleter.cs
+++ b/src/Cake.Common/IO/FileDeleter.cs
@@ -68,7 +68,7 @@ namespace Cake.Common.IO
             var file = context.FileSystem.GetFile(filePath);
             if (!file.Exists)
             {
-                const string format = "The file '{0}' do not exist.";
+                const string format = "The file '{0}' does not exist.";
                 var message = string.Format(CultureInfo.InvariantCulture, format, filePath.FullPath);
                 throw new FileNotFoundException(message, filePath.FullPath);
             }

--- a/src/Cake.Common/IO/FileMover.cs
+++ b/src/Cake.Common/IO/FileMover.cs
@@ -72,7 +72,7 @@ namespace Cake.Common.IO
             // Make sure the target directory exist.
             if (!context.FileSystem.Exist(targetDirectoryPath))
             {
-                const string format = "The directory '{0}' do not exist.";
+                const string format = "The directory '{0}' does not exist.";
                 var message = string.Format(CultureInfo.InvariantCulture, format, targetDirectoryPath.FullPath);
                 throw new DirectoryNotFoundException(message);
             }
@@ -106,7 +106,7 @@ namespace Cake.Common.IO
             var targetDirectoryPath = targetFilePath.GetDirectory().MakeAbsolute(context.Environment);
             if (!context.FileSystem.Exist(targetDirectoryPath))
             {
-                const string format = "The directory '{0}' do not exist.";
+                const string format = "The directory '{0}' does not exist.";
                 var message = string.Format(CultureInfo.InvariantCulture, format, targetDirectoryPath.FullPath);
                 throw new DirectoryNotFoundException(message);
             }
@@ -115,7 +115,7 @@ namespace Cake.Common.IO
             var file = context.FileSystem.GetFile(filePath);
             if (!file.Exists)
             {
-                const string format = "The file '{0}' do not exist.";
+                const string format = "The file '{0}' does not exist.";
                 var message = string.Format(CultureInfo.InvariantCulture, format, filePath.FullPath);
                 throw new FileNotFoundException(message, filePath.FullPath);
             }

--- a/src/Cake.Common/ReleaseNotesAliases.cs
+++ b/src/Cake.Common/ReleaseNotesAliases.cs
@@ -66,7 +66,7 @@ namespace Cake.Common
             var file = context.FileSystem.GetFile(filePath);
             if (!file.Exists)
             {
-                const string format = "Release notes file '{0}' do not exist.";
+                const string format = "Release notes file '{0}' does not exist.";
                 var message = string.Format(CultureInfo.InvariantCulture, format, filePath.FullPath);
                 throw new CakeException(message);
             }

--- a/src/Cake.Common/Solution/Project/ProjectParser.cs
+++ b/src/Cake.Common/Solution/Project/ProjectParser.cs
@@ -59,7 +59,7 @@ namespace Cake.Common.Solution.Project
             var file = _fileSystem.GetFile(projectPath);
             if (!file.Exists)
             {
-                const string format = "Project file '{0}' do not exist.";
+                const string format = "Project file '{0}' does not exist.";
                 var message = string.Format(CultureInfo.InvariantCulture, format, projectPath.FullPath);
                 throw new CakeException(message);
             }

--- a/src/Cake.Common/Solution/SolutionParser.cs
+++ b/src/Cake.Common/Solution/SolutionParser.cs
@@ -59,7 +59,7 @@ namespace Cake.Common.Solution
             var file = _fileSystem.GetFile(solutionPath);
             if (!file.Exists)
             {
-                const string format = "Solution file '{0}' do not exist.";
+                const string format = "Solution file '{0}' does not exist.";
                 var message = string.Format(CultureInfo.InvariantCulture, format, solutionPath.FullPath);
                 throw new CakeException(message);
             }

--- a/src/Cake.Common/Tools/SignTool/SignToolSignRunner.cs
+++ b/src/Cake.Common/Tools/SignTool/SignToolSignRunner.cs
@@ -87,7 +87,7 @@ namespace Cake.Common.Tools.SignTool
         {
             if (!_fileSystem.Exist(assemblyPath))
             {
-                const string format = "{0}: The assembly '{1}' do not exist.";
+                const string format = "{0}: The assembly '{1}' does not exist.";
                 var message = string.Format(CultureInfo.InvariantCulture, format, GetToolName(), assemblyPath.FullPath);
                 throw new CakeException(message);
             }
@@ -145,7 +145,7 @@ namespace Cake.Common.Tools.SignTool
 
                 if (!_fileSystem.Exist(settings.CertPath))
                 {
-                    const string format = "{0}: The certificate '{1}' do not exist.";
+                    const string format = "{0}: The certificate '{1}' does not exist.";
                     var message = string.Format(CultureInfo.InvariantCulture, format, GetToolName(), settings.CertPath.FullPath);
                     throw new CakeException(message);
                 }

--- a/src/Cake.Core.Tests/Unit/Graph/CakeGraphBuilderTests.cs
+++ b/src/Cake.Core.Tests/Unit/Graph/CakeGraphBuilderTests.cs
@@ -57,7 +57,7 @@ namespace Cake.Core.Tests.Unit.Graph
                 var result = Assert.Throws<CakeException>(() => CakeGraphBuilder.Build(tasks));
 
                 // Then
-                Assert.Equal("Task 'A' is dependent on task 'C' which do not exist.", result?.Message);
+                Assert.Equal("Task 'A' is dependent on task 'C' which does not exist.", result?.Message);
             }
         }
     }

--- a/src/Cake.Core/Graph/CakeGraphBuilder.cs
+++ b/src/Cake.Core/Graph/CakeGraphBuilder.cs
@@ -22,7 +22,7 @@ namespace Cake.Core.Graph
                 {
                     if (!graph.Exist(dependency))
                     {
-                        const string format = "Task '{0}' is dependent on task '{1}' which do not exist.";
+                        const string format = "Task '{0}' is dependent on task '{1}' which does not exist.";
                         var message = string.Format(CultureInfo.InvariantCulture, format, task.Name, dependency);
                         throw new CakeException(message);
                     }

--- a/src/Cake.Testing/Extensions/FakeFileSystemExtensions.cs
+++ b/src/Cake.Testing/Extensions/FakeFileSystemExtensions.cs
@@ -15,11 +15,11 @@ namespace Cake.Testing
     public static class FakeFileSystemExtensions
     {
         /// <summary>
-        /// Ensures that the specified file do not exist.
+        /// Ensures that the specified file does not exist.
         /// </summary>
         /// <param name="fileSystem">The file system.</param>
         /// <param name="path">The path.</param>
-        public static void EnsureFileDoNotExist(this FakeFileSystem fileSystem, FilePath path)
+        public static void EnsureFileDoesNotExist(this FakeFileSystem fileSystem, FilePath path)
         {
             if (fileSystem == null)
             {

--- a/src/Cake.Testing/Extensions/ToolFixtureExtensions.cs
+++ b/src/Cake.Testing/Extensions/ToolFixtureExtensions.cs
@@ -15,7 +15,7 @@ namespace Cake.Testing
     public static class ToolFixtureExtensions
     {
         /// <summary>
-        /// Ensures that the tool do not exist under the tool settings tool path.
+        /// Ensures that the tool does not exist under the tool settings tool path.
         /// </summary>
         /// <typeparam name="TToolSettings">The type of the tool settings.</typeparam>
         /// <typeparam name="TFixtureResult">The type of the fixture result.</typeparam>

--- a/src/Cake.Testing/FakeFileSystemTree.cs
+++ b/src/Cake.Testing/FakeFileSystemTree.cs
@@ -218,7 +218,7 @@ namespace Cake.Testing
         {
             if (!file.Exists)
             {
-                throw new FileNotFoundException("File do not exist.");
+                throw new FileNotFoundException("File does not exist.");
             }
 
             // Already exists?
@@ -237,7 +237,7 @@ namespace Cake.Testing
             var directory = FindDirectory(destination.GetDirectory());
             if (directory == null || !directory.Exists)
             {
-                throw new DirectoryNotFoundException("The destination path {0} do not exist.");
+                throw new DirectoryNotFoundException("The destination path {0} does not exist.");
             }
 
             // Make sure the file exist.


### PR DESCRIPTION
Hey guys,
 I was turned onto the project by the Hanselminutes podcast. I dove right in and noticed that the exception messages had a grammar error. So I updated the messages and associated tests to reflect the change.