### PR TITLE
Adding extension method to add multiple targets to DotNetBuildSettings

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/OctopusDeployPackerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/OctopusDeployPackerFixture.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.OctopusDeploy;
+using Cake.Testing.Fixtures;
+
+namespace Cake.Common.Tests.Fixtures.Tools
+{
+    internal sealed class OctopusDeployPackerFixture : ToolFixture<OctopusPackSettings>
+    {
+        public string Id { get; set; }
+
+        public OctopusDeployPackerFixture()
+            : base("octo.exe")
+        {
+        }
+
+        protected override void RunTool()
+        {
+            var tool = new OctopusDeployPacker(FileSystem, Environment, ProcessRunner, Tools);
+            tool.Pack(Id, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetBuildSettingsExtensionsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetBuildSettingsExtensionsTests.cs
@@ -27,6 +27,20 @@ namespace Cake.Common.Tests.Unit.Tools
             }
 
             [Fact]
+            public void Should_Add_Targets_To_Configuration()
+            {
+                // Given
+                var settings = new DotNetBuildSettings(new FilePath("./Test.sln"));
+
+                // When
+                settings.WithTarget("Target", "Target2");
+
+                // Then
+                Assert.True(settings.Targets.Contains("Target"));
+                Assert.True(settings.Targets.Contains("Target2"));
+            }
+
+            [Fact]
             public void Should_Return_The_Same_Configuration()
             {
                 // Given

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetBuildSettingsExtensionsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetBuildSettingsExtensionsTests.cs
@@ -33,7 +33,7 @@ namespace Cake.Common.Tests.Unit.Tools
                 var settings = new DotNetBuildSettings(new FilePath("./Test.sln"));
 
                 // When
-                settings.WithTarget("Target", "Target2");
+                settings.WithTargets(new[] { "Target", "Target2" });
 
                 // Then
                 Assert.True(settings.Targets.Contains("Target"));

--- a/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctoPackTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctoPackTests.cs
@@ -1,0 +1,196 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tests.Fixtures.Tools;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.OctopusDeploy
+{
+    public sealed class OctoPackTests
+    {
+        public sealed class ThePackMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Id_Is_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployPackerFixture();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "id");
+            }
+
+            [Fact]
+            public void Should_Add_Id_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployPackerFixture();
+                fixture.Id = "MyPackage";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("pack --id MyPackage", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Version_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployPackerFixture();
+                fixture.Id = "MyPackage";
+                fixture.Settings.Version = "1.2.3";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("pack --id MyPackage --version 1.2.3", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_OutFolder_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployPackerFixture();
+                fixture.Id = "MyPackage";
+                fixture.Settings.OutFolder = "out";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("pack --id MyPackage --outFolder \"/Working/out\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_BasePath_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployPackerFixture();
+                fixture.Id = "MyPackage";
+                fixture.Settings.BasePath = "base";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("pack --id MyPackage --basePath \"/Working/base\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Author_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployPackerFixture();
+                fixture.Id = "MyPackage";
+                fixture.Settings.Author = "author";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("pack --id MyPackage --author \"author\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Title_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployPackerFixture();
+                fixture.Id = "MyPackage";
+                fixture.Settings.Title = "title";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("pack --id MyPackage --title \"title\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Description_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployPackerFixture();
+                fixture.Id = "MyPackage";
+                fixture.Settings.Description = "description";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("pack --id MyPackage --description \"description\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_ReleaseNotes_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployPackerFixture();
+                fixture.Id = "MyPackage";
+                fixture.Settings.ReleaseNotes = "releasenotes";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("pack --id MyPackage --releaseNotes \"releasenotes\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_ReleaseNotesFile_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployPackerFixture();
+                fixture.Id = "MyPackage";
+                fixture.Settings.ReleaseNotesFile = "releasenotes.md";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("pack --id MyPackage --releaseNotesFile \"/Working/releasenotes.md\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Include_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployPackerFixture();
+                fixture.Id = "MyPackage";
+                fixture.Settings.Include = new[]
+                {
+                    "bin/*.dll",
+                    "bin/*.pdb"
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("pack --id MyPackage --include \"bin/*.dll\" --include \"bin/*.pdb\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Overwrite_To_Arguments_If_True()
+            {
+                // Given
+                var fixture = new OctopusDeployPackerFixture();
+                fixture.Id = "MyPackage";
+                fixture.Settings.Overwrite = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("pack --id MyPackage --overwrite", result.Args);
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetBuildSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/DotNetBuildSettingsExtensions.cs
@@ -36,7 +36,7 @@ namespace Cake.Common.Tools
         /// <param name="settings">The settings.</param>
         /// <param name="targets">The .NET build targets.</param>
         /// <returns>The same <see cref="DotNetBuildSettings"/> instance so that multiple calls can be chained.</returns>
-        public static DotNetBuildSettings WithTarget(this DotNetBuildSettings settings, params string[] targets)
+        public static DotNetBuildSettings WithTargets(this DotNetBuildSettings settings, IEnumerable<string> targets)
         {
             if (settings == null)
             {

--- a/src/Cake.Common/Tools/DotNetBuildSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/DotNetBuildSettingsExtensions.cs
@@ -31,6 +31,25 @@ namespace Cake.Common.Tools
         }
 
         /// <summary>
+        /// Adds .NET build targets to the configuration.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="targets">The .NET build targets.</param>
+        /// <returns>The same <see cref="DotNetBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetBuildSettings WithTarget(this DotNetBuildSettings settings, params string[] targets)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            foreach (var target in targets)
+            {
+                settings.Targets.Add(target);
+            }
+            return settings;
+        }
+
+        /// <summary>
         /// Adds a property to the configuration.
         /// </summary>
         /// <param name="settings">The settings.</param>

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployAliases.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployAliases.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Cake.Common.Tools.MSBuild;
 using Cake.Core;
 using Cake.Core.Annotations;
 using Cake.Core.IO;
@@ -120,6 +121,40 @@ namespace Cake.Common.Tools.OctopusDeploy
 
             var pusher = new OctopusDeployPusher(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             pusher.PushPackage(server, apiKey, packagePaths.ToArray(), settings);
+        }
+
+        /// <summary>
+        /// Packs the specified folder into an Octopus Deploy package.
+        /// </summary>
+        /// <param name="context">The cake context</param>
+        /// <param name="id">The package ID.</param>
+        [CakeMethodAlias]
+        public static void OctoPack(this ICakeContext context, string id)
+        {
+            OctoPack(context, id, null);
+        }
+
+        /// <summary>
+        /// Packs the specified folder into an Octopus Deploy package.
+        /// </summary>
+        /// <param name="context">The cake context</param>
+        /// <param name="id">The package ID.</param>
+        /// <param name="settings">The settings</param>
+        [CakeMethodAlias]
+        public static void OctoPack(this ICakeContext context, string id, OctopusPackSettings settings = null)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (id == null)
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+
+            var packer = new OctopusDeployPacker(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            packer.Pack(id, settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployPacker.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployPacker.cs
@@ -1,0 +1,130 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.OctopusDeploy
+{
+    /// <summary>
+    /// The Octopus deploy package packer
+    /// </summary>
+    public sealed class OctopusDeployPacker : Tool<OctopusPackSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OctopusDeployPacker"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="tools">The tool locator.</param>
+        public OctopusDeployPacker(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IToolLocator tools)
+            : base(fileSystem, environment, processRunner, tools)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Gets the name of the tool.
+        /// </summary>
+        /// <returns>The name of the tool.</returns>
+        protected override string GetToolName()
+        {
+            return "Octo";
+        }
+
+        /// <summary>
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return new[] { "octo.exe" };
+        }
+
+        /// <summary>
+        /// Creates an Octopus deploy package with the specified ID.
+        /// </summary>
+        /// <param name="id">The package ID.</param>
+        /// <param name="settings">The settings.</param>
+        public void Pack(string id, OctopusPackSettings settings)
+        {
+            if (id == null)
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+
+            var arguments = GetArguments(id, settings);
+            Run(settings, arguments);
+        }
+
+        private ProcessArgumentBuilder GetArguments(string id, OctopusPackSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("pack");
+            builder.Append($"--id {id}");
+
+            if (!string.IsNullOrWhiteSpace(settings.Version))
+            {
+                builder.AppendSwitch("--version", settings.Version);
+            }
+
+            if (settings.OutFolder != null)
+            {
+                builder.AppendSwitchQuoted("--outFolder", settings.OutFolder.MakeAbsolute(_environment).FullPath);
+            }
+
+            if (settings.BasePath != null)
+            {
+                builder.AppendSwitchQuoted("--basePath", settings.BasePath.MakeAbsolute(_environment).FullPath);
+            }
+
+            if (!string.IsNullOrWhiteSpace(settings.Author))
+            {
+                builder.AppendSwitchQuoted("--author", settings.Author);
+            }
+
+            if (!string.IsNullOrWhiteSpace(settings.Title))
+            {
+                builder.AppendSwitchQuoted("--title", settings.Title);
+            }
+
+            if (!string.IsNullOrWhiteSpace(settings.Description))
+            {
+                builder.AppendSwitchQuoted("--description", settings.Description);
+            }
+
+            if (!string.IsNullOrWhiteSpace(settings.ReleaseNotes))
+            {
+                builder.AppendSwitchQuoted("--releaseNotes", settings.ReleaseNotes);
+            }
+
+            if (settings.ReleaseNotesFile != null)
+            {
+                builder.AppendSwitchQuoted("--releaseNotesFile", settings.ReleaseNotesFile.MakeAbsolute(_environment).FullPath);
+            }
+
+            if (settings.Include != null)
+            {
+                foreach (var include in settings.Include)
+                {
+                    builder.AppendSwitchQuoted("--include", include);
+                }
+            }
+
+            if (settings.Overwrite)
+            {
+                builder.Append("--overwrite");
+            }
+
+            return builder;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusPackFormat.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusPackFormat.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Tools.OctopusDeploy
+{
+    /// <summary>
+    /// Represents the format of an Octopus package.
+    /// </summary>
+    public enum OctopusPackFormat
+    {
+        /// <summary>
+        /// NuGet package
+        /// </summary>
+        NuPkg,
+
+        /// <summary>
+        /// Zip package
+        /// </summary>
+        Zip
+    }
+}

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusPackSettings.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusPackSettings.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.OctopusDeploy
+{
+    /// <summary>
+    /// Contains the settings used by OctoPack.
+    /// </summary>
+    public sealed class OctopusPackSettings : ToolSettings
+    {
+        /// <summary>
+        /// Gets or sets the version.
+        /// </summary>
+        public string Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets the package format.
+        /// </summary>
+        public OctopusPackFormat Format { get; set; }
+
+        /// <summary>
+        /// Gets or sets the folder into which the package will be written. Defaults to the current folder.
+        /// </summary>
+        public DirectoryPath OutFolder { get; set; }
+
+        /// <summary>
+        /// Gets or sets the root folder containing files and folders to pack. Defaults to the current folder.
+        /// </summary>
+        public DirectoryPath BasePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the author. Only applies to NuGet packages.
+        /// </summary>
+        public string Author { get; set; }
+
+        /// <summary>
+        /// Gets or sets the title. Only applies to NuGet packages.
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the description. Only applies to NuGet packages.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the release notes. Only applies to NuGet packages.
+        /// </summary>
+        public string ReleaseNotes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the release notes file. Only applies to NuGet packages.
+        /// </summary>
+        public FilePath ReleaseNotesFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the file patterns to include. If none are specified, defaults to **.
+        /// </summary>
+        public ICollection<string> Include { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow an existing package with the same ID/version to be overwriten.
+        /// </summary>
+        public bool Overwrite { get; set; }
+    }
+}


### PR DESCRIPTION
allows adding multiple targets to a dotnetbuildsettings class

usage:
```csharp
DotNetBuild(target, settings => 
                    settings
                    .WithTarget(new[] { "targetOne" , "targetTwo" }));
```
rather than
```csharp
var targets = new[] { "targetOne" , "targetTwo" };
DotNetBuild(target, settings => { 
     foreach(var t in targets) {                    
        settings.WithTarget(t);
    }
    return settings;
});
```