### PR TITLE
GH1518: Adding BuildTools as a version to the MSBuildResolver.

### DIFF
--- a/src/Cake.Common/Tools/MSBuild/MSBuildResolver.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildResolver.cs
@@ -95,7 +95,8 @@ namespace Cake.Common.Tools.MSBuild
             {
                 "Enterprise",
                 "Professional",
-                "Community"
+                "Community",
+                "BuildTools"
             };
 
             var visualStudio2017Path = environment.GetSpecialPath(SpecialPath.ProgramFilesX86);


### PR DESCRIPTION
I have added it to the array as an edition. Fixes #1518 