### PR TITLE
GH1363: Wixheat pog fix

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/WiX/HeatRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/WiX/HeatRunnerTests.cs
@@ -444,7 +444,7 @@ namespace Cake.Common.Tests.Unit.Tools.WiX
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("dir \"/Working/src/Cake\" -pog: binaries -out \"/Working/cake.wxs\"", result.Args);
+                Assert.Equal("dir \"/Working/src/Cake\" -pog Binaries -out \"/Working/cake.wxs\"", result.Args);
             }
 
             [Fact]
@@ -458,7 +458,7 @@ namespace Cake.Common.Tests.Unit.Tools.WiX
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("dir \"/Working/src/Cake\" -pog: symbols -out \"/Working/cake.wxs\"", result.Args);
+                Assert.Equal("dir \"/Working/src/Cake\" -pog Symbols -out \"/Working/cake.wxs\"", result.Args);
             }
 
             [Fact]
@@ -472,21 +472,21 @@ namespace Cake.Common.Tests.Unit.Tools.WiX
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("dir \"/Working/src/Cake\" -pog: documents -out \"/Working/cake.wxs\"", result.Args);
+                Assert.Equal("dir \"/Working/src/Cake\" -pog Documents -out \"/Working/cake.wxs\"", result.Args);
             }
 
             [Fact]
-            public void Should_Add_Satallites_Output_Group_To_Arguments_If_Provided()
+            public void Should_Add_Satellites_Output_Group_To_Arguments_If_Provided()
             {
                 // Given
                 var fixture = new HeatFixture();
-                fixture.Settings.OutputGroup = WiXOutputGroupType.Satallites;
+                fixture.Settings.OutputGroup = WiXOutputGroupType.Satellites;
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("dir \"/Working/src/Cake\" -pog: satallites -out \"/Working/cake.wxs\"", result.Args);
+                Assert.Equal("dir \"/Working/src/Cake\" -pog Satellites -out \"/Working/cake.wxs\"", result.Args);
             }
 
             [Fact]
@@ -500,7 +500,7 @@ namespace Cake.Common.Tests.Unit.Tools.WiX
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("dir \"/Working/src/Cake\" -pog: sources -out \"/Working/cake.wxs\"", result.Args);
+                Assert.Equal("dir \"/Working/src/Cake\" -pog Sources -out \"/Working/cake.wxs\"", result.Args);
             }
 
             [Fact]
@@ -514,7 +514,7 @@ namespace Cake.Common.Tests.Unit.Tools.WiX
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("dir \"/Working/src/Cake\" -pog: content -out \"/Working/cake.wxs\"", result.Args);
+                Assert.Equal("dir \"/Working/src/Cake\" -pog Content -out \"/Working/cake.wxs\"", result.Args);
             }
 
             [Fact]

--- a/src/Cake.Common/Tools/WiX/Heat/HeatRunner.cs
+++ b/src/Cake.Common/Tools/WiX/Heat/HeatRunner.cs
@@ -264,26 +264,26 @@ namespace Cake.Common.Tools.WiX.Heat
 
             if (settings.OutputGroup != null)
             {
-                builder.Append("-pog:");
+                builder.Append("-pog");
                 switch (settings.OutputGroup)
                 {
                     case WiXOutputGroupType.Binaries:
-                        builder.Append("binaries");
+                        builder.Append("Binaries");
                         break;
                     case WiXOutputGroupType.Symbols:
-                        builder.Append("symbols");
+                        builder.Append("Symbols");
                         break;
                     case WiXOutputGroupType.Documents:
-                        builder.Append("documents");
+                        builder.Append("Documents");
                         break;
-                    case WiXOutputGroupType.Satallites:
-                        builder.Append("satallites");
+                    case WiXOutputGroupType.Satellites:
+                        builder.Append("Satellites");
                         break;
                     case WiXOutputGroupType.Sources:
-                        builder.Append("sources");
+                        builder.Append("Sources");
                         break;
                     case WiXOutputGroupType.Content:
-                        builder.Append("content");
+                        builder.Append("Content");
                         break;
                 }
             }

--- a/src/Cake.Common/Tools/WiX/Heat/WiXOutputGroupType.cs
+++ b/src/Cake.Common/Tools/WiX/Heat/WiXOutputGroupType.cs
@@ -25,9 +25,9 @@ namespace Cake.Common.Tools.WiX.Heat
         Documents = 2,
 
         /// <summary>
-        /// OutputGroup: <c>Satallites</c>
+        /// OutputGroup: <c>Satellites</c>
         /// </summary>
-        Satallites = 3,
+        Satellites = 3,
 
         /// <summary>
         /// OutputGroup: <c>Sources</c>


### PR DESCRIPTION
Fixes three issues, each of which completely prevented the parameter from working (at least with WiX 3.10):

 * `-pog: x` causes Heat to not associate `x` with `-pog` and instead sets `-pog` to an empty string, giving:
   ```
   warning HEAT1108 : The command line switch 'pog:' is deprecated. Please use 'pog' instead.
   error HEAT5301 : Invalid project output group: .
   ```
    Since the colon is deprecated anyway, I changed it simply to `-pog x`.
 * `-pog binaries` causes `error HEAT5301 : Invalid project output group: binaries.`, where as `-pog Binaries` works. All output group names were capitalized.
 * `Satallites` is also not recognized by Heat since it is misspelled. I also renamed the enum which is a breaking change to anyone using that value. (I suspect that number is negligible due to the fact that the parameter cannot currently be used without erroring Heat.)