### PR TITLE
Add pull-request detection for TeamCity provider

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Build/TeamCityInfoFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/TeamCityInfoFixture.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Build.TeamCity.Data;
+using Cake.Core;
+using NSubstitute;
+
+namespace Cake.Common.Tests.Fixtures.Build
+{
+    internal sealed class TeamCityInfoFixture
+    {
+        public ICakeEnvironment Environment { get; set; }
+
+        public TeamCityInfoFixture()
+        {
+            Environment = Substitute.For<ICakeEnvironment>();
+
+            Environment.GetEnvironmentVariable("TEAMCITY_BUILDCONF_NAME").Returns(@"Cake Build");
+            Environment.GetEnvironmentVariable("BUILD_NUMBER").Returns("10");
+
+            Environment.GetEnvironmentVariable("TEAMCITY_PROJECT_NAME").Returns("Cake");
+
+            Environment.GetEnvironmentVariable("Git_Branch").Returns("refs/pull-requests/7/from");
+        }
+
+        public TeamCityPullRequestInfo CreatePullRequestInfo()
+        {
+            return new TeamCityPullRequestInfo(Environment);
+        }
+
+        public TeamCityEnvironmentInfo CreateEnvironmentInfo()
+        {
+            return new TeamCityEnvironmentInfo(Environment);
+        }
+
+        public TeamCityBuildInfo CreateBuildInfo()
+        {
+            return new TeamCityBuildInfo(Environment);
+        }
+
+        public TeamCityProjectInfo CreateProjectInfo()
+        {
+            return new TeamCityProjectInfo(Environment);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Build/TeamCity/Data/TeamCityBuildInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TeamCity/Data/TeamCityBuildInfoTests.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tests.Fixtures.Build;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Build.TeamCity.Data
+{
+    public sealed class TeamCityBuildInfoTests
+    {
+        public sealed class TheBuildConfNameProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TeamCityInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.BuildConfName;
+
+                // Then
+                Assert.Equal("Cake Build", result);
+            }
+        }
+
+        public sealed class TheNumberProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TeamCityInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.Number;
+
+                // Then
+                Assert.Equal(10, result);
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Build/TeamCity/Data/TeamCityEnvironmentInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TeamCity/Data/TeamCityEnvironmentInfoTests.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tests.Fixtures.Build;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Build.TeamCity.Data
+{
+    public sealed class TeamCityEnvironmentInfoTests
+    {
+        public sealed class TheProjectProperty
+        {
+            [Fact]
+            public void Should_Not_Be_Null()
+            {
+                // Given
+                var info = new TeamCityInfoFixture().CreateEnvironmentInfo();
+
+                // When
+                var result = info.Project;
+
+                // Then
+                Assert.NotNull(result);
+            }
+        }
+
+        public sealed class TheBuildProperty
+        {
+            [Fact]
+            public void Should_Not_Be_Null()
+            {
+                // Given
+                var info = new TeamCityInfoFixture().CreateEnvironmentInfo();
+
+                // When
+                var result = info.Build;
+
+                // Then
+                Assert.NotNull(result);
+            }
+        }
+
+        public sealed class ThePullRequestProperty
+        {
+            [Fact]
+            public void Should_Not_Be_Null()
+            {
+                // Given
+                var info = new TeamCityInfoFixture().CreateEnvironmentInfo();
+
+                // When
+                var result = info.PullRequest;
+
+                // Then
+                Assert.NotNull(result);
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Build/TeamCity/Data/TeamCityProjectInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TeamCity/Data/TeamCityProjectInfoTests.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tests.Fixtures.Build;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Build.TeamCity.Data
+{
+    public sealed class TeamCityProjectInfoTests
+    {
+        public sealed class TheNameProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TeamCityInfoFixture().CreateProjectInfo();
+
+                // When
+                var result = info.Name;
+
+                // Then
+                Assert.Equal("Cake", result);
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Build/TeamCity/Data/TeamCityPullRequestInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TeamCity/Data/TeamCityPullRequestInfoTests.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tests.Fixtures.Build;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Build.TeamCity.Data
+{
+    public sealed class TeamCityPullRequestInfoTests
+    {
+        public sealed class TheIsPullRequestProperty
+        {
+            [Theory]
+            [InlineData("refs/pull-requests/1/merge", true)]
+            [InlineData("refs/heads/master", false)]
+            public void Should_Return_Correct_Value(string value, bool expected)
+            {
+                // Given
+                var fixture = new TeamCityInfoFixture();
+                fixture.Environment.GetEnvironmentVariable("Git_Branch").Returns(value);
+                var info = fixture.CreatePullRequestInfo();
+
+                // When
+                var result = info.IsPullRequest;
+
+                // Then
+                Assert.Equal(expected, result);
+            }
+        }
+
+        public sealed class TheNumberProperty
+        {
+            [Theory]
+            [InlineData("refs/pull-requests/1/merge", 1)]
+            [InlineData("refs/heads/master", null)]
+            public void Should_Return_Correct_Value(string value, int? expected)
+            {
+                // Given
+                var fixture = new TeamCityInfoFixture();
+                fixture.Environment.GetEnvironmentVariable("Git_Branch").Returns(value);
+                var info = fixture.CreatePullRequestInfo();
+
+                // When
+                var result = info.Number;
+
+                // Then
+                Assert.Equal(expected, result);
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Build/TeamCity/Data/TeamCityBuildInfo.cs
+++ b/src/Cake.Common/Build/TeamCity/Data/TeamCityBuildInfo.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core;
+
+namespace Cake.Common.Build.TeamCity.Data
+{
+    /// <summary>
+    /// Provides TeamCity build information for a current build.
+    /// </summary>
+    public class TeamCityBuildInfo : TeamCityInfo
+    {
+        /// <summary>
+        /// Gets the build configuration name.
+        /// </summary>
+        /// <value>
+        /// The build configuration name.
+        /// </value>
+        public string BuildConfName => GetEnvironmentString("TEAMCITY_BUILDCONF_NAME");
+
+        /// <summary>
+        /// Gets the build counter.
+        /// </summary>
+        /// <value>
+        /// The build counter.
+        /// </value>
+        public int Number => GetEnvironmentInteger("BUILD_NUMBER");
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TeamCityBuildInfo"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        public TeamCityBuildInfo(ICakeEnvironment environment)
+            : base(environment)
+        {
+        }
+    }
+}

--- a/src/Cake.Common/Build/TeamCity/Data/TeamCityEnvironmentInfo.cs
+++ b/src/Cake.Common/Build/TeamCity/Data/TeamCityEnvironmentInfo.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Build.AppVeyor;
+using Cake.Core;
+
+namespace Cake.Common.Build.TeamCity.Data
+{
+    /// <summary>
+    /// Provides TeamCity environment information for current build
+    /// </summary>
+    public class TeamCityEnvironmentInfo : AppVeyorInfo
+    {
+        /// <summary>
+        /// Gets TeamCity project information.
+        /// </summary>
+        /// <value>
+        /// The TeamCity project information.
+        /// </value>
+        public TeamCityProjectInfo Project { get; }
+
+        /// <summary>
+        /// Gets TeamCity build information.
+        /// </summary>
+        /// <value>
+        /// The TeamCity build information.
+        /// </value>
+        public TeamCityBuildInfo Build { get; }
+
+        /// <summary>
+        /// Gets TeamCity pull-request information.
+        /// </summary>
+        /// <value>
+        /// The TeamCity pull-request information.
+        /// </value>
+        public TeamCityPullRequestInfo PullRequest { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TeamCityEnvironmentInfo"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        public TeamCityEnvironmentInfo(ICakeEnvironment environment)
+            : base(environment)
+        {
+            Project = new TeamCityProjectInfo(environment);
+            Build = new TeamCityBuildInfo(environment);
+            PullRequest = new TeamCityPullRequestInfo(environment);
+        }
+    }
+}

--- a/src/Cake.Common/Build/TeamCity/Data/TeamCityProjectInfo.cs
+++ b/src/Cake.Common/Build/TeamCity/Data/TeamCityProjectInfo.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core;
+
+namespace Cake.Common.Build.TeamCity.Data
+{
+    /// <summary>
+    /// Provides TeamCity project information for current build
+    /// </summary>
+    public class TeamCityProjectInfo : TeamCityInfo
+    {
+        /// <summary>
+        /// Gets the TeamCity project name
+        /// </summary>
+        /// <value>
+        /// The TeamCity project name
+        /// </value>
+        public string Name => GetEnvironmentString("TEAMCITY_PROJECT_NAME");
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TeamCityProjectInfo"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        public TeamCityProjectInfo(ICakeEnvironment environment)
+            : base(environment)
+        {
+        }
+    }
+}

--- a/src/Cake.Common/Build/TeamCity/Data/TeamCityPullRequestInfo.cs
+++ b/src/Cake.Common/Build/TeamCity/Data/TeamCityPullRequestInfo.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core;
+
+namespace Cake.Common.Build.TeamCity.Data
+{
+    /// <summary>
+    /// Provides TeamCity pull request information for current build
+    /// </summary>
+    public class TeamCityPullRequestInfo : TeamCityInfo
+    {
+        /// <summary>
+        /// Gets a value indicating whether the current build was started by a pull request.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the current build was started by a pull request; otherwise, <c>false</c>.
+        /// </value>
+        /// <remarks>
+        /// <c>env.Git_Branch</c> is a required parameter in TeamCity for this to work
+        /// </remarks>
+        public bool IsPullRequest => GetEnvironmentString("Git_Branch").ToUpper().Contains("PULL-REQUEST");
+
+        /// <summary>
+        /// Gets the pull request number
+        /// </summary>
+        /// <value>
+        /// The pull request number
+        /// </value>
+        /// <remarks>
+        /// <c>env.Git_Branch</c> is a required parameter in TeamCity for this to work
+        /// </remarks>
+        public int? Number => IsPullRequest ? int.Parse(GetEnvironmentString("Git_Branch").Remove(GetEnvironmentString("Git_Branch").LastIndexOf('/')).Remove(0, "refs/pull-requests/".Length)) : (int?)null;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TeamCityPullRequestInfo"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        public TeamCityPullRequestInfo(ICakeEnvironment environment)
+            : base(environment)
+        {
+        }
+    }
+}

--- a/src/Cake.Common/Build/TeamCity/ITeamCityProvider.cs
+++ b/src/Cake.Common/Build/TeamCity/ITeamCityProvider.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Common.Build.TeamCity.Data;
 using Cake.Core.IO;
 
 namespace Cake.Common.Build.TeamCity
@@ -11,6 +12,56 @@ namespace Cake.Common.Build.TeamCity
     /// </summary>
     public interface ITeamCityProvider
     {
+        /// <summary>
+        /// Gets the TeamCity environment.
+        /// </summary>
+        /// <value>
+        /// The TeamCity environment.
+        /// </value>
+        /// <para>Via BuildSystem</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.TeamCity.IsRunningOnTeamCity)
+        /// {
+        ///     Information(
+        ///         @"Environment:
+        ///         PullRequest: {0}
+        ///         Build Configuration Name: {1}
+        ///         TeamCity Project Name: {2}",
+        ///         BuildSystem.TeamCity.Environment.PullRequest.IsPullRequest,
+        ///         BuildSystem.TeamCity.Environment.Build.BuildConfName,
+        ///         BuildSystem.TeamCity.Environment.Project.Name
+        ///         );
+        /// }
+        /// else
+        /// {
+        ///     Information("Not running on TeamCity");
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via TeamCity</para>
+        /// <example>
+        /// <code>
+        /// if (TeamCity.IsRunningOnTeamCity)
+        /// {
+        ///     Information(
+        ///         @"Environment:
+        ///         PullRequest: {0}
+        ///         Build Configuration Name: {1}
+        ///         TeamCity Project Name: {2}",
+        ///         BuildSystem.TeamCity.Environment.PullRequest.IsPullRequest,
+        ///         BuildSystem.TeamCity.Environment.Build.BuildConfName,
+        ///         BuildSystem.TeamCity.Environment.Project.Name
+        ///         );
+        /// }
+        /// else
+        /// {
+        ///     Information("Not running on TeamCity");
+        /// }
+        /// </code>
+        /// </example>
+        TeamCityEnvironmentInfo Environment { get; }
+
         /// <summary>
         /// Report a build problem to TeamCity.
         /// </summary>

--- a/src/Cake.Common/Build/TeamCity/TeamCityInfo.cs
+++ b/src/Cake.Common/Build/TeamCity/TeamCityInfo.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Core;
+
+namespace Cake.Common.Build.TeamCity
+{
+    /// <summary>
+    /// Base class used to provide information about the TeamCity environment.
+    /// </summary>
+    public abstract class TeamCityInfo
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Cake.Common.Build.TeamCity.TeamCityInfo"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        protected TeamCityInfo(ICakeEnvironment environment)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Gets an environment variable as a <see cref="System.String"/>.
+        /// </summary>
+        /// <param name="variable">The environment variable name.</param>
+        /// <returns>The environment variable.</returns>
+        protected string GetEnvironmentString(string variable)
+        {
+            return _environment.GetEnvironmentVariable(variable) ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Gets an environment variable as a <see cref="System.Int32"/>.
+        /// </summary>
+        /// <param name="variable">The environment variable name.</param>
+        /// <returns>The environment variable.</returns>
+        protected int GetEnvironmentInteger(string variable)
+        {
+            var value = GetEnvironmentString(variable);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                int result;
+                if (int.TryParse(value, out result))
+                {
+                    return result;
+                }
+            }
+            return 0;
+        }
+
+        /// <summary>
+        /// Gets an environment variable as a <see cref="System.Boolean"/>.
+        /// </summary>
+        /// <param name="variable">The environment variable name.</param>
+        /// <returns>The environment variable.</returns>
+        protected bool GetEnvironmentBoolean(string variable)
+        {
+            var value = GetEnvironmentString(variable);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value.Equals("true", StringComparison.OrdinalIgnoreCase);
+            }
+            return false;
+        }
+    }
+}

--- a/src/Cake.Common/Build/TeamCity/TeamCityProvider.cs
+++ b/src/Cake.Common/Build/TeamCity/TeamCityProvider.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
+using Cake.Common.Build.TeamCity.Data;
 using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
@@ -23,6 +24,56 @@ namespace Cake.Common.Build.TeamCity
         private static readonly Dictionary<string, string> _sanitizationTokens;
         private readonly ICakeEnvironment _environment;
         private readonly ICakeLog _log;
+
+        /// <summary>
+        /// Gets the TeamCity environment.
+        /// </summary>
+        /// <value>
+        /// The TeamCity environment.
+        /// </value>
+        /// <para>Via BuildSystem</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.TeamCity.IsRunningOnTeamCity)
+        /// {
+        ///     Information(
+        ///         @"Environment:
+        ///         PullRequest: {0}
+        ///         Build Configuration Name: {1}
+        ///         TeamCity Project Name: {2}",
+        ///         BuildSystem.TeamCity.Environment.PullRequest.IsPullRequest,
+        ///         BuildSystem.TeamCity.Environment.Build.BuildConfName,
+        ///         BuildSystem.TeamCity.Environment.Project.Name
+        ///         );
+        /// }
+        /// else
+        /// {
+        ///     Information("Not running on TeamCity");
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via TeamCity</para>
+        /// <example>
+        /// <code>
+        /// if (TeamCity.IsRunningOnTeamCity)
+        /// {
+        ///     Information(
+        ///         @"Environment:
+        ///         PullRequest: {0}
+        ///         Build Configuration Name: {1}
+        ///         TeamCity Project Name: {2}",
+        ///         BuildSystem.TeamCity.Environment.PullRequest.IsPullRequest,
+        ///         BuildSystem.TeamCity.Environment.Build.BuildConfName,
+        ///         BuildSystem.TeamCity.Environment.Project.Name
+        ///         );
+        /// }
+        /// else
+        /// {
+        ///     Information("Not running on TeamCity");
+        /// }
+        /// </code>
+        /// </example>
+        public TeamCityEnvironmentInfo Environment { get; }
 
         static TeamCityProvider()
         {
@@ -56,6 +107,8 @@ namespace Cake.Common.Build.TeamCity
 
             _environment = environment;
             _log = log;
+
+            Environment = new TeamCityEnvironmentInfo(environment);
         }
 
         /// <summary>


### PR DESCRIPTION
<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over CONTRIBUTING - https://github.com/cake-build/cake/blob/develop/CONTRIBUTING.md. We provide VERY defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - You are not submitting a pull request from your MASTER branch.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->


As discussed in #1416 I've used the environment variables available on the agent to expose functionality for TeamCity users. I've added:

  - `TeamCityBuildInfo`: Build name & number
  - `TeamCityProjectInfo`: Project name
  - `TeamCityPullRequestInfo`: Pull request number if the build is a pull request build. 

The pull request functionality requires that there's a __Git_Branch__ parameter be present on the agent. The value of this parameter should be `%teamcity.build.vcs.branch.{configurationid}%` as detailed at [GitVersion docs](https://gitversion.readthedocs.io/en/latest/build-server-support/build-server/teamcity/#running-inside-teamcity)
