### PR TITLE
Removed erroneous apostrophes

### DIFF
--- a/src/Cake.Common/Build/Bamboo/Data/BambooPlanInfo.cs
+++ b/src/Cake.Common/Build/Bamboo/Data/BambooPlanInfo.cs
@@ -23,7 +23,7 @@ namespace Cake.Common.Build.Bamboo.Data
         /// Gets the Bamboo short Plan Name
         /// </summary>
         /// <value>
-        ///   The Bamboo Plan Name in it's short form.
+        ///   The Bamboo Plan Name in its short form.
         /// </value>
         public string ShortPlanName => GetEnvironmentString("bamboo_shortPlanName");
 
@@ -39,7 +39,7 @@ namespace Cake.Common.Build.Bamboo.Data
         /// Gets the Bamboo short Plan Key.
         /// </summary>
         /// <value>
-        ///   The Bamboo Plan Key in it's hort form.
+        ///   The Bamboo Plan Key in its short form.
         /// </value>
         public string ShortPlanKey => GetEnvironmentString("bamboo_shortPlanKey");
 
@@ -47,7 +47,7 @@ namespace Cake.Common.Build.Bamboo.Data
         /// Gets the Bamboo short job key.
         /// </summary>
         /// <value>
-        ///   The Bamboo job key in it's short form.
+        ///   The Bamboo job key in its short form.
         /// </value>
         public string ShortJobKey => GetEnvironmentString("bamboo_shortJobKey");
 
@@ -55,7 +55,7 @@ namespace Cake.Common.Build.Bamboo.Data
         /// Gets the Bamboo short Job Name.
         /// </summary>
         /// <value>
-        ///   The Bamboo Job Name in it's short form.
+        ///   The Bamboo Job Name in its short form.
         /// </value>
         public string ShortJobName => GetEnvironmentString("bamboo_shortJobName");
 

--- a/src/Cake.Common/IO/DirectoryAliases.cs
+++ b/src/Cake.Common/IO/DirectoryAliases.cs
@@ -131,7 +131,7 @@ namespace Cake.Common.IO
 
         /// <summary>
         /// Cleans the directories matching the specified pattern.
-        /// Cleaning the directory will remove all it's content but not the directory itself.
+        /// Cleaning the directory will remove all its content but not the directory itself.
         /// </summary>
         /// <example>
         /// <code>
@@ -155,7 +155,7 @@ namespace Cake.Common.IO
 
         /// <summary>
         /// Cleans the directories matching the specified pattern.
-        /// Cleaning the directory will remove all it's content but not the directory itself.
+        /// Cleaning the directory will remove all its content but not the directory itself.
         /// </summary>
         /// <example>
         /// <code>
@@ -184,7 +184,7 @@ namespace Cake.Common.IO
 
         /// <summary>
         /// Cleans the specified directories.
-        /// Cleaning a directory will remove all it's content but not the directory itself.
+        /// Cleaning a directory will remove all its content but not the directory itself.
         /// </summary>
         /// <example>
         /// <code>
@@ -210,7 +210,7 @@ namespace Cake.Common.IO
 
         /// <summary>
         /// Cleans the specified directories.
-        /// Cleaning a directory will remove all it's content but not the directory itself.
+        /// Cleaning a directory will remove all its content but not the directory itself.
         /// </summary>
         /// <example>
         /// <code>

--- a/src/Cake.Common/Tools/Roundhouse/RoundhouseSettings.cs
+++ b/src/Cake.Common/Tools/Roundhouse/RoundhouseSettings.cs
@@ -199,7 +199,7 @@ namespace Cake.Common.Tools.Roundhouse
         /// Gets or sets the schema name to use instead of [RoundhousE].
         /// </summary>
         /// <value>
-        /// The schema where RH stores it's tables.
+        /// The schema where RH stores its tables.
         /// </value>
         public string SchemaName { get; set; }
 

--- a/src/Cake.Core/IO/FilePath.cs
+++ b/src/Cake.Core/IO/FilePath.cs
@@ -53,9 +53,9 @@ namespace Cake.Core.IO
         }
 
         /// <summary>
-        /// Gets the filename without it's extension.
+        /// Gets the filename without its extension.
         /// </summary>
-        /// <returns>The filename without it's extension.</returns>
+        /// <returns>The filename without its extension.</returns>
         public FilePath GetFilenameWithoutExtension()
         {
             var filename = System.IO.Path.GetFileNameWithoutExtension(FullPath);

--- a/src/Cake.Core/Reflection/AssemblyLoader.cs
+++ b/src/Cake.Core/Reflection/AssemblyLoader.cs
@@ -37,7 +37,7 @@ namespace Cake.Core.Reflection
 
             if (path.Segments.Length == 1 && !_fileSystem.Exist(path))
             {
-                // Not a valid path. Try loading it by it's name.
+                // Not a valid path. Try loading it by its name.
                 return Assembly.Load(new AssemblyName(path.FullPath));
             }
 

--- a/src/Cake.Core/Reflection/IAssemblyLoader.cs
+++ b/src/Cake.Core/Reflection/IAssemblyLoader.cs
@@ -13,7 +13,7 @@ namespace Cake.Core.Reflection
     public interface IAssemblyLoader
     {
         /// <summary>
-        /// Loads the specified assembly from it's assembly name.
+        /// Loads the specified assembly from its assembly name.
         /// </summary>
         /// <param name="assemblyName">The assembly name.</param>
         /// <returns>The loaded assembly.</returns>


### PR DESCRIPTION
`It's` (contraction of `it is` or `it has`) occurred many times when what was intended was `its` (possessive).