### PR TITLE
GH1544: Resolve Windows 10 SDK for SignTool

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/SignToolResolverFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/SignToolResolverFixture.cs
@@ -42,7 +42,7 @@ namespace Cake.Common.Tests.Fixtures.Tools
             }
         }
 
-        public void GivenThatToolHasRegistryKey()
+        public void GivenThatToolHasRegistryKeyMicrosoftSdks()
         {
             var signToolKey = Substitute.For<IRegistryKey>();
             signToolKey.GetValue("InstallationFolder").Returns("/SignTool");
@@ -55,6 +55,26 @@ namespace Cake.Common.Tests.Fixtures.Tools
             localMachine.OpenKey("Software\\Microsoft\\Microsoft SDKs\\Windows").Returns(windowsKey);
 
             FileSystem.Exist(Arg.Is<FilePath>(p => p.FullPath == "/SignTool/bin/signtool.exe")).Returns(true);
+            Registry.LocalMachine.Returns(localMachine);
+        }
+
+        public void GivenThatToolHasRegistryKeyWindowsKits()
+        {
+            var signToolKey = Substitute.For<IRegistryKey>();
+            signToolKey.GetValue("KitsRoot10").Returns("/SignTool");
+
+            var localMachine = Substitute.For<IRegistryKey>();
+            localMachine.OpenKey("Software\\Microsoft\\Windows Kits\\Installed Roots").Returns(signToolKey);
+
+            if (_is64Bit)
+            {
+                FileSystem.Exist(Arg.Is<FilePath>(p => p.FullPath == "/SignTool/bin/x64/signtool.exe")).Returns(true);
+            }
+            else
+            {
+                FileSystem.Exist(Arg.Is<FilePath>(p => p.FullPath == "/SignTool/bin/x86/signtool.exe")).Returns(true);
+            }
+
             Registry.LocalMachine.Returns(localMachine);
         }
 

--- a/src/Cake.Common.Tests/Unit/Tools/SignTool/SignToolResolverTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/SignTool/SignToolResolverTests.cs
@@ -77,7 +77,23 @@ namespace Cake.Common.Tests.Unit.Tools.SignTool
             {
                 // Given
                 var fixture = new SignToolResolverFixture();
-                fixture.GivenThatToolHasRegistryKey();
+                fixture.GivenThatToolHasRegistryKeyMicrosoftSdks();
+
+                // When
+                var result = fixture.Resolve();
+
+                // Then
+                Assert.NotNull(result);
+            }
+
+            [Theory]
+            [InlineData(true)]
+            [InlineData(false)]
+            public void Should_Return_From_Registry_If_Windows_Kits_Found(bool is64Bit)
+            {
+                // Given
+                var fixture = new SignToolResolverFixture(is64Bit);
+                fixture.GivenThatToolHasRegistryKeyWindowsKits();
 
                 // When
                 var result = fixture.Resolve();


### PR DESCRIPTION
Fixes #1544

Adds the Windows 10 SDK path to the SignTool resolver.
Uses the "HKLM\Software\Microsoft\Windows Kits\Installed Roots" registry key to resolve SDK install paths.