### PR TITLE
GH-670: XUnit2 x86 support added.

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/XUnit2RunnerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/XUnit2RunnerFixture.cs
@@ -19,6 +19,11 @@ namespace Cake.Common.Tests.Fixtures.Tools
             AssemblyPaths = new FilePath[] { "./Test1.dll" };
         }
 
+        public XUnit2RunnerFixture(string toolFileName) : base(toolFileName)
+        {
+            AssemblyPaths = new FilePath[] { "./Test1.dll" };
+        }
+
         protected override void RunTool()
         {
             var runner = new XUnit2Runner(FileSystem, Environment, ProcessRunner, Tools);

--- a/src/Cake.Common.Tests/Unit/Tools/XUnit/XUnit2RunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/XUnit/XUnit2RunnerTests.cs
@@ -92,6 +92,35 @@ namespace Cake.Common.Tests.Unit.Tools.XUnit
             }
 
             [Fact]
+            public void Should_Throw_If_XUnit_X86_Flag_Is_Not_Set_To_True()
+            {
+                // Given
+                var fixture = new XUnit2RunnerFixture("xunit.console.x86.exe");
+                fixture.Settings.UseX86 = false;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("xUnit.net (v2): Could not locate executable.", result?.Message);
+            }
+
+            [Fact]
+            public void Should_Find_XUnit_X86_Runner_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new XUnit2RunnerFixture("xunit.console.x86.exe");
+                fixture.Settings.UseX86 = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/Working/tools/xunit.console.x86.exe", result.Path.FullPath);
+            }
+
+            [Fact]
             public void Should_Use_Provided_Assembly_Path_In_Process_Arguments()
             {
                 // Given

--- a/src/Cake.Common.Tests/Unit/Tools/XUnit/XUnit2SettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/XUnit/XUnit2SettingsTests.cs
@@ -121,6 +121,16 @@ namespace Cake.Common.Tests.Unit.Tools.XUnit
                 // Then
                 Assert.Empty(settings.TraitsToExclude);
             }
+
+            [Fact]
+            public void Should_Set_UseX86_To_False_By_Default()
+            {
+                // Given, When
+                var settings = new XUnit2Settings();
+
+                // Then
+                Assert.False(settings.UseX86);
+            }
         }
     }
 }

--- a/src/Cake.Common/Tools/XUnit/XUnit2Runner.cs
+++ b/src/Cake.Common/Tools/XUnit/XUnit2Runner.cs
@@ -17,6 +17,7 @@ namespace Cake.Common.Tools.XUnit
     public sealed class XUnit2Runner : Tool<XUnit2Settings>
     {
         private readonly ICakeEnvironment _environment;
+        private bool _useX86;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="XUnit2Runner" /> class.
@@ -66,7 +67,7 @@ namespace Cake.Common.Tools.XUnit
                     throw new CakeException("Cannot generate NUnit XML report when no output directory has been set.");
                 }
             }
-
+            _useX86 = settings.UseX86;
             var assemblies = assemblyPaths as FilePath[] ?? assemblyPaths.ToArray();
             Run(settings, GetArguments(assemblies, settings));
         }
@@ -175,7 +176,7 @@ namespace Cake.Common.Tools.XUnit
         /// <returns>The tool executable name.</returns>
         protected override IEnumerable<string> GetToolExecutableNames()
         {
-            return new[] { "xunit.console.exe" };
+            return _useX86 ? new[] { "xunit.console.x86.exe" } : new[] { "xunit.console.exe" };
         }
     }
 }

--- a/src/Cake.Common/Tools/XUnit/XUnit2Settings.cs
+++ b/src/Cake.Common/Tools/XUnit/XUnit2Settings.cs
@@ -78,6 +78,14 @@ namespace Cake.Common.Tools.XUnit
         public ParallelismOption Parallelism { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to run tests in using x86 test runner.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> to run tests with the x86 test runner; otherwise, <c>false</c>.
+        /// </value>
+        public bool UseX86 { get; set; }
+
+        /// <summary>
         /// Gets or sets the maximum thread count for collection parallelization.
         /// </summary>
         /// <value>


### PR DESCRIPTION
x86 setting was added to XUnit2Settings to support the ability to use the x86 version of the tool.  The simplest solution was implemented and tests where added to cover the changes.