### PR TITLE
GH1166: refactor MethodAliasGenerator to support optional parameters

### DIFF
--- a/src/Cake.Core.Tests/Data/MethodAliasGeneratorData.cs
+++ b/src/Cake.Core.Tests/Data/MethodAliasGeneratorData.cs
@@ -121,5 +121,83 @@ namespace Cake.Core.Tests.Data
         {
             throw new NotImplementedException();
         }
+
+        [CakeMethodAlias]
+        public static void NonGeneric_ExtensionMethodWithOptionalObjectParameter(this ICakeContext context, int value, object option = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+        public static void NonGeneric_ExtensionMethodWithOptionalBooleanParameter(this ICakeContext context, int value, bool flag = false)
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+        public static void NonGeneric_ExtensionMethodWithOptionalStringParameter(this ICakeContext context, int value, string s = @"there is a ""string"" here and a \t tab")
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+        public static void NonGeneric_ExtensionMethodWithOptionalEnumParameter(this ICakeContext context, int value, AttributeTargets targets = AttributeTargets.Class)
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+        public static void NonGeneric_ExtensionMethodWithOptionalCharParameter(this ICakeContext context, string s, char c = 's')
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+        public static void NonGeneric_ExtensionMethodWithOptionalDecimalParameter(this ICakeContext context, string s, decimal value = 12.12m)
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+        public static void NonGeneric_ExtensionMethodWithOptionalNullableTParameter(this ICakeContext context, string s, int? value = 0)
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+        public static void NonGeneric_ExtensionMethodWithOptionalNullableBooleanParameter(this ICakeContext context, string s, bool? value = false)
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+        public static void NonGeneric_ExtensionMethodWithOptionalNullableCharParameter(this ICakeContext context, string s, char? value = 's')
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+        public static void NonGeneric_ExtensionMethodWithOptionalNullableEnumParameter(this ICakeContext context, string s, AttributeTargets? targets = AttributeTargets.Class)
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+        public static void NonGeneric_ExtensionMethodWithOptionalNullableDecimalParameter(this ICakeContext context, string s, decimal? value = 123.12m)
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+        public static void NonGeneric_ExtensionMethodWithOptionalNullableLongParameter(this ICakeContext context, string s, long? value = 1234567890L)
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+        public static void NonGeneric_ExtensionMethodWithOptionalNullableDoubleParameter(this ICakeContext context, string s, double? value = 1234567890.12)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalBooleanParameter
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalBooleanParameter
@@ -1,0 +1,4 @@
+﻿public void NonGeneric_ExtensionMethodWithOptionalBooleanParameter(System.Int32 value, System.Boolean flag = false)
+{
+    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalBooleanParameter(Context, value, flag);
+}

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalCharParameter
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalCharParameter
@@ -1,0 +1,4 @@
+﻿public void NonGeneric_ExtensionMethodWithOptionalCharParameter(System.String s, System.Char c = 's')
+{
+    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalCharParameter(Context, s, c);
+}

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalDecimalParameter
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalDecimalParameter
@@ -1,0 +1,4 @@
+﻿public void NonGeneric_ExtensionMethodWithOptionalDecimalParameter(System.String s, System.Decimal value = (System.Decimal)12.12)
+{
+    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalDecimalParameter(Context, s, value);
+}

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalEnumParameter
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalEnumParameter
@@ -1,0 +1,4 @@
+﻿public void NonGeneric_ExtensionMethodWithOptionalEnumParameter(System.Int32 value, System.AttributeTargets targets = (System.AttributeTargets)4)
+{
+    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalEnumParameter(Context, value, targets);
+}

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalNullableBooleanParameter
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalNullableBooleanParameter
@@ -1,0 +1,4 @@
+﻿public void NonGeneric_ExtensionMethodWithOptionalNullableBooleanParameter(System.String s, System.Nullable<System.Boolean> value = (System.Boolean)false)
+{
+    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalNullableBooleanParameter(Context, s, value);
+}

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalNullableCharParameter
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalNullableCharParameter
@@ -1,0 +1,4 @@
+﻿public void NonGeneric_ExtensionMethodWithOptionalNullableCharParameter(System.String s, System.Nullable<System.Char> value = (System.Char)'s')
+{
+    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalNullableCharParameter(Context, s, value);
+}

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalNullableDecimalParameter
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalNullableDecimalParameter
@@ -1,0 +1,4 @@
+﻿public void NonGeneric_ExtensionMethodWithOptionalNullableDecimalParameter(System.String s, System.Nullable<System.Decimal> value = (System.Decimal)123.12)
+{
+    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalNullableDecimalParameter(Context, s, value);
+}

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalNullableDoubleParameter
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalNullableDoubleParameter
@@ -1,0 +1,4 @@
+﻿public void NonGeneric_ExtensionMethodWithOptionalNullableDoubleParameter(System.String s, System.Nullable<System.Double> value = (System.Double)1234567890.12)
+{
+    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalNullableDoubleParameter(Context, s, value);
+}

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalNullableEnumParameter
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalNullableEnumParameter
@@ -1,0 +1,4 @@
+﻿public void NonGeneric_ExtensionMethodWithOptionalNullableEnumParameter(System.String s, System.Nullable<System.AttributeTargets> targets = (System.AttributeTargets)4)
+{
+    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalNullableEnumParameter(Context, s, targets);
+}

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalNullableLongParameter
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalNullableLongParameter
@@ -1,0 +1,4 @@
+﻿public void NonGeneric_ExtensionMethodWithOptionalNullableLongParameter(System.String s, System.Nullable<System.Int64> value = (System.Int64)1234567890)
+{
+    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalNullableLongParameter(Context, s, value);
+}

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalNullableTParameter
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalNullableTParameter
@@ -1,0 +1,4 @@
+﻿public void NonGeneric_ExtensionMethodWithOptionalNullableTParameter(System.String s, System.Nullable<System.Int32> value = (System.Int32)0)
+{
+    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalNullableTParameter(Context, s, value);
+}

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalObjectParameter
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalObjectParameter
@@ -1,0 +1,4 @@
+﻿public void NonGeneric_ExtensionMethodWithOptionalObjectParameter(System.Int32 value, System.Object option = null)
+{
+    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalObjectParameter(Context, value, option);
+}

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalStringParameter
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOptionalStringParameter
@@ -1,0 +1,4 @@
+﻿public void NonGeneric_ExtensionMethodWithOptionalStringParameter(System.Int32 value, System.String s = "there is a \"string\" here and a \t tab")
+{
+    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalStringParameter(Context, value, s);
+}

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/MethodAliasGeneratorTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/MethodAliasGeneratorTests.cs
@@ -38,6 +38,19 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
             [InlineData("NonGeneric_ExtensionMethodWithGenericExpressionParamsArrayParameter")]
             [InlineData("NonGeneric_ExtensionMethodWithReturnValue")]
             [InlineData("NonGeneric_ExtensionMethodWithParameterArray")]
+            [InlineData("NonGeneric_ExtensionMethodWithOptionalObjectParameter")]
+            [InlineData("NonGeneric_ExtensionMethodWithOptionalBooleanParameter")]
+            [InlineData("NonGeneric_ExtensionMethodWithOptionalStringParameter")]
+            [InlineData("NonGeneric_ExtensionMethodWithOptionalEnumParameter")]
+            [InlineData("NonGeneric_ExtensionMethodWithOptionalCharParameter")]
+            [InlineData("NonGeneric_ExtensionMethodWithOptionalDecimalParameter")]
+            [InlineData("NonGeneric_ExtensionMethodWithOptionalNullableTParameter")]
+            [InlineData("NonGeneric_ExtensionMethodWithOptionalNullableBooleanParameter")]
+            [InlineData("NonGeneric_ExtensionMethodWithOptionalNullableCharParameter")]
+            [InlineData("NonGeneric_ExtensionMethodWithOptionalNullableEnumParameter")]
+            [InlineData("NonGeneric_ExtensionMethodWithOptionalNullableDecimalParameter")]
+            [InlineData("NonGeneric_ExtensionMethodWithOptionalNullableLongParameter")]
+            [InlineData("NonGeneric_ExtensionMethodWithOptionalNullableDoubleParameter")]
             public void Should_Return_Correct_Generated_Code_For_Non_Generic_Methods(string name)
             {
                 // Given

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/ParameterEmitterTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/ParameterEmitterTests.cs
@@ -1,0 +1,440 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using Cake.Core.Scripting.CodeGen;
+using Xunit;
+// ReSharper disable UnusedMember.Local
+// ReSharper disable UnusedParameter.Local
+namespace Cake.Core.Tests.Unit.Scripting.CodeGen
+{
+    public sealed class ParameterEmitterTests
+    {
+        private enum TestEnum
+        {
+            None,
+            Some,
+            All
+        }
+
+        private static class ParameterFixture
+        {
+            public static void RequiredInt(int arg)
+            {
+            }
+
+            public static void RequiredDouble(double arg)
+            {
+            }
+
+            public static void RequiredDecimal(decimal arg)
+            {
+            }
+
+            public static void RequiredLong(long arg)
+            {
+            }
+
+            public static void RequiredShort(short arg)
+            {
+            }
+
+            public static void RequiredSByte(sbyte arg)
+            {
+            }
+
+            public static void RequiredByte(byte arg)
+            {
+            }
+
+            public static void RequiredULong(ulong arg)
+            {
+            }
+
+            public static void RequiredUShort(ushort arg)
+            {
+            }
+
+            public static void RequiredUInt(uint arg)
+            {
+            }
+
+            public static void RequiredFloat(float arg)
+            {
+            }
+
+            public static void RequiredEnum(TestEnum arg)
+            {
+            }
+
+            public static void RequiredBool(bool arg)
+            {
+            }
+
+            public static void RequiredString(string arg)
+            {
+            }
+
+            public static void RequiredObject(object arg)
+            {
+            }
+
+            public static void RequiredDateTime(DateTime arg)
+            {
+            }
+
+            public static void RequiredInterface(IDisposable arg)
+            {
+            }
+
+            public static void RequiredClass(CakeContext arg)
+            {
+            }
+
+            public static void RequiredType(Type type)
+            {
+            }
+
+            public static void RequiredGenericEnumerable(System.Collections.Generic.IEnumerable<string> items)
+            {
+            }
+
+            public static void OptionalInt(int arg = 1)
+            {
+            }
+
+            public static void OptionalDouble(double arg = 1)
+            {
+            }
+
+            public static void OptionalDecimal(decimal arg = 1)
+            {
+            }
+
+            public static void OptionalLong(long arg = 1)
+            {
+            }
+
+            public static void OptionalShort(short arg = 1)
+            {
+            }
+
+            public static void OptionalSByte(sbyte arg = 1)
+            {
+            }
+
+            public static void OptionalByte(byte arg = 1)
+            {
+            }
+
+            public static void OptionalULong(ulong arg = 1)
+            {
+            }
+
+            public static void OptionalUShort(ushort arg = 1)
+            {
+            }
+
+            public static void OptionalUInt(uint arg = 1)
+            {
+            }
+
+            public static void OptionalFloat(float arg = 1)
+            {
+            }
+
+            public static void OptionalEnum(TestEnum arg = TestEnum.All)
+            {
+            }
+
+            public static void OptionalBool(bool arg = true)
+            {
+            }
+
+            public static void OptionalString(string arg = "value")
+            {
+            }
+
+            public static void OptionalObject(object arg = null)
+            {
+            }
+
+            public static void OptionalInterface(IDisposable arg = null)
+            {
+            }
+
+            public static void OptionalClass(CakeContext arg = null)
+            {
+            }
+
+            public static void OptionalType(Type type = null)
+            {
+            }
+
+            public static void OptionalGenericEnumerable(System.Collections.Generic.IEnumerable<string> items = null)
+            {
+            }
+
+            public static void RequiredNullableInt(int? arg)
+            {
+            }
+
+            public static void RequiredNullableDouble(double? arg)
+            {
+            }
+
+            public static void RequiredNullableDecimal(decimal? arg)
+            {
+            }
+
+            public static void RequiredNullableLong(long? arg)
+            {
+            }
+
+            public static void RequiredNullableShort(short? arg)
+            {
+            }
+
+            public static void RequiredNullableSByte(sbyte? arg)
+            {
+            }
+
+            public static void RequiredNullableByte(byte? arg)
+            {
+            }
+
+            public static void RequiredNullableULong(ulong? arg)
+            {
+            }
+
+            public static void RequiredNullableUShort(ushort? arg)
+            {
+            }
+
+            public static void RequiredNullableUInt(uint? arg)
+            {
+            }
+
+            public static void RequiredNullableFloat(float? arg)
+            {
+            }
+
+            public static void RequiredNullableEnum(TestEnum? arg)
+            {
+            }
+
+            public static void RequiredNullableBool(bool? arg)
+            {
+            }
+
+            public static void RequiredNullableDateTime(DateTime? arg)
+            {
+            }
+
+            public static void OptionalNullableIntWithNullDefault(int? arg = null)
+            {
+            }
+
+            public static void OptionalNullableDoubleWithNullDefault(double? arg = null)
+            {
+            }
+
+            public static void OptionalNullableDecimalWithNullDefault(decimal? arg = null)
+            {
+            }
+
+            public static void OptionalNullableLongWithNullDefault(long? arg = null)
+            {
+            }
+
+            public static void OptionalNullableShortWithNullDefault(short? arg = null)
+            {
+            }
+
+            public static void OptionalNullableSByteWithNullDefault(sbyte? arg = null)
+            {
+            }
+
+            public static void OptionalNullableByteWithNullDefault(byte? arg = null)
+            {
+            }
+
+            public static void OptionalNullableULongWithNullDefault(ulong? arg = null)
+            {
+            }
+
+            public static void OptionalNullableUShortWithNullDefault(ushort? arg = null)
+            {
+            }
+
+            public static void OptionalNullableUIntWithNullDefault(uint? arg = null)
+            {
+            }
+
+            public static void OptionalNullableFloatWithNullDefault(float? arg = null)
+            {
+            }
+
+            public static void OptionalNullableEnumWithNullDefault(TestEnum? arg = null)
+            {
+            }
+
+            public static void OptionalNullableBoolWithNullDefault(bool? arg = null)
+            {
+            }
+
+            public static void OptionalNullableDateTimeWithNullDefault(DateTime? arg = null)
+            {
+            }
+
+            public static void OptionalNullableIntWithNonNullDefault(int? arg = 1)
+            {
+            }
+
+            public static void OptionalNullableDoubleWithNonNullDefault(double? arg = 1)
+            {
+            }
+
+            public static void OptionalNullableDecimalWithNonNullDefault(decimal? arg = 1)
+            {
+            }
+
+            public static void OptionalNullableLongWithNonNullDefault(long? arg = 1)
+            {
+            }
+
+            public static void OptionalNullableShortWithNonNullDefault(short? arg = 1)
+            {
+            }
+
+            public static void OptionalNullableSByteWithNonNullDefault(sbyte? arg = 1)
+            {
+            }
+
+            public static void OptionalNullableByteWithNonNullDefault(byte? arg = 1)
+            {
+            }
+
+            public static void OptionalNullableULongWithNonNullDefault(ulong? arg = 1)
+            {
+            }
+
+            public static void OptionalNullableUShortWithNonNullDefault(ushort? arg = 1)
+            {
+            }
+
+            public static void OptionalNullableUIntWithNonNullDefault(uint? arg = 1)
+            {
+            }
+
+            public static void OptionalNullableFloatWithNonNullDefault(float? arg = 1)
+            {
+            }
+
+            public static void OptionalNullableEnumWithNonNullDefault(TestEnum? arg = TestEnum.Some)
+            {
+            }
+
+            public static void OptionalNullableBoolWithNonNullDefault(bool? arg = true)
+            {
+            }
+        }
+
+        [Theory]
+        [InlineData("RequiredInt", "System.Int32 arg")]
+        [InlineData("RequiredDouble", "System.Double arg")]
+        [InlineData("RequiredDecimal", "System.Decimal arg")]
+        [InlineData("RequiredLong", "System.Int64 arg")]
+        [InlineData("RequiredShort", "System.Int16 arg")]
+        [InlineData("RequiredSByte", "System.SByte arg")]
+        [InlineData("RequiredByte", "System.Byte arg")]
+        [InlineData("RequiredULong", "System.UInt64 arg")]
+        [InlineData("RequiredUShort", "System.UInt16 arg")]
+        [InlineData("RequiredUInt", "System.UInt32 arg")]
+        [InlineData("RequiredFloat", "System.Single arg")]
+        [InlineData("RequiredEnum", "Cake.Core.Tests.Unit.Scripting.CodeGen.ParameterEmitterTests+TestEnum arg")]
+        [InlineData("RequiredBool", "System.Boolean arg")]
+        [InlineData("RequiredString", "System.String arg")]
+        [InlineData("RequiredObject", "System.Object arg")]
+        [InlineData("RequiredDateTime", "System.DateTime arg")]
+        [InlineData("RequiredInterface", "System.IDisposable arg")]
+        [InlineData("RequiredClass", "Cake.Core.CakeContext arg")]
+        [InlineData("RequiredType", "System.Type type")]
+        [InlineData("RequiredGenericEnumerable", "System.Collections.Generic.IEnumerable<System.String> items")]
+        [InlineData("OptionalInt", "System.Int32 arg = (System.Int32)1")]
+        [InlineData("OptionalDouble", "System.Double arg = (System.Double)1")]
+        [InlineData("OptionalDecimal", "System.Decimal arg = (System.Decimal)1")]
+        [InlineData("OptionalLong", "System.Int64 arg = (System.Int64)1")]
+        [InlineData("OptionalShort", "System.Int16 arg = (System.Int16)1")]
+        [InlineData("OptionalSByte", "System.SByte arg = (System.SByte)1")]
+        [InlineData("OptionalByte", "System.Byte arg = (System.Byte)1")]
+        [InlineData("OptionalULong", "System.UInt64 arg = (System.UInt64)1")]
+        [InlineData("OptionalUShort", "System.UInt16 arg = (System.UInt16)1")]
+        [InlineData("OptionalUInt", "System.UInt32 arg = (System.UInt32)1")]
+        [InlineData("OptionalFloat", "System.Single arg = (System.Single)1")]
+        [InlineData("OptionalEnum", "Cake.Core.Tests.Unit.Scripting.CodeGen.ParameterEmitterTests+TestEnum arg = (Cake.Core.Tests.Unit.Scripting.CodeGen.ParameterEmitterTests+TestEnum)2")]
+        [InlineData("OptionalBool", "System.Boolean arg = true")]
+        [InlineData("OptionalString", "System.String arg = \"value\"")]
+        [InlineData("OptionalObject", "System.Object arg = null")]
+        [InlineData("OptionalInterface", "System.IDisposable arg = null")]
+        [InlineData("OptionalClass", "Cake.Core.CakeContext arg = null")]
+        [InlineData("OptionalType", "System.Type type = null")]
+        [InlineData("OptionalGenericEnumerable", "System.Collections.Generic.IEnumerable<System.String> items = null")]
+        [InlineData("RequiredNullableInt", "System.Nullable<System.Int32> arg")]
+        [InlineData("RequiredNullableDouble", "System.Nullable<System.Double> arg")]
+        [InlineData("RequiredNullableDecimal", "System.Nullable<System.Decimal> arg")]
+        [InlineData("RequiredNullableLong", "System.Nullable<System.Int64> arg")]
+        [InlineData("RequiredNullableShort", "System.Nullable<System.Int16> arg")]
+        [InlineData("RequiredNullableSByte", "System.Nullable<System.SByte> arg")]
+        [InlineData("RequiredNullableByte", "System.Nullable<System.Byte> arg")]
+        [InlineData("RequiredNullableULong", "System.Nullable<System.UInt64> arg")]
+        [InlineData("RequiredNullableUShort", "System.Nullable<System.UInt16> arg")]
+        [InlineData("RequiredNullableUInt", "System.Nullable<System.UInt32> arg")]
+        [InlineData("RequiredNullableFloat", "System.Nullable<System.Single> arg")]
+        [InlineData("RequiredNullableEnum", "System.Nullable<Cake.Core.Tests.Unit.Scripting.CodeGen.ParameterEmitterTests+TestEnum> arg")]
+        [InlineData("RequiredNullableBool", "System.Nullable<System.Boolean> arg")]
+        [InlineData("RequiredNullableDateTime", "System.Nullable<System.DateTime> arg")]
+        [InlineData("OptionalNullableIntWithNullDefault", "System.Nullable<System.Int32> arg = null")]
+        [InlineData("OptionalNullableDoubleWithNullDefault", "System.Nullable<System.Double> arg = null")]
+        [InlineData("OptionalNullableDecimalWithNullDefault", "System.Nullable<System.Decimal> arg = null")]
+        [InlineData("OptionalNullableLongWithNullDefault", "System.Nullable<System.Int64> arg = null")]
+        [InlineData("OptionalNullableShortWithNullDefault", "System.Nullable<System.Int16> arg = null")]
+        [InlineData("OptionalNullableSByteWithNullDefault", "System.Nullable<System.SByte> arg = null")]
+        [InlineData("OptionalNullableByteWithNullDefault", "System.Nullable<System.Byte> arg = null")]
+        [InlineData("OptionalNullableULongWithNullDefault", "System.Nullable<System.UInt64> arg = null")]
+        [InlineData("OptionalNullableUShortWithNullDefault", "System.Nullable<System.UInt16> arg = null")]
+        [InlineData("OptionalNullableUIntWithNullDefault", "System.Nullable<System.UInt32> arg = null")]
+        [InlineData("OptionalNullableFloatWithNullDefault", "System.Nullable<System.Single> arg = null")]
+        [InlineData("OptionalNullableEnumWithNullDefault", "System.Nullable<Cake.Core.Tests.Unit.Scripting.CodeGen.ParameterEmitterTests+TestEnum> arg = null")]
+        [InlineData("OptionalNullableBoolWithNullDefault", "System.Nullable<System.Boolean> arg = null")]
+        [InlineData("OptionalNullableDateTimeWithNullDefault", "System.Nullable<System.DateTime> arg = null")]
+        [InlineData("OptionalNullableIntWithNonNullDefault", "System.Nullable<System.Int32> arg = (System.Int32)1")]
+        [InlineData("OptionalNullableDoubleWithNonNullDefault", "System.Nullable<System.Double> arg = (System.Double)1")]
+        [InlineData("OptionalNullableDecimalWithNonNullDefault", "System.Nullable<System.Decimal> arg = (System.Decimal)1")]
+        [InlineData("OptionalNullableLongWithNonNullDefault", "System.Nullable<System.Int64> arg = (System.Int64)1")]
+        [InlineData("OptionalNullableShortWithNonNullDefault", "System.Nullable<System.Int16> arg = (System.Int16)1")]
+        [InlineData("OptionalNullableSByteWithNonNullDefault", "System.Nullable<System.SByte> arg = (System.SByte)1")]
+        [InlineData("OptionalNullableByteWithNonNullDefault", "System.Nullable<System.Byte> arg = (System.Byte)1")]
+        [InlineData("OptionalNullableULongWithNonNullDefault", "System.Nullable<System.UInt64> arg = (System.UInt64)1")]
+        [InlineData("OptionalNullableUShortWithNonNullDefault", "System.Nullable<System.UInt16> arg = (System.UInt16)1")]
+        [InlineData("OptionalNullableUIntWithNonNullDefault", "System.Nullable<System.UInt32> arg = (System.UInt32)1")]
+        [InlineData("OptionalNullableFloatWithNonNullDefault", "System.Nullable<System.Single> arg = (System.Single)1")]
+        [InlineData("OptionalNullableEnumWithNonNullDefault", "System.Nullable<Cake.Core.Tests.Unit.Scripting.CodeGen.ParameterEmitterTests+TestEnum> arg = (Cake.Core.Tests.Unit.Scripting.CodeGen.ParameterEmitterTests+TestEnum)1")]
+        [InlineData("OptionalNullableBoolWithNonNullDefault", "System.Nullable<System.Boolean> arg = (System.Boolean)true")]
+        public void Should_Return_Correct_Generated_Code_For_Method_Parameters(string methodName, string expected)
+        {
+            // Given
+            var method = typeof(ParameterFixture).GetMethod(methodName, BindingFlags.Static | BindingFlags.Public);
+            var parameter = method.GetParameters().FirstOrDefault();
+
+            // When
+            var result = ParameterEmitter.Emit(parameter, true);
+
+            // Then
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/src/Cake.Core/Extensions/TypeExtensions.cs
+++ b/src/Cake.Core/Extensions/TypeExtensions.cs
@@ -60,6 +60,27 @@ namespace Cake.Core
                 : includeNamespace ? type.FullName : type.Name;
         }
 
+        /// <summary>
+        /// Gets whether or not a given <see cref="System.Type"/> is a subclass of an raw/open generic.
+        /// </summary>
+        /// <param name="toCheck">The type to check</param>
+        /// <param name="generic">The open generic to test</param>
+        /// <code>typeof(Nullable&lt;int&gt;).IsSubclassOfRawGeneric(typeof(Nullable&lt;&gt;));</code>
+        /// <returns>Returns <c>true</c> if the type is a subtype of a raw generic, else <c>false</c></returns>
+        public static bool IsSubclassOfRawGeneric(this Type toCheck, Type generic)
+        {
+            while (toCheck != null && toCheck != typeof(object))
+            {
+                var cur = toCheck.GetTypeInfo().IsGenericType ? toCheck.GetGenericTypeDefinition() : toCheck;
+                if (generic == cur)
+                {
+                    return true;
+                }
+                toCheck = toCheck.GetTypeInfo().BaseType;
+            }
+            return false;
+        }
+
         private static string GetGenericTypeName(this Type type, bool includeNamespace)
         {
             var builder = new StringBuilder();

--- a/src/Cake.Core/Scripting/CodeGen/MethodAliasGenerator.cs
+++ b/src/Cake.Core/Scripting/CodeGen/MethodAliasGenerator.cs
@@ -145,24 +145,8 @@ namespace Cake.Core.Scripting.CodeGen
                 {
                     yield return ", ";
                 }
-                if (parameter.IsOut)
-                {
-                    yield return "out ";
-                }
-                else if (parameter.ParameterType.IsByRef)
-                {
-                    yield return "ref ";
-                }
-                if (includeType)
-                {
-                    if (parameter.IsDefined(typeof(ParamArrayAttribute)))
-                    {
-                        yield return "params ";
-                    }
-                    yield return parameter.ParameterType.GetFullName();
-                    yield return " ";
-                }
-                yield return parameter.Name;
+
+                yield return ParameterEmitter.Emit(parameter, includeType);
             }
         }
 

--- a/src/Cake.Core/Scripting/CodeGen/ParameterEmitter.cs
+++ b/src/Cake.Core/Scripting/CodeGen/ParameterEmitter.cs
@@ -1,0 +1,134 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Cake.Core.Scripting.CodeGen
+{
+    /// <summary>
+    /// Responsible for generating parameter tokens in method alias generation
+    /// </summary>
+    internal sealed class ParameterEmitter
+    {
+        internal static string Emit(ParameterInfo parameter, bool includeType)
+        {
+            return string.Join(string.Empty, BuildParameterTokens(parameter, includeType));
+        }
+
+        private static IEnumerable<string> BuildParameterTokens(ParameterInfo parameter, bool includeType)
+        {
+            if (parameter.IsOut)
+            {
+                yield return "out ";
+            }
+            else if (parameter.ParameterType.IsByRef)
+            {
+                yield return "ref ";
+            }
+            if (includeType)
+            {
+                if (parameter.IsDefined(typeof(ParamArrayAttribute)))
+                {
+                    yield return "params ";
+                }
+                yield return parameter.ParameterType.GetFullName();
+                yield return " ";
+            }
+            yield return parameter.Name;
+
+            // GH-1166; add support for specifying default parameter values
+            if (includeType && parameter.IsOptional)
+            {
+                yield return " = ";
+                yield return BuildDefaultParameterValueToken(parameter);
+            }
+        }
+
+        private static string BuildDefaultParameterValueToken(ParameterInfo parameter)
+        {
+            var type = parameter.ParameterType;
+            var value = parameter.RawDefaultValue;
+
+            // this addresses the issue seen in Mono where both RawDefaultValue and DefaultValue
+            // return System.Reflection.Missing when parameter type is Nullable<decimal>
+            if (value is Missing && type == typeof(decimal?))
+            {
+                var attr = parameter.GetCustomAttribute(typeof(DecimalConstantAttribute)) as DecimalConstantAttribute;
+                if (attr != null)
+                {
+                    value = attr.Value;
+                }
+            }
+
+            // if the default value is null, just return the literal "null"
+            if (value == null)
+            {
+                return "null";
+            }
+
+            if (type.IsSubclassOfRawGeneric(typeof(Nullable<>)))
+            {
+                // this is really only needing to account for char? and bool?
+                // unwrap the type and use the same logic as non-nullable by calling the BuildParameterValueToken method
+                var innerType = Nullable.GetUnderlyingType(type);
+                return $"({innerType.GetFullName()}){BuildParameterValueToken(innerType, value)}";
+            }
+
+            if (typeof(Enum).IsAssignableFrom(type) || IsNumeric(type))
+            {
+                // this works around an issue in Mono where the value coming from RawDefaultValue
+                // or DefaultValue will print as EnumValue instead of the underlying numeric.
+                // arguably, this may be the more correct implementation.
+                if (typeof(Enum).IsAssignableFrom(type))
+                {
+                    value = (int)value;
+                }
+
+                // nullable numerics are handled in the previous block, so just cast it and use the value.
+                return $"({type.GetFullName()}){value}";
+            }
+
+            // if it's not a special case, just pass the call
+            return BuildParameterValueToken(type, value);
+        }
+
+        private static string BuildParameterValueToken(Type type, object value)
+        {
+            if (type == typeof(bool))
+            {
+                return value.ToString().ToLower();
+            }
+
+            if (type == typeof(string))
+            {
+                // fix quotes, wrap string in quotes
+                var s = ((string)value).Replace("\"", "\\\"");
+                return $"\"{s}\"";
+            }
+
+            if (type == typeof(char))
+            {
+                return $"'{value}'";
+            }
+
+            return value.ToString();
+        }
+
+        private static readonly HashSet<Type> _numericTypes = new HashSet<Type>
+        {
+            typeof(int),  typeof(double),  typeof(decimal),
+            typeof(long), typeof(short),   typeof(sbyte),
+            typeof(byte), typeof(ulong),   typeof(ushort),
+            typeof(uint), typeof(float)
+        };
+
+        private static bool IsNumeric(Type myType)
+        {
+            return _numericTypes.Contains(myType);
+        }
+    }
+}


### PR DESCRIPTION
@devlead 

Here is a PR for review to address GH-1166, refactoring the parameter concerns in the method alias tokenizer to support optional params.

I have added a reasonable cover of tests to prove this out, but it is not exhaustive - it does not cover all numerics, etc., but it does cover what I would consider to be the trickier of cases concerning Nullable<T> and so forth.

There are probably a couple of places where the generated code could be cleaned up for brevity, but as a first pass, I opted to be explicit, particularly in light of the fact that this isn't code that needs to be readable/maintainable, and the emphasis should be on being explicit for the sake of operability.

Happy to re-work or expand test-coverage as it might be deemed necessary.. I'm not saying "don't merge", but I think this addition warrants any extra attention we might want to give it.
