### PR TITLE
Fix #1597

### DIFF
--- a/src/Cake.Common/Tools/GitVersion/GitVersion.cs
+++ b/src/Cake.Common/Tools/GitVersion/GitVersion.cs
@@ -42,7 +42,7 @@ namespace Cake.Common.Tools.GitVersion
         /// <summary>
         /// Gets or sets the pre-release number.
         /// </summary>
-        public string PreReleaseNumber { get; set; }
+        public int PreReleaseNumber { get; set; }
 
         /// <summary>
         /// Gets or sets the build metadata.
@@ -117,7 +117,7 @@ namespace Cake.Common.Tools.GitVersion
         /// <summary>
         /// Gets or sets the commits since version source
         /// </summary>
-        public string CommitsSinceVersionSource { get; set; }
+        public int CommitsSinceVersionSource { get; set; }
 
         /// <summary>
         /// Gets or sets the commits since version source padded


### PR DESCRIPTION
Change the type from string to int for GitVersion properties "PreReleaseNumber" and "CommitsSinceVersionSource"