### PR TITLE
GH1279: Adding all current parameters for VSTest

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/VSTest/VSTestRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/VSTest/VSTestRunnerTests.cs
@@ -153,7 +153,7 @@ namespace Cake.Common.Tests.Unit.Tools.VSTest
         }
 
         [Fact]
-        public void Should_Not_Use_Isolation_By_Default()
+        public void Should_Have_No_Args_By_Default()
         {
             // Given
             var fixture = new VSTestRunnerFixture();
@@ -180,6 +180,48 @@ namespace Cake.Common.Tests.Unit.Tools.VSTest
         }
 
         [Fact]
+        public void Should_Enable_UseVsixExtensions_If_Enabled_In_Settings()
+        {
+            // Given
+            var fixture = new VSTestRunnerFixture();
+            fixture.Settings.UseVsixExtensions = true;
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            Assert.Equal("\"/Working/Test1.dll\" /UseVsixExtensions:true", result.Args);
+        }
+
+        [Fact]
+        public void Should_Disable_UseVsixExtensions_If_Disabled_In_Settings()
+        {
+            // Given
+            var fixture = new VSTestRunnerFixture();
+            fixture.Settings.UseVsixExtensions = false;
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            Assert.Equal("\"/Working/Test1.dll\" /UseVsixExtensions:false", result.Args);
+        }
+
+        [Fact]
+        public void Should_Use_TestAdapterPath_If_Provided()
+        {
+            // Given
+            var fixture = new VSTestRunnerFixture();
+            fixture.Settings.TestAdapterPath = new DirectoryPath("Path to/test adapters");
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            Assert.Equal("\"/Working/Test1.dll\" /TestAdapterPath:\"/Working/Path to/test adapters\"", result.Args);
+        }
+
+        [Fact]
         public void Should_Use_Logger_If_Provided()
         {
             // Given
@@ -191,6 +233,20 @@ namespace Cake.Common.Tests.Unit.Tools.VSTest
 
             // Then
             Assert.Equal("\"/Working/Test1.dll\" /Logger:trx", result.Args);
+        }
+
+        [Fact]
+        public void Should_Use_Diag_If_Provided()
+        {
+            // Given
+            var fixture = new VSTestRunnerFixture();
+            fixture.Settings.Diag = new FilePath("Path to/diag log.txt");
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            Assert.Equal("\"/Working/Test1.dll\" /Diag:\"/Working/Path to/diag log.txt\"", result.Args);
         }
 
         [Fact]
@@ -222,6 +278,34 @@ namespace Cake.Common.Tests.Unit.Tools.VSTest
         }
 
         [Fact]
+        public void Should_Use_Parallel_If_Enabled_In_Settings()
+        {
+            // Given
+            var fixture = new VSTestRunnerFixture();
+            fixture.Settings.Parallel = true;
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            Assert.Equal("\"/Working/Test1.dll\" /Parallel", result.Args);
+        }
+
+        [Fact]
+        public void Should_Use_EnableCodeCoverage_If_Enabled_In_Settings()
+        {
+            // Given
+            var fixture = new VSTestRunnerFixture();
+            fixture.Settings.EnableCodeCoverage = true;
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            Assert.Equal("\"/Working/Test1.dll\" /EnableCodeCoverage", result.Args);
+        }
+
+        [Fact]
         public void Should_Use_PlatformArchitecture_If_Provided()
         {
             // Given
@@ -247,6 +331,20 @@ namespace Cake.Common.Tests.Unit.Tools.VSTest
 
             // Then
             Assert.Equal("\"/Working/Test1.dll\" /Framework:Framework40", result.Args);
+        }
+
+        [Fact]
+        public void Should_Use_TestCaseFilter_If_Provided()
+        {
+            // Given
+            var fixture = new VSTestRunnerFixture();
+            fixture.Settings.TestCaseFilter = "(FullyQualifiedName~Nightly|Name=MyTestMethod)";
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            Assert.Equal("\"/Working/Test1.dll\" /TestCaseFilter:\"(FullyQualifiedName~Nightly|Name=MyTestMethod)\"", result.Args);
         }
 
         [Fact]

--- a/src/Cake.Common/Tools/VSTest/VSTestRunner.cs
+++ b/src/Cake.Common/Tools/VSTest/VSTestRunner.cs
@@ -72,9 +72,29 @@ namespace Cake.Common.Tools.VSTest
                 builder.AppendSwitchQuoted("/Settings", ":", settings.SettingsFile.MakeAbsolute(_environment).FullPath);
             }
 
+            if (settings.Parallel)
+            {
+                builder.Append("/Parallel");
+            }
+
+            if (settings.EnableCodeCoverage)
+            {
+                builder.Append("/EnableCodeCoverage");
+            }
+
             if (settings.InIsolation)
             {
                 builder.Append("/InIsolation");
+            }
+
+            if (settings.UseVsixExtensions != null)
+            {
+                builder.AppendSwitch("/UseVsixExtensions", ":", settings.UseVsixExtensions.Value ? "true" : "false");
+            }
+
+            if (settings.TestAdapterPath != null)
+            {
+                builder.AppendSwitchQuoted("/TestAdapterPath", ":", settings.TestAdapterPath.MakeAbsolute(_environment).FullPath);
             }
 
             if (settings.PlatformArchitecture != VSTestPlatform.Default)
@@ -87,9 +107,19 @@ namespace Cake.Common.Tools.VSTest
                 builder.AppendSwitch("/Framework", ":", settings.FrameworkVersion.ToString().Replace("NET", "Framework"));
             }
 
+            if (settings.TestCaseFilter != null)
+            {
+                builder.AppendSwitchQuoted("/TestCaseFilter", ":", settings.TestCaseFilter);
+            }
+
             if (settings.Logger == VSTestLogger.Trx)
             {
                 builder.Append("/Logger:trx");
+            }
+
+            if (settings.Diag != null)
+            {
+                builder.AppendSwitchQuoted("/Diag", ":", settings.Diag.MakeAbsolute(_environment).FullPath);
             }
 
             return builder;

--- a/src/Cake.Common/Tools/VSTest/VSTestSettings.cs
+++ b/src/Cake.Common/Tools/VSTest/VSTestSettings.cs
@@ -18,6 +18,16 @@ namespace Cake.Common.Tools.VSTest
         public FilePath SettingsFile { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the tests are executed in parallel. By default up to all available cores on the machine may be used. The number of cores to use may be configured using a settings file.
+        /// </summary>
+        public bool Parallel { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to enable data diagnostic adapter 'CodeCoverage' in the test run. Default settings are used if not specified using settings file.
+        /// </summary>
+        public bool EnableCodeCoverage { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to run tests within the vstest.console.exe process.
         /// This makes vstest.console.exe process less likely to be stopped on an error in the tests, but tests might run slower.
         /// Defaults to <c>false</c>.
@@ -26,6 +36,16 @@ namespace Cake.Common.Tools.VSTest
         ///   <c>true</c> if running in isolation; otherwise, <c>false</c>.
         /// </value>
         public bool InIsolation { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value overriding whether VSTest will use or skip the VSIX extensions installed (if any) in the test run.
+        /// </summary>
+        public bool? UseVsixExtensions { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that makes VSTest use custom test adapters from a given path (if any) in the test run.
+        /// </summary>
+        public DirectoryPath TestAdapterPath { get; set; }
 
         /// <summary>
         /// Gets or sets the target platform architecture to be used for test execution.
@@ -38,8 +58,23 @@ namespace Cake.Common.Tools.VSTest
         public VSTestFrameworkVersion FrameworkVersion { get; set; }
 
         /// <summary>
+        /// Gets or sets an expression to run only tests that match, of the format &lt;property&gt;Operator&lt;value&gt;[|&amp;&lt;Expression&gt;]
+        ///     where Operator is one of =, != or ~  (Operator ~ has 'contains'
+        ///     semantics and is applicable for string properties like DisplayName).
+        ///     Parenthesis () can be used to group sub-expressions.
+        /// Examples: Priority=1
+        ///           (FullyQualifiedName~Nightly|Name=MyTestMethod)
+        /// </summary>
+        public string TestCaseFilter { get; set; }
+
+        /// <summary>
         /// Gets or sets the logger to use for test results.
         /// </summary>
         public VSTestLogger Logger { get; set; }
+
+        /// <summary>
+        /// Gets or sets a path which makes VSTest write diagnosis trace logs to specified file.
+        /// </summary>
+        public FilePath Diag { get; set; }
     }
 }


### PR DESCRIPTION
This adds the following parameters:

 * Parallel
 * EnableCodeCoverage
 * UseVsixExtensions
 * TestAdapterPath
 * TestCaseFilter
 * Diag

This is all the usable parameters as per the latest VSTest in VS2015.3, except the `/List*` parameters which didn't quite fit the flow because they return information instead of running tests.
The summaries are straight from the console documentation, except...

Major complaint: I think there is great value in copying the command line help description of each parameter. The build-enforced `Gets or sets` and `Gets or sets a value indicating whether` is frustrating to work into the summary and brings down the documentation quality here and on the website. I especially like the `If set,` because it clarifies instinctively what the default is. Also, [this made me sad](https://github.com/jnm2/cake/commit/cef2a28a7c846462625ca146c2b3e0622527fd09#diff-c12c4a8cdb9f063b6dcb007fa44e6c09R76). So did [this](https://github.com/jnm2/cake/commit/cef2a28a7c846462625ca146c2b3e0622527fd09#diff-c12c4a8cdb9f063b6dcb007fa44e6c09R61).

Question: Lots of tests on `Should_Not_Use_*_By_Default` that are entirely identical. Would it be better to have a single default settings test?