### PR TITLE
GH1495: Fixes typo in SignTool docs

### DIFF
--- a/src/Cake.Common/Tools/SignTool/SignToolSignAliases.cs
+++ b/src/Cake.Common/Tools/SignTool/SignToolSignAliases.cs
@@ -69,7 +69,7 @@ namespace Cake.Common.Tools.SignTool
         ///     .Does(() =>
         /// {
         ///     var file = new FilePath("Core.dll");
-        ///     Sign(files, new SignToolSignSettings {
+        ///     Sign(file, new SignToolSignSettings {
         ///             TimeStampUri = new Uri("http://timestamp.digicert.com"),
         ///             CertPath = "digitalcertificate.pfx",
         ///             Password = "TopSecret"


### PR DESCRIPTION
Fixes #1495
