### PR TITLE
GH1557: Add support for MSBuild console logger parameters

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -1040,6 +1040,26 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 // Then
                 Assert.Equal(expected, result.Args);
             }
+
+            [Theory]
+            [InlineData(new string[] { }, @"/v:normal /target:Build ""C:/Working/src/Solution.sln""")]
+            [InlineData(new string[] { "ForceConsoleColor" }, @"/v:normal /target:Build /clp:ForceConsoleColor ""C:/Working/src/Solution.sln""")]
+            [InlineData(new string[] { "ForceConsoleColor", "ShowCommandLine" }, @"/v:normal /target:Build /clp:ForceConsoleColor;ShowCommandLine ""C:/Working/src/Solution.sln""")]
+            public void Should_Append_ConsoleLoggerParameters(string[] parameters, string expected)
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows);
+                foreach (var parameter in parameters)
+                {
+                    fixture.Settings.ConsoleLoggerParameters.Add(parameter);
+                }
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsExtensionsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsExtensionsTests.cs
@@ -503,5 +503,38 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 Assert.Equal(settings, result);
             }
         }
+
+        public sealed class TheWithConsoleLoggerParameterMethod
+        {
+            [Fact]
+            public void Should_Add_Console_Logger_Parameter()
+            {
+                // Given
+                var settings = new MSBuildSettings();
+
+               // When
+                settings.WithConsoleLoggerParameter("ForceConsoleColor");
+                settings.WithConsoleLoggerParameter("ShowCommandLine");
+
+               // Then
+                Assert.Contains("ForceConsoleColor", settings.ConsoleLoggerParameters);
+                Assert.Contains("ShowCommandLine", settings.ConsoleLoggerParameters);
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new MSBuildSettings();
+
+               // When
+                var result = settings.WithConsoleLoggerParameter("ForceConsoleColor");
+                var result1 = settings.WithConsoleLoggerParameter("ShowCommandLine");
+
+               // Then
+                Assert.Equal(settings, result);
+                Assert.Equal(settings, result1);
+            }
+        }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsTests.cs
@@ -204,5 +204,18 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 Assert.False(settings.Restore);
             }
         }
+
+        public sealed class TheConsoleLoggerParametersProperty
+        {
+            [Fact]
+            public void Should_Be_Empty_By_Default()
+            {
+                // Given
+                var settings = new MSBuildSettings();
+
+                // Then
+                Assert.Empty(settings.ConsoleLoggerParameters);
+            }
+        }
     }
 }

--- a/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
@@ -187,6 +187,13 @@ namespace Cake.Common.Tools.MSBuild
                 builder.Append("/restore");
             }
 
+            // Got any console logger parameters?
+            if (settings.ConsoleLoggerParameters.Count > 0)
+            {
+                var argument = "/clp:" + string.Join(";", settings.ConsoleLoggerParameters);
+                builder.Append(argument);
+            }
+
             // Add the solution as the last parameter.
             builder.AppendQuoted(solution.MakeAbsolute(_environment).FullPath);
 

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
@@ -135,7 +135,7 @@ namespace Cake.Common.Tools.MSBuild
         /// Use this setting when working with the new csproj format.
         /// </summary>
         public bool Restore { get; set; }
-        
+
         /// <summary>
         /// Gets the console logger parameters.
         /// </summary>

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
@@ -20,6 +20,7 @@ namespace Cake.Common.Tools.MSBuild
         private readonly List<MSBuildFileLogger> _fileLoggers;
         private readonly HashSet<string> _warningsAsErrorCodes;
         private readonly HashSet<string> _warningsAsMessageCodes;
+        private readonly HashSet<string> _consoleLoggerParameters;
 
         /// <summary>
         /// Gets the targets.
@@ -134,6 +135,11 @@ namespace Cake.Common.Tools.MSBuild
         /// Use this setting when working with the new csproj format.
         /// </summary>
         public bool Restore { get; set; }
+        
+        /// <summary>
+        /// Gets the console logger parameters.
+        /// </summary>
+        public ISet<string> ConsoleLoggerParameters => _consoleLoggerParameters;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MSBuildSettings"/> class.
@@ -146,6 +152,7 @@ namespace Cake.Common.Tools.MSBuild
             _fileLoggers = new List<MSBuildFileLogger>();
             _warningsAsErrorCodes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             _warningsAsMessageCodes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _consoleLoggerParameters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             ToolVersion = MSBuildToolVersion.Default;
             Configuration = string.Empty;

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
@@ -345,7 +345,13 @@ namespace Cake.Common.Tools.MSBuild
         /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
         public static MSBuildSettings WithConsoleLoggerParameter(this MSBuildSettings settings, string parameter)
         {
-            throw new NotImplementedException();
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            settings.ConsoleLoggerParameters.Add(parameter);
+            return settings;
         }
     }
 }

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
@@ -336,5 +336,16 @@ namespace Cake.Common.Tools.MSBuild
 
             return settings;
         }
+
+        /// <summary>
+        /// Adds a console logger parameter.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="parameter">The console logger parameter.</param>
+        /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static MSBuildSettings WithConsoleLoggerParameter(this MSBuildSettings settings, string parameter)
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
Fixes #1557

Note: I took a straightforward approach (just a `ISet<string>` on `MSBuildSettings`), but then I realized that it should probably be made more similar to file logger parameters (which has a `MSBuildFileLogger` class with bool properties for each parameter). Let me know if I should refactor (and how: for instance, should I extract a common base class between `MSBuildFileLogger` and `MSBuildConsoleLogger`?)