### PR TITLE
GH1533: Added support for dotnet nuget delete inline with Tooling v1.0

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/DotNetCore/NuGet/Delete/DotNetCoreDeleterFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/DotNetCore/NuGet/Delete/DotNetCoreDeleterFixture.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNetCore.NuGet.Delete;
+
+namespace Cake.Common.Tests.Fixtures.Tools.DotNetCore.NuGet.Delete
+{
+    internal sealed class DotNetCoreDeleterFixture : DotNetCoreFixture<DotNetCoreNuGetDeleteSettings>
+    {
+        public string PackageName { get; set; }
+        public string PackageVersion { get; set; }
+
+        protected override void RunTool()
+        {
+            var tool = new DotNetCoreNuGetDeleter(FileSystem, Environment, ProcessRunner, Tools);
+            tool.Delete(PackageName, PackageVersion, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/NuGet/Delete/DotNetCoreDeleterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/NuGet/Delete/DotNetCoreDeleterTests.cs
@@ -1,0 +1,135 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tests.Fixtures.Tools.DotNetCore.NuGet.Delete;
+using Cake.Common.Tools.DotNetCore.NuGet.Delete;
+using Cake.Testing;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.DotNetCore.NuGet.Delete
+{
+    public sealed class DotNetCoreDeleterTests
+    {
+        public sealed class TheDeleteMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new DotNetCoreDeleterFixture();
+                fixture.Settings = null;
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsArgumentNullException(result, "settings");
+            }
+
+            [Theory]
+            [InlineData(null)]
+            [InlineData("")]
+            [InlineData("       ")]
+            public void Should_Not_Throw_If_PackageName_Is_Empty(string packageName)
+            {
+                // Given
+                var fixture = new DotNetCoreDeleterFixture();
+                fixture.PackageName = packageName;
+                fixture.Settings = new DotNetCoreNuGetDeleteSettings();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("nuget delete", result.Args);
+            }
+
+            [Theory]
+            [InlineData(null)]
+            [InlineData("")]
+            [InlineData("       ")]
+            public void Should_Not_Throw_If_PackageVersion_Is_Empty(string packageVersion)
+            {
+                // Given
+                var fixture = new DotNetCoreDeleterFixture();
+                fixture.PackageName = "name";
+                fixture.PackageVersion = packageVersion;
+                fixture.Settings = new DotNetCoreNuGetDeleteSettings();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("nuget delete name", result.Args);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new DotNetCoreDeleterFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsCakeException(result, ".NET Core CLI: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new DotNetCoreDeleterFixture();
+                fixture.GivenProcessExitsWithCode(1);
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+            }
+
+            [Fact]
+            public void Should_Add_Additional_Arguments()
+            {
+                // Given
+                const string packageName = "name";
+                const string packageVersion = "1.2.3";
+                const string source = "http://www.nuget.org/api/v2/package";
+                const string apiKey = "key1234";
+
+                var fixture = new DotNetCoreDeleterFixture();
+                fixture.Settings.Source = source;
+                fixture.Settings.NonInteractive = true;
+                fixture.Settings.ApiKey = apiKey;
+                fixture.Settings.ForceEnglishOutput = true;
+                fixture.PackageName = packageName;
+                fixture.PackageVersion = packageVersion;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(string.Format("nuget delete {0} {1} --source \"{2}\" --non-interactive --api-key \"{3}\" --force-english-output", packageName, packageVersion, source, apiKey), result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Host_Arguments()
+            {
+                // Given
+                var fixture = new DotNetCoreDeleterFixture();
+                fixture.Settings.DiagnosticOutput = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("--diagnostics nuget delete", result.Args);
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -6,6 +6,7 @@ using System;
 using Cake.Common.Tools.DotNetCore.Build;
 using Cake.Common.Tools.DotNetCore.Clean;
 using Cake.Common.Tools.DotNetCore.Execute;
+using Cake.Common.Tools.DotNetCore.NuGet.Delete;
 using Cake.Common.Tools.DotNetCore.Pack;
 using Cake.Common.Tools.DotNetCore.Publish;
 using Cake.Common.Tools.DotNetCore.Restore;
@@ -588,5 +589,145 @@ namespace Cake.Common.Tools.DotNetCore
             var cleaner = new DotNetCoreCleaner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             cleaner.Clean(project, settings);
         }
+
+         /// <summary>
+         /// Delete a NuGet Package from a server.
+         /// </summary>
+         /// <param name="context">The context.</param>
+         /// <example>
+         /// <code>
+         ///     DotNetCoreNuGetDelete();
+         /// </code>
+         /// </example>
+         [CakeMethodAlias]
+         [CakeAliasCategory("NuGet")]
+         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Delete")]
+         public static void DotNetCoreNuGetDelete(this ICakeContext context)
+         {
+             context.DotNetCoreNuGetDelete(null, null, null);
+         }
+
+         /// <summary>
+         /// Deletes a package from the NuGet.org.
+         /// </summary>
+         /// <param name="context">The context.</param>
+         /// <param name="packageName">Name of package to delete.</param>
+         /// <example>
+         /// <code>
+         ///     DotNetCoreNuGetDelete("Microsoft.AspNetCore.Mvc");
+         /// </code>
+         /// </example>
+         [CakeMethodAlias]
+         [CakeAliasCategory("NuGet")]
+         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Delete")]
+         public static void DotNetCoreNuGetDelete(this ICakeContext context, string packageName)
+         {
+             context.DotNetCoreNuGetDelete(packageName, null, null);
+         }
+
+         /// <summary>
+         /// Deletes a specific version of a package from the NuGet.org.
+         /// </summary>
+         /// <param name="context">The context.</param>
+         /// <param name="packageName">Name of package to delete.</param>
+         /// <param name="packageVersion">Version of package to delete.</param>
+         /// <example>
+         /// <code>
+         ///     DotNetCoreRestore("Microsoft.AspNetCore.Mvc", "1.0");
+         /// </code>
+         /// </example>
+         [CakeMethodAlias]
+         [CakeAliasCategory("NuGet")]
+         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Delete")]
+         public static void DotNetCoreNuGetDelete(this ICakeContext context, string packageName, string packageVersion)
+         {
+             context.DotNetCoreNuGetDelete(packageName, packageVersion, null);
+         }
+
+         /// <summary>
+         /// Deletes a package from a server
+         /// </summary>
+         /// <param name="context">The context.</param>
+         /// <param name="packageName">Name of package to delete.</param>
+         /// <param name="settings">The settings.</param>
+         /// <example>
+         /// <code>
+         ///     var settings = new DotNetCoreNuGetDeleteSettings
+         ///     {
+         ///         Source = "https://www.example.com/nugetfeed",
+         ///         NonInteractive = true
+         ///     };
+         ///
+         ///     DotNetCoreNuGetDelete("Microsoft.AspNetCore.Mvc", settings);
+         /// </code>
+         /// </example>
+         [CakeMethodAlias]
+         [CakeAliasCategory("NuGet")]
+         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Delete")]
+         public static void DotNetCoreNuGetDelete(this ICakeContext context, string packageName, DotNetCoreNuGetDeleteSettings settings)
+         {
+             context.DotNetCoreNuGetDelete(packageName, null, settings);
+         }
+
+         /// <summary>
+         /// Deletes a package from a server using the specified settings.
+         /// </summary>
+         /// <param name="context">The context.</param>
+         /// <param name="settings">The settings.</param>
+         /// <example>
+         /// <code>
+         ///     var settings = new DotNetCoreNuGetDeleteSettings
+         ///     {
+         ///         Source = "https://www.example.com/nugetfeed",
+         ///         NonInteractive = true
+         ///     };
+         ///
+         ///     DotNetCoreNuGetDelete(settings);
+         /// </code>
+         /// </example>
+         [CakeMethodAlias]
+         [CakeAliasCategory("NuGet")]
+         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Delete")]
+         public static void DotNetCoreNuGetDelete(this ICakeContext context, DotNetCoreNuGetDeleteSettings settings)
+         {
+             context.DotNetCoreNuGetDelete(null, null, settings);
+         }
+
+         /// <summary>
+         /// Deletes a package from a server using the specified settings.
+         /// </summary>
+         /// <param name="context">The context.</param>
+         /// <param name="packageName">Name of package to delete.</param>
+         /// <param name="packageVersion">Version of package to delete.</param>
+         /// <param name="settings">The settings.</param>
+         /// <example>
+         ///  <code>
+         ///     var settings = new DotNetCoreNuGetDeleteSettings
+         ///     {
+         ///         Source = "https://www.example.com/nugetfeed",
+         ///         NonInteractive = true
+         ///     };
+         ///
+         ///     DotNetCoreNuGetDelete("Microsoft.AspNetCore.Mvc", "1.0", settings);
+         ///  </code>
+         /// </example>
+         [CakeMethodAlias]
+         [CakeAliasCategory("NuGet")]
+         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Delete")]
+         public static void DotNetCoreNuGetDelete(this ICakeContext context, string packageName, string packageVersion, DotNetCoreNuGetDeleteSettings settings)
+         {
+             if (context == null)
+             {
+                 throw new ArgumentNullException(nameof(context));
+             }
+
+             if (settings == null)
+             {
+                 settings = new DotNetCoreNuGetDeleteSettings();
+             }
+
+             var restorer = new DotNetCoreNuGetDeleter(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+             restorer.Delete(packageName, packageVersion, settings);
+         }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/NuGet/Delete/DotNetCoreNuGetDeleteSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/NuGet/Delete/DotNetCoreNuGetDeleteSettings.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Tools.DotNetCore.NuGet.Delete
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetCoreNuGetDeleter" />.
+    /// </summary>
+    public sealed class DotNetCoreNuGetDeleteSettings : DotNetCoreSettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating the server URL.
+        /// </summary>
+        /// <remarks>
+        /// Supported URLs for nuget.org include http://www.nuget.org, http://www.nuget.org/api/v3,
+        /// and http://www.nuget.org/api/v2/package. For private feeds, substitute the host name
+        /// (for example, %hostname%/api/v3).
+        /// </remarks>
+        public string Source { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to prompt for user input or confirmations.
+        /// </summary>
+        public bool NonInteractive { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating the API key for the server.
+        /// </summary>
+        public string ApiKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to force command-line output in English.
+        /// </summary>
+        public bool ForceEnglishOutput { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/NuGet/Delete/DotNetCoreNuGetDeleter.cs
+++ b/src/Cake.Common/Tools/DotNetCore/NuGet/Delete/DotNetCoreNuGetDeleter.cs
@@ -1,0 +1,94 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.DotNetCore.NuGet.Delete
+{
+    /// <summary>
+    /// .NET Core nuget deleter, deletes or unlists a package from the server.
+    /// </summary>
+    public sealed class DotNetCoreNuGetDeleter : DotNetCoreTool<DotNetCoreNuGetDeleteSettings>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotNetCoreNuGetDeleter" /> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="tools">The tool locator.</param>
+        public DotNetCoreNuGetDeleter(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IToolLocator tools) : base(fileSystem, environment, processRunner, tools)
+        {
+        }
+
+        /// <summary>
+        /// Delete the NuGet package using the specified name, version and settings.
+        /// </summary>
+        /// <param name="packageName">The name of the target package.</param>
+        /// <param name="version">Version of the package.</param>
+        /// <param name="settings">The settings.</param>
+        public void Delete(string packageName, string version, DotNetCoreNuGetDeleteSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            RunCommand(settings, GetArguments(packageName, version, settings));
+        }
+
+        private ProcessArgumentBuilder GetArguments(string packageName, string packageVersion, DotNetCoreNuGetDeleteSettings settings)
+        {
+            var builder = CreateArgumentBuilder(settings);
+
+            builder.Append("nuget delete");
+
+            // Specific package and version?
+            if (!string.IsNullOrWhiteSpace(packageName))
+            {
+                builder.Append(packageName);
+
+                if (!string.IsNullOrWhiteSpace(packageVersion))
+                {
+                    builder.Append(packageVersion);
+                }
+            }
+
+            // Source to delete package at
+            if (!string.IsNullOrWhiteSpace(settings.Source))
+            {
+                builder.Append("--source");
+                builder.AppendQuoted(settings.Source);
+            }
+
+            // Is it CI?
+            if (settings.NonInteractive)
+            {
+                builder.Append("--non-interactive");
+            }
+
+            // API Key
+            if (!string.IsNullOrEmpty(settings.ApiKey))
+            {
+                builder.Append("--api-key");
+                builder.AppendQuoted(settings.ApiKey);
+            }
+
+            // Force English Output
+            if (settings.ForceEnglishOutput)
+            {
+                builder.Append("--force-english-output");
+            }
+
+            return builder;
+        }
+    }
+}


### PR DESCRIPTION
* Added DotNetCoreNugetDelete Alias for `dotnet nuget delete`
* Added unit tests

For more information see #1533