### PR TITLE
GHXXX: Adds XmlPath for DotNetCoreTest

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Test/DotNetCoreTesterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Test/DotNetCoreTesterTests.cs
@@ -113,12 +113,13 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Test
                 fixture.Settings.Runtime = "runtime1";
                 fixture.Settings.Configuration = "Release";
                 fixture.Settings.OutputDirectory = "./artifacts/";
+                fixture.Settings.XmlPath = "./artifacts/testResults.xml";
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("test --output \"/Working/artifacts\" --build-base-path \"/Working/temp\" --runtime runtime1 --framework dnxcore50 --configuration Release --no-build", result.Args);
+                Assert.Equal("test --output \"/Working/artifacts\" --build-base-path \"/Working/temp\" --runtime runtime1 --framework dnxcore50 --configuration Release --no-build -xml \"/Working/artifacts/testResults.xml\"", result.Args);
             }
         }
     }

--- a/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTestSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTestSettings.cs
@@ -22,6 +22,11 @@ namespace Cake.Common.Tools.DotNetCore.Test
         public DirectoryPath OutputDirectory { get; set; }
 
         /// <summary>
+        /// Gets or sets the XML output file
+        /// </summary>
+        public FilePath XmlPath { get; set; }
+
+        /// <summary>
         /// Gets or sets the target runtime.
         /// </summary>
         public string Runtime { get; set; }

--- a/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTester.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTester.cs
@@ -99,6 +99,13 @@ namespace Cake.Common.Tools.DotNetCore.Test
                 builder.Append("--no-build");
             }
 
+            // Xml output for test results
+            if (settings.XmlPath != null)
+            {
+                builder.Append("-xml");
+                builder.AppendQuoted(settings.XmlPath.MakeAbsolute(_environment).FullPath);
+            }
+
             return builder;
         }
     }


### PR DESCRIPTION
This pull request adds the support for DotNetCoreTest to specify an output file for test results.


