### PR TITLE
GH1394: Add path comparer property to CakeEnvironment

### DIFF
--- a/src/Cake.Core.Tests/Unit/CakeEnvironmentTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeEnvironmentTests.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Testing;
+using Xunit;
+
+namespace Cake.Core.Tests.Unit
+{
+    public sealed class CakeEnvironmentTests
+    {
+        public sealed class ThePathComparerProperty
+        {
+            [Theory]
+            [InlineData(PlatformFamily.Windows, false)]
+            [InlineData(PlatformFamily.Linux, true)]
+            [InlineData(PlatformFamily.OSX, true)]
+            [InlineData(PlatformFamily.Unknown, false)]
+            public void Should_Return_Environment_Specific_PathComparer(PlatformFamily family, bool isCaseSensitive)
+            {
+                // Given
+                var environment = new CakeEnvironment(new FakePlatform(family), new FakeRuntime(), new FakeLog());
+
+                // When
+                var pathComparer = environment.PathComparer;
+
+                // Then
+                Assert.Equal(isCaseSensitive, pathComparer.IsCaseSensitive);
+            }
+        }
+    }
+}

--- a/src/Cake.Core/CakeEnvironment.cs
+++ b/src/Cake.Core/CakeEnvironment.cs
@@ -48,6 +48,12 @@ namespace Cake.Core
         public ICakeRuntime Runtime { get; }
 
         /// <summary>
+        /// Gets the environment specific path comparer.
+        /// </summary>
+        /// <value>The environment specific path comparer.</value>
+        public PathComparer PathComparer { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="CakeEnvironment" /> class.
         /// </summary>
         /// <param name="platform">The platform.</param>
@@ -57,6 +63,7 @@ namespace Cake.Core
         {
             Platform = platform;
             Runtime = runtime;
+            PathComparer = new PathComparer(this);
             _log = log;
 
             // Get the application root.

--- a/src/Cake.Core/ICakeEnvironment.cs
+++ b/src/Cake.Core/ICakeEnvironment.cs
@@ -59,6 +59,12 @@ namespace Cake.Core
         ICakeRuntime Runtime { get; }
 
         /// <summary>
+        /// Gets the environment specific path comparer.
+        /// </summary>
+        /// <value>The environment specific path comparer.</value>
+        PathComparer PathComparer { get; }
+
+        /// <summary>
         /// Gets whether or not the current operative system is 64 bit.
         /// </summary>
         /// <returns>Whether or not the current operative system is 64 bit.</returns>

--- a/src/Cake.Testing/FakeEnvironment.cs
+++ b/src/Cake.Testing/FakeEnvironment.cs
@@ -56,6 +56,12 @@ namespace Cake.Testing
         public FakeRuntime Runtime { get; }
 
         /// <summary>
+        /// Gets the environment specific path comparer.
+        /// </summary>
+        /// <value>The environment specific path comparer.</value>
+        public PathComparer PathComparer { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="FakeEnvironment"/> class.
         /// </summary>
         /// <param name="family">The platform family.</param>
@@ -64,6 +70,7 @@ namespace Cake.Testing
         {
             Platform = new FakePlatform(family, is64Bit);
             Runtime = new FakeRuntime();
+            PathComparer = new PathComparer(this);
             _environmentVariables = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             _specialPaths = new Dictionary<SpecialPath, DirectoryPath>();
         }


### PR DESCRIPTION
The cake environment now contains an extra property that can be used to
directly access the environment specific path comparer. In a cake script
somebody would simply access the property via the context.

    var files = GetFiles(./**/*.*)
    var filtered = files.Distinct( Conext.Environment.PathComparer);

This fixes (GH-1394)