### PR TITLE
GH1294: Added signing of artifacts.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -10,6 +10,7 @@
 #tool "nuget:https://www.nuget.org/api/v2?package=coveralls.io&version=1.3.4"
 #tool "nuget:https://www.nuget.org/api/v2?package=OpenCover&version=4.6.519"
 #tool "nuget:https://www.nuget.org/api/v2?package=ReportGenerator&version=2.4.5"
+#tool "nuget:https://www.nuget.org/api/v2?package=SignClient&version=0.5.0-beta4&prerelease"
 
 // Load other scripts.
 #load "./build/parameters.cake"
@@ -342,7 +343,56 @@ Task("Create-NuGet-Packages")
     });
 });
 
+Task("Sign-Binaries")
+    .IsDependentOn("Zip-Files")
+    .IsDependentOn("Create-Chocolatey-Packages")
+    .IsDependentOn("Create-NuGet-Packages")
+    .WithCriteria(() => parameters.ShouldPublish && !parameters.SkipSigning)
+    .Does(() =>
+{
+    // Get the secret.
+    var secret = EnvironmentVariable("SIGNING_SECRET");
+    if(string.IsNullOrWhiteSpace(secret)) {
+        throw new InvalidOperationException("Could not resolve signing secret.");
+    }
+
+    var client = File("./tools/SignClient/tools/SignClient.dll");
+    var settings = File("./signclient.json");
+    var filter = File("./signclient.filter");
+
+    // Get the files to sign.
+    var files = GetFiles(string.Concat(parameters.Paths.Directories.NugetRoot, "/", "*.nupkg")) 
+        + parameters.Paths.Files.ZipArtifactPathDesktop
+        + parameters.Paths.Files.ZipArtifactPathCoreClr;
+
+    foreach(var file in files) 
+    {
+        Information("Signing {0}...", file.FullPath);
+
+        // Build the argument list.
+        var arguments = new ProcessArgumentBuilder()
+            .AppendQuoted(MakeAbsolute(client.Path).FullPath)
+            .Append("zip")
+            .AppendSwitchQuoted("-c", MakeAbsolute(settings.Path).FullPath)
+            .AppendSwitchQuoted("-i", MakeAbsolute(file).FullPath)
+            .AppendSwitchQuoted("-f", MakeAbsolute(filter).FullPath)
+            .AppendSwitchQuotedSecret("-s", secret)
+            .AppendSwitchQuoted("-n", "Cake")
+            .AppendSwitchQuoted("-d", "Cake (C# Make) is a cross platform build automation system.")
+            .AppendSwitchQuoted("-u", "http://cakebuild.net");
+
+        // Sign the binary.
+        var result = StartProcess("dotnet", new ProcessSettings {  Arguments = arguments });
+        if(result != 0)
+        {
+            // We should not recover from this.
+            throw new InvalidOperationException("Signing failed!");
+        }
+    }
+});
+
 Task("Upload-AppVeyor-Artifacts")
+    .IsDependentOn("Sign-Binaries")
     .IsDependentOn("Create-Chocolatey-Packages")
     .WithCriteria(() => parameters.IsRunningOnAppVeyor)
     .Does(() =>
@@ -370,6 +420,7 @@ Task("Upload-Coverage-Report")
 });
 
 Task("Publish-MyGet")
+    .IsDependentOn("Sign-Binaries")
     .IsDependentOn("Package")
     .WithCriteria(() => parameters.ShouldPublishToMyGet)
     .Does(() =>
@@ -402,6 +453,7 @@ Task("Publish-MyGet")
 });
 
 Task("Publish-NuGet")
+    .IsDependentOn("Sign-Binaries")
     .IsDependentOn("Create-NuGet-Packages")
     .WithCriteria(() => parameters.ShouldPublish)
     .Does(() =>
@@ -434,6 +486,7 @@ Task("Publish-NuGet")
 });
 
 Task("Publish-Chocolatey")
+    .IsDependentOn("Sign-Binaries")
     .IsDependentOn("Create-Chocolatey-Packages")
     .WithCriteria(() => parameters.ShouldPublish)
     .Does(() =>
@@ -466,8 +519,9 @@ Task("Publish-Chocolatey")
 });
 
 Task("Publish-HomeBrew")
-    .WithCriteria(() => parameters.ShouldPublish)
+    .IsDependentOn("Sign-Binaries")
     .IsDependentOn("Zip-Files")
+    .WithCriteria(() => parameters.ShouldPublish)
 	.Does(() =>
 {
     var hash = CalculateFileHash(parameters.Paths.Files.ZipArtifactPathDesktop).ToHex();

--- a/build/parameters.cake
+++ b/build/parameters.cake
@@ -20,6 +20,7 @@ public class BuildParameters
     public bool IsReleaseBuild { get; private set; }
     public bool SkipGitVersion { get; private set; }
     public bool SkipOpenCover { get; private set; }
+    public bool SkipSigning { get; private set; }
     public BuildCredentials GitHub { get; private set; }
     public CoverallsCredentials Coveralls { get; private set; }
     public TwitterCredentials Twitter { get; private set; }
@@ -108,6 +109,7 @@ public class BuildParameters
             ReleaseNotes = context.ParseReleaseNotes("./ReleaseNotes.md"),
             IsPublishBuild = IsPublishing(target),
             IsReleaseBuild = IsReleasing(target),
+            SkipSigning = StringComparer.OrdinalIgnoreCase.Equals("True", context.Argument("skipsigning", "False")),
             SkipGitVersion = StringComparer.OrdinalIgnoreCase.Equals("True", context.EnvironmentVariable("CAKE_SKIP_GITVERSION")),
             SkipOpenCover = StringComparer.OrdinalIgnoreCase.Equals("True", context.EnvironmentVariable("CAKE_SKIP_OPENCOVER"))
         };

--- a/signclient.filter
+++ b/signclient.filter
@@ -1,0 +1,11 @@
+Cake.exe
+Cake.dll
+Cake.Core.dll
+Cake.Common.dll
+Cake.NuGet.dll
+lib/net45/Cake.Core.dll
+lib/netstandard1.6/Cake.Core.dll
+lib/net45/Cake.Common.dll
+lib/netstandard1.6/Cake.Common.dll
+lib/net45/Cake.Testing.dll
+lib/netstandard1.6/Cake.Testing.dll

--- a/signclient.json
+++ b/signclient.json
@@ -1,0 +1,13 @@
+{
+  "SignClient": {
+    "AzureAd": {
+      "AADInstance": "https://login.microsoftonline.com/",
+      "ClientId": "650afa3d-b722-4169-a8b7-467944360b1f",
+      "TenantId": "dotnetfoundation.onmicrosoft.com"
+    },
+    "Service": {
+      "Url": "https://dnfsignservice.azurewebsites.net/",
+      "ResourceId": "http://sign.dotnetfoundation.org/server"
+    }
+  }
+}


### PR DESCRIPTION
Signs the following:

* Zip files (for GitHub and Homebrew)
* NuGet packages
* Chocolatey packages

Signing will only occur at a real release.
You can suppress signing by passing the `--skipsigning=true` parameter to the bootstrapper.

Related to #1294