### PR TITLE
GH1463: Add possible nuget path on Mac to tool resolver

### DIFF
--- a/src/Cake.Core.Tests/Unit/IO/NuGet/NuGetToolResolverTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/NuGet/NuGetToolResolverTests.cs
@@ -117,6 +117,7 @@ namespace Cake.Core.Tests.Unit.IO.NuGet
             }
 
             [Theory]
+            [InlineData("/Library/Frameworks/Mono.framework/Versions/Current/Commands/nuget")]
             [InlineData("/usr/local/bin/nuget")]
             [InlineData("/usr/bin/nuget")]
             public void Should_Be_Able_To_Resolve_Path_Via_Special_Unix_Paths(string path)

--- a/src/Cake.Core/IO/NuGet/NuGetToolResolver.cs
+++ b/src/Cake.Core/IO/NuGet/NuGetToolResolver.cs
@@ -23,6 +23,7 @@ namespace Cake.Core.IO.NuGet
         {
             _unixSystemPaths = new[]
             {
+                new FilePath("/Library/Frameworks/Mono.framework/Versions/Current/Commands/nuget"),
                 new FilePath("/usr/local/bin/nuget"),
                 new FilePath("/usr/bin/nuget")
             };


### PR DESCRIPTION
On Mac, the nuget command alias should exist in `/Library/Frameworks/Mono.framework/Versions/Current/Commands/nuget` and so we should check there first if we are going to look through the possible system paths nuget might be found in.

This fixes #1463