### PR TITLE
GH1399: Adds support for TF Build command messages

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Build/TFBuildFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/TFBuildFixture.cs
@@ -4,6 +4,8 @@
 
 using Cake.Common.Build.TFBuild;
 using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Testing;
 using NSubstitute;
 
 namespace Cake.Common.Tests.Fixtures.Build
@@ -11,12 +13,14 @@ namespace Cake.Common.Tests.Fixtures.Build
     internal sealed class TFBuildFixture
     {
         public ICakeEnvironment Environment { get; set; }
+        public FakeLog Log { get; set; }
 
         public TFBuildFixture()
         {
             Environment = Substitute.For<ICakeEnvironment>();
             Environment.WorkingDirectory.Returns("C:\\build\\CAKE-CAKE-JOB1");
             Environment.GetEnvironmentVariable("TF_BUILD").Returns((string)null);
+            Log = new FakeLog();
         }
 
         public void IsRunningOnVSTS()
@@ -33,7 +37,7 @@ namespace Cake.Common.Tests.Fixtures.Build
 
         public TFBuildProvider CreateTFBuildService()
         {
-            return new TFBuildProvider(Environment);
+            return new TFBuildProvider(Environment, Log);
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Build/TFBuild/TFBuildCommandTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TFBuild/TFBuildCommandTests.cs
@@ -1,0 +1,380 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Common.Build.TFBuild;
+using Cake.Common.Build.TFBuild.Data;
+using Cake.Common.Tests.Fixtures.Build;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using Cake.Testing;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Build.TFBuild
+{
+    public sealed class TFBuildCommandTests
+    {
+        public sealed class TheConstructor
+        {
+            [Fact]
+            public void Should_Throw_If_Environment_Is_Null()
+            {
+                // Given, When
+                var result = Record.Exception(() => new TFBuildCommands(null, new NullLog()));
+
+                // Then
+                Assert.IsArgumentNullException(result, "environment");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Log_Is_Null()
+            {
+                // Given, When
+                var result = Record.Exception(() => new TFBuildCommands(new FakeEnvironment(PlatformFamily.Unknown), null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "log");
+            }
+        }
+
+        public sealed class TheCommands
+        {
+            [Fact]
+            public void Should_Not_Be_Null()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+
+                // When
+                var service = fixture.CreateTFBuildService();
+
+                // Then
+                Assert.NotNull(service.Commands);
+            }
+
+            [Theory]
+            [InlineData("warning")]
+            [InlineData("message")]
+            public void Should_Log_Warning_Message(string msg)
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+
+                // When
+                service.Commands.WriteWarning(msg);
+
+                // Then
+                Assert.Contains(fixture.Log.Entries, m => m.Message == $"##vso[task.logissue type=warning;]{msg}");
+            }
+
+            [Fact]
+            public void Should_Log_Warning_Message_With_Data()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+
+                // When
+                service.Commands.WriteWarning("build warning", new TFBuildMessageData
+                {
+                    SourcePath = "./code file.cs",
+                    LineNumber = 5,
+                    ColumnNumber = 12,
+                    ErrorCode = 9
+                });
+
+                // Then
+                Assert.Contains(fixture.Log.Entries, m => m.Message == $"##vso[task.logissue sourcepath=./code file.cs;linenumber=5;columnnumber=12;code=9;type=warning;]build warning");
+            }
+
+            [Theory]
+            [InlineData("error")]
+            [InlineData("message")]
+            public void Should_Log_Error_Message(string msg)
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+
+                // When
+                service.Commands.WriteError(msg);
+
+                // Then
+                Assert.Contains(fixture.Log.Entries, m => m.Message == $"##vso[task.logissue type=error;]{msg}");
+            }
+
+            [Fact]
+            public void Should_Log_Error_Message_With_Data()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+
+                // When
+                service.Commands.WriteError("build error", new TFBuildMessageData
+                {
+                    SourcePath = "./code.cs",
+                    LineNumber = 1,
+                    ColumnNumber = 2,
+                    ErrorCode = 3
+                });
+
+                // Then
+                Assert.Contains(fixture.Log.Entries, m => m.Message == $"##vso[task.logissue sourcepath=./code.cs;linenumber=1;columnnumber=2;code=3;type=error;]build error");
+            }
+
+            [Fact]
+            public void Should_Set_Current_Progress()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+
+                // When
+                service.Commands.SetProgress(75, "Testing Provider");
+
+                // Then
+                Assert.Contains(fixture.Log.Entries, m => m.Message == $"##vso[task.setprogress value=75;]Testing Provider");
+            }
+
+            [Fact]
+            public void Should_Complete_Current_Task()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+
+                // When
+                service.Commands.CompleteCurrentTask();
+
+                // Then
+                Assert.Contains(fixture.Log.Entries, m => m.Message == $"##vso[task.complete ]DONE");
+            }
+
+            [Fact]
+            public void Should_Complete_Current_Task_With_Status()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+
+                // When
+                service.Commands.CompleteCurrentTask(TFBuildTaskResult.Failed);
+
+                // Then
+                Assert.Contains(fixture.Log.Entries, m => m.Message == $"##vso[task.complete result=Failed;]DONE");
+            }
+
+            [Fact]
+            public void Should_Create_New_Record()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+
+                // When
+                var guid = service.Commands.CreateNewRecord("New record", "build", 1);
+
+                // Then
+                Assert.NotNull(guid);
+                Assert.Contains(fixture.Log.Entries, m => m.Message == $"##vso[task.logdetail id={guid.ToString()};name=New record;type=build;order=1;]create new timeline record");
+            }
+
+            [Fact]
+            public void Should_Create_New_Record_With_Data()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+                var date = DateTime.UtcNow;
+
+                // When
+                var guid = service.Commands.CreateNewRecord("New record", "build", 2, new TFBuildRecordData
+                {
+                    StartTime = date,
+                    Progress = 75,
+                    Status = TFBuildTaskStatus.Initialized
+                });
+
+                // Then
+                Assert.NotNull(guid);
+                Assert.Contains(fixture.Log.Entries, m => m.Message == $"##vso[task.logdetail starttime={date.ToString()};progress=75;state=Initialized;id={guid.ToString()};name=New record;type=build;order=2;]create new timeline record");
+            }
+
+            [Fact]
+            public void Should_Update_Existing_Record()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+                var guid = Guid.NewGuid();
+                var parent = Guid.NewGuid();
+
+                // When
+                service.Commands.UpdateRecord(guid, new TFBuildRecordData
+                {
+                    Progress = 95,
+                    Status = TFBuildTaskStatus.InProgress,
+                    ParentRecord = parent
+                });
+
+                // Then
+                Assert.Contains(fixture.Log.Entries, m => m.Message == $"##vso[task.logdetail parentid={parent.ToString()};progress=95;state=InProgress;id={guid.ToString()};]update");
+            }
+
+            [Fact]
+            public void Should_Set_Variable()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+
+                // When
+                service.Commands.SetVariable("varname", "VarValue");
+
+                // Then
+                Assert.Contains(fixture.Log.Entries,
+                    m => m.Message == $"##vso[task.setvariable variable=varname;]VarValue");
+            }
+
+            [Fact]
+            public void Should_Set_Secret_Variable()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+
+                // When
+                service.Commands.SetSecretVariable("Secret Variable", "Secret Value");
+
+                // Then
+                Assert.Contains(fixture.Log.Entries, m => m.Message == "##vso[task.setvariable variable=Secret Variable;issecret=true;]Secret Value");
+            }
+
+            [Fact]
+            public void Should_Upload_Task_Summary()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+                var path = FilePath.FromString("./summary.md").MakeAbsolute(fixture.Environment);
+
+                // When
+                service.Commands.UploadTaskSummary("./summary.md");
+
+                // Then
+                Assert.Contains(fixture.Log.Entries, m => m.Message == $"##vso[task.uploadsummary ]{path}");
+            }
+
+            [Fact]
+            public void Should_Upload_Task_Log()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+                var path = FilePath.FromString("./logs/task.log").MakeAbsolute(fixture.Environment);
+
+                // When
+                service.Commands.UploadTaskLogFile("./logs/task.log");
+
+                // Then
+                Assert.Contains(fixture.Log.Entries, m => m.Message == $"##vso[task.uploadfile ]{path}");
+            }
+
+            [Theory]
+            [InlineData("drop", TFBuildArtifactType.Container, "./drop")]
+            [InlineData("artifact", TFBuildArtifactType.FilePath, "./dist/build/artifact.file")]
+            [InlineData("ref", TFBuildArtifactType.GitRef, "895a00ec66af875c1593a7563beb0edee400aba0")]
+            public void Should_Link_Build_Artifacts(string name, TFBuildArtifactType type, string location)
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+
+                // When
+                service.Commands.LinkArtifact(name, type, location);
+
+                // Then
+                Assert.Contains(fixture.Log.Entries,
+                    m => m.Message == $"##vso[artifact.associate artifactname={name};type={type};]{location}");
+            }
+
+            [Fact]
+            public void Should_Upload_To_Container()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+                var path = FilePath.FromString("./dist/package.nupkg").MakeAbsolute(fixture.Environment).FullPath;
+
+                // When
+                service.Commands.UploadArtifact("packages", "./dist/package.nupkg");
+
+                // Then
+                Assert.Contains(fixture.Log.Entries,
+                    m => m.Message == $"##vso[artifact.upload containerfolder=packages;]{path}");
+            }
+
+            [Fact]
+            public void Should_Upload_To_Container_Artifact()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+                var path = FilePath.FromString("./artifacts/results.trx").MakeAbsolute(fixture.Environment).FullPath;
+
+                // When
+                service.Commands.UploadArtifact("tests", "./artifacts/results.trx", "Test Results");
+
+                // Then
+                Assert.Contains(fixture.Log.Entries, m => m.Message == $"##vso[artifact.upload containerfolder=tests;artifactname=Test Results;]{path}");
+            }
+
+            [Fact]
+            public void Should_Upload_Build_Log()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+                var path = FilePath.FromString("./dist/buildlog.txt").MakeAbsolute(fixture.Environment).FullPath;
+
+                // When
+                service.Commands.UploadBuildLogFile("./dist/buildlog.txt");
+
+                // Then
+                Assert.Contains(fixture.Log.Entries, m => m.Message == $"##vso[build.uploadlog ]{path}");
+            }
+
+            [Fact]
+            public void Should_Update_Build_Number()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+
+                // When
+                service.Commands.UpdateBuildNumber("CIBuild_1");
+
+                // Then
+                Assert.Contains(fixture.Log.Entries, m => m.Message == "##vso[build.updatebuildnumber ]CIBuild_1");
+            }
+
+            [Fact]
+            public void Should_Add_Build_Tag()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+
+                // When
+                service.Commands.AddBuildTag("Stable");
+
+                // Then
+                Assert.Contains(fixture.Log.Entries, m => m.Message == "##vso[build.addbuildtag ]Stable");
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Build/TFBuild/TFBuildProviderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TFBuild/TFBuildProviderTests.cs
@@ -4,6 +4,9 @@
 
 using Cake.Common.Build.TFBuild;
 using Cake.Common.Tests.Fixtures.Build;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Testing;
 using Xunit;
 
 namespace Cake.Common.Tests.Unit.Build.TFBuild
@@ -16,10 +19,20 @@ namespace Cake.Common.Tests.Unit.Build.TFBuild
             public void Should_Throw_If_Environment_Is_Null()
             {
                 // Given, When
-                var result = Record.Exception(() => new TFBuildProvider(null));
+                var result = Record.Exception(() => new TFBuildProvider(null, new NullLog()));
 
                 // Then
                 Assert.IsArgumentNullException(result, "environment");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Log_Is_Null()
+            {
+                // Given, When
+                var result = Record.Exception(() => new TFBuildProvider(new FakeEnvironment(PlatformFamily.Unknown), null));
+
+                // Then
+                Assert.IsArgumentNullException(result, "log");
             }
         }
 

--- a/src/Cake.Common/Build/BuildSystemAliases.cs
+++ b/src/Cake.Common/Build/BuildSystemAliases.cs
@@ -55,7 +55,7 @@ namespace Cake.Common.Build
             var bitbucketPipelinesProvider = new BitbucketPipelinesProvider(context.Environment);
             var goCDProvider = new GoCDProvider(context.Environment, context.Log);
             var gitlabCIProvider = new GitLabCIProvider(context.Environment);
-            var tfBuildProvider = new TFBuildProvider(context.Environment);
+            var tfBuildProvider = new TFBuildProvider(context.Environment, context.Log);
             return new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
         }
 

--- a/src/Cake.Common/Build/TFBuild/Data/TFBuildArtifactType.cs
+++ b/src/Cake.Common/Build/TFBuild/Data/TFBuildArtifactType.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Build.TFBuild.Data
+{
+    /// <summary>
+    /// Provides the type of a TF Build artifact.
+    /// </summary>
+    public enum TFBuildArtifactType
+    {
+        /// <summary>
+        /// The container type.
+        /// </summary>
+        Container,
+
+        /// <summary>
+        /// The file path type.
+        /// </summary>
+        FilePath,
+
+        /// <summary>
+        /// The version control path type.
+        /// </summary>
+        VersionControl,
+
+        /// <summary>
+        /// The git reference type.
+        /// </summary>
+        GitRef,
+
+        /// <summary>
+        /// The TFVC label type.
+        /// </summary>
+        TFVCLabel
+    }
+}

--- a/src/Cake.Common/Build/TFBuild/Data/TFBuildMessageData.cs
+++ b/src/Cake.Common/Build/TFBuild/Data/TFBuildMessageData.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Cake.Common.Build.TFBuild.Data
+{
+    /// <summary>
+    /// Provides optional data associated with a TF Build logging message.
+    /// </summary>
+    public sealed class TFBuildMessageData
+    {
+        /// <summary>
+        /// Gets or sets the source file path the message should originate from.
+        /// </summary>
+        /// <value>
+        /// The path of the originating file.
+        /// </value>
+        public string SourcePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the line number the message relates to.
+        /// </summary>
+        /// <value>
+        /// The line number.
+        /// </value>
+        public int? LineNumber { get; set; }
+
+        /// <summary>
+        /// Gets or sets the column number the message relates to.
+        /// </summary>
+        /// <value>
+        /// The column number.
+        /// </value>
+        public int? ColumnNumber { get; set; }
+
+        /// <summary>
+        /// Gets or sets the error code of the warning or error message.
+        /// </summary>
+        /// <value>
+        /// The error code of the warning or error.
+        /// </value>
+        public int? ErrorCode { get; set; }
+
+        internal Dictionary<string, string> GetProperties()
+        {
+            var properties = new Dictionary<string, string>();
+            if (!string.IsNullOrWhiteSpace(SourcePath))
+            {
+                properties.Add("sourcepath", SourcePath);
+            }
+            if (LineNumber.HasValue)
+            {
+                properties.Add("linenumber", LineNumber.ToString());
+            }
+            if (ColumnNumber.HasValue)
+            {
+                properties.Add("columnnumber", ColumnNumber.ToString());
+            }
+            if (ErrorCode.HasValue)
+            {
+                properties.Add("code", ErrorCode.ToString());
+            }
+            return properties;
+        }
+    }
+}

--- a/src/Cake.Common/Build/TFBuild/Data/TFBuildRecordData.cs
+++ b/src/Cake.Common/Build/TFBuild/Data/TFBuildRecordData.cs
@@ -1,0 +1,93 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Cake.Common.Build.TFBuild.Data
+{
+    /// <summary>
+    /// Provides optional data associated with a TF Build timeline record.
+    /// </summary>
+    public sealed class TFBuildRecordData
+    {
+        /// <summary>
+        /// Gets or sets the parent record of a new or existing timeline record.
+        /// </summary>
+        /// <value>
+        /// The ID of the parent record.
+        /// </value>
+        public Guid ParentRecord { get; set; }
+
+        /// <summary>
+        /// Gets or sets the start time of this record.
+        /// </summary>
+        /// <value>
+        /// The start time of this record.
+        /// </value>
+        public DateTime? StartTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the finish time of this record.
+        /// </summary>
+        /// <value>
+        /// The finish time of this record.
+        /// </value>
+        public DateTime? FinishTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the current progress of this record.
+        /// </summary>
+        /// <value>
+        /// The current progress of this record.
+        /// </value>
+        public int? Progress { get; set; }
+
+        /// <summary>
+        /// Gets or sets the current status of this record.
+        /// </summary>
+        /// <value>
+        /// The current status of this record.
+        /// </value>
+        public TFBuildTaskStatus? Status { get; set; }
+
+        /// <summary>
+        /// Gets or sets the result of this record.
+        /// </summary>
+        /// <value>
+        /// The result of this record.
+        /// </value>
+        public TFBuildTaskResult? Result { get; set; }
+
+        internal Dictionary<string, string> GetProperties()
+        {
+            var properties = new Dictionary<string, string>();
+            if (ParentRecord != default(Guid))
+            {
+                properties.Add("parentid", ParentRecord.ToString());
+            }
+            if (StartTime.HasValue)
+            {
+                properties.Add("starttime", StartTime.ToString());
+            }
+            if (FinishTime.HasValue)
+            {
+                properties.Add("finishtime", FinishTime.ToString());
+            }
+            if (Progress.HasValue)
+            {
+                properties.Add("progress", Progress.ToString());
+            }
+            if (Status.HasValue)
+            {
+                properties.Add("state", Status.ToString());
+            }
+            if (Result.HasValue)
+            {
+                properties.Add("result", Result.ToString());
+            }
+            return properties;
+        }
+    }
+}

--- a/src/Cake.Common/Build/TFBuild/Data/TFBuildTaskResult.cs
+++ b/src/Cake.Common/Build/TFBuild/Data/TFBuildTaskResult.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Build.TFBuild.Data
+{
+    /// <summary>
+    /// Provides the result of a TF Build task record.
+    /// </summary>
+    public enum TFBuildTaskResult
+    {
+        /// <summary>
+        /// Succeeded status.
+        /// </summary>
+        Succeeded,
+
+        /// <summary>
+        /// Succeeded with issues status.
+        /// </summary>
+        SucceededWithIssues,
+
+        /// <summary>
+        /// Failed status.
+        /// </summary>
+        Failed,
+
+        /// <summary>
+        /// Cancelled status.
+        /// </summary>
+        Cancelled,
+
+        /// <summary>
+        /// Skipped status.
+        /// </summary>
+        Skipped
+    }
+}

--- a/src/Cake.Common/Build/TFBuild/Data/TFBuildTaskStatus.cs
+++ b/src/Cake.Common/Build/TFBuild/Data/TFBuildTaskStatus.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Build.TFBuild.Data
+{
+    /// <summary>
+    /// Provides the status of a TF Build task record.
+    /// </summary>
+    public enum TFBuildTaskStatus
+    {
+        /// <summary>
+        /// Unknown status.
+        /// </summary>
+        Unknown,
+
+        /// <summary>
+        /// Initialized status.
+        /// </summary>
+        Initialized,
+
+        /// <summary>
+        /// In progress status.
+        /// </summary>
+        InProgress,
+
+        /// <summary>
+        /// Completed status.
+        /// </summary>
+        Completed
+    }
+}

--- a/src/Cake.Common/Build/TFBuild/ITFBuildCommands.cs
+++ b/src/Cake.Common/Build/TFBuild/ITFBuildCommands.cs
@@ -1,0 +1,176 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Common.Build.TFBuild.Data;
+using Cake.Core.IO;
+
+namespace Cake.Common.Build.TFBuild
+{
+    /// <summary>
+    /// Represents a TF Build command provider.
+    /// </summary>
+    public interface ITFBuildCommands
+    {
+        /// <summary>
+        /// Log a warning issue to timeline record of current task.
+        /// </summary>
+        /// <param name="message">The warning message.</param>
+        void WriteWarning(string message);
+
+        /// <summary>
+        /// Log a warning issue with detailed data to timeline record of current task.
+        /// </summary>
+        /// <param name="message">The warning message.</param>
+        /// <param name="data">The message data.</param>
+        void WriteWarning(string message, TFBuildMessageData data);
+
+        /// <summary>
+        /// Log an error to timeline record of current task.
+        /// </summary>
+        /// <param name="message">The error message.</param>
+        void WriteError(string message);
+
+        /// <summary>
+        /// Log an error with detailed data to timeline record of current task.
+        /// </summary>
+        /// <param name="message">The error message.</param>
+        /// <param name="data">The message data.</param>
+        void WriteError(string message, TFBuildMessageData data);
+
+        /// <summary>
+        /// Set progress and current operation for current task.
+        /// </summary>
+        /// <param name="progress">Current progress as percentage.</param>
+        /// <param name="currentOperation">The current operation.</param>
+        void SetProgress(int progress, string currentOperation);
+
+        /// <summary>
+        /// Finish timeline record for current task and set task result to succeeded.
+        /// </summary>
+        void CompleteCurrentTask();
+
+        /// <summary>
+        /// Finish timeline record for current task and set task result.
+        /// </summary>
+        /// <param name="result">The task result status.</param>
+        void CompleteCurrentTask(TFBuildTaskResult result);
+
+        /// <summary>
+        /// Create detail timeline record.
+        /// </summary>
+        /// <param name="name">Name of the new timeline record.</param>
+        /// <param name="type">Type of the new timeline record.</param>
+        /// <param name="order">Order of the timeline record.</param>
+        /// <returns>The timeline record ID.</returns>
+        Guid CreateNewRecord(string name, string type, int order);
+
+        /// <summary>
+        /// Create detail timeline record.
+        /// </summary>
+        /// <param name="name">Name of the new timeline record.</param>
+        /// <param name="type">Type of the new timeline record.</param>
+        /// <param name="order">Order of the timeline record.</param>
+        /// <param name="data">Additional data for the new timeline record.</param>
+        /// <returns>The timeilne record ID.</returns>
+        Guid CreateNewRecord(string name, string type, int order, TFBuildRecordData data);
+
+        /// <summary>
+        /// Update an existing detail timeline record.
+        /// </summary>
+        /// <param name="id">The ID of the existing timeline record.</param>
+        /// <param name="data">Additional data for the timeline record.</param>
+        void UpdateRecord(Guid id, TFBuildRecordData data);
+
+        /// <summary>
+        /// Sets a variable in the variable service of the task context.
+        /// </summary>
+        /// <remarks>
+        /// The variable is exposed to following tasks as an environment variable.
+        /// </remarks>
+        /// <param name="name">The variable name.</param>
+        /// <param name="value">The variable value.</param>
+        void SetVariable(string name, string value);
+
+        /// <summary>
+        /// Sets a secret variable in the variable service of the task context.
+        /// </summary>
+        /// <remarks>
+        /// The variable is not exposed to following tasks as an environment variable, and must be passed as inputs.
+        /// </remarks>
+        /// <param name="name">The variable name.</param>
+        /// <param name="value">The variable value.</param>
+        void SetSecretVariable(string name, string value);
+
+        /// <summary>
+        /// Upload and attach summary markdown to current timeline record.
+        /// </summary>
+        /// <remarks>
+        /// This summary is added to the build/release summary and is not available for download with logs.
+        /// </remarks>
+        /// <param name="markdownPath">Path to the summary markdown file.</param>
+        void UploadTaskSummary(FilePath markdownPath);
+
+        /// <summary>
+        /// Upload file as additional log information to the current timeline record.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The file shall be available for download along with task logs.
+        /// </para>
+        /// <para>
+        /// Requires agent version 1.101.
+        /// </para>
+        /// </remarks>
+        /// <param name="logFile">Path to the additional log file.</param>
+        void UploadTaskLogFile(FilePath logFile);
+
+        /// <summary>
+        /// Create an artifact link, such as a file or folder path or a version control path.
+        /// </summary>
+        /// <param name="name">The artifact name..</param>
+        /// <param name="type">The artifact type.</param>
+        /// <param name="location">The link path or value.</param>
+        void LinkArtifact(string name, TFBuildArtifactType type, string location);
+
+        /// <summary>
+        /// Upload local file into a file container folder.
+        /// </summary>
+        /// <param name="folderName">Folder that the file will upload to.</param>
+        /// <param name="file">Path to the local file.</param>
+        void UploadArtifact(string folderName, FilePath file);
+
+        /// <summary>
+        /// Upload local file into a file container folder, and create an artifact.
+        /// </summary>
+        /// <param name="folderName">Folder that the file will upload to.</param>
+        /// <param name="file">Path to the local file.</param>
+        /// <param name="artifactName">The artifact name.</param>
+        void UploadArtifact(string folderName, FilePath file, string artifactName);
+
+        /// <summary>
+        /// Upload additional log to build container's <c>logs/tool</c> folder.
+        /// </summary>
+        /// <param name="logFile">The log file.</param>
+        void UploadBuildLogFile(FilePath logFile);
+
+        /// <summary>
+        /// Update build number for current build.
+        /// </summary>
+        /// <remarks>
+        /// Requires agent version 1.88.
+        /// </remarks>
+        /// <param name="buildNumber">The build number.</param>
+        void UpdateBuildNumber(string buildNumber);
+
+        /// <summary>
+        /// Add a tag for current build.
+        /// </summary>
+        /// <remarks>
+        /// Requires agent version 1.95
+        /// </remarks>
+        /// <param name="tag">The tag.</param>
+        void AddBuildTag(string tag);
+    }
+}

--- a/src/Cake.Common/Build/TFBuild/ITFBuildProvider.cs
+++ b/src/Cake.Common/Build/TFBuild/ITFBuildProvider.cs
@@ -34,5 +34,13 @@ namespace Cake.Common.Build.TFBuild
         /// The TF Build environment.
         /// </value>
         TFBuildEnvironmentInfo Environment { get; }
+
+        /// <summary>
+        /// Gets the TF Build Commands provider.
+        /// </summary>
+        /// <value>
+        /// The TF Build commands provider.
+        /// </value>
+        ITFBuildCommands Commands { get; }
     }
 }

--- a/src/Cake.Common/Build/TFBuild/TFBuildCommands.cs
+++ b/src/Cake.Common/Build/TFBuild/TFBuildCommands.cs
@@ -1,0 +1,330 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Cake.Common.Build.TFBuild.Data;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+
+namespace Cake.Common.Build.TFBuild
+{
+    /// <summary>
+    /// Responsible for issuing TF Build agent commands (see <see href="https://github.com/Microsoft/vsts-tasks/blob/master/docs/authoring/commands.md"/>).
+    /// </summary>
+    public sealed class TFBuildCommands : ITFBuildCommands
+    {
+        private const string MessagePrefix = "##vso[";
+        private const string MessagePostfix = "]";
+        private readonly ICakeLog _log;
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TFBuildCommands"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        /// <param name="log">The log.</param>
+        public TFBuildCommands(ICakeEnvironment environment, ICakeLog log)
+        {
+            if (environment == null)
+            {
+                throw new ArgumentNullException(nameof(environment));
+            }
+            if (log == null)
+            {
+                throw new ArgumentNullException(nameof(log));
+            }
+            _environment = environment;
+            _log = log;
+        }
+
+        /// <summary>
+        /// Log a warning issue to timeline record of current task.
+        /// </summary>
+        /// <param name="message">The warning message.</param>
+        public void WriteWarning(string message)
+        {
+            WriteLoggingCommand("task.logissue", new Dictionary<string, string>
+            {
+                ["type"] = "warning"
+            }, message);
+        }
+
+        /// <summary>
+        /// Log a warning issue with detailed data to timeline record of current task.
+        /// </summary>
+        /// <param name="message">The warning message.</param>
+        /// <param name="data">The message data.</param>
+        public void WriteWarning(string message, TFBuildMessageData data)
+        {
+            var properties = data.GetProperties();
+            properties.Add("type", "warning");
+            WriteLoggingCommand("task.logissue", properties, message);
+        }
+
+        /// <summary>
+        /// Log an error to timeline record of current task.
+        /// </summary>
+        /// <param name="message">The error message.</param>
+        public void WriteError(string message)
+        {
+            WriteLoggingCommand("task.logissue", new Dictionary<string, string>
+            {
+                ["type"] = "error"
+            }, message);
+        }
+
+        /// <summary>
+        /// Log an error with detailed data to timeline record of current task.
+        /// </summary>
+        /// <param name="message">The error message.</param>
+        /// <param name="data">The message data.</param>
+        public void WriteError(string message, TFBuildMessageData data)
+        {
+            var properties = data.GetProperties();
+            properties.Add("type", "error");
+            WriteLoggingCommand("task.logissue", properties, message);
+        }
+
+        /// <summary>
+        /// Set progress and current operation for current task.
+        /// </summary>
+        /// <param name="progress">Current progress as percentage.</param>
+        /// <param name="currentOperation">The current operation.</param>
+        public void SetProgress(int progress, string currentOperation)
+        {
+            WriteLoggingCommand("task.setprogress", new Dictionary<string, string>
+            {
+                ["value"] = progress.ToString()
+            }, currentOperation);
+        }
+
+        /// <summary>
+        /// Finish timeline record for current task and set task result to succeeded.
+        /// </summary>
+        public void CompleteCurrentTask()
+        {
+            WriteLoggingCommand("task.complete", "DONE");
+        }
+
+        /// <summary>
+        /// Finish timeline record for current task and set task result.
+        /// </summary>
+        /// <param name="result">The task result status.</param>
+        public void CompleteCurrentTask(TFBuildTaskResult result)
+        {
+            WriteLoggingCommand("task.complete", new Dictionary<string, string>
+            {
+                ["result"] = result.ToString()
+            }, "DONE");
+        }
+
+        /// <summary>
+        /// Create detail timeline record.
+        /// </summary>
+        /// <param name="name">Name of the new timeline record.</param>
+        /// <param name="type">Type of the new timeline record.</param>
+        /// <param name="order">Order of the timeline record.</param>
+        /// <returns>The timeline record ID.</returns>
+        public Guid CreateNewRecord(string name, string type, int order)
+        {
+            var guid = Guid.NewGuid();
+            WriteLoggingCommand("task.logdetail", new Dictionary<string, string>
+            {
+                ["id"] = guid.ToString(),
+                ["name"] = name,
+                ["type"] = type,
+                ["order"] = order.ToString()
+            }, "create new timeline record");
+            return guid;
+        }
+
+        /// <summary>
+        /// Create detail timeline record.
+        /// </summary>
+        /// <param name="name">Name of the new timeline record.</param>
+        /// <param name="type">Type of the new timeline record.</param>
+        /// <param name="order">Order of the timeline record.</param>
+        /// <param name="data">Additional data for the new timeline record.</param>
+        /// <returns>The timeilne record ID.</returns>
+        public Guid CreateNewRecord(string name, string type, int order, TFBuildRecordData data)
+        {
+            var guid = Guid.NewGuid();
+            var properties = data.GetProperties();
+            properties.Add("id", guid.ToString());
+            properties.Add("name", name);
+            properties.Add("type", type);
+            properties.Add("order", order.ToString());
+            WriteLoggingCommand("task.logdetail", properties, "create new timeline record");
+            return guid;
+        }
+
+        /// <summary>
+        /// Update an existing detail timeline record.
+        /// </summary>
+        /// <param name="id">The ID of the existing timeline record.</param>
+        /// <param name="data">Additional data for the timeline record.</param>
+        public void UpdateRecord(Guid id, TFBuildRecordData data)
+        {
+            var properties = data.GetProperties();
+            properties.Add("id", id.ToString());
+            WriteLoggingCommand("task.logdetail", properties, "update");
+        }
+
+        /// <summary>
+        /// Sets a variable in the variable service of the task context.
+        /// </summary>
+        /// <remarks>
+        /// The variable is exposed to following tasks as an environment variable.
+        /// </remarks>
+        /// <param name="name">The variable name.</param>
+        /// <param name="value">The variable value.</param>
+        public void SetVariable(string name, string value)
+        {
+            WriteLoggingCommand("task.setvariable", new Dictionary<string, string>
+            {
+                ["variable"] = name
+            }, value);
+        }
+
+        /// <summary>
+        /// Sets a secret variable in the variable service of the task context.
+        /// </summary>
+        /// <remarks>
+        /// The variable is not exposed to following tasks as an environment variable, and must be passed as inputs.
+        /// </remarks>
+        /// <param name="name">The variable name.</param>
+        /// <param name="value">The variable value.</param>
+        public void SetSecretVariable(string name, string value)
+        {
+            WriteLoggingCommand("task.setvariable", new Dictionary<string, string>
+            {
+                ["variable"] = name,
+                ["issecret"] = "true"
+            }, value);
+        }
+
+        /// <summary>
+        /// Upload and attach summary markdown to current timeline record.
+        /// </summary>
+        /// <remarks>
+        /// This summary is added to the build/release summary and is not available for download with logs.
+        /// </remarks>
+        /// <param name="markdownPath">Path to the summary markdown file.</param>
+        public void UploadTaskSummary(FilePath markdownPath)
+        {
+            WriteLoggingCommand("task.uploadsummary", markdownPath.MakeAbsolute(_environment).FullPath);
+        }
+
+        /// <summary>
+        /// Upload file as additional log information to the current timeline record.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The file shall be available for download along with task logs.
+        /// </para>
+        /// <para>
+        /// Requires agent version 1.101.
+        /// </para>
+        /// </remarks>
+        /// <param name="logFile">Path to the additional log file.</param>
+        public void UploadTaskLogFile(FilePath logFile)
+        {
+            WriteLoggingCommand("task.uploadfile", logFile.MakeAbsolute(_environment).FullPath);
+        }
+
+        /// <summary>
+        /// Create an artifact link, such as a file or folder path or a version control path.
+        /// </summary>
+        /// <param name="name">The artifact name..</param>
+        /// <param name="type">The artifact type.</param>
+        /// <param name="location">The link path or value.</param>
+        public void LinkArtifact(string name, TFBuildArtifactType type, string location)
+        {
+            WriteLoggingCommand("artifact.associate", new Dictionary<string, string>
+            {
+                ["artifactname"] = name,
+                ["type"] = type.ToString()
+            }, location);
+        }
+
+        /// <summary>
+        /// Upload local file into a file container folder.
+        /// </summary>
+        /// <param name="folderName">Folder that the file will upload to.</param>
+        /// <param name="file">Path to the local file.</param>
+        public void UploadArtifact(string folderName, FilePath file)
+        {
+            WriteLoggingCommand("artifact.upload", new Dictionary<string, string>
+            {
+                ["containerfolder"] = folderName
+            }, file.MakeAbsolute(_environment).FullPath);
+        }
+
+        /// <summary>
+        /// Upload local file into a file container folder, and create an artifact.
+        /// </summary>
+        /// <param name="folderName">Folder that the file will upload to.</param>
+        /// <param name="file">Path to the local file.</param>
+        /// <param name="artifactName">The artifact name.</param>
+        public void UploadArtifact(string folderName, FilePath file, string artifactName)
+        {
+            WriteLoggingCommand("artifact.upload", new Dictionary<string, string>
+            {
+                ["containerfolder"] = folderName,
+                ["artifactname"] = artifactName
+            }, file.MakeAbsolute(_environment).FullPath);
+        }
+
+        /// <summary>
+        /// Upload additional log to build container's <c>logs/tool</c> folder.
+        /// </summary>
+        /// <param name="logFile">The log file.</param>
+        public void UploadBuildLogFile(FilePath logFile)
+        {
+            WriteLoggingCommand("build.uploadlog", logFile.MakeAbsolute(_environment).FullPath);
+        }
+
+        /// <summary>
+        /// Update build number for current build.
+        /// </summary>
+        /// <remarks>
+        /// Requires agent version 1.88.
+        /// </remarks>
+        /// <param name="buildNumber">The build number.</param>
+        public void UpdateBuildNumber(string buildNumber)
+        {
+            WriteLoggingCommand("build.updatebuildnumber", buildNumber);
+        }
+
+        /// <summary>
+        /// Add a tag for current build.
+        /// </summary>
+        /// <remarks>
+        /// Requires agent version 1.95
+        /// </remarks>
+        /// <param name="tag">The tag.</param>
+        public void AddBuildTag(string tag)
+        {
+            WriteLoggingCommand("build.addbuildtag", tag);
+        }
+
+        private void WriteLoggingCommand(string actionName, string value)
+        {
+            WriteLoggingCommand(actionName, new Dictionary<string, string>(), value);
+        }
+
+        private void WriteLoggingCommand(string actionName, Dictionary<string, string> properties, string value)
+        {
+            var props = string.Join(string.Empty, properties.Select(pair =>
+            {
+                return string.Format(CultureInfo.InvariantCulture, "{0}={1};", pair.Key, pair.Value);
+            }));
+            _log.Write(Verbosity.Quiet, LogLevel.Information, "{0}{1} {2}{3}{4}", MessagePrefix, actionName, props, MessagePostfix, value);
+        }
+    }
+}

--- a/src/Cake.Common/Build/TFBuild/TFBuildProvider.cs
+++ b/src/Cake.Common/Build/TFBuild/TFBuildProvider.cs
@@ -5,6 +5,7 @@
 using System;
 using Cake.Common.Build.TFBuild.Data;
 using Cake.Core;
+using Cake.Core.Diagnostics;
 
 namespace Cake.Common.Build.TFBuild
 {
@@ -19,14 +20,20 @@ namespace Cake.Common.Build.TFBuild
         /// Initializes a new instance of the <see cref="TFBuildProvider"/> class.
         /// </summary>
         /// <param name="environment">The environment.</param>
-        public TFBuildProvider(ICakeEnvironment environment)
+        /// <param name="log">The log.</param>
+        public TFBuildProvider(ICakeEnvironment environment, ICakeLog log)
         {
             if (environment == null)
             {
                 throw new ArgumentNullException(nameof(environment));
             }
+            if (log == null)
+            {
+                throw new ArgumentNullException(nameof(log));
+            }
             _environment = environment;
             Environment = new TFBuildEnvironmentInfo(environment);
+            Commands = new TFBuildCommands(environment, log);
         }
 
         /// <summary>
@@ -54,6 +61,14 @@ namespace Cake.Common.Build.TFBuild
         /// The TF Build environment.
         /// </value>
         public TFBuildEnvironmentInfo Environment { get; }
+
+        /// <summary>
+        /// Gets the TF Build Commands provider.
+        /// </summary>
+        /// <value>
+        /// The TF Build commands provider.
+        /// </value>
+        public ITFBuildCommands Commands { get; }
 
         /// <summary>
         /// Gets a value indicating whether the current build is running on a hosted build agent.


### PR DESCRIPTION
Initial support for TF Build logging commands. There's some minor inconsistencies between MS documentation and the real behaviour, but I've followed documentation here, so should be pretty solid.

Resolves #1399

Let me know of any issues. 

> Sidenote: Formatting might be a bit off (I have full confidence in Patrik's spotting ability) as this PR was done entirely in Rider!