### PR TITLE
GH1469: Added a more reliable method to detect Mac OSX

### DIFF
--- a/src/Cake.Core/Polyfill/EnvironmentHelper.cs
+++ b/src/Cake.Core/Polyfill/EnvironmentHelper.cs
@@ -14,6 +14,10 @@ namespace Cake.Core.Polyfill
 {
     internal class EnvironmentHelper
     {
+#if !NETCORE
+        private static bool? _isRunningOnMac;
+#endif
+
         public static bool Is64BitOperativeSystem()
         {
 #if NETCORE
@@ -41,17 +45,21 @@ namespace Cake.Core.Polyfill
             }
 #else
             var platform = (int)Environment.OSVersion.Platform;
-            if (platform == (int)PlatformID.MacOSX)
+            if (platform <= 3 || platform == 5)
+            {
+                return PlatformFamily.Windows;
+            }
+            if (!_isRunningOnMac.HasValue)
+            {
+                _isRunningOnMac = Native.MacOSX.IsRunningOnMac();
+            }
+            if (_isRunningOnMac ?? false || platform == (int)PlatformID.MacOSX)
             {
                 return PlatformFamily.OSX;
             }
             if (platform == 4 || platform == 6 || platform == 128)
             {
                 return PlatformFamily.Linux;
-            }
-            if (platform <= 3 || platform == 5)
-            {
-                return PlatformFamily.Windows;
             }
 #endif
             return PlatformFamily.Unknown;

--- a/src/Cake.Core/Polyfill/MacOSXNative.cs
+++ b/src/Cake.Core/Polyfill/MacOSXNative.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////
+// This code was taken and adapted from the MonoDevelop project.
+// https://github.com/mono/monodevelop/blob/master/main/src/core/Mono.Texteditor/Mono.TextEditor/Platform.cs
+// Copyright (c) 2009 Novell, Inc. (http://www.novell.com)
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+/////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#if !NETCORE
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using Cake.Core.IO;
+
+namespace Cake.Core.Polyfill
+{
+    internal static partial class Native
+    {
+        public static class MacOSX
+        {
+            [DllImport("libc")]
+            internal static extern int uname(IntPtr buf);
+
+            public static bool IsRunningOnMac()
+            {
+                try
+                {
+                    IntPtr buf = IntPtr.Zero;
+                    try
+                    {
+                        buf = Marshal.AllocHGlobal(8192);
+                        if (uname(buf) == 0)
+                        {
+                            string os = Marshal.PtrToStringAnsi(buf);
+                            if (os == "Darwin")
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        if (buf != IntPtr.Zero)
+                        {
+                            Marshal.FreeHGlobal(buf);
+                        }
+                    }
+                }
+                catch
+                {
+                    // Ignore any other possible failures on non-OSX platforms
+                }
+
+                return false;
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Previously on mono, the PlatformID enum was being used to detect OSX.  As of mono 2.2+ the value on Mac is always returned as 4, which makes it impossible to use to distinguish from any other unix based system.

The fix uses a method that’s tried and tested in MonoDevelop (Xamarin Studio & Visual Studio for Mac) calling out to `uname` and checking if the value is Darwin.
