### PR TITLE
GH1274: Add GitLab CI Build System

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Build/GitLabCIFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/GitLabCIFixture.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Build.GitLabCI;
+using Cake.Core;
+using NSubstitute;
+
+namespace Cake.Common.Tests.Fixtures.Build
+{
+    internal sealed class GitLabCIFixture
+    {
+        public ICakeEnvironment Environment { get; set; }
+
+        public GitLabCIFixture()
+        {
+            Environment = Substitute.For<ICakeEnvironment>();
+            Environment.GetEnvironmentVariable("CI_SERVER").Returns((string)null);
+        }
+
+        public void IsRunningOnGitLabCI()
+        {
+            Environment.GetEnvironmentVariable("CI_SERVER").Returns("yes");
+        }
+
+        public GitLabCIProvider CreateGitLabCIService()
+        {
+            return new GitLabCIProvider(Environment);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Fixtures/Build/GitLabCIInfoFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/GitLabCIInfoFixture.cs
@@ -1,0 +1,76 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Build.GitLabCI.Data;
+using Cake.Core;
+using NSubstitute;
+
+namespace Cake.Common.Tests.Fixtures.Build
+{
+    internal sealed class GitLabCIInfoFixture
+    {
+        public ICakeEnvironment Environment { get; set; }
+
+        public GitLabCIInfoFixture()
+        {
+            Environment = Substitute.For<ICakeEnvironment>();
+
+            // Example values taken from https://docs.gitlab.com/ce/ci/variables/README.html
+            Environment.GetEnvironmentVariable("CI_SERVER").Returns("yes");
+            Environment.GetEnvironmentVariable("CI_BUILD_ID").Returns("50");
+            Environment.GetEnvironmentVariable("CI_BUILD_REF").Returns("1ecfd275763eff1d6b4844ea3168962458c9f27a");
+            Environment.GetEnvironmentVariable("CI_BUILD_REF_NAME").Returns("master");
+            Environment.GetEnvironmentVariable("CI_BUILD_REPO").Returns("https://gitab-ci-token:abcde-1234ABCD5678ef@gitlab.com/gitlab-org/gitlab-ce.git");
+            Environment.GetEnvironmentVariable("CI_BUILD_TAG").Returns("1.0.0");
+            Environment.GetEnvironmentVariable("CI_BUILD_NAME").Returns("spec:other");
+            Environment.GetEnvironmentVariable("CI_BUILD_STAGE").Returns("test");
+            Environment.GetEnvironmentVariable("CI_BUILD_MANUAL").Returns("true");
+            Environment.GetEnvironmentVariable("CI_BUILD_TRIGGERED").Returns("true");
+            Environment.GetEnvironmentVariable("CI_BUILD_TOKEN").Returns("abcde-1234ABCD5678ef");
+            Environment.GetEnvironmentVariable("CI_PIPELINE_ID").Returns("1000");
+            Environment.GetEnvironmentVariable("CI_PROJECT_ID").Returns("34");
+            Environment.GetEnvironmentVariable("CI_PROJECT_DIR").Returns("/builds/gitlab-org/gitlab-ce");
+            Environment.GetEnvironmentVariable("CI_PROJECT_NAME").Returns("gitlab-ce");
+            Environment.GetEnvironmentVariable("CI_PROJECT_NAMESPACE").Returns("gitlab-org");
+            Environment.GetEnvironmentVariable("CI_PROJECT_PATH").Returns("gitlab-org/gitlab-ce");
+            Environment.GetEnvironmentVariable("CI_PROJECT_URL").Returns("https://gitlab.com/gitlab-org/gitlab-ce");
+            Environment.GetEnvironmentVariable("CI_REGISTRY").Returns("registry.gitlab.com");
+            Environment.GetEnvironmentVariable("CI_REGISTRY_IMAGE").Returns("registry.gitlab.com/gitlab-org/gitlab-ce");
+            Environment.GetEnvironmentVariable("CI_RUNNER_ID").Returns("10");
+            Environment.GetEnvironmentVariable("CI_RUNNER_DESCRIPTION").Returns("my runner");
+            Environment.GetEnvironmentVariable("CI_RUNNER_TAGS").Returns("docker, linux");
+            Environment.GetEnvironmentVariable("CI_SERVER").Returns("yes");
+            Environment.GetEnvironmentVariable("CI_SERVER_NAME").Returns("GitLab");
+            Environment.GetEnvironmentVariable("CI_SERVER_REVISION").Returns("70606bf");
+            Environment.GetEnvironmentVariable("CI_SERVER_VERSION").Returns("8.9.0");
+            Environment.GetEnvironmentVariable("GITLAB_USER_ID").Returns("42");
+            Environment.GetEnvironmentVariable("GITLAB_USER_EMAIL").Returns("anthony@warwickcontrol.com");
+        }
+
+        public GitLabCIBuildInfo CreateBuildInfo()
+        {
+            return new GitLabCIBuildInfo(Environment);
+        }
+
+        public GitLabCIProjectInfo CreateProjectInfo()
+        {
+            return new GitLabCIProjectInfo(Environment);
+        }
+
+        public GitLabCIRunnerInfo CreateRunnerInfo()
+        {
+            return new GitLabCIRunnerInfo(Environment);
+        }
+
+        public GitLabCIServerInfo CreateServerInfo()
+        {
+            return new GitLabCIServerInfo(Environment);
+        }
+
+        public GitLabCIEnvironmentInfo CreateEnvironmentInfo()
+        {
+            return new GitLabCIEnvironmentInfo(Environment);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Build/BuildSystemAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/BuildSystemAliasesTests.cs
@@ -109,5 +109,18 @@ namespace Cake.Common.Tests.Unit.Build
                 Assert.IsArgumentNullException(result, "context");
             }
         }
+
+        public sealed class TheGitLabCIMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Context_Is_Null()
+            {
+                // Given, When
+                var result = Record.Exception(() => BuildSystemAliases.GitLabCI(null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "context");
+            }
+        }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Build/BuildSystemTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/BuildSystemTests.cs
@@ -8,6 +8,7 @@ using Cake.Common.Build.Bamboo;
 using Cake.Common.Build.BitbucketPipelines;
 using Cake.Common.Build.Bitrise;
 using Cake.Common.Build.ContinuaCI;
+using Cake.Common.Build.GitLabCI;
 using Cake.Common.Build.GoCD;
 using Cake.Common.Build.Jenkins;
 using Cake.Common.Build.MyGet;
@@ -35,9 +36,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(null, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider));
+                var result = Record.Exception(() => new BuildSystem(null, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "appVeyorProvider");
@@ -56,9 +58,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, null, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, null, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "teamCityProvider");
@@ -77,9 +80,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, null, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, null, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "myGetProvider");
@@ -98,9 +102,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, null, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, null, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "bambooProvider");
@@ -119,9 +124,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, null,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, null,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "continuaCIProvider");
@@ -140,9 +146,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, null, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, null, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "jenkinsProvider");
@@ -161,9 +168,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, null, travisCIProvider, bitbucketPipelinesProvider, goCDProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, null, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "bitriseProvider");
@@ -182,9 +190,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, null, bitbucketPipelinesProvider, goCDProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, null, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "travisCIProvider");
@@ -203,9 +212,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, null, goCDProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, null, goCDProvider, gitlabCIProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "bitbucketPipelinesProvider");
@@ -224,12 +234,35 @@ namespace Cake.Common.Tests.Unit.Build
                 var bitriseProvider = Substitute.For<IBitriseProvider>();
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, null));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, null, gitlabCIProvider));
 
                 // Then
                 Assert.IsArgumentNullException(result, "goCDProvider");
+            }
+
+            [Fact]
+            public void Should_Throw_If_GitLabCI_Is_Null()
+            {
+                // Given
+                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
+                var teamCityProvider = Substitute.For<ITeamCityProvider>();
+                var myGetProvider = Substitute.For<IMyGetProvider>();
+                var bambooProvider = Substitute.For<IBambooProvider>();
+                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
+                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
+                var bitriseProvider = Substitute.For<IBitriseProvider>();
+                var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
+                var goCDProvider = Substitute.For<IGoCDProvider>();
+
+                // When
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "gitlabCIProvider");
             }
         }
 
@@ -249,9 +282,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnAppVeyor;
@@ -277,9 +311,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 teamCityProvider.IsRunningOnTeamCity.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnTeamCity;
@@ -305,9 +340,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 myGetProvider.IsRunningOnMyGet.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnMyGet;
@@ -333,9 +369,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 bambooProvider.IsRunningOnBamboo.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnBamboo;
@@ -361,9 +398,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 continuaCIProvider.IsRunningOnContinuaCI.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnContinuaCI;
@@ -389,9 +427,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 jenkinsProvider.IsRunningOnJenkins.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnJenkins;
@@ -417,9 +456,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 bitriseProvider.IsRunningOnBitrise.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnBitrise;
@@ -445,9 +485,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 travisCIProvider.IsRunningOnTravisCI.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnTravisCI;
@@ -473,9 +514,10 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnBitbucketPipelines;
@@ -501,12 +543,42 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 goCDProvider.IsRunningOnGoCD.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnGoCD;
+
+                // Then
+                Assert.True(result);
+            }
+        }
+
+        public sealed class TheIsRunningOnGitLabCIProperty
+        {
+            [Fact]
+            public void Should_Return_True_If_Running_On_GitLabCI()
+            {
+                // Given
+                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
+                var teamCityProvider = Substitute.For<ITeamCityProvider>();
+                var myGetProvider = Substitute.For<IMyGetProvider>();
+                var bambooProvider = Substitute.For<IBambooProvider>();
+                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
+                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
+                var bitriseProvider = Substitute.For<IBitriseProvider>();
+                var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
+                var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+
+                gitlabCIProvider.IsRunningOnGitLabCI.Returns(true);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+
+                // When
+                var result = buildSystem.IsRunningOnGitLabCI;
 
                 // Then
                 Assert.True(result);
@@ -529,6 +601,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(true);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -539,7 +612,8 @@ namespace Cake.Common.Tests.Unit.Build
                 bitriseProvider.IsRunningOnBitrise.Returns(false);
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider);
+                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -562,6 +636,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(true);
@@ -572,7 +647,8 @@ namespace Cake.Common.Tests.Unit.Build
                 bitriseProvider.IsRunningOnBitrise.Returns(false);
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider);
+                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -595,6 +671,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -605,7 +682,8 @@ namespace Cake.Common.Tests.Unit.Build
                 bitriseProvider.IsRunningOnBitrise.Returns(false);
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider);
+                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -628,6 +706,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -638,7 +717,8 @@ namespace Cake.Common.Tests.Unit.Build
                 bitriseProvider.IsRunningOnBitrise.Returns(false);
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider);
+                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -661,6 +741,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -671,7 +752,8 @@ namespace Cake.Common.Tests.Unit.Build
                 bitriseProvider.IsRunningOnBitrise.Returns(false);
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider);
+                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -694,6 +776,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -704,7 +787,8 @@ namespace Cake.Common.Tests.Unit.Build
                 bitriseProvider.IsRunningOnBitrise.Returns(false);
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider);
+                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -727,6 +811,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -737,7 +822,8 @@ namespace Cake.Common.Tests.Unit.Build
                 bitriseProvider.IsRunningOnBitrise.Returns(true);
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider);
+                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -760,6 +846,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -770,7 +857,8 @@ namespace Cake.Common.Tests.Unit.Build
                 bitriseProvider.IsRunningOnBitrise.Returns(false);
                 travisCIProvider.IsRunningOnTravisCI.Returns(true);
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider);
+                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -793,6 +881,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -803,7 +892,8 @@ namespace Cake.Common.Tests.Unit.Build
                 bitriseProvider.IsRunningOnBitrise.Returns(false);
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider);
+                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -826,6 +916,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -837,7 +928,44 @@ namespace Cake.Common.Tests.Unit.Build
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
                 goCDProvider.IsRunningOnGoCD.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider);
+                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
+
+                // When
+                var result = buildSystem.IsLocalBuild;
+
+                // Then
+                Assert.False(result);
+            }
+
+            [Fact]
+            public void Should_Return_False_If_Running_On_GitLabCI()
+            {
+                // Given
+                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
+                var teamCityProvider = Substitute.For<ITeamCityProvider>();
+                var myGetProvider = Substitute.For<IMyGetProvider>();
+                var bambooProvider = Substitute.For<IBambooProvider>();
+                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
+                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
+                var bitriseProvider = Substitute.For<IBitriseProvider>();
+                var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
+                var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+
+                appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
+                teamCityProvider.IsRunningOnTeamCity.Returns(false);
+                myGetProvider.IsRunningOnMyGet.Returns(false);
+                bambooProvider.IsRunningOnBamboo.Returns(false);
+                continuaCIProvider.IsRunningOnContinuaCI.Returns(false);
+                jenkinsProvider.IsRunningOnJenkins.Returns(false);
+                bitriseProvider.IsRunningOnBitrise.Returns(false);
+                travisCIProvider.IsRunningOnTravisCI.Returns(false);
+                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
+                goCDProvider.IsRunningOnGoCD.Returns(false);
+                gitlabCIProvider.IsRunningOnGitLabCI.Returns(true);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;
@@ -860,6 +988,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var travisCIProvider = Substitute.For<ITravisCIProvider>();
                 var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
                 var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
                 teamCityProvider.IsRunningOnTeamCity.Returns(false);
@@ -870,7 +999,8 @@ namespace Cake.Common.Tests.Unit.Build
                 travisCIProvider.IsRunningOnTravisCI.Returns(false);
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
                 goCDProvider.IsRunningOnGoCD.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider);
+                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
 
                 // When
                 var result = buildSystem.IsLocalBuild;

--- a/src/Cake.Common.Tests/Unit/Build/GitLabCI/Data/GitLabCIBuildInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/GitLabCI/Data/GitLabCIBuildInfoTests.cs
@@ -1,0 +1,221 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Build.GitLabCI;
+using Cake.Common.Tests.Fixtures.Build;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Build.GitLabCI.Data
+{
+    public sealed class GitLabCIBuildInfoTests
+    {
+        public sealed class TheIdProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.Id;
+
+                // Then
+                Assert.Equal(50, result);
+            }
+        }
+
+        public sealed class TheManualProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.Manual;
+
+                // Then
+                Assert.Equal(true, result);
+            }
+        }
+
+        public sealed class TheNameProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.Name;
+
+                // Then
+                Assert.Equal("spec:other", result);
+            }
+        }
+
+        public sealed class ThePipelineIdProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.PipelineId;
+
+                // Then
+                Assert.Equal(1000, result);
+            }
+        }
+
+        public sealed class TheReferenceProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.Reference;
+
+                // Then
+                Assert.Equal("1ecfd275763eff1d6b4844ea3168962458c9f27a", result);
+            }
+        }
+
+        public sealed class TheRefNameProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.RefName;
+
+                // Then
+                Assert.Equal("master", result);
+            }
+        }
+
+        public sealed class TheRepoUrlProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.RepoUrl;
+
+                // Then
+                Assert.Equal("https://gitab-ci-token:abcde-1234ABCD5678ef@gitlab.com/gitlab-org/gitlab-ce.git", result);
+            }
+        }
+
+        public sealed class TheStageProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.Stage;
+
+                // Then
+                Assert.Equal("test", result);
+            }
+        }
+
+        public sealed class TheTagProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.Tag;
+
+                // Then
+                Assert.Equal("1.0.0", result);
+            }
+        }
+
+        public sealed class TheTokenProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.Token;
+
+                // Then
+                Assert.Equal("abcde-1234ABCD5678ef", result);
+            }
+        }
+
+        public sealed class TheTriggeredProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.Triggered;
+
+                // Then
+                Assert.Equal(true, result);
+            }
+        }
+
+        public sealed class TheUserEmailProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.UserEmail;
+
+                // Then
+                Assert.Equal("anthony@warwickcontrol.com", result);
+            }
+        }
+
+        public sealed class TheUserIdProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.UserId;
+
+                // Then
+                Assert.Equal(42, result);
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Build/GitLabCI/Data/GitLabCIProjectInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/GitLabCI/Data/GitLabCIProjectInfoTests.cs
@@ -1,0 +1,109 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Build.GitLabCI;
+using Cake.Common.Tests.Fixtures.Build;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Build.GitLabCI.Data
+{
+    public sealed class GitLabCIProjectInfoTests
+    {
+        public sealed class TheDirectoryProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreateProjectInfo();
+
+                // When
+                var result = info.Directory;
+
+                // Then
+                Assert.Equal("/builds/gitlab-org/gitlab-ce", result);
+            }
+        }
+
+        public sealed class TheIdProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreateProjectInfo();
+
+                // When
+                var result = info.Id;
+
+                // Then
+                Assert.Equal(34, result);
+            }
+        }
+
+        public sealed class TheNameProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreateProjectInfo();
+
+                // When
+                var result = info.Name;
+
+                // Then
+                Assert.Equal("gitlab-ce", result);
+            }
+        }
+
+        public sealed class TheNamespaceProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreateProjectInfo();
+
+                // When
+                var result = info.Namespace;
+
+                // Then
+                Assert.Equal("gitlab-org", result);
+            }
+        }
+
+        public sealed class ThePathProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreateProjectInfo();
+
+                // When
+                var result = info.Path;
+
+                // Then
+                Assert.Equal("gitlab-org/gitlab-ce", result);
+            }
+        }
+
+        public sealed class TheUrlProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreateProjectInfo();
+
+                // When
+                var result = info.Url;
+
+                // Then
+                Assert.Equal("https://gitlab.com/gitlab-org/gitlab-ce", result);
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Build/GitLabCI/Data/GitLabCIRunnerInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/GitLabCI/Data/GitLabCIRunnerInfoTests.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Build.GitLabCI;
+using Cake.Common.Tests.Fixtures.Build;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Build.GitLabCI.Data
+{
+    public sealed class GitLabCIRunnerInfoTests
+    {
+        public sealed class TheDescriptionProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreateRunnerInfo();
+
+                // When
+                var result = info.Description;
+
+                // Then
+                Assert.Equal("my runner", result);
+            }
+        }
+
+        public sealed class TheIdProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreateRunnerInfo();
+
+                // When
+                var result = info.Id;
+
+                // Then
+                Assert.Equal(10, result);
+            }
+        }
+
+        public sealed class TheTagsProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreateRunnerInfo();
+
+                // When
+                var result = info.Tags;
+
+                // Then
+                Assert.Equal(new[] { "docker", "linux" }, result);
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Build/GitLabCI/Data/GitLabCIServerInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/GitLabCI/Data/GitLabCIServerInfoTests.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Build.GitLabCI;
+using Cake.Common.Tests.Fixtures.Build;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Build.GitLabCI.Data
+{
+    public sealed class GitLabCIServerInfoTests
+    {
+        public sealed class TheNameProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreateServerInfo();
+
+                // When
+                var result = info.Name;
+
+                // Then
+                Assert.Equal("GitLab", result);
+            }
+        }
+    }
+
+    public sealed class TheRevisionProperty
+    {
+        [Fact]
+        public void Should_Return_Correct_Value()
+        {
+            // Given
+            var info = new GitLabCIInfoFixture().CreateServerInfo();
+
+            // When
+            var result = info.Revision;
+
+            // Then
+            Assert.Equal("70606bf", result);
+        }
+    }
+
+    public sealed class TheVersionProperty
+    {
+        [Fact]
+        public void Should_Return_Correct_Value()
+        {
+            // Given
+            var info = new GitLabCIInfoFixture().CreateServerInfo();
+
+            // When
+            var result = info.Version;
+
+            // Then
+            Assert.Equal("8.9.0", result);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Build/GitLabCI/GitLabCIProviderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/GitLabCI/GitLabCIProviderTests.cs
@@ -1,0 +1,75 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Build.GitLabCI;
+using Cake.Common.Tests.Fixtures.Build;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Build.GitLabCI
+{
+    public sealed class GitLabCIProviderTests
+    {
+        public sealed class TheConstructor
+        {
+            [Fact]
+            public void Should_Throw_If_Environment_Is_Null()
+            {
+                // Given, When
+                var result = Record.Exception(() => new GitLabCIProvider(null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "environment");
+            }
+        }
+
+        public sealed class TheIsRunningOnGitLabCIProperty
+        {
+            [Fact]
+            public void Should_Return_True_If_Running_On_GitLabCI()
+            {
+                // Given
+                var fixture = new GitLabCIFixture();
+                fixture.IsRunningOnGitLabCI();
+                var gitlabCI = fixture.CreateGitLabCIService();
+
+                // When
+                var result = gitlabCI.IsRunningOnGitLabCI;
+
+                // Then
+                Assert.True(result);
+            }
+
+            [Fact]
+            public void Should_Return_False_If_Not_Running_On_GitLabCI()
+            {
+                // Given
+                var fixture = new GitLabCIFixture();
+                var gitlabCI = fixture.CreateGitLabCIService();
+
+                // When
+                var result = gitlabCI.IsRunningOnGitLabCI;
+
+                // Then
+                Assert.False(result);
+            }
+        }
+
+        public sealed class TheEnvironmentProperty
+        {
+            [Fact]
+            public void Should_Return_Non_Null_Reference()
+            {
+                // Given
+                var fixture = new GitLabCIFixture();
+                var gitlabCI = fixture.CreateGitLabCIService();
+
+                // When
+                var result = gitlabCI.Environment;
+
+                // Then
+                Assert.NotNull(result);
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Build/BuildSystem.cs
+++ b/src/Cake.Common/Build/BuildSystem.cs
@@ -8,6 +8,7 @@ using Cake.Common.Build.Bamboo;
 using Cake.Common.Build.BitbucketPipelines;
 using Cake.Common.Build.Bitrise;
 using Cake.Common.Build.ContinuaCI;
+using Cake.Common.Build.GitLabCI;
 using Cake.Common.Build.GoCD;
 using Cake.Common.Build.Jenkins;
 using Cake.Common.Build.MyGet;
@@ -35,6 +36,7 @@ namespace Cake.Common.Build
         /// <param name="travisCIProvider">The Travis CI provider.</param>
         /// <param name="bitbucketPipelinesProvider">The Bitbucket Pipelines provider.</param>
         /// <param name="goCDProvider">The Go.CD provider.</param>
+        /// <param name="gitlabCIProvider">The GitLab CI provider.</param>
         public BuildSystem(
             IAppVeyorProvider appVeyorProvider,
             ITeamCityProvider teamCityProvider,
@@ -45,7 +47,8 @@ namespace Cake.Common.Build
             IBitriseProvider bitriseProvider,
             ITravisCIProvider travisCIProvider,
             IBitbucketPipelinesProvider bitbucketPipelinesProvider,
-            IGoCDProvider goCDProvider)
+            IGoCDProvider goCDProvider,
+            IGitLabCIProvider gitlabCIProvider)
         {
             if (appVeyorProvider == null)
             {
@@ -87,6 +90,10 @@ namespace Cake.Common.Build
             {
                 throw new ArgumentNullException(nameof(goCDProvider));
             }
+            if (gitlabCIProvider == null)
+            {
+                throw new ArgumentNullException(nameof(gitlabCIProvider));
+            }
 
             AppVeyor = appVeyorProvider;
             TeamCity = teamCityProvider;
@@ -98,6 +105,7 @@ namespace Cake.Common.Build
             TravisCI = travisCIProvider;
             BitbucketPipelines = bitbucketPipelinesProvider;
             GoCD = goCDProvider;
+            GitLabCI = gitlabCIProvider;
         }
 
         /// <summary>
@@ -417,6 +425,37 @@ namespace Cake.Common.Build
         public IGoCDProvider GoCD { get; }
 
         /// <summary>
+        /// Gets the GitLab CI Provider.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// if(BuildSystem.IsRunningOnGitLabCI)
+        /// {
+        ///     // Get the build commit hash.
+        ///     var commitHash = BuildSystem.GitLabCI.Environment.Build.Reference;
+        /// }
+        /// </code>
+        /// </example>
+        public IGitLabCIProvider GitLabCI { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this instance is running on GitLab CI.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// if(BuildSystem.IsRunningOnGitLabCI)
+        /// {
+        ///     // Get the build commit hash.
+        ///     var commitHash = BuildSystem.GitLabCI.Environment.Build.Reference;
+        /// }
+        /// </code>
+        /// </example>
+        /// <value>
+        /// <c>true</c> if this instance is running on GitLab CI; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsRunningOnGitLabCI => GitLabCI.IsRunningOnGitLabCI;
+
+        /// <summary>
         /// Gets a value indicating whether the current build is local build.
         /// </summary>
         /// <example>
@@ -435,6 +474,6 @@ namespace Cake.Common.Build
         /// <value>
         ///   <c>true</c> if the current build is local build; otherwise, <c>false</c>.
         /// </value>
-        public bool IsLocalBuild => !(IsRunningOnAppVeyor || IsRunningOnTeamCity || IsRunningOnMyGet || IsRunningOnBamboo || IsRunningOnContinuaCI || IsRunningOnJenkins || IsRunningOnBitrise || IsRunningOnTravisCI || IsRunningOnBitbucketPipelines || IsRunningOnGoCD);
+        public bool IsLocalBuild => !(IsRunningOnAppVeyor || IsRunningOnTeamCity || IsRunningOnMyGet || IsRunningOnBamboo || IsRunningOnContinuaCI || IsRunningOnJenkins || IsRunningOnBitrise || IsRunningOnTravisCI || IsRunningOnBitbucketPipelines || IsRunningOnGoCD || IsRunningOnGitLabCI);
     }
 }

--- a/src/Cake.Common/Build/BuildSystemAliases.cs
+++ b/src/Cake.Common/Build/BuildSystemAliases.cs
@@ -8,6 +8,7 @@ using Cake.Common.Build.Bamboo;
 using Cake.Common.Build.BitbucketPipelines;
 using Cake.Common.Build.Bitrise;
 using Cake.Common.Build.ContinuaCI;
+using Cake.Common.Build.GitLabCI;
 using Cake.Common.Build.GoCD;
 using Cake.Common.Build.Jenkins;
 using Cake.Common.Build.MyGet;
@@ -52,8 +53,8 @@ namespace Cake.Common.Build
             var travisCIProvider = new TravisCIProvider(context.Environment, context.Log);
             var bitbucketPipelinesProvider = new BitbucketPipelinesProvider(context.Environment);
             var goCDProvider = new GoCDProvider(context.Environment);
-
-            return new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider);
+            var gitlabCIProvider = new GitLabCIProvider(context.Environment);
+            return new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider);
         }
 
         /// <summary>
@@ -298,6 +299,31 @@ namespace Cake.Common.Build
 
             var buildSystem = context.BuildSystem();
             return buildSystem.GoCD;
+        }
+
+        /// <summary>
+        /// Gets a <see cref="GitLabCIProvider"/> instance that can be user to
+        /// obtain information from the GitLab CI environment.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var isGitLabCIBuild = GitLabCI.IsRunningOnGitLabCI;
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <returns>A <see cref="Build.GitLabCI"/> instance.</returns>
+        [CakePropertyAlias(Cache = true)]
+        [CakeNamespaceImport("Cake.Common.Build.GitLabCI")]
+        [CakeNamespaceImport("Cake.Common.Build.GitLabCI.Data")]
+        public static IGitLabCIProvider GitLabCI(this ICakeContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var buildSystem = context.BuildSystem();
+            return buildSystem.GitLabCI;
         }
     }
 }

--- a/src/Cake.Common/Build/GitLabCI/Data/GitLabCIBuildInfo.cs
+++ b/src/Cake.Common/Build/GitLabCI/Data/GitLabCIBuildInfo.cs
@@ -1,0 +1,127 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core;
+
+namespace Cake.Common.Build.GitLabCI.Data
+{
+    /// <summary>
+    /// Provide GitLab CI build information for a current build
+    /// </summary>
+    public sealed class GitLabCIBuildInfo : GitLabCIInfo
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GitLabCIBuildInfo"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        public GitLabCIBuildInfo(ICakeEnvironment environment)
+            : base(environment)
+        {
+        }
+
+        /// <summary>
+        /// Gets the unique id of the current build that GitLab CI uses internally.
+        /// </summary>
+        /// <value>
+        /// The build ID.
+        /// </value>
+        public int Id => GetEnvironmentInteger("CI_BUILD_ID");
+
+        /// <summary>
+        /// Gets the commit revision for which project is built.
+        /// </summary>
+        /// <value>
+        /// The commit revision hash.
+        /// </value>
+        public string Reference => GetEnvironmentString("CI_BUILD_REF");
+
+        /// <summary>
+        /// Gets the commit tag name. Present only when building tags.
+        /// </summary>
+        /// <value>
+        /// The build tag name.
+        /// </value>
+        public string Tag => GetEnvironmentString("CI_BUILD_TAG");
+
+        /// <summary>
+        /// Gets the name of the build as defined in .gitlab-ci.yml.
+        /// </summary>
+        /// <value>
+        /// The name of the build.
+        /// </value>
+        public string Name => GetEnvironmentString("CI_BUILD_NAME");
+
+        /// <summary>
+        /// Gets the name of the stage as defined in .gitlab-ci.yml.
+        /// </summary>
+        /// <value>
+        /// The name of the current stage.
+        /// </value>
+        public string Stage => GetEnvironmentString("CI_BUILD_STAGE");
+
+        /// <summary>
+        /// Gets the branch or tag name for which project is built.
+        /// </summary>
+        /// <value>
+        /// The branch or tag for this build.
+        /// </value>
+        public string RefName => GetEnvironmentString("CI_BUILD_REF_NAME");
+
+        /// <summary>
+        /// Gets the URL to clone the Git repository.
+        /// </summary>
+        /// <value>
+        /// The repository URL.
+        /// </value>
+        public string RepoUrl => GetEnvironmentString("CI_BUILD_REPO");
+
+        /// <summary>
+        /// Gets a value indicating whether the build was triggered.
+        /// </summary>
+        /// <value>
+        /// <c>True</c> if the build was triggered, otherwise <c>false</c>.
+        /// </value>
+        public bool Triggered => GetEnvironmentBoolean("CI_BUILD_TRIGGERED");
+
+        /// <summary>
+        /// Gets a value indicating whether the build was manually started.
+        /// </summary>
+        /// <value>
+        /// <c>True</c> if the build was started manually, otherwise <c>false</c>.
+        /// </value>
+        public bool Manual => GetEnvironmentBoolean("CI_BUILD_MANUAL");
+
+        /// <summary>
+        /// Gets the token used for authenticating with the GitLab Container Registry.
+        /// </summary>
+        /// <value>
+        /// The build authorisation token.
+        /// </value>
+        public string Token => GetEnvironmentString("CI_BUILD_TOKEN");
+
+        /// <summary>
+        /// Gets the unique id of the current pipeline that GitLab CI uses internally.
+        /// </summary>
+        /// <value>
+        /// The unique build ID.
+        /// </value>
+        public int PipelineId => GetEnvironmentInteger("CI_PIPELINE_ID");
+
+        /// <summary>
+        /// Gets the id of the user who started the build.
+        /// </summary>
+        /// <value>
+        /// The user ID.
+        /// </value>
+        public int UserId => GetEnvironmentInteger("GITLAB_USER_ID");
+
+        /// <summary>
+        /// Gets the email of the user who started the build.
+        /// </summary>
+        /// <value>
+        /// The email address of the user.
+        /// </value>
+        public string UserEmail => GetEnvironmentString("GITLAB_USER_EMAIL");
+    }
+}

--- a/src/Cake.Common/Build/GitLabCI/Data/GitLabCIEnvironmentInfo.cs
+++ b/src/Cake.Common/Build/GitLabCI/Data/GitLabCIEnvironmentInfo.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core;
+
+namespace Cake.Common.Build.GitLabCI.Data
+{
+    /// <summary>
+    /// Provides GitLab CI environment information for a current build.
+    /// </summary>
+    public sealed class GitLabCIEnvironmentInfo : GitLabCIInfo
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GitLabCIEnvironmentInfo"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        public GitLabCIEnvironmentInfo(ICakeEnvironment environment)
+            : base(environment)
+        {
+            Server = new GitLabCIServerInfo(environment);
+            Build = new Data.GitLabCIBuildInfo(environment);
+            Project = new Data.GitLabCIProjectInfo(environment);
+            Runner = new Data.GitLabCIRunnerInfo(environment);
+        }
+
+        /// <summary>
+        /// Gets the GitLab CI runner information.
+        /// </summary>
+        /// <value>
+        /// The GitLab CI runner information.
+        /// </value>
+        public GitLabCIRunnerInfo Runner { get; }
+
+        /// <summary>
+        /// Gets the GitLab CI server information.
+        /// </summary>
+        /// <value>
+        /// The GitLab CI server information.
+        /// </value>
+        public GitLabCIServerInfo Server { get; }
+
+        /// <summary>
+        /// Gets the GitLab CI build information.
+        /// </summary>
+        /// <value>
+        /// The GitLab CI build information.
+        /// </value>
+        public GitLabCIBuildInfo Build { get; }
+
+        /// <summary>
+        /// Gets the GitLab CI project information.
+        /// </summary>
+        /// <value>
+        /// The GitLab CI project information.
+        /// </value>
+        public GitLabCIProjectInfo Project { get; }
+    }
+}

--- a/src/Cake.Common/Build/GitLabCI/Data/GitLabCIProjectInfo.cs
+++ b/src/Cake.Common/Build/GitLabCI/Data/GitLabCIProjectInfo.cs
@@ -1,0 +1,71 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core;
+
+namespace Cake.Common.Build.GitLabCI.Data
+{
+    /// <summary>
+    /// Provides GitLab CI project information for a current build
+    /// </summary>
+    public sealed class GitLabCIProjectInfo : GitLabCIInfo
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GitLabCIProjectInfo"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        public GitLabCIProjectInfo(ICakeEnvironment environment)
+            : base(environment)
+        {
+        }
+
+        /// <summary>
+        /// Gets the unique id of the current project that GitLab CI uses internally.
+        /// </summary>
+        /// <value>
+        /// The project ID.
+        /// </value>
+        public int Id => GetEnvironmentInteger("CI_PROJECT_ID");
+
+        /// <summary>
+        /// Gets the project name that is currently being built.
+        /// </summary>
+        /// <value>
+        /// The project name.
+        /// </value>
+        public string Name => GetEnvironmentString("CI_PROJECT_NAME");
+
+        /// <summary>
+        /// Gets the project namespace (username or groupname) that is currently being built.
+        /// </summary>
+        /// <value>
+        /// The project namespace.
+        /// </value>
+        public string Namespace => GetEnvironmentString("CI_PROJECT_NAMESPACE");
+
+        /// <summary>
+        /// Gets the namespace with project name.
+        /// </summary>
+        /// <value>
+        /// The project namespace and project name.
+        /// </value>
+        public string Path => GetEnvironmentString("CI_PROJECT_PATH");
+
+        /// <summary>
+        /// Gets the HTTP address to access the project.
+        /// </summary>
+        /// <value>
+        /// The HTTP address to access the project.
+        /// </value>
+        public string Url => GetEnvironmentString("CI_PROJECT_URL");
+
+        /// <summary>
+        /// Gets the full path where the repository is cloned and where the build is run.
+        /// </summary>
+        /// <value>
+        /// The full path where the repository is cloned and where the build is run.
+        /// </value>
+        public string Directory => GetEnvironmentString("CI_PROJECT_DIR");
+    }
+}

--- a/src/Cake.Common/Build/GitLabCI/Data/GitLabCIRunnerInfo.cs
+++ b/src/Cake.Common/Build/GitLabCI/Data/GitLabCIRunnerInfo.cs
@@ -43,6 +43,17 @@ namespace Cake.Common.Build.GitLabCI.Data
         /// <value>
         /// The defined runner tags.
         /// </value>
-        public string[] Tags => GetEnvironmentString("CI_RUNNER_TAGS").Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+        public string[] Tags
+        {
+            get
+            {
+                var tags = GetEnvironmentString("CI_RUNNER_TAGS").Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                for (int i = 0; i < tags.Length; i++)
+                {
+                    tags[i] = tags[i].Trim();
+                }
+                return tags;
+            }
+        }
     }
 }

--- a/src/Cake.Common/Build/GitLabCI/Data/GitLabCIRunnerInfo.cs
+++ b/src/Cake.Common/Build/GitLabCI/Data/GitLabCIRunnerInfo.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Core;
+
+namespace Cake.Common.Build.GitLabCI.Data
+{
+    /// <summary>
+    /// Provides GitLab CI runner information for a current build.
+    /// </summary>
+    public sealed class GitLabCIRunnerInfo : GitLabCIInfo
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GitLabCIRunnerInfo"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        public GitLabCIRunnerInfo(ICakeEnvironment environment)
+            : base(environment)
+        {
+        }
+
+        /// <summary>
+        /// Gets the unique id of runner being used.
+        /// </summary>
+        /// <value>
+        /// The unique id of runner being used.
+        /// </value>
+        public int Id => GetEnvironmentInteger("CI_RUNNER_ID");
+
+        /// <summary>
+        /// Gets the description of the runner as saved in GitLab.
+        /// </summary>
+        /// <value>
+        /// The description of the runner as saved in GitLab.
+        /// </value>
+        public string Description => GetEnvironmentString("CI_RUNNER_DESCRIPTION");
+
+        /// <summary>
+        /// Gets an array of the defined runner tags.
+        /// </summary>
+        /// <value>
+        /// The defined runner tags.
+        /// </value>
+        public string[] Tags => GetEnvironmentString("CI_RUNNER_TAGS").Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+    }
+}

--- a/src/Cake.Common/Build/GitLabCI/Data/GitLabCIServerInfo.cs
+++ b/src/Cake.Common/Build/GitLabCI/Data/GitLabCIServerInfo.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core;
+
+namespace Cake.Common.Build.GitLabCI.Data
+{
+    /// <summary>
+    /// Provides GitLab CI server information for a current build.
+    /// </summary>
+    public sealed class GitLabCIServerInfo : GitLabCIInfo
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GitLabCIServerInfo"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        public GitLabCIServerInfo(ICakeEnvironment environment)
+            : base(environment)
+        {
+        }
+
+        /// <summary>
+        /// Gets the name of CI server that is used to coordinate builds.
+        /// </summary>
+        /// <value>
+        /// The name of CI server that is used to coordinate builds.
+        /// </value>
+        public string Name => GetEnvironmentString("CI_SERVER_NAME");
+
+        /// <summary>
+        /// Gets the GitLab version that is used to schedule builds.
+        /// </summary>
+        /// <value>
+        /// The GitLab version that is used to schedule builds.
+        /// </value>
+        public string Version => GetEnvironmentString("CI_SERVER_VERSION");
+
+        /// <summary>
+        /// Gets the GitLab revision that is used to schedule builds.
+        /// </summary>
+        /// <value>
+        /// The GitLab revision that is used to schedule builds.
+        /// </value>
+        public string Revision => GetEnvironmentString("CI_SERVER_REVISION");
+    }
+}

--- a/src/Cake.Common/Build/GitLabCI/GitLabCIInfo.cs
+++ b/src/Cake.Common/Build/GitLabCI/GitLabCIInfo.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Core;
+
+namespace Cake.Common.Build.GitLabCI
+{
+    /// <summary>
+    /// Base class used to provide information about the Bitbucket Pipelines environment.
+    /// </summary>
+    public abstract class GitLabCIInfo
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GitLabCIInfo"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        protected GitLabCIInfo(ICakeEnvironment environment)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Gets an environment variable as a <see cref="System.String"/>.
+        /// </summary>
+        /// <param name="variable">The environment variable name.</param>
+        /// <returns>The environment variable.</returns>
+        protected string GetEnvironmentString(string variable)
+        {
+            return _environment.GetEnvironmentVariable(variable) ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Gets an environment variable as a <see cref="System.Int32"/>.
+        /// </summary>
+        /// <param name="variable">The environment variable name.</param>
+        /// <returns>The environment variable.</returns>
+        protected int GetEnvironmentInteger(string variable)
+        {
+            var value = GetEnvironmentString(variable);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                int result;
+                if (int.TryParse(value, out result))
+                {
+                    return result;
+                }
+            }
+            return 0;
+        }
+
+        /// <summary>
+        /// Gets an environment variable as a <see cref="System.Boolean"/>.
+        /// </summary>
+        /// <param name="variable">The environment variable name.</param>
+        /// <returns>The environment variable.</returns>
+        protected bool GetEnvironmentBoolean(string variable)
+        {
+            var value = GetEnvironmentString(variable);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value.Equals("true", StringComparison.OrdinalIgnoreCase);
+            }
+            return false;
+        }
+    }
+}

--- a/src/Cake.Common/Build/GitLabCI/GitLabCIProvider.cs
+++ b/src/Cake.Common/Build/GitLabCI/GitLabCIProvider.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Cake.Common.Build.GitLabCI.Data;
+using Cake.Core;
+
+namespace Cake.Common.Build.GitLabCI
+{
+    /// <summary>
+    /// Responsible for communicating with GitLab CI.
+    /// </summary>
+    public class GitLabCIProvider : IGitLabCIProvider
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GitLabCIProvider"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        public GitLabCIProvider(ICakeEnvironment environment)
+        {
+            if (environment == null)
+            {
+                throw new ArgumentNullException(nameof(environment));
+            }
+            _environment = environment;
+            Environment = new GitLabCIEnvironmentInfo(environment);
+        }
+
+        /// <summary>
+        /// Gets the GitLab CI environment.
+        /// </summary>
+        /// <value>
+        /// The GitLab CI environment.
+        /// </value>
+        public GitLabCIEnvironmentInfo Environment { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the current build is running on GitLab CI.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the current build is running on GitLab CI; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsRunningOnGitLabCI => !string.IsNullOrWhiteSpace(_environment.GetEnvironmentVariable("GITLAB_CI"));
+    }
+}

--- a/src/Cake.Common/Build/GitLabCI/GitLabCIProvider.cs
+++ b/src/Cake.Common/Build/GitLabCI/GitLabCIProvider.cs
@@ -42,6 +42,6 @@ namespace Cake.Common.Build.GitLabCI
         /// <value>
         /// <c>true</c> if the current build is running on GitLab CI; otherwise, <c>false</c>.
         /// </value>
-        public bool IsRunningOnGitLabCI => !string.IsNullOrWhiteSpace(_environment.GetEnvironmentVariable("GITLAB_CI"));
+        public bool IsRunningOnGitLabCI => _environment.GetEnvironmentVariable("CI_SERVER")?.Equals("yes", StringComparison.OrdinalIgnoreCase) ?? false;
     }
 }

--- a/src/Cake.Common/Build/GitLabCI/IGitLabCIProvider.cs
+++ b/src/Cake.Common/Build/GitLabCI/IGitLabCIProvider.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Build.GitLabCI.Data;
+
+namespace Cake.Common.Build.GitLabCI
+{
+    /// <summary>
+    /// Represents a GitLab CI provider.
+    /// </summary>
+    public interface IGitLabCIProvider
+    {
+        /// <summary>
+        /// Gets a value indicating whether the current build is running on GitLab CI.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the current build is running on GitLab CI; otherwise, <c>false</c>.
+        /// </value>
+        bool IsRunningOnGitLabCI { get; }
+
+        /// <summary>
+        /// Gets the GitLab CI environment.
+        /// </summary>
+        /// <value>
+        /// The GitLab CI environment.
+        /// </value>
+        GitLabCIEnvironmentInfo Environment { get; }
+    }
+}


### PR DESCRIPTION
This PR adds support for the build system GitLab CI (#1274).

I have added support for reading the environment variables added by GitLab as they are documented in [the GitLab CI readme](https://docs.gitlab.com/ce/ci/variables/README.html).

There are test fixtures for the new classes and I have extended the Build System test cases to cover GitLab as well.

I have run the test suite locally and everything passes as well as testing the new code on a GitLab instance to verify that the properties are all parsed correctly.