### PR TITLE
GH-1566: Correct the MethodAliasGenerator to for generic type constraints

### DIFF
--- a/src/Cake.Core.Tests/Data/MethodAliasGeneratorData.cs
+++ b/src/Cake.Core.Tests/Data/MethodAliasGeneratorData.cs
@@ -89,6 +89,14 @@ namespace Cake.Core.Tests.Data
         }
 
         [CakeMethodAlias]
+        public static TOut Generic_ExtensionMethodWithGenericReturnValueAndTypeParamConstraints<TIn, TOut>(this ICakeContext context, TIn arg)
+            where TIn : class, new()
+            where TOut : System.Collections.ArrayList, IDisposable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
         public static void NonGeneric_ExtensionMethodWithParameterArray(this ICakeContext context, params int[] values)
         {
             throw new NotImplementedException();

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/Generic_ExtensionMethodWithGenericReturnValueAndTypeParamConstraints
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/Generic_ExtensionMethodWithGenericReturnValueAndTypeParamConstraints
@@ -1,0 +1,6 @@
+﻿public TOut Generic_ExtensionMethodWithGenericReturnValueAndTypeParamConstraints<TIn, TOut>(TIn arg)
+where TIn : class, new()
+where TOut : System.Collections.ArrayList, System.IDisposable
+{
+    return Cake.Core.Tests.Data.MethodAliasGeneratorData.Generic_ExtensionMethodWithGenericReturnValueAndTypeParamConstraints<TIn, TOut>(Context, arg);
+}

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/GenericConstraintFakes.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/GenericConstraintFakes.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Core.Tests.Unit.Scripting.CodeGen
+{
+    /// <summary>
+    /// Provides test/marker classes for tests in <see cref="GenericParameterConstraintEmitterTests"/>
+    /// </summary>
+    internal static class GenericConstraintFakes
+    {
+        internal class FakeClass
+        {
+        }
+
+        internal interface IFakeInterface
+        {
+        }
+    }
+}

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/GenericParameterConstraintEmitterTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/GenericParameterConstraintEmitterTests.cs
@@ -1,0 +1,133 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Cake.Core.Scripting.CodeGen;
+using Xunit;
+// ReSharper disable UnusedMember.Local
+// ReSharper disable UnusedParameter.Local
+namespace Cake.Core.Tests.Unit.Scripting.CodeGen
+{
+    public sealed class GenericParameterConstraintEmitterTests
+    {
+        // ReSharper disable once ClassNeverInstantiated.Local
+        private class FakeClass
+        {
+        }
+
+        private interface IFakeInterface
+        {
+        }
+
+        private static class GenericParameterConstraintEmitterFixture
+        {
+            public static TResult Test_TResult_No_Constraints<TResult>()
+            {
+                throw new NotImplementedException();
+            }
+
+            public static TResult Test_TResult_class<TResult>() where TResult : class
+            {
+                throw new NotImplementedException();
+            }
+
+            public static TResult Test_TResult_class_new<TResult>() where TResult : class, new()
+            {
+                throw new NotImplementedException();
+            }
+
+            public static TResult Test_TResult_struct<TResult>() where TResult : struct
+            {
+                throw new NotImplementedException();
+            }
+
+            public static TResult Test_TResult_struct_and_IFakeInterface<TResult>() where TResult : struct, IFakeInterface
+            {
+                throw new NotImplementedException();
+            }
+
+            public static TOut Test_TOut_TIn_NoConstraints<TIn, TOut>(TIn obj)
+            {
+                throw new NotImplementedException();
+            }
+
+            public static TOut Test_TOut_TIn_TIn_is_FakeClass<TIn, TOut>(TIn obj) where TIn : FakeClass
+            {
+                throw new NotImplementedException();
+            }
+
+            public static TOut Test_TOut_TIn_TIn_is_IFakeInterface<TIn, TOut>(TIn obj) where TIn : IFakeInterface
+            {
+                throw new NotImplementedException();
+            }
+
+            public static TOut Test_TOut_TIn_TIn_is_IFakeInterface_and_DefaultCtor<TIn, TOut>(TIn obj) where TIn : IFakeInterface, new()
+            {
+                throw new NotImplementedException();
+            }
+
+            public static TOut Test_TOut_TIn_TIn_is_FakeClass_and_DefaultCtor<TIn, TOut>(TIn obj) where TIn : FakeClass, new()
+            {
+                throw new NotImplementedException();
+            }
+
+            public static TOut Test_TOut_TIn_TIn_is_FakeClass_and_IFakeInterface<TIn, TOut>(TIn obj) where TIn : FakeClass, IFakeInterface
+            {
+                throw new NotImplementedException();
+            }
+
+            public static TOut Test_TOut_TIn_TIn_is_FakeClass_and_IFakeInterface_and_DefaultCtor<TIn, TOut>(TIn obj) where TIn : FakeClass, IFakeInterface, new()
+            {
+                throw new NotImplementedException();
+            }
+
+            public static TOut Test_TOut_TIn_TIn_is_FakeClass_and_IFakeInterface_and_TOut_IsIFakeInterface<TIn, TOut>(TIn obj)
+                where TIn : FakeClass, IFakeInterface
+                where TOut : IFakeInterface
+            {
+                throw new NotImplementedException();
+            }
+
+            public static void Test_TIn_TIn_is_NestedFakeClass_and_NestedFakeInterface<TIn>(TIn obj) where TIn : Cake.Core.Tests.Unit.Scripting.CodeGen.GenericConstraintFakes.FakeClass, Cake.Core.Tests.Unit.Scripting.CodeGen.GenericConstraintFakes.IFakeInterface
+            {
+                throw new NotImplementedException();
+            }
+
+            public static void Test_TIn_TIn_Is_IEnumerable_int<TIn>(TIn obj)
+                where TIn : IEnumerable<int>
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [Theory]
+        [InlineData("Test_TResult_No_Constraints", "")]
+        [InlineData("Test_TResult_class", "where TResult : class")]
+        [InlineData("Test_TResult_class_new", "where TResult : class, new()")]
+        [InlineData("Test_TResult_struct", "where TResult : struct")]
+        [InlineData("Test_TResult_struct_and_IFakeInterface", "where TResult : struct, Cake.Core.Tests.Unit.Scripting.CodeGen.GenericParameterConstraintEmitterTests.IFakeInterface")]
+        [InlineData("Test_TOut_TIn_NoConstraints", "")]
+        [InlineData("Test_TOut_TIn_TIn_is_FakeClass", "where TIn : Cake.Core.Tests.Unit.Scripting.CodeGen.GenericParameterConstraintEmitterTests.FakeClass")]
+        [InlineData("Test_TOut_TIn_TIn_is_IFakeInterface_and_DefaultCtor", "where TIn : Cake.Core.Tests.Unit.Scripting.CodeGen.GenericParameterConstraintEmitterTests.IFakeInterface, new()")]
+        [InlineData("Test_TOut_TIn_TIn_is_FakeClass_and_DefaultCtor", "where TIn : Cake.Core.Tests.Unit.Scripting.CodeGen.GenericParameterConstraintEmitterTests.FakeClass, new()")]
+        [InlineData("Test_TOut_TIn_TIn_is_FakeClass_and_IFakeInterface", "where TIn : Cake.Core.Tests.Unit.Scripting.CodeGen.GenericParameterConstraintEmitterTests.FakeClass, Cake.Core.Tests.Unit.Scripting.CodeGen.GenericParameterConstraintEmitterTests.IFakeInterface")]
+        [InlineData("Test_TOut_TIn_TIn_is_FakeClass_and_IFakeInterface_and_DefaultCtor", "where TIn : Cake.Core.Tests.Unit.Scripting.CodeGen.GenericParameterConstraintEmitterTests.FakeClass, Cake.Core.Tests.Unit.Scripting.CodeGen.GenericParameterConstraintEmitterTests.IFakeInterface, new()")]
+        [InlineData("Test_TOut_TIn_TIn_is_FakeClass_and_IFakeInterface_and_TOut_IsIFakeInterface", "where TIn : Cake.Core.Tests.Unit.Scripting.CodeGen.GenericParameterConstraintEmitterTests.FakeClass, Cake.Core.Tests.Unit.Scripting.CodeGen.GenericParameterConstraintEmitterTests.IFakeInterface\r\nwhere TOut : Cake.Core.Tests.Unit.Scripting.CodeGen.GenericParameterConstraintEmitterTests.IFakeInterface")]
+        [InlineData("Test_TIn_TIn_is_NestedFakeClass_and_NestedFakeInterface", "where TIn : Cake.Core.Tests.Unit.Scripting.CodeGen.GenericConstraintFakes.FakeClass, Cake.Core.Tests.Unit.Scripting.CodeGen.GenericConstraintFakes.IFakeInterface")]
+        [InlineData("Test_TIn_TIn_Is_IEnumerable_int", "where TIn : System.Collections.Generic.IEnumerable<System.Int32>")]
+        public void Should_Return_Correct_Generated_Code_For_Generic_Method_Parameter_Constraints(string methodName, string expected)
+        {
+            // Given
+            var method = typeof(GenericParameterConstraintEmitterFixture).GetMethod(methodName, BindingFlags.Static | BindingFlags.Public);
+
+            // When
+            var result = GenericParameterConstraintEmitter.Emit(method);
+
+            // Then
+            Assert.Equal(expected.NormalizeLineEndings(), result.NormalizeLineEndings());
+        }
+    }
+}

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/MethodAliasGeneratorTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/MethodAliasGeneratorTests.cs
@@ -68,6 +68,7 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
             [InlineData("Generic_ExtensionMethod")]
             [InlineData("Generic_ExtensionMethodWithParameter")]
             [InlineData("Generic_ExtensionMethodWithGenericReturnValue")]
+            [InlineData("Generic_ExtensionMethodWithGenericReturnValueAndTypeParamConstraints")]
             public void Should_Return_Correct_Generated_Code_For_Generic_Methods(string name)
             {
                 // Given

--- a/src/Cake.Core/Scripting/CodeGen/GenericParameterConstraintEmitter.cs
+++ b/src/Cake.Core/Scripting/CodeGen/GenericParameterConstraintEmitter.cs
@@ -1,0 +1,100 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace Cake.Core.Scripting.CodeGen
+{
+    /// <summary>
+    /// Responsible for generating generic parameter constraints on generated generic methods
+    /// </summary>
+    internal sealed class GenericParameterConstraintEmitter
+    {
+        internal static string Emit(MethodInfo method)
+        {
+            var builder = new StringBuilder();
+            BuildGenericConstraints(method, builder);
+            return builder.ToString().Trim();
+        }
+
+        internal static void BuildGenericConstraints(MethodInfo method, StringBuilder builder)
+        {
+            if (!method.IsGenericMethod)
+            {
+                return;
+            }
+
+            /*
+             Possible permutations:
+             T : class
+             T : class, new(),
+             T : SomeClass
+             T : ISomeInterface
+             T : SomeClass, ISomeInterface
+             T : SomeClass, ISomeInterface, new()
+             T : struct
+             T : struct, ISomeInterface
+
+             Cannot specify both ClassType and [struct|class]
+             Cannot specify `struct, new()`
+             */
+
+            foreach (var argument in method.GetGenericMethodDefinition().GetGenericArguments())
+            {
+                var paramAttributes = argument.GetTypeInfo().GenericParameterAttributes;
+                var tokens = new List<string>();
+
+                if (paramAttributes.HasFlag(GenericParameterAttributes.NotNullableValueTypeConstraint))
+                {
+                    tokens.Add("struct");
+
+                    // iterate type constraints; it's possible that you can have ` where T : struct, ISomeInterface`
+                    foreach (var constraint in argument.GetTypeInfo().GetGenericParameterConstraints())
+                    {
+                        // however, the struct constraint will return System.ValueType.
+                        // it's not necessarily to emit that as syntax in a generated method
+                        if (constraint == typeof(System.ValueType))
+                        {
+                            continue;
+                        }
+
+                        // fix any nested type names
+                        tokens.Add(constraint.GetFullName().Replace('+', '.'));
+                    }
+                }
+                else
+                {
+                    // if it's declared a struct, we can't use any other constraints (inherits/implements or default ctor)
+
+                    // special considerations? reference/value
+                    if (paramAttributes.HasFlag(GenericParameterAttributes.ReferenceTypeConstraint))
+                    {
+                        tokens.Add("class");
+                    }
+
+                    // iterate type constraints
+                    foreach (var constraint in argument.GetTypeInfo().GetGenericParameterConstraints())
+                    {
+                        // fix any nested type names
+                        tokens.Add(constraint.GetFullName().Replace('+', '.'));
+                    }
+
+                    // default constructor has to come last, can't be used in conjunction w/ struct
+                    if (paramAttributes.HasFlag(GenericParameterAttributes.DefaultConstructorConstraint))
+                    {
+                        tokens.Add("new()");
+                    }
+                }
+
+                if (tokens.Count > 0)
+                {
+                    builder.AppendLine();
+                    builder.AppendFormat("where {0} : {1}", argument.Name, string.Join(", ", tokens));
+                }
+            }
+        }
+    }
+}

--- a/src/Cake.Core/Scripting/CodeGen/MethodAliasGenerator.cs
+++ b/src/Cake.Core/Scripting/CodeGen/MethodAliasGenerator.cs
@@ -50,6 +50,13 @@ namespace Cake.Core.Scripting.CodeGen
             builder.Append("(");
             builder.Append(string.Concat(GetProxyParameters(parameters, true)));
             builder.Append(")");
+
+            // if the method is generic, emit any constraints that might exist.
+            if (method.IsGenericMethod)
+            {
+                GenericParameterConstraintEmitter.BuildGenericConstraints(method, builder);
+            }
+
             builder.AppendLine();
             builder.Append("{");
             builder.AppendLine();


### PR DESCRIPTION
This addresses the issues described in GH-1566

Refactor logic to GenericParameterConstraintEmitter to properly generate any type constraints that might exist on the alias methods.
Add logic to handle emitting the various type constraints
Add test coverage
