### PR TITLE
Updated documentation for DotNetCoreTest

### DIFF
--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -506,12 +506,12 @@ namespace Cake.Common.Tools.DotNetCore
         /// <param name="settings">The settings.</param>
         /// <example>
         /// <code>
-        ///     var settings = new DotNetCoreRunSettings
+        ///     var settings = new DotNetCoreTestSettings
         ///     {
         ///         Configuration = "Release"
         ///     };
         ///
-        ///     DotNetCoreRun("./test/Project.Tests", settings);
+        ///     DotNetCoreTest("./test/Project.Tests", settings);
         /// </code>
         /// </example>
         [CakeMethodAlias]


### PR DESCRIPTION
Code example of DotNetCoreTest was showing an example of DotNetCoreRun. Updated the documentation to the correct alias of DotNetCoreTest.