### PR TITLE
GH-1342 - Unkown Token when directory contains @

### DIFF
--- a/src/Cake.Core.Tests/Fixtures/GlobberFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/GlobberFixture.cs
@@ -48,6 +48,7 @@ namespace Cake.Core.Tests.Fixtures
             FileSystem.CreateFile("C:/Tools + Services/MyTool.dll");
             FileSystem.CreateFile("C:/Some %2F Directory/MyTool.dll");
             FileSystem.CreateFile("C:/Some ! Directory/MyTool.dll");
+            FileSystem.CreateFile("C:/Some@Directory/MyTool.dll");
         }
 
         private void PrepareUnixFixture()
@@ -62,6 +63,7 @@ namespace Cake.Core.Tests.Fixtures
             FileSystem.CreateDirectory("/Working/Bar");
             FileSystem.CreateDirectory("/Foo/Bar");
             FileSystem.CreateDirectory("/Foo (Bar)");
+            FileSystem.CreateDirectory("/Foo@Bar/");
 
             // Files
             FileSystem.CreateFile("/Working/Foo/Bar/Qux.c");
@@ -76,6 +78,7 @@ namespace Cake.Core.Tests.Fixtures
             FileSystem.CreateFile("/Working/Quz.FooTest.dll");
             FileSystem.CreateFile("/Foo/Bar.baz");
             FileSystem.CreateFile("/Foo (Bar)/Baz.c");
+            FileSystem.CreateFile("/Foo@Bar/Baz.c");
         }
 
         public void SetWorkingDirectory(DirectoryPath path)

--- a/src/Cake.Core.Tests/Unit/IO/GlobberTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/GlobberTests.cs
@@ -156,6 +156,20 @@ namespace Cake.Core.Tests.Unit.IO
                     Assert.Equal(1, result.Length);
                     Assert.ContainsFilePath(result, "C:/Some ! Directory/MyTool.dll");
                 }
+
+                [WindowsFact]
+                public void Should_Parse_Glob_Expressions_With_AtSign_In_Them()
+                {
+                    // Given
+                    var fixture = new GlobberFixture(windows: true);
+
+                    // When
+                    var result = fixture.Match("C:/Some@Directory/*.dll");
+
+                    // Then
+                    Assert.Equal(1, result.Length);
+                    Assert.ContainsFilePath(result, "C:/Some@Directory/MyTool.dll");
+                }
             }
 
             public sealed class WithPredicate
@@ -534,6 +548,20 @@ namespace Cake.Core.Tests.Unit.IO
                 // Then
                 Assert.Equal(1, result.Length);
                 Assert.ContainsFilePath(result, "/Foo (Bar)/Baz.c");
+            }
+
+            [Fact]
+            public void Should_Parse_Glob_Expressions_With_AtSign_In_Them()
+            {
+                // Given
+                var fixture = new GlobberFixture();
+
+                // When
+                var result = fixture.Match("/Foo@Bar/Baz.*");
+
+                // Then
+                Assert.Equal(1, result.Length);
+                Assert.ContainsFilePath(result, "/Foo@Bar/Baz.c");
             }
 
             [Fact]

--- a/src/Cake.Core/IO/Globbing/GlobTokenizer.cs
+++ b/src/Cake.Core/IO/Globbing/GlobTokenizer.cs
@@ -27,7 +27,7 @@ namespace Cake.Core.IO.Globbing
             _sourceIndex = 0;
             _currentContent = string.Empty;
             _currentCharacter = _pattern[_sourceIndex];
-            _identifierRegex = new Regex("^[0-9a-zA-Z\\+&%!(). _-]$", RegexOptions.Compiled);
+            _identifierRegex = new Regex("^[0-9a-zA-Z\\+&%!@(). _-]$", RegexOptions.Compiled);
         }
 
         public GlobToken Scan()


### PR DESCRIPTION
Affects Windows and *nix environments.

- Added @ into `_identifierRegex`.
- Added Unit Tests
    - WindowsFact: Should_Parse_Glob_Expressions_With_AtSign_In_Them()
    - Fact: Should_Parse_Glob_Expressions_With_AtSign_In_Them()