### PR TITLE
GH1533: Added support for dotnet msbuild inline with Tooling v1.0

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/DotNetCore/MSBuild/DotNetCoreMSBuildBuilderFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/DotNetCore/MSBuild/DotNetCoreMSBuildBuilderFixture.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNetCore.MSBuild;
+
+namespace Cake.Common.Tests.Fixtures.Tools.DotNetCore.MSBuild
+{
+    internal sealed class DotNetCoreMSBuildBuilderFixture : DotNetCoreFixture<DotNetCoreMSBuildSettings>
+    {
+        public string Project { get; set; }
+
+        protected override void RunTool()
+        {
+            var tool = new DotNetCoreMSBuildBuilder(FileSystem, Environment, ProcessRunner, Tools);
+            tool.Build(Project, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/MSBuild/DotNetCoreMSBuildBuilderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/MSBuild/DotNetCoreMSBuildBuilderTests.cs
@@ -1,0 +1,1137 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Cake.Common.Tests.Fixtures.Tools.DotNetCore.MSBuild;
+using Cake.Common.Tools.DotNetCore;
+using Cake.Common.Tools.DotNetCore.MSBuild;
+using Cake.Common.Tools.MSBuild;
+using Cake.Testing;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.DotNetCore.MSBuild
+{
+    public sealed class DotNetCoreMSBuildBuilderTests
+    {
+        public sealed class TheBuildMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Project = "./src/*";
+                fixture.Settings = null;
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Not_Throw_If_Project_Is_Null()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture()
+                {
+                    Settings = new DotNetCoreMSBuildSettings()
+                };
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.Null(result);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture()
+                {
+                    Project = "./src/*",
+                    Settings = new DotNetCoreMSBuildSettings()
+                };
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture()
+                {
+                    Project = "./src/*"
+                };
+                fixture.GivenProcessExitsWithCode(1);
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+            }
+
+            [Fact]
+            public void Should_Use_Project_Path_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Project = "./src/foo/foo.csproj";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild \"./src/foo/foo.csproj\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Use_Directory_Path_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Project = "./src/";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild \"./src/\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Target_Argument()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.Targets.Add("A");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /target:A", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_Target_Argument_When_Multiple_Values()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.Targets.Add("A");
+                fixture.Settings.Targets.Add("B");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /target:A;B", result.Args);
+            }
+
+            [Theory]
+            [InlineData(null)]
+            [InlineData("")]
+            [InlineData("          ")]
+            public void Should_Throw_If_Target_Has_No_Value(string targetValue)
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.Targets.Add(targetValue);
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentException(result, "Targets", "Specify the name of the target");
+            }
+
+            [Fact]
+            public void Should_Add_Property_Argument()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.Properties.Add("A", new[] { "B" });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /property:A=B", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Multiple_Property_Arguments_When_Multiple_Values()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.Properties.Add("A", new[] { "B", "E" });
+                fixture.Settings.Properties.Add("C", new[] { "D" });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /property:A=B /property:A=E /property:C=D", result.Args);
+            }
+
+            [Theory]
+            [InlineData(null)]
+            [InlineData(new object[] { new string[] { } })]
+            [InlineData(new object[] { new[] { "" } })]
+            [InlineData(new object[] { new[] { "          " } })]
+            public void Should_Throw_If_Property_Has_No_Value(string[] propertyValues)
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.Properties.Add("F", propertyValues);
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentException(result, "Properties", "A property must have at least one non-empty value");
+            }
+
+            [Theory]
+            [InlineData(0)]
+            [InlineData(-10)]
+            public void Should_Use_As_Many_Processors_As_Possible_If_MaxCpuCount_Is_Zero_Or_Less(int maxCpuCount)
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.MaxCpuCount = maxCpuCount;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /maxcpucount", result.Args);
+            }
+
+            [Fact]
+            public void Should_Use_Specified_Number_Of_Max_Processors()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.MaxCpuCount = 4;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /maxcpucount:4", result.Args);
+            }
+
+            [Theory]
+            [InlineData(MSBuildVersion.MSBuild20, "2.0")]
+            [InlineData(MSBuildVersion.MSBuild35, "3.5")]
+            [InlineData(MSBuildVersion.MSBuild4, "4.0")]
+            [InlineData(MSBuildVersion.MSBuild12, "12.0")]
+            [InlineData(MSBuildVersion.MSBuild14, "14.0")]
+            [InlineData(MSBuildVersion.MSBuild15, "15.0")]
+            public void Should_Add_ToolVersion_Argument_If_Specified(MSBuildVersion toolVersion, string expectedToolVersion)
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.ToolVersion = toolVersion;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal($"msbuild /toolsversion:{expectedToolVersion}", result.Args);
+            }
+
+            [Theory]
+            [InlineData(100)]
+            [InlineData(-8)]
+            [InlineData(0)]
+            public void Should_Throw_If_ToolVersion_Is_Invalid(int toolVersion)
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.ToolVersion = (MSBuildVersion)toolVersion;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsExceptionWithMessage<ArgumentOutOfRangeException>(result, $"Invalid value{Environment.NewLine}Parameter name: toolVersion{Environment.NewLine}Actual value was {toolVersion}.");
+            }
+
+            [Fact]
+            public void Should_Add_NoConsoleLogger_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.DisableConsoleLogger = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /noconsolelogger", result.Args);
+            }
+
+            [Fact]
+            public void Should_Ignore_Console_Logger_Settings_If_No_Console_Logger_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.DisableConsoleLogger = true;
+                fixture.Settings.ConsoleLoggerSettings = new MSBuildLoggerSettings();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /noconsolelogger", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_ConsoleLoggerParameters_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.ConsoleLoggerSettings = new MSBuildLoggerSettings
+                {
+                    PerformanceSummary = true,
+                    SummaryOutputLevel = MSBuildLoggerOutputLevel.ErrorsOnly,
+                    Verbosity = DotNetCoreVerbosity.Diagnostic
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /consoleloggerparameters:PerformanceSummary;ErrorsOnly;Verbosity=Diagnostic", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_FileLogger_Arguments()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings { AppendToLogFile = false, PerformanceSummary = true, Verbosity = DotNetCoreVerbosity.Diagnostic });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(@"msbuild /fileLogger /fileloggerparameters:PerformanceSummary;Verbosity=Diagnostic", result.Args);
+            }
+
+            [Fact]
+            public void Should_Throw_Exception_For_Too_Many_FileLoggers()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings());
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings());
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings());
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings());
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings());
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings());
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings());
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings());
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings());
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings());
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings());
+
+                // When
+                var ex = Assert.Throws<InvalidOperationException>(() => fixture.Run());
+
+                // Then
+                Assert.Equal(@"Too Many FileLoggers", ex.Message);
+            }
+
+            [Fact]
+            public void Should_Add_DistributedLogger_Argument()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.DistributedLoggers.Add(new MSBuildDistributedLogger
+                {
+                    CentralLogger = new MSBuildLogger { Assembly = "A" },
+                    ForwardingLogger = new MSBuildLogger { Assembly = "B" }
+                });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /distributedlogger:\"A\"*\"B\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Multiple_DistributedLogger_Arguments_When_Multiple_Values()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.DistributedLoggers.Add(new MSBuildDistributedLogger
+                {
+                    CentralLogger = new MSBuildLogger { Assembly = "A" },
+                    ForwardingLogger = new MSBuildLogger { Assembly = "B" }
+                });
+
+                fixture.Settings.DistributedLoggers.Add(new MSBuildDistributedLogger
+                {
+                    CentralLogger = new MSBuildLogger { Class = "C", Assembly = "D" },
+                    ForwardingLogger = new MSBuildLogger { Class = "E", Assembly = "F", Parameters = "g" }
+                });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /distributedlogger:\"A\"*\"B\" /distributedlogger:C,D*E,F;g", result.Args);
+            }
+
+            [Theory]
+            [InlineData(null, null)]
+            [InlineData(null, "A")]
+            [InlineData("A", null)]
+            [InlineData("", "")]
+            [InlineData("", "A")]
+            [InlineData("A", "")]
+            [InlineData("          ", "          ")]
+            [InlineData("          ", "A")]
+            [InlineData("A", "          ")]
+            public void Should_Throw_If_DistributedLogger_Has_No_Assembly_Value(string centralLoggerAssembly, string forwardingLoggerAssembly)
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.DistributedLoggers.Add(new MSBuildDistributedLogger
+                {
+                    CentralLogger = new MSBuildLogger { Assembly = centralLoggerAssembly },
+                    ForwardingLogger = new MSBuildLogger { Assembly = forwardingLoggerAssembly }
+                });
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "Assembly");
+            }
+
+            [Fact]
+            public void Should_Add_DistributedFileLogger_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.DistributedFileLogger = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /distributedFileLogger", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Logger_Argument()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.Loggers.Add(new MSBuildLogger { Assembly = "A" });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /logger:\"A\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Multiple_Logger_Arguments_When_Multiple_Values()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.Loggers.Add(new MSBuildLogger { Assembly = "A" });
+                fixture.Settings.Loggers.Add(new MSBuildLogger { Class = "C", Assembly = "B" });
+                fixture.Settings.Loggers.Add(new MSBuildLogger { Class = "E", Assembly = "F", Parameters = "g" });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /logger:\"A\" /logger:C,B /logger:E,F;g", result.Args);
+            }
+
+            [Theory]
+            [InlineData(null)]
+            [InlineData("")]
+            [InlineData("          ")]
+            public void Should_Throw_If_Logger_Has_No_Assembly_Value(string loggerAssembly)
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.Loggers.Add(new MSBuildLogger { Assembly = loggerAssembly });
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "Assembly");
+            }
+
+            [Theory]
+            [InlineData(MSBuildTreatAllWarningsAs.Default, new[] { "Err1" }, ":Err1")]
+            [InlineData(MSBuildTreatAllWarningsAs.Default, new[] { "Err1", "Err2" }, ":Err1;Err2")]
+            [InlineData(MSBuildTreatAllWarningsAs.Error, new[] { "Err1", "Err2" }, "")]
+            [InlineData(MSBuildTreatAllWarningsAs.Error, new string[] { }, "")]
+            public void Should_Add_WarnAsError_Argument(MSBuildTreatAllWarningsAs treatAllWarningsAs, string[] errorCodes, string expectedValue)
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.TreatAllWarningsAs = treatAllWarningsAs;
+
+                foreach (var errorCode in errorCodes)
+                {
+                    fixture.Settings.WarningCodesAsError.Add(errorCode);
+                }
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal($"msbuild /warnaserror{expectedValue}", result.Args);
+            }
+
+            [Theory]
+            [InlineData(MSBuildTreatAllWarningsAs.Default, new[] { "Err1" }, ":Err1")]
+            [InlineData(MSBuildTreatAllWarningsAs.Default, new[] { "Err1", "Err2" }, ":Err1;Err2")]
+            [InlineData(MSBuildTreatAllWarningsAs.Message, new[] { "Err1", "Err2" }, "")]
+            [InlineData(MSBuildTreatAllWarningsAs.Message, new string[] { }, "")]
+            public void Should_Add_WarnAsMessage_Argument(MSBuildTreatAllWarningsAs treatAllWarningsAs, string[] errorCodes, string expectedValue)
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.TreatAllWarningsAs = treatAllWarningsAs;
+
+                foreach (var errorCode in errorCodes)
+                {
+                    fixture.Settings.WarningCodesAsMessage.Add(errorCode);
+                }
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal($"msbuild /warnasmessage{expectedValue}", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_IgnoreProjectExtensions_Argument()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.IgnoreProjectExtensions.Add(".sln");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /ignoreprojectextensions:.sln", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_IgnoreProjectExtensions_Argument_When_Multiple_Values()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.IgnoreProjectExtensions.Add(".vcproj");
+                fixture.Settings.IgnoreProjectExtensions.Add(".sln");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /ignoreprojectextensions:.vcproj,.sln", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_DetailedSummary_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.DetailedSummary = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /detailedsummary", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_NoAutoResponse_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.ExcludeAutoResponseFiles = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /noautoresponse", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_NoLogo_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.NoLogo = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /nologo", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_ResponseFile_Argument()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.ResponseFiles.Add("/src/inputs.rsp");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild @\"/src/inputs.rsp\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_ResponseFile_Argument_When_Multiple_Values()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.ResponseFiles.Add("/src/inputs1.rsp");
+                fixture.Settings.ResponseFiles.Add("/src/inputs_2.rsp");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild @\"/src/inputs1.rsp\" @\"/src/inputs_2.rsp\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Host_Arguments()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.DiagnosticOutput = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("--diagnostics msbuild", result.Args);
+            }
+        }
+
+        public class TheConsoleLoggerSettingsProperty
+        {
+            [Fact]
+            public void Should_Append_PerformanceSummary_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.ConsoleLoggerSettings = new MSBuildLoggerSettings
+                {
+                    PerformanceSummary = true
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /consoleloggerparameters:PerformanceSummary", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_NoSummary_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.ConsoleLoggerSettings = new MSBuildLoggerSettings
+                {
+                    NoSummary = true
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /consoleloggerparameters:NoSummary", result.Args);
+            }
+
+            [Theory]
+            [InlineData(MSBuildLoggerOutputLevel.ErrorsOnly)]
+            [InlineData(MSBuildLoggerOutputLevel.WarningsOnly)]
+            public void Should_Append_SummaryOutputLevel_If_Specified(MSBuildLoggerOutputLevel outputLevel)
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.ConsoleLoggerSettings = new MSBuildLoggerSettings
+                {
+                    SummaryOutputLevel = outputLevel
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal($"msbuild /consoleloggerparameters:{outputLevel}", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Append_SummaryOutputLevel_If_Default()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.ConsoleLoggerSettings = new MSBuildLoggerSettings
+                {
+                    SummaryOutputLevel = MSBuildLoggerOutputLevel.Default
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_HideItemAndPropertyList_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.ConsoleLoggerSettings = new MSBuildLoggerSettings
+                {
+                    HideItemAndPropertyList = true
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /consoleloggerparameters:NoItemAndPropertyList", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_ShowCommandLine_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.ConsoleLoggerSettings = new MSBuildLoggerSettings
+                {
+                    ShowCommandLine = true
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /consoleloggerparameters:ShowCommandLine", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_ShowTimestamp_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.ConsoleLoggerSettings = new MSBuildLoggerSettings
+                {
+                    ShowTimestamp = true
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /consoleloggerparameters:ShowTimestamp", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_ForceNoAlign_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.ConsoleLoggerSettings = new MSBuildLoggerSettings
+                {
+                    ForceNoAlign = true
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /consoleloggerparameters:ForceNoAlign", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_ShowEventId_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.ConsoleLoggerSettings = new MSBuildLoggerSettings
+                {
+                    ShowEventId = true
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /consoleloggerparameters:ShowEventId", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_DisableConsoleColor_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.ConsoleLoggerSettings = new MSBuildLoggerSettings
+                {
+                    ConsoleColorType = MSBuildConsoleColorType.Disabled
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /consoleloggerparameters:DisableConsoleColor", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_ForceConsoleColor_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.ConsoleLoggerSettings = new MSBuildLoggerSettings
+                {
+                    ConsoleColorType = MSBuildConsoleColorType.ForceAnsi
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /consoleloggerparameters:ForceConsoleColor", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_DisableMultiprocessorLogging_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.ConsoleLoggerSettings = new MSBuildLoggerSettings
+                {
+                    DisableMultiprocessorLogging = true
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /consoleloggerparameters:DisableMPLogging", result.Args);
+            }
+
+            [Theory]
+            [InlineData(DotNetCoreVerbosity.Quiet)]
+            [InlineData(DotNetCoreVerbosity.Minimal)]
+            [InlineData(DotNetCoreVerbosity.Normal)]
+            [InlineData(DotNetCoreVerbosity.Detailed)]
+            [InlineData(DotNetCoreVerbosity.Diagnostic)]
+            public void Should_Append_Verbosity_If_Specified(DotNetCoreVerbosity verbosity)
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.ConsoleLoggerSettings = new MSBuildLoggerSettings
+                {
+                    Verbosity = verbosity
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal($"msbuild /consoleloggerparameters:Verbosity={verbosity}", result.Args);
+            }
+        }
+
+        public sealed class TheFileLoggerSettingsProperty
+        {
+            public string FileEncoding { get; set; }
+
+            [Fact]
+            public void Should_Append_LogFile_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings
+                {
+                    LogFile = "msbuild.log"
+                });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /fileLogger /fileloggerparameters:LogFile=\"/Working/msbuild.log\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_LogFile_If_Empty()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings { LogFile = string.Empty });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /fileLogger /fileloggerparameters:LogFile=\"\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_AppendToLogFile_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings { AppendToLogFile = true });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /fileLogger /fileloggerparameters:Append", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_FileEncoding_If_Specified()
+            {
+                // Given
+                const string fileEncoding = "UTF8";
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings { FileEncoding = fileEncoding });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal($"msbuild /fileLogger /fileloggerparameters:Encoding={fileEncoding}", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_PerformanceSummary_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings { PerformanceSummary = true });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /fileLogger /fileloggerparameters:PerformanceSummary", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_NoSummary_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings { NoSummary = true });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /fileLogger /fileloggerparameters:NoSummary", result.Args);
+            }
+
+            [Theory]
+            [InlineData(MSBuildLoggerOutputLevel.ErrorsOnly)]
+            [InlineData(MSBuildLoggerOutputLevel.WarningsOnly)]
+            public void Should_Append_SummaryOutputLevel_If_Specified(MSBuildLoggerOutputLevel outputLevel)
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings { SummaryOutputLevel = outputLevel });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal($"msbuild /fileLogger /fileloggerparameters:{outputLevel}", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Append_SummaryOutputLevel_If_Default()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings { SummaryOutputLevel = MSBuildLoggerOutputLevel.Default });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_HideItemAndPropertyList_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings { HideItemAndPropertyList = true });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /fileLogger /fileloggerparameters:NoItemAndPropertyList", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_ShowCommandLine_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings { ShowCommandLine = true });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /fileLogger /fileloggerparameters:ShowCommandLine", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_ShowTimestamp_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings { ShowTimestamp = true });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /fileLogger /fileloggerparameters:ShowTimestamp", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_ForceNoAlign_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings { ForceNoAlign = true });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /fileLogger /fileloggerparameters:ForceNoAlign", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_ShowEventId_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings { ShowEventId = true });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /fileLogger /fileloggerparameters:ShowEventId", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_DisableConsoleColor_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings { ConsoleColorType = MSBuildConsoleColorType.Disabled });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /fileLogger /fileloggerparameters:DisableConsoleColor", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_ForceConsoleColor_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings { ConsoleColorType = MSBuildConsoleColorType.ForceAnsi });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /fileLogger /fileloggerparameters:ForceConsoleColor", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_DisableMultiprocessorLogging_If_Specified()
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings { DisableMultiprocessorLogging = true });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /fileLogger /fileloggerparameters:DisableMPLogging", result.Args);
+            }
+
+            [Theory]
+            [InlineData(DotNetCoreVerbosity.Quiet)]
+            [InlineData(DotNetCoreVerbosity.Minimal)]
+            [InlineData(DotNetCoreVerbosity.Normal)]
+            [InlineData(DotNetCoreVerbosity.Detailed)]
+            [InlineData(DotNetCoreVerbosity.Diagnostic)]
+            public void Should_Append_Verbosity_If_Specified(DotNetCoreVerbosity verbosity)
+            {
+                // Given
+                var fixture = new DotNetCoreMSBuildBuilderFixture();
+                fixture.Settings.FileLoggers.Add(new MSBuildFileLoggerSettings { Verbosity = verbosity });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal($"msbuild /fileLogger /fileloggerparameters:Verbosity={verbosity}", result.Args);
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/MSBuild/DotNetCoreMSBuildSettingsExtensionsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/MSBuild/DotNetCoreMSBuildSettingsExtensionsTests.cs
@@ -1,0 +1,849 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Cake.Common.Tools.DotNetCore.MSBuild;
+using Cake.Common.Tools.MSBuild;
+using Cake.Core.IO;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.DotNetCore.MSBuild
+{
+    public sealed class DotNetCoreMSBuildSettingsExtensionsTests
+    {
+        public sealed class TheWithTargetMethod
+        {
+            [Fact]
+            public void Should_Add_Target_To_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                settings.WithTarget("Target");
+
+                // Then
+                Assert.True(settings.Targets.Contains("Target"));
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.WithTarget("Target");
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheWithPropertyMethod
+        {
+            [Fact]
+            public void Should_Add_Property_To_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                settings.WithProperty("PropertyName", "Value");
+
+                // Then
+                Assert.True(settings.Properties.ContainsKey("PropertyName"));
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.WithProperty("PropertyName", "Value");
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheDetailedSummaryMethod
+        {
+            [Fact]
+            public void Should_Set_Detailed_Summary()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                settings.ShowDetailedSummary();
+
+                // Then
+                Assert.True(settings.DetailedSummary);
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.ShowDetailedSummary();
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheWithIgnoredProjectExtensionMethod
+        {
+            [Fact]
+            public void Should_Add_Ignored_Extension_To_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                settings.WithIgnoredProjectExtension(".sln");
+
+                // Then
+                Assert.True(settings.IgnoreProjectExtensions.Contains(".sln"));
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.WithIgnoredProjectExtension(".sln");
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheSetMaxCpuCountMethod
+        {
+            [Fact]
+            public void Should_Set_MaxCpuCount()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                settings.SetMaxCpuCount(4);
+
+                // Then
+                Assert.Equal(4, settings.MaxCpuCount);
+            }
+
+            [Fact]
+            public void Should_Set_MaxCpuCount_To_Zero_If_Negative_Value()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                settings.SetMaxCpuCount(-1);
+
+                // Then
+                Assert.Equal(0, settings.MaxCpuCount);
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.SetMaxCpuCount(4);
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheExcludeAutoResponseFilesMethod
+        {
+            [Fact]
+            public void Should_Set_Exclude_Auto_Response_Files()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                settings.ExcludeAutoResponseFiles();
+
+                // Then
+                Assert.True(settings.ExcludeAutoResponseFiles);
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.ExcludeAutoResponseFiles();
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheHideLogoMethod
+        {
+            [Fact]
+            public void Should_Set_No_Logo()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                settings.HideLogo();
+
+                // Then
+                Assert.True(settings.NoLogo);
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.HideLogo();
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheUseToolVersionMethod
+        {
+            [Fact]
+            public void Should_Set_Tool_Version()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                settings.UseToolVersion(MSBuildVersion.MSBuild35);
+
+                // Then
+                Assert.Equal(MSBuildVersion.MSBuild35, settings.ToolVersion);
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.UseToolVersion(MSBuildVersion.MSBuild35);
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheValidateProjectFileMethod
+        {
+            [Fact]
+            public void Should_Set_Validate_Project_File()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                settings.ValidateProjectFile();
+
+                // Then
+                Assert.True(settings.ValidateProjectFile);
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.ValidateProjectFile();
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheWithResponseFileMethod
+        {
+            [Fact]
+            public void Should_Add_Response_File_To_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+                var filePath = FilePath.FromString(".sln");
+
+                // When
+                settings.WithResponseFile(filePath);
+
+                // Then
+                Assert.True(settings.ResponseFiles.Contains(filePath));
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.WithResponseFile(".sln");
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheUseDistributedFileLoggerMethod
+        {
+            [Fact]
+            public void Should_Set_Distributed_File_Logger()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                settings.UseDistributedFileLogger();
+
+                // Then
+                Assert.True(settings.DistributedFileLogger);
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.UseDistributedFileLogger();
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheWithDistributedLoggerMethod
+        {
+            [Fact]
+            public void Should_Add_Distributed_Logger_To_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+                var distributedLogger = new MSBuildDistributedLogger
+                {
+                    CentralLogger = new MSBuildLogger
+                    {
+                        Assembly = "LoggerAssembly1",
+                        Class = "LoggerClass1",
+                        Parameters = "LoggerParameters1"
+                    },
+                    ForwardingLogger = new MSBuildLogger
+                    {
+                        Assembly = "LoggerAssembly2",
+                        Class = "LoggerClass2",
+                        Parameters = "LoggerParameters2"
+                    }
+                };
+
+                // When
+                settings.WithDistributedLogger(distributedLogger);
+
+                // Then
+                Assert.True(settings.DistributedLoggers.Contains(distributedLogger));
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.WithDistributedLogger(new MSBuildDistributedLogger());
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheSetConsoleLoggerSettingsMethod
+        {
+            [Fact]
+            public void Should_Set_Console_Logger_Settings()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+                var consoleLoggerParameters = new MSBuildLoggerSettings
+                {
+                    PerformanceSummary = true,
+                    ConsoleColorType = MSBuildConsoleColorType.ForceAnsi
+                };
+
+                // When
+                settings.SetConsoleLoggerSettings(consoleLoggerParameters);
+
+                // Then
+                Assert.Same(consoleLoggerParameters, settings.ConsoleLoggerSettings);
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.SetConsoleLoggerSettings(new MSBuildLoggerSettings());
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheAddFileLoggerMethod
+        {
+            [Fact]
+            public void Should_Add_Logger()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+                var fileLogger = new MSBuildFileLoggerSettings();
+                var fileLogger2 = new MSBuildFileLoggerSettings() { LogFile = "A" };
+
+                // When
+                settings.AddFileLogger(fileLogger);
+                settings.AddFileLogger(fileLogger2);
+
+                // Then
+                var loggers = settings.FileLoggers.ToArray();
+                Assert.Equal(2, loggers.Length);
+                Assert.Equal(fileLogger, loggers[0]);
+                Assert.Equal(fileLogger2, loggers[1]);
+                Assert.Equal("A", loggers[1].LogFile);
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.AddFileLogger(new MSBuildFileLoggerSettings());
+                var result1 = settings.AddFileLogger();
+
+                // Then
+                Assert.Equal(settings, result);
+                Assert.Equal(settings, result1);
+            }
+        }
+
+        public sealed class TheWithLoggerMethod
+        {
+            [Fact]
+            public void Should_Add_Logger()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                settings.WithLogger("LoggerAssembly1", "LoggerClass1", "LoggerParameters1");
+                settings.WithLogger("LoggerAssembly2", "LoggerClass2", "LoggerParameters2");
+
+                // Then
+                var loggers = settings.Loggers.ToArray();
+                Assert.Equal(2, loggers.Length);
+                Assert.Equal("LoggerAssembly1", loggers[0].Assembly);
+                Assert.Equal("LoggerClass1", loggers[0].Class);
+                Assert.Equal("LoggerParameters1", loggers[0].Parameters);
+                Assert.Equal("LoggerAssembly2", loggers[1].Assembly);
+                Assert.Equal("LoggerClass2", loggers[1].Class);
+                Assert.Equal("LoggerParameters2", loggers[1].Parameters);
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.WithLogger("Logger");
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheDisableConsoleLoggerMethod
+        {
+            [Fact]
+            public void Should_Set_Disable_Console_Logger()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                settings.DisableConsoleLogger();
+
+                // Then
+                Assert.True(settings.DisableConsoleLogger);
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.DisableConsoleLogger();
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheSetWarningCodeAsErrorMethod
+        {
+            [Fact]
+            public void Should_Add_Warning_Code_To_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                settings.SetWarningCodeAsError("ERR1");
+
+                // Then
+                Assert.True(settings.WarningCodesAsError.Contains("ERR1"));
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.SetWarningCodeAsError("ERR1");
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+
+            [Theory]
+            [InlineData(null)]
+            [InlineData("")]
+            [InlineData("          ")]
+            public void Should_Throw_Exception_If_Null_Or_Whitespace(string warningCode)
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = Record.Exception(() => settings.SetWarningCodeAsError(warningCode));
+
+                // Then
+                AssertEx.IsArgumentException(result, "warningCode", "Warning code cannot be null or empty");
+            }
+        }
+
+        public sealed class TheSetWarningCodeAsMessageMethod
+        {
+            [Fact]
+            public void Should_Add_Warning_Code_To_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                settings.SetWarningCodeAsMessage("ERR1");
+
+                // Then
+                Assert.True(settings.WarningCodesAsMessage.Contains("ERR1"));
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.SetWarningCodeAsMessage("ERR1");
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+
+            [Theory]
+            [InlineData(null)]
+            [InlineData("")]
+            [InlineData("          ")]
+            public void Should_Throw_Exception_If_Null_Or_Whitespace(string warningCode)
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = Record.Exception(() => settings.SetWarningCodeAsMessage(warningCode));
+
+                // Then
+                AssertEx.IsArgumentException(result, "warningCode", "Warning code cannot be null or empty");
+            }
+        }
+
+        public sealed class TheTreatAllWarningsAsMethod
+        {
+            [Theory]
+            [InlineData(MSBuildTreatAllWarningsAs.Message)]
+            [InlineData(MSBuildTreatAllWarningsAs.Error)]
+            public void Should_Set_Warning_Code_Behaviour(MSBuildTreatAllWarningsAs treatAllAs)
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                settings.TreatAllWarningsAs(treatAllAs);
+
+                // Then
+                Assert.Equal(treatAllAs, settings.TreatAllWarningsAs);
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.TreatAllWarningsAs(MSBuildTreatAllWarningsAs.Error);
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheSetConfigurationMethod
+        {
+            private const string Configuration = "TheConfiguration";
+
+            [Fact]
+            public void Should_Set_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+                const string key = "Configuration";
+
+                // When
+                settings.SetConfiguration(Configuration);
+
+                // Then
+                Assert.True(settings.Properties.ContainsKey(key));
+                Assert.Equal(Configuration, settings.Properties[key].FirstOrDefault());
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.SetConfiguration(Configuration);
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheSetVersionMethod
+        {
+            private const string Version = "1.0.0-test";
+
+            [Fact]
+            public void Should_Set_Version()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+                const string key = "Version";
+
+                // When
+                settings.SetVersion(Version);
+
+                // Then
+                Assert.True(settings.Properties.ContainsKey(key));
+                Assert.Equal(Version, settings.Properties[key].FirstOrDefault());
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.SetVersion(Version);
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheSetVersionPrefixMethod
+        {
+            private const string VersionPrefix = "1.0.0";
+
+            [Fact]
+            public void Should_Set_Version_Prefix()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+                const string key = "VersionPrefix";
+
+                // When
+                settings.SetVersionPrefix(VersionPrefix);
+
+                // Then
+                Assert.True(settings.Properties.ContainsKey(key));
+                Assert.Equal(VersionPrefix, settings.Properties[key].FirstOrDefault());
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.SetVersionPrefix(VersionPrefix);
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheSetVersionSuffixMethod
+        {
+            private const string VersionSuffix = "test";
+
+            [Fact]
+            public void Should_Set_Version_Suffix()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+                const string key = "VersionSuffix";
+
+                // When
+                settings.SetVersionSuffix(VersionSuffix);
+
+                // Then
+                Assert.True(settings.Properties.ContainsKey(key));
+                Assert.Equal(VersionSuffix, settings.Properties[key].FirstOrDefault());
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.SetVersionSuffix(VersionSuffix);
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheSetTargetFrameworkMethod
+        {
+            private const string TargetFramework = "netstandard1.6";
+
+            [Fact]
+            public void Should_Set_Target_Framework()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+                const string key = "TargetFrameworks";
+
+                // When
+                settings.SetTargetFramework(TargetFramework);
+
+                // Then
+                Assert.True(settings.Properties.ContainsKey(key));
+                Assert.Equal(TargetFramework, settings.Properties[key].FirstOrDefault());
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.SetTargetFramework(TargetFramework);
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheSetRuntimeMethod
+        {
+            private const string Runtime = "ubuntu.16.10-x64";
+
+            [Fact]
+            public void Should_Set_Runtime()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+                const string key = "RuntimeIdentifiers";
+
+                // When
+                settings.SetRuntime(Runtime);
+
+                // Then
+                Assert.True(settings.Properties.ContainsKey(key));
+                Assert.Equal(Runtime, settings.Properties[key].FirstOrDefault());
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.SetRuntime(Runtime);
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/MSBuild/DotNetCoreMSBuildSettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/MSBuild/DotNetCoreMSBuildSettingsTests.cs
@@ -1,0 +1,272 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNetCore.MSBuild;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.DotNetCore.MSBuild
+{
+    public sealed class DotNetCoreMSBuildSettingsTests
+    {
+        public sealed class TheDistributedFileLoggerProperty
+        {
+            [Fact]
+            public void Should_Be_Null_By_Default()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // Then
+                Assert.False(settings.DistributedFileLogger);
+            }
+        }
+
+        public sealed class TheValidateProjectFileProperty
+        {
+            [Fact]
+            public void Should_Be_Null_By_Default()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // Then
+                Assert.False(settings.ValidateProjectFile);
+            }
+        }
+
+        public sealed class TheExcludeAutoResponseFilesProperty
+        {
+            [Fact]
+            public void Should_Be_Null_By_Default()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // Then
+                Assert.False(settings.ExcludeAutoResponseFiles);
+            }
+        }
+
+        public sealed class TheTreatAllWarningsAsProperty
+        {
+            [Fact]
+            public void Should_Be_Default_By_Default()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // Then
+                Assert.Equal(MSBuildTreatAllWarningsAs.Default, settings.TreatAllWarningsAs);
+            }
+        }
+
+        public sealed class TheWarningCodesAsErrorProperty
+        {
+            [Fact]
+            public void Should_Be_Empty_By_Default()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // Then
+                Assert.Empty(settings.WarningCodesAsError);
+            }
+        }
+
+        public sealed class TheWarningCodesAsMessageProperty
+        {
+            [Fact]
+            public void Should_Be_Empty_By_Default()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // Then
+                Assert.Empty(settings.WarningCodesAsMessage);
+            }
+        }
+
+        public sealed class TheConsoleLoggerSettingsProperty
+        {
+            [Fact]
+            public void Should_Be_Null_By_Default()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // Then
+                Assert.Null(settings.ConsoleLoggerSettings);
+            }
+        }
+
+        public sealed class TheVerbosityProperty
+        {
+            [Fact]
+            public void Should_Be_Null_By_Default()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // Then
+                Assert.Null(settings.Verbosity);
+            }
+        }
+
+        public sealed class TheToolVersionProperty
+        {
+            [Fact]
+            public void Should_Be_Null_By_Default()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // Then
+                Assert.Null(settings.ToolVersion);
+            }
+        }
+
+        public sealed class TheTargetsProperty
+        {
+            [Fact]
+            public void Should_Be_Empty_By_Default()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // Then
+                Assert.Empty(settings.Targets);
+            }
+        }
+
+        public sealed class ThePropertiesProperty
+        {
+            [Fact]
+            public void Should_Be_Empty_By_Default()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // Then
+                Assert.Empty(settings.Properties);
+            }
+
+            [Fact]
+            public void Should_Return_A_Dictionary_That_Is_Case_Insensitive()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                settings.Properties.Add("THEKEY", new[] { "THEVALUE" });
+
+                // Then
+                Assert.True(settings.Properties.ContainsKey("thekey"));
+            }
+        }
+
+        public sealed class TheMaxCpuCountProperty
+        {
+            [Fact]
+            public void Should_Be_Null_By_Default()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // Then
+                Assert.Null(settings.MaxCpuCount);
+            }
+        }
+
+        public sealed class TheDetailedSummaryProperty
+        {
+            [Fact]
+            public void Should_Be_Null_By_Default()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // Then
+                Assert.False(settings.DetailedSummary);
+            }
+        }
+
+        public sealed class TheDisableConsoleLoggerProperty
+        {
+            [Fact]
+            public void Should_Be_Null_By_Default()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // Then
+                Assert.False(settings.DisableConsoleLogger);
+            }
+        }
+
+        public sealed class TheLoggersProperty
+        {
+            [Fact]
+            public void Should_Be_Empty_By_Default()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // Then
+                Assert.Empty(settings.Loggers);
+            }
+        }
+
+        public sealed class TheFileLoggersProperty
+        {
+            [Fact]
+            public void Should_Be_Empty_By_Default()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // Then
+                Assert.Empty(settings.FileLoggers);
+            }
+        }
+
+        public sealed class TheIgnoreProjectExtensionsProperty
+        {
+            [Fact]
+            public void Should_Be_Empty_By_Default()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // Then
+                Assert.Empty(settings.IgnoreProjectExtensions);
+            }
+        }
+
+        public sealed class TheResponseFilesProperty
+        {
+            [Fact]
+            public void Should_Be_Empty_By_Default()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // Then
+                Assert.Empty(settings.ResponseFiles);
+            }
+        }
+
+        public sealed class TheDistributedLoggersProperty
+        {
+            [Fact]
+            public void Should_Be_Empty_By_Default()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // Then
+                Assert.Empty(settings.DistributedLoggers);
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/Build/DotNetCoreBuildSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Build/DotNetCoreBuildSettings.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Core.IO;
 
 namespace Cake.Common.Tools.DotNetCore.Build
@@ -46,5 +47,10 @@ namespace Cake.Common.Tools.DotNetCore.Build
         /// Gets or sets a value indicating whether to ignore project to project references and only build the root project.
         /// </summary>
         public bool NoDependencies { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional arguments to be passed to MSBuild.
+        /// </summary>
+        public DotNetCoreMSBuildSettings MSBuildSettings { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/Build/DotNetCoreBuilder.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Build/DotNetCoreBuilder.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
@@ -108,6 +109,11 @@ namespace Cake.Common.Tools.DotNetCore.Build
             if (settings.NoDependencies)
             {
                 builder.Append("--no-dependencies");
+            }
+
+            if (settings.MSBuildSettings != null)
+            {
+                builder.AppendMSBuildSettings(settings.MSBuildSettings, _environment);
             }
 
             return builder;

--- a/src/Cake.Common/Tools/DotNetCore/Clean/DotNetCoreCleanSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Clean/DotNetCoreCleanSettings.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Core.IO;
 
 namespace Cake.Common.Tools.DotNetCore.Clean
@@ -25,5 +26,10 @@ namespace Cake.Common.Tools.DotNetCore.Clean
         /// Gets or sets the specific framework to compile.
         /// </summary>
         public string Framework { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional arguments to be passed to MSBuild.
+        /// </summary>
+        public DotNetCoreMSBuildSettings MSBuildSettings { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/Clean/DotNetCoreCleaner.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Clean/DotNetCoreCleaner.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
@@ -82,6 +83,11 @@ namespace Cake.Common.Tools.DotNetCore.Clean
             {
                 builder.Append("--configuration");
                 builder.Append(settings.Configuration);
+            }
+
+            if (settings.MSBuildSettings != null)
+            {
+                builder.AppendMSBuildSettings(settings.MSBuildSettings, _environment);
             }
 
             return builder;

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -6,6 +6,7 @@ using System;
 using Cake.Common.Tools.DotNetCore.Build;
 using Cake.Common.Tools.DotNetCore.Clean;
 using Cake.Common.Tools.DotNetCore.Execute;
+using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Common.Tools.DotNetCore.NuGet.Delete;
 using Cake.Common.Tools.DotNetCore.NuGet.Push;
 using Cake.Common.Tools.DotNetCore.Pack;
@@ -762,18 +763,18 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Delete")]
         public static void DotNetCoreNuGetDelete(this ICakeContext context, string packageName, string packageVersion, DotNetCoreNuGetDeleteSettings settings)
         {
-             if (context == null)
-             {
-                 throw new ArgumentNullException(nameof(context));
-             }
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
 
-             if (settings == null)
-             {
-                 settings = new DotNetCoreNuGetDeleteSettings();
-             }
+            if (settings == null)
+            {
+                settings = new DotNetCoreNuGetDeleteSettings();
+            }
 
-             var restorer = new DotNetCoreNuGetDeleter(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-             restorer.Delete(packageName, packageVersion, settings);
+            var nugetDeleter = new DotNetCoreNuGetDeleter(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            nugetDeleter.Delete(packageName, packageVersion, settings);
         }
 
         /// <summary>
@@ -828,6 +829,113 @@ namespace Cake.Common.Tools.DotNetCore
 
             var restorer = new DotNetCoreNuGetPusher(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             restorer.Push(packageName, settings);
+        }
+
+        /// <summary>
+        /// Builds the specified targets in a project file found in the current working directory.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <example>
+        ///  <code>
+        ///     DotNetCoreMSBuild();
+        ///  </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("MSBuild")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.MSBuild")]
+        public static void DotNetCoreMSBuild(this ICakeContext context)
+        {
+            context.DotNetCoreMSBuild(null, null);
+        }
+
+        /// <summary>
+        /// Builds the specified targets in the project file.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="projectOrDirectory">Project file or directory to search for project file.</param>
+        /// <example>
+        ///  <code>
+        ///     DotNetCoreMSBuild("foobar.proj");
+        ///  </code>
+        /// </example>
+        /// <remarks>
+        /// If a directory is specified, MSBuild searches that directory for a project file.
+        /// </remarks>
+        [CakeMethodAlias]
+        [CakeAliasCategory("MSBuild")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.MSBuild")]
+        public static void DotNetCoreMSBuild(this ICakeContext context, string projectOrDirectory)
+        {
+            if (string.IsNullOrWhiteSpace(projectOrDirectory))
+            {
+                throw new ArgumentNullException(nameof(projectOrDirectory));
+            }
+
+            context.DotNetCoreMSBuild(projectOrDirectory, null);
+        }
+
+        /// <summary>
+        /// Builds the specified targets in a project file found in the current working directory.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        ///  <code>
+        ///     var settings = new DotNetCoreMSBuildSettings
+        ///     {
+        ///         NoLogo = true,
+        ///         MaxCpuCount = -1
+        ///     };
+        ///
+        ///     DotNetCoreMSBuild(settings);
+        ///  </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("MSBuild")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.MSBuild")]
+        public static void DotNetCoreMSBuild(this ICakeContext context, DotNetCoreMSBuildSettings settings)
+        {
+            context.DotNetCoreMSBuild(null, settings);
+        }
+
+        /// <summary>
+        /// Builds the specified targets in the project file.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="projectOrDirectory">Project file or directory to search for project file.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        ///  <code>
+        ///     var settings = new DotNetCoreMSBuildSettings
+        ///     {
+        ///         NoLogo = true,
+        ///         MaxCpuCount = -1
+        ///     };
+        ///
+        ///     DotNetCoreMSBuild("foobar.proj", settings);
+        ///  </code>
+        /// </example>
+        /// <remarks>
+        /// If a project file is not specified, MSBuild searches the current working directory for a file that has a file
+        /// extension that ends in "proj" and uses that file. If a directory is specified, MSBuild searches that directory for a project file.
+        /// </remarks>
+        [CakeMethodAlias]
+        [CakeAliasCategory("MSBuild")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.MSBuild")]
+        public static void DotNetCoreMSBuild(this ICakeContext context, string projectOrDirectory, DotNetCoreMSBuildSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (settings == null)
+            {
+                settings = new DotNetCoreMSBuildSettings();
+            }
+
+            var builder = new DotNetCoreMSBuildBuilder(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            builder.Build(projectOrDirectory, settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/MSBuild/DotNetCoreMSBuildBuilder.cs
+++ b/src/Cake.Common/Tools/DotNetCore/MSBuild/DotNetCoreMSBuildBuilder.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.DotNetCore.MSBuild
+{
+    /// <summary>
+    /// .NET Core project builder.
+    /// </summary>
+    public sealed class DotNetCoreMSBuildBuilder : DotNetCoreTool<DotNetCoreMSBuildSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotNetCoreMSBuildBuilder" /> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="tools">The tool locator.</param>
+        public DotNetCoreMSBuildBuilder(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IToolLocator tools) : base(fileSystem, environment, processRunner, tools)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Build the project using the specified path and settings.
+        /// </summary>
+        /// <param name="projectOrDirectory">The target project path.</param>
+        /// <param name="settings">The settings.</param>
+        public void Build(string projectOrDirectory, DotNetCoreMSBuildSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            RunCommand(settings, GetArguments(projectOrDirectory, settings));
+        }
+
+        private ProcessArgumentBuilder GetArguments(string projectOrDirectory, DotNetCoreMSBuildSettings settings)
+        {
+            var builder = CreateArgumentBuilder(settings);
+
+            builder.Append("msbuild");
+
+            // add msbuild settings
+            builder.AppendMSBuildSettings(settings, _environment);
+
+            // Specific path?
+            if (projectOrDirectory != null)
+            {
+                builder.AppendQuoted(projectOrDirectory);
+            }
+
+            return builder;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/MSBuild/DotNetCoreMSBuildSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/MSBuild/DotNetCoreMSBuildSettings.cs
@@ -1,0 +1,148 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Cake.Common.Tools.MSBuild;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotNetCore.MSBuild
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetCoreMSBuildBuilder" />.
+    /// </summary>
+    public sealed class DotNetCoreMSBuildSettings : DotNetCoreSettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to show detailed information at the end of the build log about the configurations that were built and how they were scheduled to nodes.
+        /// </summary>
+        public bool DetailedSummary { get; set; }
+
+        /// <summary>
+        /// Gets or sets extensions to ignore when determining which project file to build.
+        /// </summary>
+        public ICollection<string> IgnoreProjectExtensions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of concurrent processes to use when building.
+        /// </summary>
+        /// <remarks>
+        /// If you don't include this switch, the default value is 1. If you specifying a value that is zero or less, MSBuild will use up to the number of processors in the computer.
+        /// </remarks>
+        public int? MaxCpuCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to exclude any MSBuild.rsp files automatically.
+        /// </summary>
+        public bool ExcludeAutoResponseFiles { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to display the startup banner and the copyright message.
+        /// </summary>
+        public bool NoLogo { get; set; }
+
+        /// <summary>
+        /// Gets the project-level properties to set or override.
+        /// </summary>
+        public IDictionary<string, ICollection<string>> Properties { get; }
+
+        /// <summary>
+        /// Gets the targets to build in the project.
+        /// </summary>
+        /// <remarks>
+        /// If you specify any targets, they are run instead of any targets in the DefaultTargets attribute in the project file.
+        /// </remarks>
+        public ICollection<string> Targets { get; }
+
+        /// <summary>
+        /// Gets or sets the version of the Toolset to use to build the project.
+        /// </summary>
+        public MSBuildVersion? ToolVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to validate the project file and, if validation succeeds, build the project.
+        /// </summary>
+        public bool ValidateProjectFile { get; set; }
+
+        /// <summary>
+        /// Gets the response files to use.
+        /// </summary>
+        /// <remarks>
+        /// A response file is a text file that is used to insert command-line switches. For more information see https://docs.microsoft.com/en-gb/visualstudio/msbuild/msbuild-response-files
+        /// </remarks>
+        public ICollection<FilePath> ResponseFiles { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to log the build output of each MSBuild node to its own file.
+        /// </summary>
+        /// <remarks>
+        /// The initial location for these files is the current directory. By default, the files are named "MSBuildNodeId.log". You can use the /fileLoggerParameters switch to specify the location of the files and other parameters for the fileLogger.
+        /// If you name a log file by using the /fileLoggerParameters switch, the distributed logger will use that name as a template and append the node ID to that name when creating a log file for each node.
+        /// </remarks>
+        public bool DistributedFileLogger { get; set; }
+
+        /// <summary>
+        /// Gets the distributed loggers to use.
+        /// </summary>
+        /// <remarks>
+        /// A distributed logger consists of a central and forwarding logger. MSBuild will attach an instance of the forwarding logger to each secondary node.
+        /// For more information see https://msdn.microsoft.com/en-us/library/bb383987.aspx
+        /// </remarks>
+        public ICollection<MSBuildDistributedLogger> DistributedLoggers { get; }
+
+        /// <summary>
+        /// Gets or sets the parameters for the console logger.
+        /// </summary>
+        public MSBuildLoggerSettings ConsoleLoggerSettings { get; set; }
+
+        /// <summary>
+        /// Gets the file loggers to use.
+        /// </summary>
+        public ICollection<MSBuildFileLoggerSettings> FileLoggers { get; }
+
+        /// <summary>
+        /// Gets the loggers to use to log events from MSBuild.
+        /// </summary>
+        public ICollection<MSBuildLogger> Loggers { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to disable the default console logger, and not log events to the console.
+        /// </summary>
+        public bool DisableConsoleLogger { get; set; }
+
+        /// <summary>
+        /// Gets the warning codes to treats as errors.
+        /// </summary>
+        /// <remarks>
+        /// When a warning is treated as an error the target will continue to execute as if it was a warning but the overall build will fail.
+        /// </remarks>
+        public IList<string> WarningCodesAsError { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating how all warnings should be treated.
+        /// </summary>
+        public MSBuildTreatAllWarningsAs TreatAllWarningsAs { get; set; }
+
+        /// <summary>
+        /// Gets the warning codes to treats as low importance messages.
+        /// </summary>
+        public IList<string> WarningCodesAsMessage { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotNetCoreMSBuildSettings"/> class.
+        /// </summary>
+        public DotNetCoreMSBuildSettings()
+        {
+            Properties = new Dictionary<string, ICollection<string>>(StringComparer.OrdinalIgnoreCase);
+            Targets = new List<string>();
+            ResponseFiles = new List<FilePath>();
+            DistributedLoggers = new List<MSBuildDistributedLogger>();
+            FileLoggers = new List<MSBuildFileLoggerSettings>();
+            Loggers = new List<MSBuildLogger>();
+            WarningCodesAsError = new List<string>();
+            WarningCodesAsMessage = new List<string>();
+            IgnoreProjectExtensions = new List<string>();
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/MSBuild/DotNetCoreMSBuildSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/DotNetCore/MSBuild/DotNetCoreMSBuildSettingsExtensions.cs
@@ -1,0 +1,434 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cake.Common.Tools.MSBuild;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotNetCore.MSBuild
+{
+    /// <summary>
+    /// Contains functionality related to .NET Core MSBuild settings.
+    /// </summary>
+    public static class DotNetCoreMSBuildSettingsExtensions
+    {
+        /// <summary>
+        /// Adds a MSBuild target to the configuration.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="target">The MSBuild target.</param>
+        /// <returns>The same <see cref="DotNetCoreMSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        /// <remarks>Ignores a target if already added.</remarks>
+        public static DotNetCoreMSBuildSettings WithTarget(this DotNetCoreMSBuildSettings settings, string target)
+        {
+            EnsureSettings(settings);
+
+            if (!settings.Targets.Contains(target))
+            {
+                settings.Targets.Add(target);
+            }
+
+            return settings;
+        }
+
+        /// <summary>
+        /// Adds a property to the configuration.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="name">The property name.</param>
+        /// <param name="values">The property values.</param>
+        /// <returns>The same <see cref="DotNetCoreMSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetCoreMSBuildSettings WithProperty(this DotNetCoreMSBuildSettings settings, string name, params string[] values)
+        {
+            EnsureSettings(settings);
+
+            ICollection<string> currentValue;
+
+            // try to get existing values of properties and add new property values
+            currentValue = settings.Properties.TryGetValue(name, out currentValue) && currentValue != null
+                ? currentValue.Concat(values).ToList()
+                : new List<string>(values);
+
+            settings.Properties[name] = currentValue;
+
+            return settings;
+        }
+
+        /// <summary>
+        /// Shows detailed information at the end of the build log about the configurations that were built and how they were scheduled to nodes.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The same <see cref="DotNetCoreMSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetCoreMSBuildSettings ShowDetailedSummary(this DotNetCoreMSBuildSettings settings)
+        {
+            EnsureSettings(settings);
+
+            settings.DetailedSummary = true;
+            return settings;
+        }
+
+        /// <summary>
+        /// Adds a extension to ignore when determining which project file to build.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="extension">The extension to ignore.</param>
+        /// <returns>The same <see cref="DotNetCoreMSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetCoreMSBuildSettings WithIgnoredProjectExtension(this DotNetCoreMSBuildSettings settings, string extension)
+        {
+            EnsureSettings(settings);
+
+            settings.IgnoreProjectExtensions.Add(extension);
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the maximum CPU count. Without this set MSBuild will compile projects in this solution one at a time.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="maxCpuCount">The maximum CPU count. Set this value to zero to use as many MSBuild processes as available CPUs.</param>
+        /// <returns>The same <see cref="DotNetCoreMSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetCoreMSBuildSettings SetMaxCpuCount(this DotNetCoreMSBuildSettings settings, int? maxCpuCount)
+        {
+            EnsureSettings(settings);
+
+            settings.MaxCpuCount = maxCpuCount.HasValue
+                                    ? Math.Max(0, maxCpuCount.Value)
+                                    : 0;
+            return settings;
+        }
+
+        /// <summary>
+        /// Exclude any MSBuild.rsp files automatically.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The same <see cref="DotNetCoreMSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetCoreMSBuildSettings ExcludeAutoResponseFiles(this DotNetCoreMSBuildSettings settings)
+        {
+            EnsureSettings(settings);
+
+            settings.ExcludeAutoResponseFiles = true;
+            return settings;
+        }
+
+        /// <summary>
+        /// Hide the startup banner and the copyright message.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The same <see cref="DotNetCoreMSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetCoreMSBuildSettings HideLogo(this DotNetCoreMSBuildSettings settings)
+        {
+            EnsureSettings(settings);
+
+            settings.NoLogo = true;
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the version of the Toolset to use to build the project.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="version">The version.</param>
+        /// <returns>The same <see cref="DotNetCoreMSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetCoreMSBuildSettings UseToolVersion(this DotNetCoreMSBuildSettings settings, MSBuildVersion version)
+        {
+            EnsureSettings(settings);
+
+            settings.ToolVersion = version;
+            return settings;
+        }
+
+        /// <summary>
+        /// Validate the project file and, if validation succeeds, build the project.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The same <see cref="DotNetCoreMSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetCoreMSBuildSettings ValidateProjectFile(this DotNetCoreMSBuildSettings settings)
+        {
+            EnsureSettings(settings);
+
+            settings.ValidateProjectFile = true;
+            return settings;
+        }
+
+        /// <summary>
+        /// Adds a response file to use.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="responseFile">The response file to add.</param>
+        /// <returns>The same <see cref="DotNetCoreMSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        /// <remarks>
+        /// A response file is a text file that is used to insert command-line switches. For more information see https://docs.microsoft.com/en-gb/visualstudio/msbuild/msbuild-response-files
+        /// </remarks>
+        public static DotNetCoreMSBuildSettings WithResponseFile(this DotNetCoreMSBuildSettings settings, FilePath responseFile)
+        {
+            EnsureSettings(settings);
+
+            settings.ResponseFiles.Add(responseFile);
+            return settings;
+        }
+
+        /// <summary>
+        /// Log the build output of each MSBuild node to its own file.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The same <see cref="DotNetCoreMSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetCoreMSBuildSettings UseDistributedFileLogger(this DotNetCoreMSBuildSettings settings)
+        {
+            EnsureSettings(settings);
+
+            settings.DistributedFileLogger = true;
+            return settings;
+        }
+
+        /// <summary>
+        /// Adds a distributed loggers to use.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="logger">The response file to add.</param>
+        /// <returns>The same <see cref="DotNetCoreMSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        /// <remarks>
+        /// A distributed logger consists of a central and forwarding logger. MSBuild will attach an instance of the forwarding logger to each secondary node.
+        /// For more information see https://msdn.microsoft.com/en-us/library/bb383987.aspx
+        /// </remarks>
+        public static DotNetCoreMSBuildSettings WithDistributedLogger(this DotNetCoreMSBuildSettings settings, MSBuildDistributedLogger logger)
+        {
+            EnsureSettings(settings);
+
+            settings.DistributedLoggers.Add(logger);
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the parameters for the console logger.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="consoleLoggerParameters">The console logger parameters to set.</param>
+        /// <returns>The same <see cref="DotNetCoreMSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetCoreMSBuildSettings SetConsoleLoggerSettings(this DotNetCoreMSBuildSettings settings, MSBuildLoggerSettings consoleLoggerParameters)
+        {
+            EnsureSettings(settings);
+
+            settings.ConsoleLoggerSettings = consoleLoggerParameters ?? throw new ArgumentNullException(nameof(consoleLoggerParameters));
+
+            return settings;
+        }
+
+        /// <summary>
+        /// Adds a file logger.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="fileLoggerParameters">Parameters to be passed to the logger.</param>
+        /// <returns>The same <see cref="DotNetCoreMSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        /// <remarks>
+        /// Each file logger will be declared in the order added.
+        /// The first file logger will match up to the /fl parameter.
+        /// The next nine (max) file loggers will match up to the /fl1 through /fl9 respectively.
+        /// </remarks>
+        public static DotNetCoreMSBuildSettings AddFileLogger(this DotNetCoreMSBuildSettings settings, MSBuildFileLoggerSettings fileLoggerParameters)
+        {
+            EnsureSettings(settings);
+
+            if (fileLoggerParameters == null)
+            {
+                throw new ArgumentNullException(nameof(fileLoggerParameters));
+            }
+
+            settings.FileLoggers.Add(fileLoggerParameters);
+
+            return settings;
+        }
+
+        /// <summary>
+        /// Adds a file logger with all the default settings.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The same <see cref="DotNetCoreMSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        /// <remarks>
+        /// Each file logger will be declared in the order added.
+        /// The first file logger will match up to the /fl parameter.
+        /// The next nine (max) file loggers will match up to the /fl1 through /fl9 respectively.
+        /// </remarks>
+        public static DotNetCoreMSBuildSettings AddFileLogger(this DotNetCoreMSBuildSettings settings)
+        {
+            EnsureSettings(settings);
+
+            settings.FileLoggers.Add(new MSBuildFileLoggerSettings());
+
+            return settings;
+        }
+
+        /// <summary>
+        /// Adds a custom logger.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="loggerAssembly">The assembly containing the logger. Should match the format {AssemblyName[,StrongName] | AssemblyFile}</param>
+        /// <param name="loggerClass">The class implementing the logger. Should match the format [PartialOrFullNamespace.]LoggerClassName. If the assembly contains only one logger, class does not need to be specified.</param>
+        /// <param name="loggerParameters">Parameters to be passed to the logger.</param>
+        /// <returns>The same <see cref="DotNetCoreMSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetCoreMSBuildSettings WithLogger(this DotNetCoreMSBuildSettings settings, string loggerAssembly, string loggerClass = null, string loggerParameters = null)
+        {
+            EnsureSettings(settings);
+
+            if (string.IsNullOrWhiteSpace(loggerAssembly))
+            {
+                throw new ArgumentException(nameof(loggerAssembly));
+            }
+
+            settings.Loggers.Add(new MSBuildLogger
+            {
+                Assembly = loggerAssembly,
+                Class = loggerClass,
+                Parameters = loggerParameters
+            });
+
+            return settings;
+        }
+
+        /// <summary>
+        /// Disables the default console logger, and not log events to the console.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The same <see cref="DotNetCoreMSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetCoreMSBuildSettings DisableConsoleLogger(this DotNetCoreMSBuildSettings settings)
+        {
+            EnsureSettings(settings);
+
+            settings.DisableConsoleLogger = true;
+
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the warning code to treats as an error.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="warningCode">The warning code to treat as an error.</param>
+        /// <returns>The same <see cref="DotNetCoreMSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        /// <remarks>
+        /// When a warning is treated as an error the target will continue to execute as if it was a warning but the overall build will fail.
+        /// </remarks>
+        public static DotNetCoreMSBuildSettings SetWarningCodeAsError(this DotNetCoreMSBuildSettings settings, string warningCode)
+        {
+            EnsureSettings(settings);
+
+            if (string.IsNullOrWhiteSpace(warningCode))
+            {
+                throw new ArgumentException("Warning code cannot be null or empty", nameof(warningCode));
+            }
+
+            settings.WarningCodesAsError.Add(warningCode);
+
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the warning code to treats as a message.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="warningCode">The warning code to treat as a message.</param>
+        /// <returns>The same <see cref="DotNetCoreMSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetCoreMSBuildSettings SetWarningCodeAsMessage(this DotNetCoreMSBuildSettings settings, string warningCode)
+        {
+            EnsureSettings(settings);
+
+            if (string.IsNullOrWhiteSpace(warningCode))
+            {
+                throw new ArgumentException("Warning code cannot be null or empty", nameof(warningCode));
+            }
+
+            settings.WarningCodesAsMessage.Add(warningCode);
+
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets how all warnings should be treated.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="behaviour">How all warning should be treated.</param>
+        /// <returns>The same <see cref="DotNetCoreMSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetCoreMSBuildSettings TreatAllWarningsAs(this DotNetCoreMSBuildSettings settings, MSBuildTreatAllWarningsAs behaviour)
+        {
+            EnsureSettings(settings);
+
+            settings.TreatAllWarningsAs = behaviour;
+
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the configuration.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="configuration">The configuration.</param>
+        /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetCoreMSBuildSettings SetConfiguration(this DotNetCoreMSBuildSettings settings, string configuration)
+            => settings.WithProperty("configuration", configuration);
+
+        /// <summary>
+        /// Sets the version.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="version">The version.</param>
+        /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        /// <remarks>
+        /// Version will override VersionPrefix and VersionSuffix if set.
+        /// This may also override version settings during packaging.
+        /// </remarks>
+        public static DotNetCoreMSBuildSettings SetVersion(this DotNetCoreMSBuildSettings settings, string version)
+            => settings.WithProperty("Version", version);
+
+        /// <summary>
+        /// Sets the version prefix.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="versionPrefix">The version prefix.</param>
+        /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetCoreMSBuildSettings SetVersionPrefix(this DotNetCoreMSBuildSettings settings, string versionPrefix)
+            => settings.WithProperty("VersionPrefix", versionPrefix);
+
+        /// <summary>
+        /// Sets the version Suffix.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="versionSuffix">The version prefix.</param>
+        /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetCoreMSBuildSettings SetVersionSuffix(this DotNetCoreMSBuildSettings settings, string versionSuffix)
+            => settings.WithProperty("VersionSuffix", versionSuffix);
+
+        /// <summary>
+        /// Adds a framework to target.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="targetFramework">The framework to target.</param>
+        /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        /// <remarks>
+        /// For list of target frameworks see https://docs.microsoft.com/en-us/dotnet/standard/frameworks.
+        /// </remarks>
+        public static DotNetCoreMSBuildSettings SetTargetFramework(this DotNetCoreMSBuildSettings settings, string targetFramework)
+            => settings.WithProperty("TargetFrameworks", targetFramework);
+
+        /// <summary>
+        /// Sets a target operating systems where the application or assembly will run.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="runtimeId">The runtime id of the operating system.</param>
+        /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        /// <remarks>
+        /// For list of runtime ids see https://docs.microsoft.com/en-us/dotnet/core/rid-catalog.
+        /// </remarks>
+        public static DotNetCoreMSBuildSettings SetRuntime(this DotNetCoreMSBuildSettings settings, string runtimeId)
+            => settings.WithProperty("RuntimeIdentifiers", runtimeId);
+
+        private static void EnsureSettings(DotNetCoreMSBuildSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/MSBuild/MSBuildArgumentBuilderExtensions.cs
+++ b/src/Cake.Common/Tools/DotNetCore/MSBuild/MSBuildArgumentBuilderExtensions.cs
@@ -1,0 +1,376 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Cake.Common.Tools.MSBuild;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotNetCore.MSBuild
+{
+    /// <summary>
+    /// Contains functionality related to MSBuild arguments.
+    /// </summary>
+    public static class MSBuildArgumentBuilderExtensions
+    {
+        /// <summary>
+        /// Adds MSBuild arguments
+        /// </summary>
+        /// <param name="builder">Argument builder.</param>
+        /// <param name="settings">MSBuild settings to add.</param>
+        /// <param name="environment">The environment.</param>
+        /// <exception cref="InvalidOperationException">Throws if 10 or more file loggers specified.</exception>
+        public static void AppendMSBuildSettings(this ProcessArgumentBuilder builder, DotNetCoreMSBuildSettings settings, ICakeEnvironment environment)
+        {
+            // Got any targets?
+            if (settings.Targets.Any())
+            {
+                if (settings.Targets.All(string.IsNullOrWhiteSpace))
+                {
+                    throw new ArgumentException("Specify the name of the target", nameof(settings.Targets));
+                }
+
+                builder.AppendMSBuildSwitch("target", string.Join(";", settings.Targets));
+            }
+
+            // Got any properties?
+            foreach (var property in settings.Properties)
+            {
+                if (property.Value == null || property.Value.All(string.IsNullOrWhiteSpace))
+                {
+                    throw new ArgumentException("A property must have at least one non-empty value", nameof(settings.Properties));
+                }
+
+                foreach (var value in property.Value)
+                {
+                    if (string.IsNullOrWhiteSpace(value))
+                    {
+                        continue;
+                    }
+
+                    builder.AppendMSBuildSwitch("property", $"{property.Key}={value}");
+                }
+            }
+
+            // Set the maximum number of processors?
+            if (settings.MaxCpuCount.HasValue)
+            {
+                builder.AppendMSBuildSwitchWithOptionalValue("maxcpucount", settings.MaxCpuCount.Value, maxCpuCount => maxCpuCount > 0);
+            }
+
+            // use different version of msbuild?
+            if (settings.ToolVersion.HasValue)
+            {
+                builder.AppendMSBuildSwitch("toolsversion", GetToolVersionValue(settings.ToolVersion.Value));
+            }
+
+            // configure console logger?
+            if (!settings.DisableConsoleLogger && settings.ConsoleLoggerSettings != null)
+            {
+                var arguments = GetLoggerSettings(settings.ConsoleLoggerSettings);
+
+                if (arguments.Any())
+                {
+                    builder.AppendMSBuildSwitch("consoleloggerparameters", arguments);
+                }
+            }
+
+            // disable console logger?
+            if (settings.DisableConsoleLogger)
+            {
+                builder.AppendMSBuildSwitch("noconsolelogger");
+            }
+
+            // Got any file loggers?
+            if (settings.FileLoggers.Any())
+            {
+                if (settings.FileLoggers.Count >= 10)
+                {
+                    throw new InvalidOperationException("Too Many FileLoggers");
+                }
+
+                var arguments = settings
+                                    .FileLoggers
+                                    .Select((logger, index) => GetLoggerArgument(index, logger, environment))
+                                    .Where(arg => !string.IsNullOrEmpty(arg));
+
+                foreach (var argument in arguments)
+                {
+                    builder.Append(argument);
+                }
+            }
+
+            // Got any distributed loggers?
+            foreach (var distributedLogger in settings.DistributedLoggers)
+            {
+                builder.AppendMSBuildSwitch("distributedlogger", $"{GetLoggerValue(distributedLogger.CentralLogger)}*{GetLoggerValue(distributedLogger.ForwardingLogger)}");
+            }
+
+            // use a file logger for each node?
+            if (settings.DistributedFileLogger)
+            {
+                builder.AppendMSBuildSwitch("distributedFileLogger");
+            }
+
+            // Got any loggers?
+            foreach (var logger in settings.Loggers)
+            {
+                builder.AppendMSBuildSwitch("logger", GetLoggerValue(logger));
+            }
+
+            var showWarningsAsError = settings.TreatAllWarningsAs == MSBuildTreatAllWarningsAs.Error || settings.WarningCodesAsError.Any();
+            var showWarningsAsMessages = settings.TreatAllWarningsAs == MSBuildTreatAllWarningsAs.Message || settings.WarningCodesAsMessage.Any();
+
+            // Treat all or some warnings as errors?
+            if (showWarningsAsError)
+            {
+                builder.AppendMSBuildSwitchWithOptionalValueIfNotEmpty("warnaserror", GetWarningCodes(settings.TreatAllWarningsAs == MSBuildTreatAllWarningsAs.Error, settings.WarningCodesAsError));
+            }
+
+            // Treat all or some warnings as messages?
+            if (showWarningsAsMessages)
+            {
+                builder.AppendMSBuildSwitchWithOptionalValueIfNotEmpty("warnasmessage", GetWarningCodes(settings.TreatAllWarningsAs == MSBuildTreatAllWarningsAs.Message, settings.WarningCodesAsMessage));
+            }
+
+            // set project file extensions to ignore when searching for project file
+            if (settings.IgnoreProjectExtensions.Any())
+            {
+                builder.AppendMSBuildSwitch("ignoreprojectextensions", string.Join(",", settings.IgnoreProjectExtensions));
+            }
+
+            // detailed summary?
+            if (settings.DetailedSummary)
+            {
+                builder.AppendMSBuildSwitch("detailedsummary");
+            }
+
+            // Include response files?
+            foreach (var responseFile in settings.ResponseFiles)
+            {
+                builder.AppendSwitchQuoted("@", string.Empty, responseFile.MakeAbsolute(environment).FullPath);
+            }
+
+            // exclude auto response files?
+            if (settings.ExcludeAutoResponseFiles)
+            {
+                builder.AppendMSBuildSwitch("noautoresponse");
+            }
+
+            // don't output MSBuild logo?
+            if (settings.NoLogo)
+            {
+                builder.AppendMSBuildSwitch("nologo");
+            }
+        }
+
+        private static string GetLoggerValue(MSBuildLogger logger)
+        {
+            if (string.IsNullOrWhiteSpace(logger.Assembly))
+            {
+                throw new ArgumentNullException(nameof(logger.Assembly), "Assembly must be a strong name or file");
+            }
+
+            var argumentBuilder = new StringBuilder();
+            if (!string.IsNullOrWhiteSpace(logger.Class))
+            {
+                argumentBuilder.Append(logger.Class);
+                argumentBuilder.Append(",");
+                argumentBuilder.Append(logger.Assembly);
+            }
+            else
+            {
+                argumentBuilder.Append(logger.Assembly?.Quote());
+            }
+
+            if (!string.IsNullOrWhiteSpace(logger.Parameters))
+            {
+                argumentBuilder.Append(";");
+                argumentBuilder.Append(logger.Parameters);
+            }
+
+            return argumentBuilder.ToString();
+        }
+
+        private static string GetLoggerArgument(int index, MSBuildFileLoggerSettings logger, ICakeEnvironment environment)
+        {
+            var parameters = GetLoggerSettings(logger, environment);
+            if (string.IsNullOrWhiteSpace(parameters))
+            {
+                return string.Empty;
+            }
+
+            var counter = index == 0 ? string.Empty : index.ToString();
+            return $"/fileLogger{counter} /fileloggerparameters{counter}:{parameters}";
+        }
+
+        private static string GetToolVersionValue(MSBuildVersion toolVersion)
+        {
+            switch (toolVersion)
+            {
+                case MSBuildVersion.MSBuild20:
+                    return "2.0";
+                case MSBuildVersion.MSBuild35:
+                    return "3.5";
+                case MSBuildVersion.MSBuild4:
+                    return "4.0";
+                case MSBuildVersion.MSBuild12:
+                    return "12.0";
+                case MSBuildVersion.MSBuild14:
+                    return "14.0";
+                case MSBuildVersion.MSBuild15:
+                    return "15.0";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(toolVersion), toolVersion, "Invalid value");
+            }
+        }
+
+        private static string GetLoggerSettings(MSBuildFileLoggerSettings loggerSettings, ICakeEnvironment environment)
+        {
+            var settings = new List<string>();
+
+            var commonArguments = GetLoggerSettings(loggerSettings);
+
+            if (commonArguments.Any())
+            {
+                settings.Add(commonArguments);
+            }
+
+            if (loggerSettings.LogFile != null)
+            {
+                var filePath = string.IsNullOrWhiteSpace(loggerSettings.LogFile)
+                    ? string.Empty
+                    : FilePath.FromString(loggerSettings.LogFile).MakeAbsolute(environment).ToString();
+
+                settings.Add($"LogFile=\"{filePath}\"");
+            }
+
+            if (loggerSettings.AppendToLogFile)
+            {
+                settings.Add("Append");
+            }
+
+            if (!string.IsNullOrWhiteSpace(loggerSettings.FileEncoding))
+            {
+                settings.Add($"Encoding={loggerSettings.FileEncoding}");
+            }
+
+            return string.Join(";", settings);
+        }
+
+        private static string GetLoggerSettings(MSBuildLoggerSettings loggerSettings)
+        {
+            var settings = new List<string>();
+
+            if (loggerSettings.PerformanceSummary)
+            {
+                settings.Add("PerformanceSummary");
+            }
+
+            if (loggerSettings.NoSummary)
+            {
+                settings.Add("NoSummary");
+            }
+
+            if (loggerSettings.SummaryOutputLevel != MSBuildLoggerOutputLevel.Default)
+            {
+                switch (loggerSettings.SummaryOutputLevel)
+                {
+                    case MSBuildLoggerOutputLevel.WarningsOnly:
+                        settings.Add("WarningsOnly");
+                        break;
+                    case MSBuildLoggerOutputLevel.ErrorsOnly:
+                        settings.Add("ErrorsOnly");
+                        break;
+                }
+            }
+
+            if (loggerSettings.HideItemAndPropertyList)
+            {
+                settings.Add("NoItemAndPropertyList");
+            }
+
+            if (loggerSettings.ShowCommandLine)
+            {
+                settings.Add("ShowCommandLine");
+            }
+
+            if (loggerSettings.ShowTimestamp)
+            {
+                settings.Add("ShowTimestamp");
+            }
+
+            if (loggerSettings.ShowEventId)
+            {
+                settings.Add("ShowEventId");
+            }
+
+            if (loggerSettings.ForceNoAlign)
+            {
+                settings.Add("ForceNoAlign");
+            }
+
+            if (loggerSettings.ConsoleColorType == MSBuildConsoleColorType.Disabled)
+            {
+                settings.Add("DisableConsoleColor");
+            }
+
+            if (loggerSettings.ConsoleColorType == MSBuildConsoleColorType.ForceAnsi)
+            {
+                settings.Add("ForceConsoleColor");
+            }
+
+            if (loggerSettings.DisableMultiprocessorLogging)
+            {
+                settings.Add("DisableMPLogging");
+            }
+
+            if (loggerSettings.Verbosity.HasValue)
+            {
+                settings.Add($"Verbosity={loggerSettings.Verbosity}");
+            }
+
+            return string.Join(";", settings);
+        }
+
+        private static string GetWarningCodes(bool shouldApplyToAllWarnings, IList<string> warningCodes)
+            => shouldApplyToAllWarnings
+                ? null
+                : string.Join(";", warningCodes);
+
+        private static void AppendMSBuildSwitch(this ProcessArgumentBuilder builder, string @switch)
+            => builder.Append($"/{@switch}");
+
+        private static void AppendMSBuildSwitch(this ProcessArgumentBuilder builder, string @switch, string value)
+            => builder.AppendSwitch($"/{@switch}", ":", value);
+
+        private static void AppendMSBuildSwitchQuoted(this ProcessArgumentBuilder builder, string @switch, string value)
+            => builder.AppendSwitchQuoted($"/{@switch}", ":", value);
+
+        private static void AppendMSBuildSwitchWithOptionalValueIfNotEmpty(this ProcessArgumentBuilder builder, string @switch, string value)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                builder.AppendMSBuildSwitch(@switch, value);
+                return;
+            }
+
+            builder.AppendMSBuildSwitch(@switch);
+        }
+
+        private static void AppendMSBuildSwitchWithOptionalValue<T>(this ProcessArgumentBuilder builder, string @switch, T value, Func<T, bool> predicate)
+        {
+            if (predicate(value))
+            {
+                builder.AppendMSBuildSwitch(@switch, value.ToString());
+                return;
+            }
+
+            builder.AppendMSBuildSwitch(@switch);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/MSBuild/MSBuildConsoleColorType.cs
+++ b/src/Cake.Common/Tools/DotNetCore/MSBuild/MSBuildConsoleColorType.cs
@@ -1,0 +1,23 @@
+﻿namespace Cake.Common.Tools.DotNetCore.MSBuild
+{
+    /// <summary>
+    /// Represents how the console color should behave in a console.
+    /// </summary>
+    public enum MSBuildConsoleColorType
+    {
+        /// <summary>
+        /// Use the normal console color behaviour.
+        /// </summary>
+        Normal = 0,
+
+        /// <summary>
+        /// Use the default console color for all logging messages.
+        /// </summary>
+        Disabled,
+
+        /// <summary>
+        /// Use ANSI console colors even if console does not support it
+        /// </summary>
+        ForceAnsi
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/MSBuild/MSBuildDistributedLogger.cs
+++ b/src/Cake.Common/Tools/DotNetCore/MSBuild/MSBuildDistributedLogger.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.MSBuild;
+
+namespace Cake.Common.Tools.DotNetCore.MSBuild
+{
+    /// <summary>
+    /// Represents the Distributed Logging Model with a central logger and forwarding logger.
+    /// </summary>
+    public class MSBuildDistributedLogger
+    {
+        /// <summary>
+        /// Gets or sets the logger to use as the central logger.
+        /// </summary>
+        public MSBuildLogger CentralLogger { get; set; }
+
+        /// <summary>
+        /// Gets or sets the logger to use as the forwarding logger.
+        /// </summary>
+        public MSBuildLogger ForwardingLogger { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/MSBuild/MSBuildFileLoggerSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/MSBuild/MSBuildFileLoggerSettings.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotNetCore.MSBuild
+{
+    /// <summary>
+    /// Represents the settings for a file logger.
+    /// </summary>
+    public class MSBuildFileLoggerSettings : MSBuildLoggerSettings
+    {
+        /// <summary>
+        /// Gets or sets the path to the log file into which the build log is written.
+        /// </summary>
+        /// <remarks>
+        /// An empty string will use msbuild.log, in the current directory.
+        /// </remarks>
+        public string LogFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the build log is appended to the log file or overwrites it.
+        /// </summary>
+        public bool AppendToLogFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the encoding for the file (for example, UTF-8, Unicode, or ASCII).
+        /// </summary>
+        public string FileEncoding { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/MSBuild/MSBuildLoggerOutputLevel.cs
+++ b/src/Cake.Common/Tools/DotNetCore/MSBuild/MSBuildLoggerOutputLevel.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Tools.DotNetCore.MSBuild
+{
+    /// <summary>
+    /// Represents the logging output level for a MSBuild logger.
+    /// </summary>
+    public enum MSBuildLoggerOutputLevel
+    {
+        /// <summary>
+        /// Show the error and warning summary at the end.
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// Show only warnings summary at the end.
+        /// </summary>
+        WarningsOnly,
+
+        /// <summary>
+        /// Show only errors summary at the end.
+        /// </summary>
+        ErrorsOnly
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/MSBuild/MSBuildLoggerSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/MSBuild/MSBuildLoggerSettings.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Tools.DotNetCore.MSBuild
+{
+    /// <summary>
+    /// Represents the common settings for a logger.
+    /// </summary>
+    public class MSBuildLoggerSettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to show the time that’s spent in tasks, targets, and projects.
+        /// </summary>
+        public bool PerformanceSummary { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to hide the error and warning summary at the end.
+        /// </summary>
+        public bool NoSummary { get; set; }
+
+        /// <summary>
+        /// Gets or sets value that indicates the level of summary output at the end for the logger.
+        /// </summary>
+        /// <remarks>Default is to show errors and summary.</remarks>
+        public MSBuildLoggerOutputLevel SummaryOutputLevel { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to hide the list of items and properties that would appear at the start of each project build if the verbosity level is set to diagnostic.
+        /// </summary>
+        public bool HideItemAndPropertyList { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to show TaskCommandLineEvent messages.
+        /// </summary>
+        public bool ShowCommandLine { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to show the timestamp as a prefix to any message.
+        /// </summary>
+        public bool ShowTimestamp { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to show the event Id for each started event, finished event, and message.
+        /// </summary>
+        public bool ShowEventId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to not align the text to the size of the console buffer.
+        /// </summary>
+        public bool ForceNoAlign { get; set; }
+
+        /// <summary>
+        /// Gets or sets value that indicates the type of console color to use for all logging messages.
+        /// </summary>
+        public MSBuildConsoleColorType ConsoleColorType { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to disable the multiprocessor logging style of output when running in non-multiprocessor mode.
+        /// </summary>
+        public bool DisableMultiprocessorLogging { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that overrides the /verbosity setting for this logger.
+        /// </summary>
+        public DotNetCoreVerbosity? Verbosity { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/MSBuild/MSBuildTreatAllWarningsAs.cs
+++ b/src/Cake.Common/Tools/DotNetCore/MSBuild/MSBuildTreatAllWarningsAs.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Tools.DotNetCore.MSBuild
+{
+    /// <summary>
+    /// Represents how all warnings should be treated as by MSBuild.
+    /// </summary>
+    public enum MSBuildTreatAllWarningsAs
+    {
+        /// <summary>
+        /// Use the default MSBuild behaviour.
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// Treat all warnings as low importance messages.
+        /// </summary>
+        Message = 1,
+
+        /// <summary>
+        /// Treat all warnings as errors.
+        /// </summary>
+        Error = 2
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/Pack/DotNetCorePackSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Pack/DotNetCorePackSettings.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Core.IO;
 
 namespace Cake.Common.Tools.DotNetCore.Pack
@@ -49,5 +50,10 @@ namespace Cake.Common.Tools.DotNetCore.Pack
         /// For more information, see https://aka.ms/nupkgservicing
         /// </remarks>
         public bool Serviceable { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional arguments to be passed to MSBuild.
+        /// </summary>
+        public DotNetCoreMSBuildSettings MSBuildSettings { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/Pack/DotNetCorePacker.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Pack/DotNetCorePacker.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
@@ -102,6 +103,11 @@ namespace Cake.Common.Tools.DotNetCore.Pack
             if (settings.Serviceable)
             {
                 builder.Append("--serviceable");
+            }
+
+            if (settings.MSBuildSettings != null)
+            {
+                builder.AppendMSBuildSettings(settings.MSBuildSettings, _environment);
             }
 
             return builder;

--- a/src/Cake.Common/Tools/DotNetCore/Publish/DotNetCorePublishSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Publish/DotNetCorePublishSettings.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Core.IO;
 
 namespace Cake.Common.Tools.DotNetCore.Publish
@@ -35,5 +36,10 @@ namespace Cake.Common.Tools.DotNetCore.Publish
         /// Gets or sets the value that defines what `*` should be replaced with in version field in project.json.
         /// </summary>
         public string VersionSuffix { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional arguments to be passed to MSBuild.
+        /// </summary>
+        public DotNetCoreMSBuildSettings MSBuildSettings { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/Publish/DotNetCorePublisher.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Publish/DotNetCorePublisher.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
@@ -92,6 +93,11 @@ namespace Cake.Common.Tools.DotNetCore.Publish
             {
                 builder.Append("--version-suffix");
                 builder.Append(settings.VersionSuffix);
+            }
+
+            if (settings.MSBuildSettings != null)
+            {
+                builder.AppendMSBuildSettings(settings.MSBuildSettings, _environment);
             }
 
             return builder;

--- a/src/Cake.Common/Tools/DotNetCore/Restore/DotNetCoreRestoreSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Restore/DotNetCoreRestoreSettings.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Core.IO;
 
 namespace Cake.Common.Tools.DotNetCore.Restore
@@ -51,5 +52,10 @@ namespace Cake.Common.Tools.DotNetCore.Restore
         /// Gets or sets a value indicating whether to ignore project to project references and restore only the root project.
         /// </summary>
         public bool NoDependencies { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional arguments to be passed to MSBuild.
+        /// </summary>
+        public DotNetCoreMSBuildSettings MSBuildSettings { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/Restore/DotNetCoreRestorer.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Restore/DotNetCoreRestorer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
@@ -117,6 +118,11 @@ namespace Cake.Common.Tools.DotNetCore.Restore
             if (settings.NoDependencies)
             {
                 builder.Append("--no-dependencies");
+            }
+
+            if (settings.MSBuildSettings != null)
+            {
+                builder.AppendMSBuildSettings(settings.MSBuildSettings, _environment);
             }
 
             return builder;

--- a/src/Cake.Common/Tools/MSBuild/MSBuildVersion.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildVersion.cs
@@ -4,13 +4,27 @@
 
 namespace Cake.Common.Tools.MSBuild
 {
-    internal enum MSBuildVersion
+    /// <summary>
+    /// Represents a MSBuild version
+    /// </summary>
+    public enum MSBuildVersion
     {
+        /// <summary>Version 2.0</summary>
         MSBuild20 = 1,
+
+        /// <summary>Version 3.5</summary>
         MSBuild35 = 2,
+
+        /// <summary>Version 4.0</summary>
         MSBuild4 = 3,
+
+        /// <summary>Version 12.0</summary>
         MSBuild12 = 4,
+
+        /// <summary>Version 14.0</summary>
         MSBuild14 = 5,
+
+        /// <summary>Version 15.0</summary>
         MSBuild15 = 6
     }
 }


### PR DESCRIPTION
* add alias and related files to support `dotnet msbuild` for v1.0.4 of command line tools
* updated clean, restore, build, pack, publish aliases to support msbuild settings
* extension methods
* unit tests

See #1533 for more info