### PR TITLE
Correcting bamboo code sample

### DIFF
--- a/src/Cake.Common/Build/BuildSystemAliases.cs
+++ b/src/Cake.Common/Build/BuildSystemAliases.cs
@@ -138,7 +138,7 @@ namespace Cake.Common.Build
         /// </summary>
         /// <example>
         /// <code>
-        /// var isBambooBuild = Bamboo.IsRunningBamboo;
+        /// var isBambooBuild = Bamboo.IsRunningOnBamboo;
         /// </code>
         /// </example>
         /// <param name="context">The context.</param>


### PR DESCRIPTION
2 char code sample fix incorrect docs
currently reads
```csharp
var isBambooBuild = Bamboo.IsRunningBamboo;
```
should read 
```csharp
var isBambooBuild = Bamboo.IsRunningOnBamboo;
```