### PR TITLE
GH1344: addin-path: Use relative default path

### DIFF
--- a/src/Cake.Core.Tests/Unit/Scripting/ScriptRunnerTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/ScriptRunnerTests.cs
@@ -319,7 +319,7 @@ namespace Cake.Core.Tests.Unit.Scripting
                 // Then
                 fixture.ScriptProcessor.Received(1).InstallAddins(
                     Arg.Any<ScriptAnalyzerResult>(),
-                    Arg.Is<DirectoryPath>(path => path.FullPath == "/Working/Addins"));
+                    Arg.Is<DirectoryPath>(path => path.FullPath == "/Working/tools/Addins"));
             }
 
             [Fact]

--- a/src/Cake.Core/Scripting/ScriptRunner.cs
+++ b/src/Cake.Core/Scripting/ScriptRunner.cs
@@ -138,8 +138,7 @@ namespace Cake.Core.Scripting
             _processor.InstallTools(result, toolsPath);
 
             // Install addins.
-            var applicationRoot = _environment.ApplicationRoot;
-            var addinRoot = GetAddinPath(applicationRoot);
+            var addinRoot = GetAddinPath(scriptPath.GetDirectory());
             var addinReferences = _processor.InstallAddins(result, addinRoot);
             foreach (var addinReference in addinReferences)
             {
@@ -150,6 +149,7 @@ namespace Cake.Core.Scripting
             var session = _engine.CreateSession(host, arguments);
 
             // Load all references.
+            var applicationRoot = _environment.ApplicationRoot;
             var assemblies = new HashSet<Assembly>();
             assemblies.AddRange(_conventions.GetDefaultAssemblies(applicationRoot));
 
@@ -212,7 +212,7 @@ namespace Cake.Core.Scripting
             return root.Combine("tools");
         }
 
-        private DirectoryPath GetAddinPath(DirectoryPath applicationRoot)
+        private DirectoryPath GetAddinPath(DirectoryPath root)
         {
             var addinPath = _configuration.GetValue(Constants.Paths.Addins);
             if (!string.IsNullOrWhiteSpace(addinPath))
@@ -220,7 +220,8 @@ namespace Cake.Core.Scripting
                 return new DirectoryPath(addinPath).MakeAbsolute(_environment);
             }
 
-            return applicationRoot.Combine("../Addins").Collapse();
+            var toolPath = GetToolPath(root);
+            return toolPath.Combine("Addins").Collapse();
         }
     }
 }

--- a/src/Cake/Constants.cs
+++ b/src/Cake/Constants.cs
@@ -13,6 +13,8 @@ namespace Cake
 
         public static class Paths
         {
+            public const string Tools = "Paths_Tools";
+
             public const string Modules = "Paths_Modules";
         }
     }


### PR DESCRIPTION
The default path that is used for addin installation is being constructed
by using the application root. This is not the propagated default behavior
on the website. Let's use the relative path `./tools/addins` as default.

This fixes (GH-1344)

---

It turned out that only the default of the addins installation folder was affected.