### PR TITLE
Fix for unquoted VSTest settings file path

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/VSTest/VSTestRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/VSTest/VSTestRunnerTests.cs
@@ -204,7 +204,21 @@ namespace Cake.Common.Tests.Unit.Tools.VSTest
             var result = fixture.Run();
 
             // Then
-            Assert.Equal("\"/Working/Test1.dll\" /Settings:Local.RunSettings", result.Args);
+            Assert.Equal("\"/Working/Test1.dll\" /Settings:\"/Working/Local.RunSettings\"", result.Args);
+        }
+
+        [Fact]
+        public void Should_Quote_Absolute_SettingsFile_Path()
+        {
+            // Given
+            var fixture = new VSTestRunnerFixture();
+            fixture.Settings.SettingsFile = new FilePath("Filename with spaces.RunSettings");
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            Assert.Equal("\"/Working/Test1.dll\" /Settings:\"/Working/Filename with spaces.RunSettings\"", result.Args);
         }
 
         [Fact]

--- a/src/Cake.Common/Tools/VSTest/VSTestRunner.cs
+++ b/src/Cake.Common/Tools/VSTest/VSTestRunner.cs
@@ -64,12 +64,12 @@ namespace Cake.Common.Tools.VSTest
             // Add the assembly to build.
             foreach (var assemblyPath in assemblyPaths)
             {
-                builder.Append(assemblyPath.MakeAbsolute(_environment).FullPath.Quote());
+                builder.AppendQuoted(assemblyPath.MakeAbsolute(_environment).FullPath);
             }
 
             if (settings.SettingsFile != null)
             {
-                builder.Append(string.Format(CultureInfo.InvariantCulture, "/Settings:{0}", settings.SettingsFile));
+                builder.AppendSwitchQuoted("/Settings", ":", settings.SettingsFile.MakeAbsolute(_environment).FullPath);
             }
 
             if (settings.InIsolation)
@@ -79,12 +79,12 @@ namespace Cake.Common.Tools.VSTest
 
             if (settings.PlatformArchitecture != VSTestPlatform.Default)
             {
-                builder.Append(string.Format(CultureInfo.InvariantCulture, "/Platform:{0}", settings.PlatformArchitecture));
+                builder.AppendSwitch("/Platform", ":", settings.PlatformArchitecture.ToString());
             }
 
             if (settings.FrameworkVersion != VSTestFrameworkVersion.Default)
             {
-                builder.Append(string.Format(CultureInfo.InvariantCulture, "/Framework:{0}", settings.FrameworkVersion.ToString().Replace("NET", "Framework")));
+                builder.AppendSwitch("/Framework", ":", settings.FrameworkVersion.ToString().Replace("NET", "Framework"));
             }
 
             if (settings.Logger == VSTestLogger.Trx)


### PR DESCRIPTION
I wanted to add a different path VSTest argument and I looked at `SettingsFile` as a pattern to copy, but I believe I found some issues with its current implementation.

The `SettingsFile` argument is not quoted. Filenames that contain spaces will cause problems. I've confirmed the expected behavior at the command line. What I'm not sure about is what the resolution should be.

Is there written guidance on handling of whitespace and more specifically in conjunction with rooting relative paths?
Should it mimic the assembly path argument building, `assemblyPath.MakeAbsolute(_environment).FullPath.Quote()`? This means `Local.RunSettings` would become `/settings:"/Working/Local.RunSettings"`. Is that outcome correct in the context of Cake? The PR currently reflects this, but as you see it impacted the test. Is `/settings:"Local.RunSettings"` more desirable?

Should a test be added specifically for whitespace in every parameter like this or is it not worth it?

One last question that affects all quoting in general. `\"` is the standard escape sequence to allow a single quote to exist inside a quoted argument, and if I remember correctly  `\\` is the escape sequence that would allow a literal `\"` to exist. `string.Quote()` naively surrounds the string with quotes, but what happens if the path _were_ ever to end with a `\`? You end up building this string:
`app /path "path\with\trailing\slash\" /notapath 3` which gets parsed as:
`app`, `/path`, and `path\with\trailing\slash" /notapath 3`.
The correct built string would double just the ending slash:
`app /path "path\with\trailing\slash\\" /notapath 3` which gets parsed as:
`app`, `/path`, `path\with\trailing\slash\`, `/notapath`, and `3`.

Literal (post-escape) `"` is incidentally not allowed in any path, but both `\` and `"` present opportunities for injection attacks depending where the path is coming from.

I apologize for the complexity, but it would be good to fix this bug and also set a precedent which people like me can refer to when we add new parameters and paths.
