### PR TITLE
GH1352: add support for global namespace imports at the assembly level

### DIFF
--- a/src/Cake.Core.Tests/Unit/Annotations/CakeNamespaceImportAttributeTests.cs
+++ b/src/Cake.Core.Tests/Unit/Annotations/CakeNamespaceImportAttributeTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Reflection;
 using Cake.Core.Annotations;
 using Xunit;
 
@@ -19,6 +21,38 @@ namespace Cake.Core.Tests.Unit.Annotations
 
                 // Then
                 Assert.IsArgumentNullException(result, "namespace");
+            }
+        }
+
+        public sealed class TheType
+        {
+            private readonly AttributeUsageAttribute _attributeUsage;
+
+            public TheType()
+            {
+                // Given, When
+                _attributeUsage = (AttributeUsageAttribute)typeof(CakeNamespaceImportAttribute).GetTypeInfo().GetCustomAttribute(typeof(AttributeUsageAttribute));
+            }
+
+            [Fact]
+            public void Should_Be_Able_To_Target_Method()
+            {
+                // Then
+                Assert.True(_attributeUsage.ValidOn.HasFlag(AttributeTargets.Method));
+            }
+
+            [Fact]
+            public void Should_Be_Able_To_Target_Class()
+            {
+                // Then
+                Assert.True(_attributeUsage.ValidOn.HasFlag(AttributeTargets.Class));
+            }
+
+            [Fact]
+            public void Should_Be_Able_To_Target_Assembly()
+            {
+                // Then
+                Assert.True(_attributeUsage.ValidOn.HasFlag(AttributeTargets.Assembly));
             }
         }
     }

--- a/src/Cake.Core/Annotations/CakeNamespaceImportAttribute.cs
+++ b/src/Cake.Core/Annotations/CakeNamespaceImportAttribute.cs
@@ -9,9 +9,9 @@ namespace Cake.Core.Annotations
     /// <summary>
     /// An attribute used to hint Cake about additional namespaces that need
     /// to be imported for an alias to work. This attribute can mark an
-    /// extension method or the extension method class.
+    /// extension method, the extension method class, or the assembly to provide a global set of imports
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
     public sealed class CakeNamespaceImportAttribute : Attribute
     {
         /// <summary>

--- a/src/Cake.Core/Scripting/ScriptAliasFinder.cs
+++ b/src/Cake.Core/Scripting/ScriptAliasFinder.cs
@@ -123,6 +123,13 @@ namespace Cake.Core.Scripting
                     namespaces.Add(namespaceAttribute.Namespace);
                 }
 
+                // Find out if the assembly has been decorated with any more namespaces
+                namespaceAttributes = method.DeclaringType.GetTypeInfo().Assembly.GetCustomAttributes<CakeNamespaceImportAttribute>();
+                foreach (var namespaceAttribute in namespaceAttributes)
+                {
+                    namespaces.Add(namespaceAttribute.Namespace);
+                }
+
                 return new ScriptAlias(method, type, namespaces);
             }
             catch (Exception ex)


### PR DESCRIPTION
This addresses GH-1352.  Changes opens the `CakeNamespaceImportAttribute` up to be applied at the assembly level and extends the logic in `ScriptAliasFinder` to import namespaces declared for import at the assembly level.