### PR TITLE
GH1476: Look for msbuild in default install path on mac

### DIFF
--- a/src/Cake.Common/Tools/MSBuild/MSBuildResolver.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildResolver.cs
@@ -12,6 +12,18 @@ namespace Cake.Common.Tools.MSBuild
     {
         public static FilePath GetMSBuildPath(IFileSystem fileSystem, ICakeEnvironment environment, MSBuildToolVersion version, MSBuildPlatform buildPlatform)
         {
+            if (environment.Platform.Family == PlatformFamily.OSX)
+            {
+                var macMSBuildPath = new FilePath("/Library/Frameworks/Mono.framework/Versions/Current/Commands/msbuild");
+
+                if (fileSystem.Exist(macMSBuildPath))
+                {
+                    return macMSBuildPath;
+                }
+
+                throw new CakeException("Could not resolve MSBuild.");
+            }
+
             var binPath = version == MSBuildToolVersion.Default
                 ? GetHighestAvailableMSBuildVersion(fileSystem, environment, buildPlatform)
                 : GetMSBuildPath(fileSystem, environment, (MSBuildVersion)version, buildPlatform);


### PR DESCRIPTION
This will look for the default install location of `msbuild` on _macOS_.

This is related to #1476 