### PR TITLE
GH-1349: OctoPack not passing --format to octo.exe

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctoPackTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctoPackTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Cake.Common.Tests.Fixtures.Tools;
+using Cake.Common.Tools.OctopusDeploy;
 using Xunit;
 
 namespace Cake.Common.Tests.Unit.Tools.OctopusDeploy
@@ -190,6 +191,21 @@ namespace Cake.Common.Tests.Unit.Tools.OctopusDeploy
 
                 // Then
                 Assert.Equal("pack --id MyPackage --overwrite", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Format_To_Arguments_If_Zip()
+            {
+               // Given
+               var fixture = new OctopusDeployPackerFixture();
+               fixture.Id = "MyPackage";
+               fixture.Settings.Format = OctopusPackFormat.Zip;
+
+               // When
+               var result = fixture.Run();
+
+               // Then
+               Assert.Equal("pack --id MyPackage --format Zip", result.Args);
             }
         }
     }

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployPacker.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployPacker.cs
@@ -124,6 +124,11 @@ namespace Cake.Common.Tools.OctopusDeploy
                 builder.Append("--overwrite");
             }
 
+            if (settings.Format == OctopusPackFormat.Zip)
+            {
+                builder.AppendSwitch("--format", "Zip");
+            }
+
             return builder;
         }
     }


### PR DESCRIPTION
Updated OctopusDeployPacker to include the --format switch if the Format property is set to OctopackFormat.Zip. If OctopusDeployPacker.NuPkg is set, then the switch is not added and uses the default format by octo.exe.