### PR TITLE
GH1455: Add log string & object methods

### DIFF
--- a/src/Cake.Common.Tests/Unit/Diagnostics/LoggingAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/Diagnostics/LoggingAliasesTests.cs
@@ -44,6 +44,36 @@ namespace Cake.Common.Tests.Unit.Diagnostics
                 fixture.Context.Log.Received(1).Write(Verbosity.Quiet, LogLevel.Error, fixture.Format, fixture.Args);
                 Assert.True(fixture.Evaluated);
             }
+
+            [Fact]
+            public void Should_Write_Error_String_Value_To_Log()
+            {
+                // Given
+                var context = Substitute.For<ICakeContext>();
+                context.Log.Returns(Substitute.For<ICakeLog>());
+                const string value = "Hello {0}";
+
+                // When
+                context.Error(value);
+
+                // Then
+                context.Log.Received(1).Write(Verbosity.Quiet, LogLevel.Error, "{0}", value);
+            }
+
+            [Fact]
+            public void Should_Write_Error_Object_Value_To_Log()
+            {
+                // Given
+                var context = Substitute.For<ICakeContext>();
+                context.Log.Returns(Substitute.For<ICakeLog>());
+                var value = new { FirstName = "John", LastName="Doe" };
+
+                // When
+                context.Error(value);
+
+                // Then
+                context.Log.Received(1).Write(Verbosity.Quiet, LogLevel.Error, "{0}", value);
+            }
         }
 
         public sealed class TheWarningMethod
@@ -90,6 +120,36 @@ namespace Cake.Common.Tests.Unit.Diagnostics
                 // Then
                 fixture.Context.Log.DidNotReceive().Write(Verbosity.Minimal, LogLevel.Warning, fixture.Format, fixture.Args);
                 Assert.False(fixture.Evaluated);
+            }
+
+            [Fact]
+            public void Should_Write_Warning_String_Value_To_Log()
+            {
+                // Given
+                var context = Substitute.For<ICakeContext>();
+                context.Log.Returns(Substitute.For<ICakeLog>());
+                const string value = "Hello {0}";
+
+                // When
+                context.Warning(value);
+
+                // Then
+                context.Log.Received(1).Write(Verbosity.Minimal, LogLevel.Warning, "{0}", value);
+            }
+
+            [Fact]
+            public void Should_Write_Warning_Object_Value_To_Log()
+            {
+                // Given
+                var context = Substitute.For<ICakeContext>();
+                context.Log.Returns(Substitute.For<ICakeLog>());
+                var value = new { FirstName = "John", LastName="Doe" };
+
+                // When
+                context.Warning(value);
+
+                // Then
+                context.Log.Received(1).Write(Verbosity.Minimal, LogLevel.Warning, "{0}", value);
             }
         }
 
@@ -138,6 +198,36 @@ namespace Cake.Common.Tests.Unit.Diagnostics
                 fixture.Context.Log.DidNotReceive().Write(Verbosity.Normal, LogLevel.Information, fixture.Format, fixture.Args);
                 Assert.False(fixture.Evaluated);
             }
+
+            [Fact]
+            public void Should_Write_Information_String_Value_To_Log()
+            {
+                // Given
+                var context = Substitute.For<ICakeContext>();
+                context.Log.Returns(Substitute.For<ICakeLog>());
+                const string value = "Hello {0}";
+
+                // When
+                context.Information(value);
+
+                // Then
+                context.Log.Received(1).Write(Verbosity.Normal, LogLevel.Information, "{0}", value);
+            }
+
+            [Fact]
+            public void Should_Write_Information_Object_Value_To_Log()
+            {
+                // Given
+                var context = Substitute.For<ICakeContext>();
+                context.Log.Returns(Substitute.For<ICakeLog>());
+                var value = new { FirstName = "John", LastName="Doe" };
+
+                // When
+                context.Information(value);
+
+                // Then
+                context.Log.Received(1).Write(Verbosity.Normal, LogLevel.Information, "{0}", value);
+            }
         }
 
         public sealed class TheVerboseMethod
@@ -185,6 +275,36 @@ namespace Cake.Common.Tests.Unit.Diagnostics
                 fixture.Context.Log.DidNotReceive().Write(Verbosity.Verbose, LogLevel.Verbose, fixture.Format, fixture.Args);
                 Assert.False(fixture.Evaluated);
             }
+
+            [Fact]
+            public void Should_Write_Verbose_String_Value_To_Log()
+            {
+                // Given
+                var context = Substitute.For<ICakeContext>();
+                context.Log.Returns(Substitute.For<ICakeLog>());
+                const string value = "Hello {0}";
+
+                // When
+                context.Verbose(value);
+
+                // Then
+                context.Log.Received(1).Write(Verbosity.Verbose, LogLevel.Verbose, "{0}", value);
+            }
+
+            [Fact]
+            public void Should_Write_Verbose_Object_Value_To_Log()
+            {
+                // Given
+                var context = Substitute.For<ICakeContext>();
+                context.Log.Returns(Substitute.For<ICakeLog>());
+                var value = new { FirstName = "John", LastName="Doe" };
+
+                // When
+                context.Verbose(value);
+
+                // Then
+                context.Log.Received(1).Write(Verbosity.Verbose, LogLevel.Verbose, "{0}", value);
+            }
         }
 
         public sealed class TheDebugMethod
@@ -231,6 +351,36 @@ namespace Cake.Common.Tests.Unit.Diagnostics
                 // Then
                 fixture.Context.Log.DidNotReceive().Write(Verbosity.Diagnostic, LogLevel.Debug, fixture.Format, fixture.Args);
                 Assert.False(fixture.Evaluated);
+            }
+
+            [Fact]
+            public void Should_Write_Debug_String_Value_To_Log()
+            {
+                // Given
+                var context = Substitute.For<ICakeContext>();
+                context.Log.Returns(Substitute.For<ICakeLog>());
+                const string value = "Hello {0}";
+
+                // When
+                context.Debug(value);
+
+                // Then
+                context.Log.Received(1).Write(Verbosity.Diagnostic, LogLevel.Debug, "{0}", value);
+            }
+
+            [Fact]
+            public void Should_Write_Debug_Object_Value_To_Log()
+            {
+                // Given
+                var context = Substitute.For<ICakeContext>();
+                context.Log.Returns(Substitute.For<ICakeLog>());
+                var value = new { FirstName = "John", LastName="Doe" };
+
+                // When
+                context.Debug(value);
+
+                // Then
+                context.Log.Received(1).Write(Verbosity.Diagnostic, LogLevel.Debug, "{0}", value);
             }
         }
     }

--- a/src/Cake.Common.Tests/project.json
+++ b/src/Cake.Common.Tests/project.json
@@ -7,12 +7,14 @@
       "/additionalfile:../stylecop.json"
     ],
     "compile": {
-        "includeFiles": [
-            "../SolutionInfo.cs"
-        ]
+      "includeFiles": [
+        "../SolutionInfo.cs"
+      ]
     },
     "copyToOutput": {
-        "include": [ "./Properties/PropertyList-1.0.dtd" ]
+      "include": [
+        "./Properties/PropertyList-1.0.dtd"
+      ]
     }
   },
   "configurations": {

--- a/src/Cake.Common/Diagnostics/LoggingAliases.cs
+++ b/src/Cake.Common/Diagnostics/LoggingAliases.cs
@@ -58,6 +58,46 @@ namespace Cake.Common.Diagnostics
         }
 
         /// <summary>
+        /// Writes an error message to the log using the specified value.
+        /// </summary>
+        /// <param name="context">the context.</param>
+        /// <param name="value">The value.</param>
+        /// <example>
+        /// <code>
+        /// Error(new {FirstName = "John", LastName="Doe"});
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static void Error(this ICakeContext context, object value)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            context.Log.Error(value);
+        }
+
+        /// <summary>
+        /// Writes an error message to the log using the specified string value.
+        /// </summary>
+        /// <param name="context">the context.</param>
+        /// <param name="value">The value.</param>
+        /// <example>
+        /// <code>
+        /// Error("{string}");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static void Error(this ICakeContext context, string value)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            context.Log.Error(value);
+        }
+
+        /// <summary>
         /// Writes a warning message to the log using the specified format information.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -97,6 +137,46 @@ namespace Cake.Common.Diagnostics
                 throw new ArgumentNullException(nameof(context));
             }
             context.Log.Warning(logAction);
+        }
+
+        /// <summary>
+        /// Writes an warning message to the log using the specified value.
+        /// </summary>
+        /// <param name="context">the context.</param>
+        /// <param name="value">The value.</param>
+        /// <example>
+        /// <code>
+        /// Warning(new {FirstName = "John", LastName="Doe"});
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static void Warning(this ICakeContext context, object value)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            context.Log.Warning(value);
+        }
+
+        /// <summary>
+        /// Writes an warning message to the log using the specified string value.
+        /// </summary>
+        /// <param name="context">the context.</param>
+        /// <param name="value">The value.</param>
+        /// <example>
+        /// <code>
+        /// Warning("{string}");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static void Warning(this ICakeContext context, string value)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            context.Log.Warning(value);
         }
 
         /// <summary>
@@ -142,6 +222,46 @@ namespace Cake.Common.Diagnostics
         }
 
         /// <summary>
+        /// Writes an informational message to the log using the specified value.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="value">The value.</param>
+        /// <example>
+        /// <code>
+        /// Information(new {FirstName = "John", LastName="Doe"});
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static void Information(this ICakeContext context, object value)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            context.Log.Information(value);
+        }
+
+        /// <summary>
+        /// Writes an informational message to the log using the specified string value.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="value">The value.</param>
+        /// <example>
+        /// <code>
+        /// Information("{string}");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static void Information(this ICakeContext context, string value)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            context.Log.Information(value);
+        }
+
+        /// <summary>
         /// Writes a verbose message to the log using the specified format information.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -184,6 +304,46 @@ namespace Cake.Common.Diagnostics
         }
 
         /// <summary>
+        /// Writes a verbose message to the log using the specified value.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="value">The value.</param>
+        /// <example>
+        /// <code>
+        /// Verbose(new {FirstName = "John", LastName="Doe"});
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static void Verbose(this ICakeContext context, object value)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            context.Log.Verbose(value);
+        }
+
+        /// <summary>
+        /// Writes a verbose message to the log using the specified string value.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="value">The value.</param>
+        /// <example>
+        /// <code>
+        /// Verbose("{string}");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static void Verbose(this ICakeContext context, string value)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            context.Log.Verbose(value);
+        }
+
+        /// <summary>
         /// Writes a debug message to the log using the specified format information.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -223,6 +383,46 @@ namespace Cake.Common.Diagnostics
                 throw new ArgumentNullException(nameof(context));
             }
             context.Log.Debug(logAction);
+        }
+
+        /// <summary>
+        /// Writes a debug message to the log using the specified value.
+        /// </summary>
+        /// <param name="context">the context.</param>
+        /// <param name="value">The value.</param>
+        /// <example>
+        /// <code>
+        /// Debug(new {FirstName = "John", LastName="Doe"});
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static void Debug(this ICakeContext context, object value)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            context.Log.Debug(value);
+        }
+
+        /// <summary>
+        /// Writes a debug message to the log using the specified string value.
+        /// </summary>
+        /// <param name="context">the context.</param>
+        /// <param name="value">The value.</param>
+        /// <example>
+        /// <code>
+        /// Debug("{string}");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static void Debug(this ICakeContext context, string value)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            context.Log.Debug(value);
         }
     }
 }

--- a/src/Cake.Core/Diagnostics/LogExtensions.cs
+++ b/src/Cake.Core/Diagnostics/LogExtensions.cs
@@ -56,6 +56,26 @@ namespace Cake.Core.Diagnostics
         }
 
         /// <summary>
+        /// Writes an error message to the log using the specified value.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="value">The value.</param>
+        public static void Error(this ICakeLog log, object value)
+        {
+            log.Error("{0}", value);
+        }
+
+        /// <summary>
+        /// Writes an error message to the log using the specified string value.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="value">The value.</param>
+        public static void Error(this ICakeLog log, string value)
+        {
+            log.Error("{0}", value);
+        }
+
+        /// <summary>
         /// Writes a warning message to the log using the specified format information.
         /// </summary>
         /// <param name="log">The log.</param>
@@ -99,6 +119,26 @@ namespace Cake.Core.Diagnostics
         public static void Warning(this ICakeLog log, Verbosity verbosity, LogAction logAction)
         {
             Write(log, verbosity, LogLevel.Warning, logAction);
+        }
+
+        /// <summary>
+        /// Writes an warning message to the log using the specified value.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="value">The value.</param>
+        public static void Warning(this ICakeLog log, object value)
+        {
+            log.Warning("{0}", value);
+        }
+
+        /// <summary>
+        /// Writes an warning message to the log using the specified string value.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="value">The value.</param>
+        public static void Warning(this ICakeLog log, string value)
+        {
+            log.Warning("{0}", value);
         }
 
         /// <summary>
@@ -148,6 +188,26 @@ namespace Cake.Core.Diagnostics
         }
 
         /// <summary>
+        /// Writes an informational message to the log using the specified value.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="value">The value.</param>
+        public static void Information(this ICakeLog log, object value)
+        {
+            log.Information("{0}", value);
+        }
+
+        /// <summary>
+        /// Writes an informational message to the log using the specified string value.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="value">The value.</param>
+        public static void Information(this ICakeLog log, string value)
+        {
+            log.Information("{0}", value);
+        }
+
+        /// <summary>
         /// Writes a verbose message to the log using the specified format information.
         /// </summary>
         /// <param name="log">The log.</param>
@@ -194,6 +254,26 @@ namespace Cake.Core.Diagnostics
         }
 
         /// <summary>
+        /// Writes a verbose message to the log using the specified value.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="value">The value.</param>
+        public static void Verbose(this ICakeLog log, object value)
+        {
+            log.Verbose("{0}", value);
+        }
+
+        /// <summary>
+        /// Writes a verbose message to the log using the specified string value.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="value">The value.</param>
+        public static void Verbose(this ICakeLog log, string value)
+        {
+            log.Verbose("{0}", value);
+        }
+
+        /// <summary>
         /// Writes a debug message to the log using the specified format information.
         /// </summary>
         /// <param name="log">The log.</param>
@@ -237,6 +317,26 @@ namespace Cake.Core.Diagnostics
         public static void Debug(this ICakeLog log, Verbosity verbosity, LogAction logAction)
         {
             Write(log, verbosity, LogLevel.Debug, logAction);
+        }
+
+        /// <summary>
+        /// Writes a debug message to the log using the specified value.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="value">The value.</param>
+        public static void Debug(this ICakeLog log, object value)
+        {
+            log.Debug("{0}", value);
+        }
+
+        /// <summary>
+        /// Writes a debug message to the log using the specified string value.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="value">The value.</param>
+        public static void Debug(this ICakeLog log, string value)
+        {
+            log.Debug("{0}", value);
         }
 
         /// <summary>


### PR DESCRIPTION
Enables to log just an object and if string bypass string format allowing any string to be logged. 

* fixes #1455 `Information("{Bon}jour");`
