### PR TITLE
GH1591: Add ChocolateyDownload alias

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/Download/ChocolateyDownloadFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/Download/ChocolateyDownloadFixture.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.Chocolatey.Download;
+
+namespace Cake.Common.Tests.Fixtures.Tools.Chocolatey.Download
+{
+    internal sealed class ChocolateyDownloadFixture : ChocolateyFixture<ChocolateyDownloadSettings>
+    {
+        public string PackageId { get; set; }
+
+        public ChocolateyDownloadFixture()
+        {
+            PackageId = "MyPackage";
+        }
+
+        protected override void RunTool()
+        {
+            var tool = new ChocolateyDownloader(FileSystem, Environment, ProcessRunner, Tools, Resolver);
+            tool.Download(PackageId, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Download/ChocolateyDownloadTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Download/ChocolateyDownloadTests.cs
@@ -1,0 +1,544 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tests.Fixtures.Tools.Chocolatey.Download;
+using Cake.Testing;
+using Cake.Testing.Xunit;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Download
+{
+    public sealed class ChocolateyDownloadTests
+    {
+        public sealed class TheDownloadMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Package_Id_Is_Null()
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.PackageId = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "packageId");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Chocolatey_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, "Chocolatey: Could not locate executable.");
+            }
+
+            [Theory]
+            [InlineData("/bin/chocolatey/choco.exe", "/bin/chocolatey/choco.exe")]
+            [InlineData("./chocolatey/choco.exe", "/Working/chocolatey/choco.exe")]
+            public void Should_Use_Chocolatey_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.ToolPath = toolPath;
+                fixture.GivenSettingsToolPathExist();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Path.FullPath);
+            }
+
+            [WindowsTheory]
+            [InlineData("C:/ProgramData/chocolatey/choco.exe", "C:/ProgramData/chocolatey/choco.exe")]
+            public void Should_Use_Chocolatey_Executable_From_Tool_Path_If_Provided_On_Windows(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.ToolPath = toolPath;
+                fixture.GivenSettingsToolPathExist();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Path.FullPath);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, "Chocolatey: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.GivenProcessExitsWithCode(1);
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, "Chocolatey: Process returned an error (exit code 1).");
+            }
+
+            [Fact]
+            public void Should_Find_Chocolatey_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/Working/tools/choco.exe", result.Path.FullPath);
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("download \"MyPackage\" -y", result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "download \"MyPackage\" -d -y")]
+            [InlineData(false, "download \"MyPackage\" -y")]
+            public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.Debug = debug;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "download \"MyPackage\" -v -y")]
+            [InlineData(false, "download \"MyPackage\" -y")]
+            public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.Verbose = verbose;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "download \"MyPackage\" --acceptLicense -y")]
+            [InlineData(false, "download \"MyPackage\" -y")]
+            public void Should_Add_AcceptLicense_Flag_To_Arguments_If_Set(bool acceptLicense, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.AcceptLicense = acceptLicense;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "download \"MyPackage\" -y -f")]
+            [InlineData(false, "download \"MyPackage\" -y")]
+            public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.Force = force;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "download \"MyPackage\" -y --noop")]
+            [InlineData(false, "download \"MyPackage\" -y")]
+            public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.Noop = noop;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "download \"MyPackage\" -y -r")]
+            [InlineData(false, "download \"MyPackage\" -y")]
+            public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.LimitOutput = limitOutput;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(5, "download \"MyPackage\" -y --execution-timeout \"5\"")]
+            [InlineData(0, "download \"MyPackage\" -y")]
+            public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.ExecutionTimeout = executionTimeout;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(@"c:\temp", "download \"MyPackage\" -y -c \"c:\\temp\"")]
+            [InlineData("", "download \"MyPackage\" -y")]
+            public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.CacheLocation = cacheLocation;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "download \"MyPackage\" -y --allowunofficial")]
+            [InlineData(false, "download \"MyPackage\" -y")]
+            public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.AllowUnofficial = allowUnofficial;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Source_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.Source = "A";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("download \"MyPackage\" -y -s \"A\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Version_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.Version = "1.0.0";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("download \"MyPackage\" -y --version \"1.0.0\"", result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "download \"MyPackage\" -y --pre")]
+            [InlineData(false, "download \"MyPackage\" -y")]
+            public void Should_Add_Prerelease_Flag_To_Arguments_If_Set(bool prerelease, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.Prerelease = prerelease;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Output_Directory_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.OutputDirectory = "./Foo";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("download \"MyPackage\" -y --outputdirectory \"/Working/Foo\"", result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "download \"MyPackage\" -y -i")]
+            [InlineData(false, "download \"MyPackage\" -y")]
+            public void Should_Add_IgnoreDependencies_Flag_To_Arguments_If_Set(bool ignoreDependencies, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.IgnoreDependencies = ignoreDependencies;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "download \"MyPackage\" -y --internalize")]
+            [InlineData(false, "download \"MyPackage\" -y")]
+            public void Should_Add_Internalize_Flag_To_Arguments_If_Set(bool internalize, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.Internalize = internalize;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(@"\\foo", "download \"MyPackage\" -y --internalize --resources-location=\"\\\\foo\"")]
+            [InlineData("https://foo.local", "download \"MyPackage\" -y --internalize --resources-location=\"https://foo.local\"")]
+            [InlineData(null, "download \"MyPackage\" -y --internalize")]
+            [InlineData("", "download \"MyPackage\" -y --internalize")]
+            public void Should_Add_ResourceLocation_To_Arguments_If_Set(string resourcesLocation, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.Internalize = true;
+                fixture.Settings.ResourcesLocation = resourcesLocation;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(@"\\foo")]
+            [InlineData("https://foo.local")]
+            [InlineData(null)]
+            [InlineData("")]
+            public void Should_Not_Add_ResourceLocation_To_Arguments_If_Internalize_Is_Not_Set(string resourcesLocation)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.Internalize = false;
+                fixture.Settings.ResourcesLocation = resourcesLocation;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("download \"MyPackage\" -y", result.Args);
+            }
+
+            [Theory]
+            [InlineData(@"\\foo", "download \"MyPackage\" -y --internalize --resources-location=\"\\\\resources\" --download-location=\"\\\\foo\"")]
+            [InlineData("https://foo.local", "download \"MyPackage\" -y --internalize --resources-location=\"\\\\resources\" --download-location=\"https://foo.local\"")]
+            [InlineData(null, "download \"MyPackage\" -y --internalize --resources-location=\"\\\\resources\"")]
+            [InlineData("", "download \"MyPackage\" -y --internalize --resources-location=\"\\\\resources\"")]
+            public void Should_Add_DownloadLocation_To_Arguments_If_Set(string downloadLocation, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.Internalize = true;
+                fixture.Settings.ResourcesLocation = @"\\resources";
+                fixture.Settings.DownloadLocation = downloadLocation;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(@"\\foo")]
+            [InlineData("https://foo.local")]
+            [InlineData(null)]
+            [InlineData("")]
+            public void Should_Not_Add_DownloadLocation_To_Arguments_If_Internalize_Is_Not_Set(string downloadLocation)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.Internalize = false;
+                fixture.Settings.ResourcesLocation = @"\\foo";
+                fixture.Settings.DownloadLocation = downloadLocation;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("download \"MyPackage\" -y", result.Args);
+            }
+
+            [Theory]
+            [InlineData(@"\\foo")]
+            [InlineData("https://foo.local")]
+            [InlineData(null)]
+            [InlineData("")]
+            public void Should_Not_Add_DownloadLocation_To_Arguments_If_ResourcesLocation_Is_Not_Set(string downloadLocation)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.Internalize = true;
+                fixture.Settings.ResourcesLocation = null;
+                fixture.Settings.DownloadLocation = downloadLocation;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("download \"MyPackage\" -y --internalize", result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "download \"MyPackage\" -y --internalize --append-useoriginallocation")]
+            [InlineData(false, "download \"MyPackage\" -y --internalize")]
+            public void Should_Add_AppendUseOriginalLocation_Flag_To_Arguments_If_Set(bool appendUseOriginalLocation, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.Internalize = true;
+                fixture.Settings.AppendUseOriginalLocation = appendUseOriginalLocation;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true)]
+            [InlineData(false)]
+            public void Should_Not_Add_AppendUseOriginalLocation_Flag_To_Arguments_If_Internalize_Is_Not_Set(bool appendUseOriginalLocation)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.Internalize = false;
+                fixture.Settings.AppendUseOriginalLocation = appendUseOriginalLocation;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("download \"MyPackage\" -y", result.Args);
+            }
+
+            [Theory]
+            [InlineData("user1", "download \"MyPackage\" -y -u \"user1\"")]
+            [InlineData("", "download \"MyPackage\" -y")]
+            public void Should_Add_User_To_Arguments_If_Set(string user, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.User = user;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("password1", "download \"MyPackage\" -y -p \"password1\"")]
+            [InlineData("", "download \"MyPackage\" -y")]
+            public void Should_Add_Password_To_Arguments_If_Set(string password, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.Password = password;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using Cake.Common.Tools.Chocolatey.ApiKey;
 using Cake.Common.Tools.Chocolatey.Config;
+using Cake.Common.Tools.Chocolatey.Download;
 using Cake.Common.Tools.Chocolatey.Features;
 using Cake.Common.Tools.Chocolatey.Install;
 using Cake.Common.Tools.Chocolatey.New;
@@ -1141,6 +1142,64 @@ namespace Cake.Common.Tools.Chocolatey
             var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
             var runner = new ChocolateyScaffolder(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools, resolver);
             runner.CreatePackage(packageId, settings);
+        }
+
+        /// <summary>
+        /// Downloads a Chocolatey package to the current working directory.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="packageId">The id of the package to download.</param>
+        /// <example>
+        /// <code>
+        /// ChocolateyDownload("MyChocolateyPackage");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Download")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Download")]
+        public static void ChocolateyDownload(this ICakeContext context, string packageId)
+        {
+            var settings = new ChocolateyDownloadSettings();
+            ChocolateyDownload(context, packageId, settings);
+        }
+
+        /// <summary>
+        /// Downloads a Chocolatey package using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="packageId">The id of the package to install.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <para>Download a package to a specific folder:</para>
+        /// <code>
+        /// ChocolateyDownload(
+        ///     "MyChocolateyPackage",
+        ///     new ChocolateyDownloadSettings {
+        ///         OutputDirectory = @"C:\download\"
+        ///     });
+        /// </code>
+        /// <para>Download and internalize a package:</para>
+        /// <code>
+        /// ChocolateyDownload(
+        ///     "MyChocolateyPackage",
+        ///     new ChocolateyDownloadSettings {
+        ///         Internalize = true
+        ///     });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Download")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Download")]
+        public static void ChocolateyDownload(this ICakeContext context, string packageId, ChocolateyDownloadSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
+            var runner = new ChocolateyDownloader(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools, resolver);
+            runner.Download(packageId, settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/Chocolatey/Download/ChocolateyDownloadSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Download/ChocolateyDownloadSettings.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.Chocolatey.Download
+{
+    /// <summary>
+    /// Contains settings used by <see cref="ChocolateyDownloader"/>.
+    /// </summary>
+    public sealed class ChocolateyDownloadSettings : ChocolateySettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow downloading of prerelease packages.
+        /// </summary>
+        public bool Prerelease { get; set; }
+
+        /// <summary>
+        /// Gets or sets the directory for the downloaded Chocolatey packages.
+        /// By default the current working directory is used.
+        /// </summary>
+        public DirectoryPath OutputDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to ignore dependencies.
+        /// Requires Chocolatey licensed edition.
+        /// </summary>
+        public bool IgnoreDependencies { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether all external resources should be downloaded
+        /// and the package be recompiled to use the local resources instead.
+        /// Requires Chocolatey business edition.
+        /// </summary>
+        public bool Internalize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the location for downloaded resource when <see cref="Internalize"/> is set.
+        /// <c>null</c> or <see cref="string.Empty"/> if downloaded resources should be embedded in the package.
+        /// Can be a file share or an internal URL location.
+        /// When it is a file share, it will attempt to download to that location.
+        /// When it is an internal url, it will download locally and give further instructions
+        /// where it should be uploaded to match package edits.
+        /// By default resources are embedded in the package.
+        /// Requires Chocolatey business edition.
+        /// </summary>
+        public string ResourcesLocation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the location where resources should be downloaded to when <see cref="ResourcesLocation"/> is set.
+        /// <c>null</c> or <see cref="string.Empty"/> if <see cref="ResourcesLocation"/> should be used.
+        /// By default <see cref="ResourcesLocation"/> is used.
+        /// Requires Chocolatey business edition.
+        /// </summary>
+        public string DownloadLocation { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the <c>-useOriginalLocation</c> parameter will be passed to any
+        /// <c>Install-ChocolateyPackage</c> call in the package and avoiding downloading of resources when
+        /// <see cref="Internalize"/> is set.
+        /// Overrides the global <c>internalizeAppendUseOriginalLocation</c> feature.
+        /// By default set to <c>false</c>.
+        /// Requires Chocolatey business edition and Chocolatey v0.10.1 or newer.
+        /// </summary>
+        public bool AppendUseOriginalLocation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user for authenticated feeds.
+        /// </summary>
+        public string User { get; set; }
+
+        /// <summary>
+        /// Gets or sets the password for authenticated feeds.
+        /// </summary>
+        public string Password { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/Download/ChocolateyDownloader.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Download/ChocolateyDownloader.cs
@@ -1,0 +1,125 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.Chocolatey.Download
+{
+    /// <summary>
+    /// The Chocolatey package downloader used to download Chocolatey packages.
+    /// </summary>
+    public sealed class ChocolateyDownloader : ChocolateyTool<ChocolateyDownloadSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChocolateyDownloader"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="tools">The tool locator.</param>
+        /// <param name="resolver">The Chocolatey tool resolver.</param>
+        public ChocolateyDownloader(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IToolLocator tools,
+            IChocolateyToolResolver resolver) : base(fileSystem, environment, processRunner, tools, resolver)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Downloads Chocolatey packages using the specified package id and settings.
+        /// </summary>
+        /// <param name="packageId">The source package id.</param>
+        /// <param name="settings">The settings.</param>
+        public void Download(string packageId, ChocolateyDownloadSettings settings)
+        {
+            if (string.IsNullOrWhiteSpace(packageId))
+            {
+                throw new ArgumentNullException(nameof(packageId));
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            Run(settings, GetArguments(packageId, settings));
+        }
+
+        private ProcessArgumentBuilder GetArguments(string packageId, ChocolateyDownloadSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("download");
+            builder.AppendQuoted(packageId);
+
+            AddCommonArguments(settings, builder);
+
+            // Prerelease
+            if (settings.Prerelease)
+            {
+                builder.Append("--pre");
+            }
+
+            // Output directory
+            if (settings.OutputDirectory != null)
+            {
+                builder.Append("--outputdirectory");
+                builder.AppendQuoted(settings.OutputDirectory.MakeAbsolute(_environment).FullPath);
+            }
+
+            // Ignore Dependencies
+            if (settings.IgnoreDependencies)
+            {
+                builder.Append("-i");
+            }
+
+            // Internalize
+            if (settings.Internalize)
+            {
+                builder.Append("--internalize");
+
+                // Resources Location
+                if (!string.IsNullOrWhiteSpace(settings.ResourcesLocation))
+                {
+                    builder.AppendSwitchQuoted("--resources-location", "=", settings.ResourcesLocation);
+
+                    // Download Location
+                    if (!string.IsNullOrWhiteSpace(settings.DownloadLocation))
+                    {
+                        builder.AppendSwitchQuoted("--download-location", "=", settings.DownloadLocation);
+                    }
+                }
+
+                // Append -UseOriginalLocation
+                if (settings.AppendUseOriginalLocation)
+                {
+                    builder.Append("--append-useoriginallocation");
+                }
+            }
+
+            // User
+            if (!string.IsNullOrWhiteSpace(settings.User))
+            {
+                builder.Append("-u");
+                builder.AppendQuoted(settings.User);
+            }
+
+            // Password
+            if (!string.IsNullOrWhiteSpace(settings.Password))
+            {
+                builder.Append("-p");
+                builder.AppendQuoted(settings.Password);
+            }
+
+            return builder;
+        }
+    }
+}


### PR DESCRIPTION
Add alias for `choco download`. Mentionend in the XML comments functionality which requires Chocolatey busines or licensed editions.

Fixes #1591.
