### PR TITLE
GH-1577: DotNetCoolTool Alias 

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/DotNetCore/Tool/DotNetCoreToolFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/DotNetCore/Tool/DotNetCoreToolFixture.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNetCore.Tool;
+using Cake.Core.IO;
+using Cake.Testing;
+
+namespace Cake.Common.Tests.Fixtures.Tools.DotNetCore.Tool
+{
+    internal sealed class DotNetCoreToolFixture : DotNetCoreFixture<DotNetCoreToolSettings>
+    {
+        public FilePath ProjectPath { get; set; }
+
+        public string Command { get; set; }
+
+        public ProcessArgumentBuilder Arguments { get; set; }
+
+        protected override void RunTool()
+        {
+            var tool = new DotNetCoreToolRunner(FileSystem, Environment, ProcessRunner, Tools);
+
+            tool.Execute(ProjectPath, Command, Arguments, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Tool/DotNetCoreToolTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Tool/DotNetCoreToolTests.cs
@@ -1,0 +1,104 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tests.Fixtures.Tools.DotNetCore.Tool;
+using Cake.Common.Tools.DotNetCore;
+using Cake.Common.Tools.DotNetCore.Tool;
+using Cake.Testing;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Tool
+{
+    public sealed class DotNetCoreToolTests
+    {
+        public sealed class TheToolMethod
+        {
+            [Fact]
+            public void Should_Throw_If_ProjectPath_IsNull()
+            {
+                // Given
+                var fixture = new DotNetCoreToolFixture();
+                fixture.ProjectPath = null;
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "projectPath");
+            }
+
+            [Theory]
+            [InlineData("")]
+            [InlineData(null)]
+            public void Should_Throw_If_Command_IsNull(string command)
+            {
+                // Given
+                var fixture = new DotNetCoreToolFixture();
+                fixture.ProjectPath = "./tests/Cake.Common.Tests/";
+                fixture.Command = command;
+
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "command");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new DotNetCoreToolFixture();
+                fixture.ProjectPath = "./tests/Cake.Common.Tests/";
+                fixture.Command = "xunit";
+                fixture.Settings = null;
+
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new DotNetCoreToolFixture();
+                fixture.ProjectPath = "./tests/Cake.Common.Tests/";
+                fixture.Command = "xunit";
+                fixture.Settings = new DotNetCoreToolSettings();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new DotNetCoreToolFixture();
+                fixture.ProjectPath = "./tests/Cake.Common.Tests/";
+                fixture.Command = "xunit";
+                fixture.Settings = new DotNetCoreToolSettings();
+                fixture.GivenProcessExitsWithCode(1);
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -16,6 +16,7 @@ using Cake.Common.Tools.DotNetCore.Publish;
 using Cake.Common.Tools.DotNetCore.Restore;
 using Cake.Common.Tools.DotNetCore.Run;
 using Cake.Common.Tools.DotNetCore.Test;
+using Cake.Common.Tools.DotNetCore.Tool;
 using Cake.Common.Tools.DotNetCore.VSTest;
 using Cake.Core;
 using Cake.Core.Annotations;
@@ -1052,6 +1053,63 @@ namespace Cake.Common.Tools.DotNetCore
 
             var tester = new DotNetCoreVSTester(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             tester.Test(testFiles, settings);
+        }
+
+        /// <summary>
+        /// /// Execute an .NET Core Extensibility Tool.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="project">The projects path.</param>
+        /// <param name="command">The command to execute.</param>
+        /// <example>
+        /// <code>
+        ///     DotNetCoreTool("./src/project", "xunit", "-xml report.xml");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Tool")]
+        public static void DotNetCoreTool(this ICakeContext context, string project, string command)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var arguments = new ProcessArgumentBuilder();
+            var settings = new DotNetCoreToolSettings();
+            var projectPath = FilePath.FromString(project);
+
+            var runner = new DotNetCoreToolRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            runner.Execute(projectPath, command, arguments, settings);
+        }
+
+        /// <summary>
+        /// Execute an .NET Core Extensibility Tool.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="projectPath">The projects path.</param>
+        /// <param name="command">The command to execute.</param>
+        /// <param name="arguments">The arguments.</param>
+        /// <example>
+        /// <code>
+        ///     DotNetCoreTool("./src/project", "xunit", "-xml report.xml");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Tool")]
+        public static void DotNetCoreTool(this ICakeContext context, FilePath projectPath, string command, ProcessArgumentBuilder arguments)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var settings = new DotNetCoreToolSettings();
+            var runner = new DotNetCoreToolRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+
+            runner.Execute(projectPath, command, arguments, settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreTool.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreTool.cs
@@ -64,6 +64,20 @@ namespace Cake.Common.Tools.DotNetCore
         }
 
         /// <summary>
+        /// Runs the dotnet cli command using the specified settings and arguments.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="arguments">The arguments.</param>
+        /// <param name="processSettings">The processSettings.</param>
+        protected void RunCommand(TSettings settings, ProcessArgumentBuilder arguments, ProcessSettings processSettings)
+        {
+            // add arguments common to all commands last
+            AppendCommonArguments(arguments, settings);
+
+            Run(settings, arguments, processSettings, null);
+        }
+
+        /// <summary>
         /// Creates a <see cref="ProcessArgumentBuilder"/> and adds common commandline arguments.
         /// </summary>
         /// <param name="settings">The settings.</param>

--- a/src/Cake.Common/Tools/DotNetCore/Tool/DotNetCoreToolRunner.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Tool/DotNetCoreToolRunner.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.DotNetCore.Tool
+{
+    /// <summary>
+    /// .NET Core Extensibility Commands Runner.
+    /// </summary>
+    public sealed class DotNetCoreToolRunner : DotNetCoreTool<DotNetCoreSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotNetCoreToolRunner" /> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="tools">The tool locator.</param>
+        public DotNetCoreToolRunner(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IToolLocator tools) : base(fileSystem, environment, processRunner, tools)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Execute an assembly using arguments and settings.
+        /// </summary>
+        /// <param name="projectPath">The target project path.</param>
+        /// <param name="command">The command to execute.</param>
+        /// <param name="arguments">The arguments.</param>
+        /// <param name="settings">The settings.</param>
+        public void Execute(FilePath projectPath, string command, ProcessArgumentBuilder arguments, DotNetCoreToolSettings settings)
+        {
+            if (projectPath == null)
+            {
+                throw new ArgumentNullException(nameof(projectPath));
+            }
+
+            if (string.IsNullOrWhiteSpace(command))
+            {
+                throw new ArgumentNullException(nameof(command));
+            }
+
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            var processSettings = new ProcessSettings();
+            processSettings.WorkingDirectory = projectPath.GetDirectory();
+
+            RunCommand(settings, GetArguments(command, arguments, settings), processSettings);
+        }
+
+        private ProcessArgumentBuilder GetArguments(string command, ProcessArgumentBuilder arguments, DotNetCoreToolSettings settings)
+        {
+            var builder = CreateArgumentBuilder(settings);
+
+            builder.Append(command);
+
+            // Arguments
+            if (!arguments.IsNullOrEmpty())
+            {
+                arguments.CopyTo(builder);
+            }
+
+            return builder;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/Tool/DotNetCoreToolSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Tool/DotNetCoreToolSettings.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Tools.DotNetCore.Tool
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetCoreToolRunner" />.
+    /// </summary>
+    public sealed class DotNetCoreToolSettings : DotNetCoreSettings
+    {
+    }
+}


### PR DESCRIPTION
Created a generic DotNetCoreTool alias allowing per-project extension commands to be executed.

Example usage:

```
Task("Test")
    .Does(() => {
        var testProjects = GetFiles("./test/**/*.csproj");

        foreach(var testProject in testProjects)
        {
            DotNetCoreTool(testProject, "xunit", "-xml report.xml");
        }
    }
);
```

Related: GH-1533