### PR TITLE
(GH-1556) Change TeamCityBuildInfo.Number to string

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Build/TeamCityInfoFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/TeamCityInfoFixture.cs
@@ -17,7 +17,7 @@ namespace Cake.Common.Tests.Fixtures.Build
             Environment = Substitute.For<ICakeEnvironment>();
 
             Environment.GetEnvironmentVariable("TEAMCITY_BUILDCONF_NAME").Returns(@"Cake Build");
-            Environment.GetEnvironmentVariable("BUILD_NUMBER").Returns("10");
+            Environment.GetEnvironmentVariable("BUILD_NUMBER").Returns("10-Foo");
 
             Environment.GetEnvironmentVariable("TEAMCITY_PROJECT_NAME").Returns("Cake");
 

--- a/src/Cake.Common.Tests/Unit/Build/TeamCity/Data/TeamCityBuildInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TeamCity/Data/TeamCityBuildInfoTests.cs
@@ -37,7 +37,7 @@ namespace Cake.Common.Tests.Unit.Build.TeamCity.Data
                 var result = info.Number;
 
                 // Then
-                Assert.Equal(10, result);
+                Assert.Equal("10-Foo", result);
             }
         }
     }

--- a/src/Cake.Common/Build/TeamCity/Data/TeamCityBuildInfo.cs
+++ b/src/Cake.Common/Build/TeamCity/Data/TeamCityBuildInfo.cs
@@ -20,12 +20,12 @@ namespace Cake.Common.Build.TeamCity.Data
         public string BuildConfName => GetEnvironmentString("TEAMCITY_BUILDCONF_NAME");
 
         /// <summary>
-        /// Gets the build counter.
+        /// Gets the build number.
         /// </summary>
         /// <value>
-        /// The build counter.
+        /// The build number.
         /// </value>
-        public int Number => GetEnvironmentInteger("BUILD_NUMBER");
+        public string Number => GetEnvironmentString("BUILD_NUMBER");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TeamCityBuildInfo"/> class.


### PR DESCRIPTION
Change datatype of `TeamCityBuildInfo.Number` from `int` to `string`.

Fixes #1556 