### PR TITLE
Fix doc comments in InnoSetupAliases

### DIFF
--- a/src/Cake.Common/Tools/InnoSetup/InnoSetupAliases.cs
+++ b/src/Cake.Common/Tools/InnoSetup/InnoSetupAliases.cs
@@ -24,7 +24,7 @@ namespace Cake.Common.Tools.InnoSetup
         /// Compiles the given Inno Setup script using the default settings.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="scriptFile">The path to the <c>.nsi</c> script file to compile.</param>
+        /// <param name="scriptFile">The path to the <c>.iss</c> script file to compile.</param>
         /// <example>
         /// <code>
         /// InnoSetup("./src/Cake.iss");
@@ -40,7 +40,7 @@ namespace Cake.Common.Tools.InnoSetup
         /// Compiles the given Inno Setup script using the given <paramref name="settings"/>.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="scriptFile">The path to the <c>.nsi</c> script file to compile.</param>
+        /// <param name="scriptFile">The path to the <c>.iss</c> script file to compile.</param>
         /// <param name="settings">The <see cref="InnoSetupSettings"/> to use.</param>
         /// <example>
         /// <code>


### PR DESCRIPTION
The comments were referring to the ".nsi" script file, which is the extension for NSIS, instead of ".iss", which is the extension for InnoSetup.