### PR TITLE
GH1281: Add a "Prepend" extension for the ProcessArgumentBuilder

### DIFF
--- a/src/Cake.Core.Tests/Unit/Extensions/ProcessArgumentListExtensionsTests.cs
+++ b/src/Cake.Core.Tests/Unit/Extensions/ProcessArgumentListExtensionsTests.cs
@@ -32,6 +32,30 @@ namespace Cake.Core.Tests.Unit.Extensions
                 Assert.Equal("/arg1:Value1 /arg2:Value2", result);
             }
         }
+        public class ThePrependMethods
+        {
+            [Fact]
+            public void ShouldPrependTextArgument()
+            {
+                var result = new ProcessArgumentBuilder()
+                    .Append("string arg")
+                    .Prepend("first")
+                    .RenderSafe();
+
+                Assert.Equal("first string arg", result);
+            }
+
+            [Fact]
+            public void ShouldPrependFormattedTextArgument()
+            {
+                var result = new ProcessArgumentBuilder()
+                    .Append("string arg")
+                    .Prepend("/arg1:{0} /arg2:{1}", "Value1", "Value2")
+                    .RenderSafe();
+
+                Assert.Equal("/arg1:Value1 /arg2:Value2 string arg", result);
+            }
+        }
         public class TheAppendQuotedMethods
         {
             [Fact]
@@ -62,6 +86,42 @@ namespace Cake.Core.Tests.Unit.Extensions
                     .RenderSafe();
 
                 Assert.Equal("\"/arg1:Value1\"", result);
+            }
+        }
+
+        public class ThePrependQuotedMethods
+        {
+            [Fact]
+            public void ShouldPrependTextArgument()
+            {
+                var result = new ProcessArgumentBuilder()
+                    .Append("last")
+                    .PrependQuoted("string arg")
+                    .RenderSafe();
+
+                Assert.Equal("\"string arg\" last", result);
+            }
+
+            [Fact]
+            public void ShouldPrependProcessArgument()
+            {
+                var result = new ProcessArgumentBuilder()
+                    .Append("last")
+                    .PrependQuoted(new TextArgument("text arg"))
+                    .RenderSafe();
+
+                Assert.Equal("\"text arg\" last", result);
+            }
+
+            [Fact]
+            public void ShouldPrependFormattedTextArgument()
+            {
+                var result = new ProcessArgumentBuilder()
+                    .Append("last")
+                    .PrependQuoted("/arg1:{0}", "Value1")
+                    .RenderSafe();
+
+                Assert.Equal("\"/arg1:Value1\" last", result);
             }
         }
 
@@ -98,6 +158,42 @@ namespace Cake.Core.Tests.Unit.Extensions
             }
         }
 
+        public class ThePrependSecretMethods
+        {
+            [Fact]
+            public void ShouldPrependTextArgument()
+            {
+                var result = new ProcessArgumentBuilder()
+                    .Append("last")
+                    .PrependSecret("string arg")
+                    .Render();
+
+                Assert.Equal("string arg last", result);
+            }
+
+            [Fact]
+            public void ShouldPrependProcessArgument()
+            {
+                var result = new ProcessArgumentBuilder()
+                    .Append("last")
+                    .PrependSecret(new TextArgument("text arg"))
+                    .Render();
+
+                Assert.Equal("text arg last", result);
+            }
+
+            [Fact]
+            public void ShouldPrependFormattedTextArgument()
+            {
+                var result = new ProcessArgumentBuilder()
+                    .Append("last")
+                    .PrependSecret("/arg1:{0}", "Value1")
+                    .Render();
+
+                Assert.Equal("/arg1:Value1 last", result);
+            }
+        }
+
         public class TheAppendQuotedSecretMethods
         {
             [Fact]
@@ -128,6 +224,42 @@ namespace Cake.Core.Tests.Unit.Extensions
                     .Render();
 
                 Assert.Equal("\"/arg1:Value1 /arg2:Value2\"", result);
+            }
+        }
+
+        public class ThePrependQuotedSecretMethods
+        {
+            [Fact]
+            public void ShouldPrependTextArgument()
+            {
+                var result = new ProcessArgumentBuilder()
+                    .Append("last")
+                    .PrependQuotedSecret("string arg")
+                    .Render();
+
+                Assert.Equal("\"string arg\" last", result);
+            }
+
+            [Fact]
+            public void ShouldPrependProcessArgument()
+            {
+                var result = new ProcessArgumentBuilder()
+                    .Append("last")
+                    .PrependQuotedSecret(new TextArgument("text arg"))
+                    .Render();
+
+                Assert.Equal("\"text arg\" last", result);
+            }
+
+            [Fact]
+            public void ShouldPrependFormattedTextArgument()
+            {
+                var result = new ProcessArgumentBuilder()
+                    .Append("last")
+                    .PrependQuotedSecret("/arg1:{0} /arg2:{1}", "Value1", "Value2")
+                    .Render();
+
+                Assert.Equal("\"/arg1:Value1 /arg2:Value2\" last", result);
             }
         }
     }

--- a/src/Cake.Core/Extensions/ProcessArgumentListExtensions.cs
+++ b/src/Cake.Core/Extensions/ProcessArgumentListExtensions.cs
@@ -28,6 +28,18 @@ namespace Cake.Core
         }
 
         /// <summary>
+        /// Prepend the specified text to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="text">The text to be prepended.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder Prepend(this ProcessArgumentBuilder builder, string text)
+        {
+            builder?.Prepend(new TextArgument(text));
+            return builder;
+        }
+
+        /// <summary>
         /// Formats and appends the specified text to the argument builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
@@ -43,6 +55,21 @@ namespace Cake.Core
         }
 
         /// <summary>
+        /// Formats and prepends the specified text to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="format" /> or <paramref name="args" /> is null. </exception>
+        /// <exception cref="FormatException"><paramref name="format" /> is invalid.-or- The index of a format item is less than zero, or greater than or equal to the length of the <paramref name="args" /> array. </exception>
+        public static ProcessArgumentBuilder Prepend(this ProcessArgumentBuilder builder, string format, params object[] args)
+        {
+            var text = string.Format(CultureInfo.InvariantCulture, format, args);
+            return Prepend(builder, text);
+        }
+
+        /// <summary>
         /// Quotes and appends the specified text to the argument builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
@@ -51,6 +78,18 @@ namespace Cake.Core
         public static ProcessArgumentBuilder AppendQuoted(this ProcessArgumentBuilder builder, string text)
         {
             builder?.Append(new QuotedArgument(new TextArgument(text)));
+            return builder;
+        }
+
+        /// <summary>
+        /// Quotes and prepends the specified text to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="text">The text to be quoted and prepended.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder PrependQuoted(this ProcessArgumentBuilder builder, string text)
+        {
+            builder?.Prepend(new QuotedArgument(new TextArgument(text)));
             return builder;
         }
 
@@ -70,6 +109,21 @@ namespace Cake.Core
         }
 
         /// <summary>
+        /// Formats, quotes and prepends the specified text to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="format">A composite format string to be quoted and prepended.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="format" /> or <paramref name="args" /> is null. </exception>
+        /// <exception cref="FormatException"><paramref name="format" /> is invalid.-or- The index of a format item is less than zero, or greater than or equal to the length of the <paramref name="args" /> array. </exception>
+        public static ProcessArgumentBuilder PrependQuoted(this ProcessArgumentBuilder builder, string format, params object[] args)
+        {
+            var text = string.Format(CultureInfo.InvariantCulture, format, args);
+            return PrependQuoted(builder, text);
+        }
+
+        /// <summary>
         /// Quotes and appends the specified argument to the argument builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
@@ -82,6 +136,18 @@ namespace Cake.Core
         }
 
         /// <summary>
+        /// Quotes and prepends the specified argument to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="argument">The argument to be quoted and prepended.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder PrependQuoted(this ProcessArgumentBuilder builder, IProcessArgument argument)
+        {
+            builder?.Prepend(new QuotedArgument(argument));
+            return builder;
+        }
+
+        /// <summary>
         /// Appends the specified secret text to the argument builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
@@ -90,6 +156,18 @@ namespace Cake.Core
         public static ProcessArgumentBuilder AppendSecret(this ProcessArgumentBuilder builder, string text)
         {
             builder?.Append(new SecretArgument(new TextArgument(text)));
+            return builder;
+        }
+
+        /// <summary>
+        /// Prepends the specified secret text to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="text">The secret text to be prepended.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder PrependSecret(this ProcessArgumentBuilder builder, string text)
+        {
+            builder?.Prepend(new SecretArgument(new TextArgument(text)));
             return builder;
         }
 
@@ -110,6 +188,22 @@ namespace Cake.Core
         }
 
         /// <summary>
+        /// Formats and prepend the specified secret text to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="format">A composite format string for the secret text to be prepended.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="format" /> or <paramref name="args" /> is null. </exception>
+        /// <exception cref="FormatException"><paramref name="format" /> is invalid.-or- The index of a format item is less than zero, or greater than or equal to the length of the <paramref name="args" /> array. </exception>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder PrependSecret(this ProcessArgumentBuilder builder, string format, params object[] args)
+        {
+            var text = string.Format(CultureInfo.InvariantCulture, format, args);
+            return PrependSecret(builder, text);
+        }
+
+        /// <summary>
         /// Appends the specified secret text to the argument builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
@@ -122,6 +216,18 @@ namespace Cake.Core
         }
 
         /// <summary>
+        /// Prepend the specified secret text to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="argument">The secret argument to be prepended.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder PrependSecret(this ProcessArgumentBuilder builder, IProcessArgument argument)
+        {
+            builder?.Prepend(new SecretArgument(argument));
+            return builder;
+        }
+
+        /// <summary>
         /// Quotes and appends the specified secret text to the argument builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
@@ -130,6 +236,18 @@ namespace Cake.Core
         public static ProcessArgumentBuilder AppendQuotedSecret(this ProcessArgumentBuilder builder, string text)
         {
             builder?.AppendQuoted(new SecretArgument(new TextArgument(text)));
+            return builder;
+        }
+
+        /// <summary>
+        /// Quotes and prepends the specified secret text to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="text">The secret text to be quoted and prepended.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder PrependQuotedSecret(this ProcessArgumentBuilder builder, string text)
+        {
+            builder?.PrependQuoted(new SecretArgument(new TextArgument(text)));
             return builder;
         }
 
@@ -150,6 +268,22 @@ namespace Cake.Core
         }
 
         /// <summary>
+        /// Formats, quotes and prepends the specified secret text to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="format">A composite format string for the secret text to be quoted and prepended.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="format" /> or <paramref name="args" /> is null. </exception>
+        /// <exception cref="FormatException"><paramref name="format" /> is invalid.-or- The index of a format item is less than zero, or greater than or equal to the length of the <paramref name="args" /> array. </exception>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder PrependQuotedSecret(this ProcessArgumentBuilder builder, string format, params object[] args)
+        {
+            var text = string.Format(CultureInfo.InvariantCulture, format, args);
+            return PrependQuotedSecret(builder, text);
+        }
+
+        /// <summary>
         /// Quotes and appends the specified secret text to the argument builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
@@ -158,6 +292,18 @@ namespace Cake.Core
         public static ProcessArgumentBuilder AppendQuotedSecret(this ProcessArgumentBuilder builder, IProcessArgument argument)
         {
             builder?.AppendQuoted(new SecretArgument(argument));
+            return builder;
+        }
+
+        /// <summary>
+        /// Quotes and prepends the specified secret text to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="argument">The secret argument to be prepended.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder PrependQuotedSecret(this ProcessArgumentBuilder builder, IProcessArgument argument)
+        {
+            builder?.PrependQuoted(new SecretArgument(argument));
             return builder;
         }
 
@@ -171,6 +317,18 @@ namespace Cake.Core
         public static ProcessArgumentBuilder AppendSwitch(this ProcessArgumentBuilder builder, string @switch, string text)
         {
             return AppendSwitch(builder, @switch, " ", text);
+        }
+
+        /// <summary>
+        /// Prepend the specified switch to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="switch">The switch preceding the text.</param>
+        /// <param name="text">The text to be prepended.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder PrependSwitch(this ProcessArgumentBuilder builder, string @switch, string text)
+        {
+            return PrependSwitch(builder, @switch, " ", text);
         }
 
         /// <summary>
@@ -188,6 +346,20 @@ namespace Cake.Core
         }
 
         /// <summary>
+        /// Prepend the specified switch to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="switch">The switch preceding the text.</param>
+        /// <param name="separator">The separator between the switch and argument.</param>
+        /// <param name="text">The text to be prepended.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder PrependSwitch(this ProcessArgumentBuilder builder, string @switch, string separator, string text)
+        {
+            builder?.Prepend(new SwitchArgument(@switch, new TextArgument(text), separator));
+            return builder;
+        }
+
+        /// <summary>
         /// Quotes and appends the specified text to the argument builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
@@ -197,6 +369,18 @@ namespace Cake.Core
         public static ProcessArgumentBuilder AppendSwitchQuoted(this ProcessArgumentBuilder builder, string @switch, string text)
         {
             return AppendSwitchQuoted(builder, @switch, " ", text);
+        }
+
+        /// <summary>
+        /// Quotes and prepends the specified text to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="switch">The switch preceding the text.</param>
+        /// <param name="text">The text to be quoted and prepended.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder PrependSwitchQuoted(this ProcessArgumentBuilder builder, string @switch, string text)
+        {
+            return PrependSwitchQuoted(builder, @switch, " ", text);
         }
 
         /// <summary>
@@ -214,6 +398,20 @@ namespace Cake.Core
         }
 
         /// <summary>
+        /// Quotes and prepends the specified text to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="switch">The switch preceding the text.</param>
+        /// <param name="separator">The separator between the switch and argument.</param>
+        /// <param name="text">The text to be quoted and prepended.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder PrependSwitchQuoted(this ProcessArgumentBuilder builder, string @switch, string separator, string text)
+        {
+            builder?.Prepend(new SwitchArgument(@switch, new QuotedArgument(new TextArgument(text)), separator));
+            return builder;
+        }
+
+        /// <summary>
         /// Quotes and appends the specified argument to the argument builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
@@ -223,6 +421,18 @@ namespace Cake.Core
         public static ProcessArgumentBuilder AppendSwitchQuoted(this ProcessArgumentBuilder builder, string @switch, IProcessArgument argument)
         {
             return AppendSwitchQuoted(builder, @switch, " ", argument);
+        }
+
+        /// <summary>
+        /// Quotes and prepends the specified argument to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="switch">The switch preceding the text.</param>
+        /// <param name="argument">The argument to be quoted and prepended.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder PrependSwitchQuoted(this ProcessArgumentBuilder builder, string @switch, IProcessArgument argument)
+        {
+            return PrependSwitchQuoted(builder, @switch, " ", argument);
         }
 
         /// <summary>
@@ -240,6 +450,20 @@ namespace Cake.Core
         }
 
         /// <summary>
+        /// Quotes and prepends the specified argument to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="switch">The switch preceding the text.</param>
+        /// <param name="separator">The separator between the switch and argument.</param>
+        /// <param name="argument">The argument to be quoted and prepended.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder PrependSwitchQuoted(this ProcessArgumentBuilder builder, string @switch, string separator, IProcessArgument argument)
+        {
+            builder?.Prepend(new SwitchArgument(@switch, new QuotedArgument(argument), separator));
+            return builder;
+        }
+
+        /// <summary>
         /// Appends the specified secret text to the argument builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
@@ -249,6 +473,18 @@ namespace Cake.Core
         public static ProcessArgumentBuilder AppendSwitchSecret(this ProcessArgumentBuilder builder, string @switch, string text)
         {
             return AppendSwitchSecret(builder, @switch, " ", text);
+        }
+
+        /// <summary>
+        /// Prepend the specified secret text to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="switch">The switch preceding the text.</param>
+        /// <param name="text">The secret text to be prepended.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder PrependSwitchSecret(this ProcessArgumentBuilder builder, string @switch, string text)
+        {
+            return PrependSwitchSecret(builder, @switch, " ", text);
         }
 
         /// <summary>
@@ -266,6 +502,20 @@ namespace Cake.Core
         }
 
         /// <summary>
+        /// Prepend the specified secret text to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="switch">The switch preceding the text.</param>
+        /// <param name="separator">The separator between the switch and argument</param>
+        /// <param name="text">The secret text to be prepended.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder PrependSwitchSecret(this ProcessArgumentBuilder builder, string @switch, string separator, string text)
+        {
+            builder?.Prepend(new SwitchArgument(@switch, new SecretArgument(new TextArgument(text)), separator));
+            return builder;
+        }
+
+        /// <summary>
         /// Appends the specified secret text to the argument builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
@@ -275,6 +525,18 @@ namespace Cake.Core
         public static ProcessArgumentBuilder AppendSwitchSecret(this ProcessArgumentBuilder builder, string @switch, IProcessArgument argument)
         {
             return AppendSwitchSecret(builder, @switch, " ", argument);
+        }
+
+        /// <summary>
+        /// Prepend the specified secret text to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="switch">The switch preceding the text.</param>
+        /// <param name="argument">The secret argument to be prepended.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder PrependSwitchSecret(this ProcessArgumentBuilder builder, string @switch, IProcessArgument argument)
+        {
+            return PrependSwitchSecret(builder, @switch, " ", argument);
         }
 
         /// <summary>
@@ -292,6 +554,20 @@ namespace Cake.Core
         }
 
         /// <summary>
+        /// Prepend the specified secret text to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="switch">The switch preceding the text.</param>
+        /// <param name="separator">The separator between the switch and argument</param>
+        /// <param name="argument">The secret argument to be prepended.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder PrependSwitchSecret(this ProcessArgumentBuilder builder, string @switch, string separator, IProcessArgument argument)
+        {
+            builder?.Prepend(new SwitchArgument(@switch, new SecretArgument(argument), separator));
+            return builder;
+        }
+
+        /// <summary>
         /// Quotes and appends the specified secret text to the argument builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
@@ -301,6 +577,18 @@ namespace Cake.Core
         public static ProcessArgumentBuilder AppendSwitchQuotedSecret(this ProcessArgumentBuilder builder, string @switch, string text)
         {
             return AppendSwitchQuotedSecret(builder, @switch, " ", text);
+        }
+
+        /// <summary>
+        /// Quotes and prepend the specified secret text to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="switch">The switch preceding the text.</param>
+        /// <param name="text">The secret text to be quoted and prepended.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder PrependSwitchQuotedSecret(this ProcessArgumentBuilder builder, string @switch, string text)
+        {
+            return PrependSwitchQuotedSecret(builder, @switch, " ", text);
         }
 
         /// <summary>
@@ -318,6 +606,20 @@ namespace Cake.Core
         }
 
         /// <summary>
+        /// Quotes and prepends the specified secret text to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="switch">The switch preceding the text.</param>
+        /// <param name="separator">The separator between the switch and argument.</param>
+        /// <param name="text">The secret text to be quoted and prepended.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder PrependSwitchQuotedSecret(this ProcessArgumentBuilder builder, string @switch, string separator, string text)
+        {
+            builder?.PrependSwitchQuoted(@switch, separator, new SecretArgument(new TextArgument(text)));
+            return builder;
+        }
+
+        /// <summary>
         /// Quotes and appends the specified secret text to the argument builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
@@ -327,6 +629,18 @@ namespace Cake.Core
         public static ProcessArgumentBuilder AppendQuotedSecret(this ProcessArgumentBuilder builder, string @switch, IProcessArgument argument)
         {
             return AppendQuotedSecret(builder, @switch, " ", argument);
+        }
+
+        /// <summary>
+        /// Quotes and prepends the specified secret text to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="switch">The switch preceding the text.</param>
+        /// <param name="argument">The secret argument to be prepended.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder PrependQuotedSecret(this ProcessArgumentBuilder builder, string @switch, IProcessArgument argument)
+        {
+            return PrependQuotedSecret(builder, @switch, " ", argument);
         }
 
         /// <summary>
@@ -340,6 +654,20 @@ namespace Cake.Core
         public static ProcessArgumentBuilder AppendQuotedSecret(this ProcessArgumentBuilder builder, string @switch, string separator, IProcessArgument argument)
         {
             builder?.AppendSwitchQuoted(@switch, separator, new SecretArgument(argument));
+            return builder;
+        }
+
+        /// <summary>
+        /// Quotes and prepend the specified secret text to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="switch">The switch preceding the text.</param>
+        /// <param name="separator">The separator between the switch and argument</param>
+        /// <param name="argument">The secret argument to be prepended.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder PrependQuotedSecret(this ProcessArgumentBuilder builder, string @switch, string separator, IProcessArgument argument)
+        {
+            builder?.PrependSwitchQuoted(@switch, separator, new SecretArgument(argument));
             return builder;
         }
 

--- a/src/Cake.Core/IO/ProcessArgumentBuilder.cs
+++ b/src/Cake.Core/IO/ProcessArgumentBuilder.cs
@@ -48,6 +48,15 @@ namespace Cake.Core.IO
         }
 
         /// <summary>
+        /// Prepends an argument.
+        /// </summary>
+        /// <param name="argument">The argument.</param>
+        public void Prepend(IProcessArgument argument)
+        {
+            _tokens.Insert(0, argument);
+        }
+
+        /// <summary>
         /// Renders the arguments as a <see cref="string"/>.
         /// Sensitive information will be included.
         /// </summary>


### PR DESCRIPTION
See issue #1281.
This PR adds a corresponding `Prepend` extension method for all of the existing `Append` extension methods for the ProcessArgumentBuilder class.

This allows the script to insert new arguments at the start of a tool command for instances where the final argument of a tool has special significance (such as SignTool where the final argument is the file(s) to sign) and adding new arguments to the end can cause an issue.