### PR TITLE
Update OSX Run method

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ RunTarget(target);
 ./build.ps1
 ```
 
-##### Linux / OS X
+##### Linux
 
 ```console
 # Adjust the permissions for the bootstrapper script.
@@ -109,6 +109,24 @@ chmod +x build.sh
 
 # Execute the bootstrapper script.
 ./build.sh
+```
+##### OS X
+
+```console
+# Install Cake with Homebrew
+brew install cake
+
+# Download OSX specific script
+curl -Lsfo build-osx.sh http://cakebuild.net/download/bootstrapper/osx
+
+# Remove the tools folder that contains non-OSX files which would otherwise causes `Error: An item with the same key has already been added`.
+rm -rf tools
+
+# Adjust the permissions for the bootstrapper script.
+chmod +x build.sh
+
+# Run it
+./build-osx.sh
 ```
 
 ## Contributing


### PR DESCRIPTION
The OSX instructions are not working. Added a working one. The `./build.sh` doesn't work with osx, need the osx specific one. And the `tools` folder in the repo causes `Error: An item with the same key has already been added.` even if I use osx specific script. I highly suggest add `tools/` to `.gitignore`

Since this is a trivial build guidance change, no issue has been opened, if needed please comment.
