### PR TITLE
GH1293: Add mechanism to validate addins

### DIFF
--- a/src/Cake.Core/Constants.cs
+++ b/src/Cake.Core/Constants.cs
@@ -2,10 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 namespace Cake.Core
 {
     internal static class Constants
     {
+        public static readonly Version LatestBreakingChange = new Version(0, 16, 0);
+
+        public static class Settings
+        {
+            public const string SkipVerification = "Settings_SkipVerification";
+        }
+
         public static class Paths
         {
             public const string Tools = "Paths_Tools";

--- a/src/Cake.Core/Modules/CoreModule.cs
+++ b/src/Cake.Core/Modules/CoreModule.cs
@@ -50,6 +50,7 @@ namespace Cake.Core.Modules
 
             // Reflection
             registrar.RegisterType<AssemblyLoader>().As<IAssemblyLoader>().Singleton();
+            registrar.RegisterType<AssemblyVerifier>().AsSelf().Singleton();
 
             // Tooling
             registrar.RegisterType<ToolRepository>().As<IToolRepository>().Singleton();

--- a/src/Cake.Core/Reflection/AssemblyVerifier.cs
+++ b/src/Cake.Core/Reflection/AssemblyVerifier.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+using Cake.Core.Configuration;
+using Cake.Core.Diagnostics;
+
+namespace Cake.Core.Reflection
+{
+    internal sealed class AssemblyVerifier
+    {
+        private readonly ICakeLog _log;
+        private readonly bool _skipVerification;
+
+        public AssemblyVerifier(ICakeConfiguration configuration, ICakeLog log)
+        {
+            _log = log;
+            var skip = configuration.GetValue(Constants.Settings.SkipVerification);
+            _skipVerification = skip != null && skip.Equals("true", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public void Verify(Assembly assembly)
+        {
+            if (_skipVerification)
+            {
+                _log.Debug("Skipping verification of assembly '{0}'.", assembly.FullName);
+                return;
+            }
+
+            // Verify that the assembly is valid.
+            // We're still pre 1.0, so there are breaking changes from time to time.
+            // We can refuse to load assemblies that reference too old version of Cake.
+            var references = assembly.GetReferencedAssemblies();
+            foreach (var reference in references)
+            {
+                if (reference.Name.Equals("Cake.Core") && reference.Version < Constants.LatestBreakingChange)
+                {
+                    // The assembly is referencing a version of Cake that contains breaking changes.
+                    throw new CakeException($"The assembly '{assembly.FullName}' is referencing an older version of Cake.Core ({reference.Version.ToString(3)}). " +
+                        $"This assembly need to reference at least Cake.Core version {Constants.LatestBreakingChange.ToString(3)}. " +
+                        $"Another option is to downgrade Cake to an earlier version.");
+                }
+            }
+        }
+    }
+}

--- a/src/Cake.Core/Reflection/IAssemblyLoader.cs
+++ b/src/Cake.Core/Reflection/IAssemblyLoader.cs
@@ -23,7 +23,8 @@ namespace Cake.Core.Reflection
         /// Loads the specified assembly from the specified path.
         /// </summary>
         /// <param name="path">The assembly path to load.</param>
+        /// <param name="verify">If the assembly should be verified whether or not it will work properly with Cake or not.</param>
         /// <returns>The loaded assembly.</returns>
-        Assembly Load(FilePath path);
+        Assembly Load(FilePath path, bool verify);
     }
 }

--- a/src/Cake.Core/Scripting/ScriptConventions.cs
+++ b/src/Cake.Core/Scripting/ScriptConventions.cs
@@ -103,7 +103,7 @@ namespace Cake.Core.Scripting
                 var cakeAssemblies = assemblyDirectory.GetFiles(pattern, SearchScope.Current);
                 foreach (var cakeAssembly in cakeAssemblies)
                 {
-                    result.Add(_loader.Load(cakeAssembly.Path));
+                    result.Add(_loader.Load(cakeAssembly.Path, false));
                 }
             }
             return result;

--- a/src/Cake.Core/Scripting/ScriptRunner.cs
+++ b/src/Cake.Core/Scripting/ScriptRunner.cs
@@ -158,7 +158,7 @@ namespace Cake.Core.Scripting
                 var referencePath = new FilePath(reference);
                 if (host.Context.FileSystem.Exist(referencePath))
                 {
-                    var assembly = _assemblyLoader.Load(referencePath);
+                    var assembly = _assemblyLoader.Load(referencePath, true);
                     assemblies.Add(assembly);
                 }
                 else

--- a/src/Cake/Composition/ModuleSearcher.cs
+++ b/src/Cake/Composition/ModuleSearcher.cs
@@ -92,30 +92,7 @@ namespace Cake.Composition
 
         private Assembly LoadAssembly(FilePath path)
         {
-            VerifyCompatibility(path);
-            return _assemblyLoader.Load(path);
-        }
-
-        private static void VerifyCompatibility(FilePath path)
-        {
-#if !NETCORE
-            // Make sure that the module is compatible.
-            // Kind of hackish, but this will have to do until we figure out a better way...
-            var assembly = Assembly.ReflectionOnlyLoadFrom(path.FullPath);
-            var references = assembly.GetReferencedAssemblies();
-            foreach (var reference in references)
-            {
-                if (reference.Name != null && reference.Name.Equals("Cake.Core", StringComparison.OrdinalIgnoreCase))
-                {
-                    var minVersion = new Version(0, 16, 0);
-                    if (reference.Version < minVersion)
-                    {
-                        const string format = "The module '{0}' is targeting an incompatible version of Cake.Core.dll. It needs to target at least version {1}.";
-                        throw new CakeException(string.Format(format, path.GetFilename().FullPath, minVersion.ToString(3)));
-                    }
-                }
-            }
-#endif
+            return _assemblyLoader.Load(path, true);
         }
     }
 }

--- a/src/Cake/Scripting/XPlat/XPlatScriptSession.cs
+++ b/src/Cake/Scripting/XPlat/XPlatScriptSession.cs
@@ -53,7 +53,7 @@ namespace Cake.Scripting.XPlat
 
             _log.Debug("Adding reference to {0}...", path.GetFilename().FullPath);
 #if NETCORE
-            References.Add(_loader.Load(path));
+            References.Add(_loader.Load(path, true));
 #else
             ReferencePaths.Add(path);
 #endif


### PR DESCRIPTION
* Added verification of addins, modules and directly references assemblies.

~~Haven't added functionality for letting addins decide what version of Cake they require yet.~~
I will add the attribute now for addins to use to require and we'll add the check in a later version.