### PR TITLE
xmlpeek: Add switch to suppress warnings

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/XmlPeekAliasesFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/XmlPeekAliasesFixture.cs
@@ -15,12 +15,13 @@ namespace Cake.Common.Tests.Fixtures
     {
        public IFileSystem FileSystem { get; set; }
        public ICakeContext Context { get; set; }
+       public FakeLog FakeLog { get; set; }
        public FilePath XmlPath { get; set; }
        public XmlPeekSettings Settings { get; set; }
 
-       public XmlPeekAliasesFixture(bool xmlExists = true, bool xmlWithDtd = false)
+       public XmlPeekAliasesFixture(bool xmlExists = true, bool xmlWithDtd = false, bool suppressWarning = false)
        {
-           Settings = new XmlPeekSettings();
+           Settings = new XmlPeekSettings { SuppressWarning = suppressWarning };
 
            var environment = FakeEnvironment.CreateUnixEnvironment();
            var fileSystem = new FakeFileSystem(environment);
@@ -34,10 +35,12 @@ namespace Cake.Common.Tests.Fixtures
            }
 
            FileSystem = fileSystem;
+           FakeLog = new FakeLog();
 
            Context = Substitute.For<ICakeContext>();
            Context.FileSystem.Returns(FileSystem);
            Context.Environment.Returns(environment);
+           Context.Log.Returns(FakeLog);
        }
 
        public string Peek(string xpath)

--- a/src/Cake.Common.Tests/Unit/XML/XmlPeekAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/XML/XmlPeekAliasesTests.cs
@@ -3,8 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Linq;
 using Cake.Common.Tests.Fixtures;
 using Cake.Common.Xml;
+using Cake.Core.Diagnostics;
+using Cake.Testing;
 using Xunit;
 
 namespace Cake.Common.Tests.Unit.XML
@@ -104,6 +107,36 @@ namespace Cake.Common.Tests.Unit.XML
 
                 // Then
                 Assert.Equal("CFBundleDisplayName", result);
+            }
+
+            [Fact]
+            public void Should_Log_Unknown_Warning_With_Suppress_Warnings_Off()
+            {
+                // Given
+                var fixture = new XmlPeekAliasesFixture();
+
+                // When
+                var result = fixture.Peek("/configuration/test2/text()");
+
+                // Then
+                Assert.Equal(null, result);
+                var warning = fixture.FakeLog.Entries.FirstOrDefault(x => x.Level == LogLevel.Warning);
+                Assert.Equal("Warning: Failed to find node matching the XPath '/configuration/test2/text()'", warning.Message);
+            }
+
+            [Fact]
+            public void Should_Not_Log_Unknown_Warning_With_Suppress_Warnings_On()
+            {
+                // Given
+                var fixture = new XmlPeekAliasesFixture(true, false, true);
+
+                // When
+                var result = fixture.Peek("/configuration/test2/text()");
+
+                // Then
+                Assert.Equal(null, result);
+                var warning = fixture.FakeLog.Entries.FirstOrDefault(x => x.Level == LogLevel.Warning);
+                Assert.Equal(null, warning);
             }
         }
     }

--- a/src/Cake.Common/Xml/XmlPeekAliases.cs
+++ b/src/Cake.Common/Xml/XmlPeekAliases.cs
@@ -60,6 +60,11 @@ namespace Cake.Common.Xml
         ///     new XmlPeekSettings {
         ///         Namespaces = new Dictionary&lt;string, string&gt; {{ "pastery", "http://cakebuild.net/pastery" }}
         ///     });
+        /// string unknown = XmlPeek("./pastery.xml", "/pastery:pastery/pastery:cake/@recipe",
+        ///     new XmlPeekSettings {
+        ///         Namespaces = new Dictionary&lt;string, string&gt; {{ "pastery", "http://cakebuild.net/pastery" }},
+        ///         SuppressWarnings = true
+        ///     });
         /// </code>
         /// </example>
         [CakeMethodAlias]
@@ -91,7 +96,7 @@ namespace Cake.Common.Xml
             using (var xmlReader = XmlReader.Create(fileStream, GetXmlReaderSettings(settings)))
             {
                 var xmlValue = XmlPeek(xmlReader, xpath, settings);
-                if (xmlValue == null)
+                if (xmlValue == null && !settings.SuppressWarning)
                 {
                     context.Log.Warning("Warning: Failed to find node matching the XPath '{0}'", xpath);
                 }

--- a/src/Cake.Common/Xml/XmlPeekSettings.cs
+++ b/src/Cake.Common/Xml/XmlPeekSettings.cs
@@ -22,6 +22,11 @@ namespace Cake.Common.Xml
         public bool PreserveWhitespace { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to suppress the xpath not found warning.
+        /// </summary>
+        public bool SuppressWarning { get; set; }
+
+        /// <summary>
         /// Gets or sets a value that determines the processing of DTDs.
         /// </summary>
         public XmlDtdProcessing DtdProcessing { get; set; }


### PR DESCRIPTION
The `XmlPeekSettings` learned to remember a setting if warnings should be suppressed or not. That setting will be evaluated before calling `context.Log.Warning()` if the `XmlPeek` alias can not find the provided xpath.

With this new setting in place, users can now _opt out_ of displaying the warning if the xpath was not found.

This fixes (GH-1438)