### PR TITLE
Make runner internal

### DIFF
--- a/src/Cake.Common/Tools/Cake/CakeRunner.cs
+++ b/src/Cake.Common/Tools/Cake/CakeRunner.cs
@@ -19,7 +19,7 @@ namespace Cake.Common.Tools.Cake
     /// <summary>
     /// Cake out process runner
     /// </summary>
-    public sealed class CakeRunner : Tool<CakeSettings>
+    internal sealed class CakeRunner : Tool<CakeSettings>
     {
         private readonly ICakeEnvironment _environment;
         private readonly IFileSystem _fileSystem;

--- a/src/Cake.Common/Tools/Chocolatey/ApiKey/ChocolateyApiKeySetter.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ApiKey/ChocolateyApiKeySetter.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.Chocolatey.ApiKey
     /// <summary>
     /// The Chocolatey package pinner used to pin Chocolatey packages.
     /// </summary>
-    public sealed class ChocolateyApiKeySetter : ChocolateyTool<ChocolateyApiKeySettings>
+    internal sealed class ChocolateyApiKeySetter : ChocolateyTool<ChocolateyApiKeySettings>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ChocolateyApiKeySetter"/> class.

--- a/src/Cake.Common/Tools/Chocolatey/Config/ChocolateyConfigSetter.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Config/ChocolateyConfigSetter.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.Chocolatey.Config
     /// <summary>
     /// The Chocolatey configuration setter.
     /// </summary>
-    public sealed class ChocolateyConfigSetter : ChocolateyTool<ChocolateyConfigSettings>
+    internal sealed class ChocolateyConfigSetter : ChocolateyTool<ChocolateyConfigSettings>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ChocolateyConfigSetter"/> class.

--- a/src/Cake.Common/Tools/Chocolatey/Features/ChocolateyFeatureToggler.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Features/ChocolateyFeatureToggler.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.Chocolatey.Features
     /// <summary>
     /// The Chocolatey feature toggler used to enable/disable Chocolatey Features.
     /// </summary>
-    public sealed class ChocolateyFeatureToggler : ChocolateyTool<ChocolateyFeatureSettings>
+    internal sealed class ChocolateyFeatureToggler : ChocolateyTool<ChocolateyFeatureSettings>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ChocolateyFeatureToggler"/> class.

--- a/src/Cake.Common/Tools/Chocolatey/Install/ChocolateyInstaller.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Install/ChocolateyInstaller.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.Chocolatey.Install
     /// <summary>
     /// The Chocolatey package installer used to install Chocolatey packages.
     /// </summary>
-    public sealed class ChocolateyInstaller : ChocolateyTool<ChocolateyInstallSettings>
+    internal sealed class ChocolateyInstaller : ChocolateyTool<ChocolateyInstallSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/Chocolatey/New/ChocolateyScaffolder.cs
+++ b/src/Cake.Common/Tools/Chocolatey/New/ChocolateyScaffolder.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.Chocolatey.New
     /// <summary>
     /// The Chocolatey project scaffolder used to generate package specification files for a new package.
     /// </summary>
-    public sealed class ChocolateyScaffolder : ChocolateyTool<ChocolateyNewSettings>
+    internal sealed class ChocolateyScaffolder : ChocolateyTool<ChocolateyNewSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyPacker.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyPacker.cs
@@ -14,7 +14,7 @@ namespace Cake.Common.Tools.Chocolatey.Pack
     /// <summary>
     /// The Chocolatey packer.
     /// </summary>
-    public sealed class ChocolateyPacker : ChocolateyTool<ChocolateyPackSettings>
+    internal sealed class ChocolateyPacker : ChocolateyTool<ChocolateyPackSettings>
     {
         private readonly IFileSystem _fileSystem;
         private readonly ICakeEnvironment _environment;

--- a/src/Cake.Common/Tools/Chocolatey/Pin/ChocolateyPinner.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Pin/ChocolateyPinner.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.Chocolatey.Pin
     /// <summary>
     /// The Chocolatey package pinner used to pin Chocolatey packages.
     /// </summary>
-    public sealed class ChocolateyPinner : ChocolateyTool<ChocolateyPinSettings>
+    internal sealed class ChocolateyPinner : ChocolateyTool<ChocolateyPinSettings>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ChocolateyPinner"/> class.

--- a/src/Cake.Common/Tools/Chocolatey/Push/ChocolateyPusher.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Push/ChocolateyPusher.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.Chocolatey.Push
     /// <summary>
     /// The Chocolatey package pusher.
     /// </summary>
-    public sealed class ChocolateyPusher : ChocolateyTool<ChocolateyPushSettings>
+    internal sealed class ChocolateyPusher : ChocolateyTool<ChocolateyPushSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/Chocolatey/Sources/ChocolateySources.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Sources/ChocolateySources.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.Chocolatey.Sources
     /// <summary>
     /// The Chocolatey sources is used to work with user config feeds &amp; credentials
     /// </summary>
-    public sealed class ChocolateySources : ChocolateyTool<ChocolateySourcesSettings>
+    internal sealed class ChocolateySources : ChocolateyTool<ChocolateySourcesSettings>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ChocolateySources"/> class.

--- a/src/Cake.Common/Tools/Chocolatey/Uninstall/ChocolateyUninstaller.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Uninstall/ChocolateyUninstaller.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.Chocolatey.Uninstall
     /// <summary>
     /// The Chocolatey package uninstall used to uninstall Chocolatey packages.
     /// </summary>
-    public sealed class ChocolateyUninstaller : ChocolateyTool<ChocolateyUninstallSettings>
+    internal sealed class ChocolateyUninstaller : ChocolateyTool<ChocolateyUninstallSettings>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ChocolateyUninstaller"/> class.

--- a/src/Cake.Common/Tools/Chocolatey/Upgrade/ChocolateyUpgrader.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Upgrade/ChocolateyUpgrader.cs
@@ -12,7 +12,7 @@ namespace Cake.Common.Tools.Chocolatey.Upgrade
     /// <summary>
     /// The Chocolatey package upgrader.
     /// </summary>
-    public sealed class ChocolateyUpgrader : ChocolateyTool<ChocolateyUpgradeSettings>
+    internal sealed class ChocolateyUpgrader : ChocolateyTool<ChocolateyUpgradeSettings>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ChocolateyUpgrader"/> class.

--- a/src/Cake.Common/Tools/DotCover/Analyse/DotCoverAnalyser.cs
+++ b/src/Cake.Common/Tools/DotCover/Analyse/DotCoverAnalyser.cs
@@ -12,7 +12,7 @@ namespace Cake.Common.Tools.DotCover.Analyse
     /// <summary>
     /// DotCover Analyser builder.
     /// </summary>
-    public sealed class DotCoverAnalyser : DotCoverCoverageTool<DotCoverAnalyseSettings>
+    internal sealed class DotCoverAnalyser : DotCoverCoverageTool<DotCoverAnalyseSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/DotCover/Cover/DotCoverCoverer.cs
+++ b/src/Cake.Common/Tools/DotCover/Cover/DotCoverCoverer.cs
@@ -12,7 +12,7 @@ namespace Cake.Common.Tools.DotCover.Cover
     /// <summary>
     /// DotCover Coverer builder.
     /// </summary>
-    public sealed class DotCoverCoverer : DotCoverCoverageTool<DotCoverCoverSettings>
+    internal sealed class DotCoverCoverer : DotCoverCoverageTool<DotCoverCoverSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/DotCover/Merge/DotCoverMerger.cs
+++ b/src/Cake.Common/Tools/DotCover/Merge/DotCoverMerger.cs
@@ -14,7 +14,7 @@ namespace Cake.Common.Tools.DotCover.Merge
     /// <summary>
     /// DotCover Merge merger.
     /// </summary>
-    public sealed class DotCoverMerger : DotCoverTool<DotCoverMergeSettings>
+    internal sealed class DotCoverMerger : DotCoverTool<DotCoverMergeSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/DotCover/Report/DotCoverReporter.cs
+++ b/src/Cake.Common/Tools/DotCover/Report/DotCoverReporter.cs
@@ -12,7 +12,7 @@ namespace Cake.Common.Tools.DotCover.Report
     /// <summary>
     /// DotCover Report reporter.
     /// </summary>
-    public sealed class DotCoverReporter : DotCoverTool<DotCoverReportSettings>
+    internal sealed class DotCoverReporter : DotCoverTool<DotCoverReportSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/DotNetCore/Build/DotNetCoreBuilder.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Build/DotNetCoreBuilder.cs
@@ -12,7 +12,7 @@ namespace Cake.Common.Tools.DotNetCore.Build
     /// <summary>
     /// .NET Core project builder.
     /// </summary>
-    public sealed class DotNetCoreBuilder : DotNetCoreTool<DotNetCoreBuildSettings>
+    internal sealed class DotNetCoreBuilder : DotNetCoreTool<DotNetCoreBuildSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/DotNetCore/Execute/DotNetCoreExecutor.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Execute/DotNetCoreExecutor.cs
@@ -12,7 +12,7 @@ namespace Cake.Common.Tools.DotNetCore.Execute
     /// <summary>
     /// .NET Core assembly executor.
     /// </summary>
-    public sealed class DotNetCoreExecutor : DotNetCoreTool<DotNetCoreSettings>
+    internal sealed class DotNetCoreExecutor : DotNetCoreTool<DotNetCoreSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/DotNetCore/Pack/DotNetCorePacker.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Pack/DotNetCorePacker.cs
@@ -12,7 +12,7 @@ namespace Cake.Common.Tools.DotNetCore.Pack
     /// <summary>
     /// .NET Core project packer.
     /// </summary>
-    public sealed class DotNetCorePacker : DotNetCoreTool<DotNetCorePackSettings>
+    internal sealed class DotNetCorePacker : DotNetCoreTool<DotNetCorePackSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/DotNetCore/Publish/DotNetCorePublisher.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Publish/DotNetCorePublisher.cs
@@ -12,7 +12,7 @@ namespace Cake.Common.Tools.DotNetCore.Publish
     /// <summary>
     /// .NET Core project runner.
     /// </summary>
-    public sealed class DotNetCorePublisher : DotNetCoreTool<DotNetCorePublishSettings>
+    internal sealed class DotNetCorePublisher : DotNetCoreTool<DotNetCorePublishSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/DotNetCore/Restore/DotNetCoreRestorer.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Restore/DotNetCoreRestorer.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.DotNetCore.Restore
     /// <summary>
     /// .NET Core project restorer.
     /// </summary>
-    public sealed class DotNetCoreRestorer : DotNetCoreTool<DotNetCoreRestoreSettings>
+    internal sealed class DotNetCoreRestorer : DotNetCoreTool<DotNetCoreRestoreSettings>
     {
         private readonly ICakeEnvironment _environment;
         private readonly ICakeLog _log;

--- a/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTester.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTester.cs
@@ -12,7 +12,7 @@ namespace Cake.Common.Tools.DotNetCore.Test
     /// <summary>
     /// .NET Core project tester.
     /// </summary>
-    public sealed class DotNetCoreTester : DotNetCoreTool<DotNetCoreTestSettings>
+    internal sealed class DotNetCoreTester : DotNetCoreTool<DotNetCoreTestSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/DupFinder/DupFinderRunner.cs
+++ b/src/Cake.Common/Tools/DupFinder/DupFinderRunner.cs
@@ -17,7 +17,7 @@ namespace Cake.Common.Tools.DupFinder
     /// <summary>
     /// DupFinder runner
     /// </summary>
-    public sealed class DupFinderRunner : Tool<DupFinderSettings>
+    internal sealed class DupFinderRunner : Tool<DupFinderSettings>
     {
         private readonly IFileSystem _fileSystem;
         private readonly ICakeEnvironment _environment;

--- a/src/Cake.Common/Tools/Fixie/FixieRunner.cs
+++ b/src/Cake.Common/Tools/Fixie/FixieRunner.cs
@@ -14,7 +14,7 @@ namespace Cake.Common.Tools.Fixie
     /// <summary>
     /// The Fixie test runner.
     /// </summary>
-    public sealed class FixieRunner : Tool<FixieSettings>
+    internal sealed class FixieRunner : Tool<FixieSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/GitLink/GitLinkRunner.cs
+++ b/src/Cake.Common/Tools/GitLink/GitLinkRunner.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.GitLink
     /// <summary>
     /// GitLink runner
     /// </summary>
-    public sealed class GitLinkRunner : Tool<GitLinkSettings>
+    internal sealed class GitLinkRunner : Tool<GitLinkSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/GitReleaseManager/AddAssets/GitReleaseManagerAssetsAdder.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/AddAssets/GitReleaseManagerAssetsAdder.cs
@@ -12,7 +12,7 @@ namespace Cake.Common.Tools.GitReleaseManager.AddAssets
     /// <summary>
     /// The GitReleaseManager Asset Adder used to add assets to a release.
     /// </summary>
-    public sealed class GitReleaseManagerAssetsAdder : GitReleaseManagerTool<GitReleaseManagerAddAssetsSettings>
+    internal sealed class GitReleaseManagerAssetsAdder : GitReleaseManagerTool<GitReleaseManagerAddAssetsSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/GitReleaseManager/Close/GitReleaseManagerMilestoneCloser.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Close/GitReleaseManagerMilestoneCloser.cs
@@ -12,7 +12,7 @@ namespace Cake.Common.Tools.GitReleaseManager.Close
     /// <summary>
     /// The GitReleaseManager Milestone Closer used to close milestones.
     /// </summary>
-    public sealed class GitReleaseManagerMilestoneCloser : GitReleaseManagerTool<GitReleaseManagerCloseMilestoneSettings>
+    internal sealed class GitReleaseManagerMilestoneCloser : GitReleaseManagerTool<GitReleaseManagerCloseMilestoneSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/GitReleaseManager/Create/GitReleaseManagerCreator.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Create/GitReleaseManagerCreator.cs
@@ -12,7 +12,7 @@ namespace Cake.Common.Tools.GitReleaseManager.Create
     /// <summary>
     /// The GitReleaseManager Release Creator used to create releases.
     /// </summary>
-    public sealed class GitReleaseManagerCreator : GitReleaseManagerTool<GitReleaseManagerCreateSettings>
+    internal sealed class GitReleaseManagerCreator : GitReleaseManagerTool<GitReleaseManagerCreateSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/GitReleaseManager/Export/GitReleaseManagerExporter.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Export/GitReleaseManagerExporter.cs
@@ -12,7 +12,7 @@ namespace Cake.Common.Tools.GitReleaseManager.Export
     /// <summary>
     /// The GitReleaseManager Release Publisher used to publish releases.
     /// </summary>
-    public sealed class GitReleaseManagerExporter : GitReleaseManagerTool<GitReleaseManagerExportSettings>
+    internal sealed class GitReleaseManagerExporter : GitReleaseManagerTool<GitReleaseManagerExportSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/GitReleaseManager/Publish/GitReleaseManagerPublisher.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Publish/GitReleaseManagerPublisher.cs
@@ -12,7 +12,7 @@ namespace Cake.Common.Tools.GitReleaseManager.Publish
     /// <summary>
     /// The GitReleaseManager Release Publisher used to publish releases.
     /// </summary>
-    public sealed class GitReleaseManagerPublisher : GitReleaseManagerTool<GitReleaseManagerPublishSettings>
+    internal sealed class GitReleaseManagerPublisher : GitReleaseManagerTool<GitReleaseManagerPublishSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/GitReleaseNotes/GitReleaseNotesRunner.cs
+++ b/src/Cake.Common/Tools/GitReleaseNotes/GitReleaseNotesRunner.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.GitReleaseNotes
     /// <summary>
     /// The GitReleaseNotes runner.
     /// </summary>
-    public sealed class GitReleaseNotesRunner : Tool<GitReleaseNotesSettings>
+    internal sealed class GitReleaseNotesRunner : Tool<GitReleaseNotesSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/GitVersion/GitVersionRunner.cs
+++ b/src/Cake.Common/Tools/GitVersion/GitVersionRunner.cs
@@ -17,7 +17,7 @@ namespace Cake.Common.Tools.GitVersion
     /// <summary>
     /// The GitVersion runner.
     /// </summary>
-    public sealed class GitVersionRunner : Tool<GitVersionSettings>
+    internal sealed class GitVersionRunner : Tool<GitVersionSettings>
     {
         private readonly ICakeLog _log;
 

--- a/src/Cake.Common/Tools/ILMerge/ILMergeRunner.cs
+++ b/src/Cake.Common/Tools/ILMerge/ILMergeRunner.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.ILMerge
     /// <summary>
     /// The ILMerge runner.
     /// </summary>
-    public sealed class ILMergeRunner : Tool<ILMergeSettings>
+    internal sealed class ILMergeRunner : Tool<ILMergeSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/ILRepack/ILRepackRunner.cs
+++ b/src/Cake.Common/Tools/ILRepack/ILRepackRunner.cs
@@ -14,7 +14,7 @@ namespace Cake.Common.Tools.ILRepack
     /// <summary>
     /// The ILMerge runner.
     /// </summary>
-    public sealed class ILRepackRunner : Tool<ILRepackSettings>
+    internal sealed class ILRepackRunner : Tool<ILRepackSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/InnoSetup/InnoSetupRunner.cs
+++ b/src/Cake.Common/Tools/InnoSetup/InnoSetupRunner.cs
@@ -15,7 +15,7 @@ namespace Cake.Common.Tools.InnoSetup
     /// <summary>
     /// The runner which executes Inno Setup.
     /// </summary>
-    public sealed class InnoSetupRunner : Tool<InnoSetupSettings>
+    internal sealed class InnoSetupRunner : Tool<InnoSetupSettings>
     {
         private readonly IRegistry _registry;
         private readonly ICakeEnvironment _environment;

--- a/src/Cake.Common/Tools/InspectCode/InspectCodeRunner.cs
+++ b/src/Cake.Common/Tools/InspectCode/InspectCodeRunner.cs
@@ -17,7 +17,7 @@ namespace Cake.Common.Tools.InspectCode
     /// <summary>
     /// InspectCode runner
     /// </summary>
-    public sealed class InspectCodeRunner : Tool<InspectCodeSettings>
+    internal sealed class InspectCodeRunner : Tool<InspectCodeSettings>
     {
         private readonly IFileSystem _fileSystem;
         private readonly ICakeEnvironment _environment;

--- a/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
@@ -17,7 +17,7 @@ namespace Cake.Common.Tools.MSBuild
     /// <summary>
     /// The MSBuild runner.
     /// </summary>
-    public sealed class MSBuildRunner : Tool<MSBuildSettings>
+    internal sealed class MSBuildRunner : Tool<MSBuildSettings>
     {
         private readonly ICakeEnvironment _environment;
         private readonly IFileSystem _fileSystem;

--- a/src/Cake.Common/Tools/MSTest/MSTestRunner.cs
+++ b/src/Cake.Common/Tools/MSTest/MSTestRunner.cs
@@ -14,7 +14,7 @@ namespace Cake.Common.Tools.MSTest
     /// <summary>
     /// The MSTest unit test runner.
     /// </summary>
-    public sealed class MSTestRunner : Tool<MSTestSettings>
+    internal sealed class MSTestRunner : Tool<MSTestSettings>
     {
         private readonly IFileSystem _fileSystem;
         private readonly ICakeEnvironment _environment;

--- a/src/Cake.Common/Tools/NSIS/MakeNSISRunner.cs
+++ b/src/Cake.Common/Tools/NSIS/MakeNSISRunner.cs
@@ -15,7 +15,7 @@ namespace Cake.Common.Tools.NSIS
     /// The runner which executes NSIS.
     /// </summary>
     // ReSharper disable once InconsistentNaming
-    public sealed class MakeNSISRunner : Tool<MakeNSISSettings>
+    internal sealed class MakeNSISRunner : Tool<MakeNSISSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/NUnit/NUnit3Runner.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnit3Runner.cs
@@ -15,7 +15,7 @@ namespace Cake.Common.Tools.NUnit
     /// <summary>
     /// The NUnit unit test runner.
     /// </summary>
-    public sealed class NUnit3Runner : Tool<NUnit3Settings>
+    internal sealed class NUnit3Runner : Tool<NUnit3Settings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/NUnit/NUnitRunner.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnitRunner.cs
@@ -14,7 +14,7 @@ namespace Cake.Common.Tools.NUnit
     /// <summary>
     /// The NUnit unit test runner.
     /// </summary>
-    public sealed class NUnitRunner : Tool<NUnitSettings>
+    internal sealed class NUnitRunner : Tool<NUnitSettings>
     {
         private readonly ICakeEnvironment _environment;
         private bool _x86;

--- a/src/Cake.Common/Tools/NuGet/Add/NuGetAdder.cs
+++ b/src/Cake.Common/Tools/NuGet/Add/NuGetAdder.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.NuGet.Add
     /// <summary>
     /// The NuGet package add tool used to add NuGet packages to folder or UNC shares.
     /// </summary>
-    public sealed class NuGetAdder : NuGetTool<NuGetAddSettings>
+    internal sealed class NuGetAdder : NuGetTool<NuGetAddSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/NuGet/Init/NuGetIniter.cs
+++ b/src/Cake.Common/Tools/NuGet/Init/NuGetIniter.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.NuGet.Init
     /// <summary>
     /// The NuGet package init tool copies all the packages from the source to the hierarchical destination.
     /// </summary>
-    public sealed class NuGetIniter : NuGetTool<NuGetInitSettings>
+    internal sealed class NuGetIniter : NuGetTool<NuGetInitSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/NuGet/Install/NuGetInstaller.cs
+++ b/src/Cake.Common/Tools/NuGet/Install/NuGetInstaller.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.NuGet.Install
     /// <summary>
     /// The NuGet package installer used to install NuGet packages.
     /// </summary>
-    public sealed class NuGetInstaller : NuGetTool<NuGetInstallSettings>
+    internal sealed class NuGetInstaller : NuGetTool<NuGetInstallSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/NuGet/Pack/NuGetPacker.cs
+++ b/src/Cake.Common/Tools/NuGet/Pack/NuGetPacker.cs
@@ -15,7 +15,7 @@ namespace Cake.Common.Tools.NuGet.Pack
     /// <summary>
     /// The NuGet packer.
     /// </summary>
-    public sealed class NuGetPacker : NuGetTool<NuGetPackSettings>
+    internal sealed class NuGetPacker : NuGetTool<NuGetPackSettings>
     {
         private readonly IFileSystem _fileSystem;
         private readonly ICakeEnvironment _environment;

--- a/src/Cake.Common/Tools/NuGet/Push/NuGetPusher.cs
+++ b/src/Cake.Common/Tools/NuGet/Push/NuGetPusher.cs
@@ -15,7 +15,7 @@ namespace Cake.Common.Tools.NuGet.Push
     /// <summary>
     /// The NuGet package pusher.
     /// </summary>
-    public sealed class NuGetPusher : NuGetTool<NuGetPushSettings>
+    internal sealed class NuGetPusher : NuGetTool<NuGetPushSettings>
     {
         private readonly ICakeEnvironment _environment;
         private readonly ICakeLog _log;

--- a/src/Cake.Common/Tools/NuGet/Restore/NuGetRestorer.cs
+++ b/src/Cake.Common/Tools/NuGet/Restore/NuGetRestorer.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.NuGet.Restore
     /// <summary>
     /// The NuGet package restorer used to restore solution packages.
     /// </summary>
-    public sealed class NuGetRestorer : NuGetTool<NuGetRestoreSettings>
+    internal sealed class NuGetRestorer : NuGetTool<NuGetRestoreSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/NuGet/SetApiKey/NuGetSetApiKey.cs
+++ b/src/Cake.Common/Tools/NuGet/SetApiKey/NuGetSetApiKey.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.NuGet.SetApiKey
     /// <summary>
     /// The NuGet set API key used to set API key used for API/feed authentication.
     /// </summary>
-    public sealed class NuGetSetApiKey : NuGetTool<NuGetSetApiKeySettings>
+    internal sealed class NuGetSetApiKey : NuGetTool<NuGetSetApiKeySettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/NuGet/SetProxy/NuGetSetProxy.cs
+++ b/src/Cake.Common/Tools/NuGet/SetProxy/NuGetSetProxy.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.NuGet.SetProxy
     /// <summary>
     /// The NuGet set command used to set the proxy settings to be used while connecting to your NuGet feed.
     /// </summary>
-    public sealed class NuGetSetProxy : NuGetTool<NuGetSetProxySettings>
+    internal sealed class NuGetSetProxy : NuGetTool<NuGetSetProxySettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/NuGet/Sources/NuGetSources.cs
+++ b/src/Cake.Common/Tools/NuGet/Sources/NuGetSources.cs
@@ -15,7 +15,7 @@ namespace Cake.Common.Tools.NuGet.Sources
     /// <summary>
     /// The NuGet sources is used to work with user config feeds &amp; credentials
     /// </summary>
-    public sealed class NuGetSources : NuGetTool<NuGetSourcesSettings>
+    internal sealed class NuGetSources : NuGetTool<NuGetSourcesSettings>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NuGetSources"/> class.

--- a/src/Cake.Common/Tools/NuGet/Update/NuGetUpdater.cs
+++ b/src/Cake.Common/Tools/NuGet/Update/NuGetUpdater.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.NuGet.Update
     /// <summary>
     /// The NuGet package updater.
     /// </summary>
-    public sealed class NuGetUpdater : NuGetTool<NuGetUpdateSettings>
+    internal sealed class NuGetUpdater : NuGetTool<NuGetUpdateSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployPacker.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployPacker.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.OctopusDeploy
     /// <summary>
     /// The Octopus deploy package packer
     /// </summary>
-    public sealed class OctopusDeployPacker : Tool<OctopusPackSettings>
+    internal sealed class OctopusDeployPacker : Tool<OctopusPackSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployPusher.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployPusher.cs
@@ -14,7 +14,7 @@ namespace Cake.Common.Tools.OctopusDeploy
     /// <summary>
     /// The Octopus Deploy package push runner
     /// </summary>
-    public class OctopusDeployPusher : Tool<OctopusPushSettings>
+    internal class OctopusDeployPusher : Tool<OctopusPushSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployReleaseCreator.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployReleaseCreator.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.OctopusDeploy
     /// <summary>
     /// The Octopus Deploy release creator runner
     /// </summary>
-    public sealed class OctopusDeployReleaseCreator : Tool<CreateReleaseSettings>
+    internal sealed class OctopusDeployReleaseCreator : Tool<CreateReleaseSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployReleaseDeployer.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployReleaseDeployer.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.OctopusDeploy
     /// <summary>
     /// The Octopus Deploy Release Deploy runner. This class facilitates deploying existing releases in Octopus Deploy.
     /// </summary>
-    public sealed class OctopusDeployReleaseDeployer : Tool<OctopusDeployReleaseDeploymentSettings>
+    internal sealed class OctopusDeployReleaseDeployer : Tool<OctopusDeployReleaseDeploymentSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverRunner.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverRunner.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.OpenCover
     /// <summary>
     /// The OpenCover runner.
     /// </summary>
-    public sealed class OpenCoverRunner : Tool<OpenCoverSettings>
+    internal sealed class OpenCoverRunner : Tool<OpenCoverSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/ReportGenerator/ReportGeneratorRunner.cs
+++ b/src/Cake.Common/Tools/ReportGenerator/ReportGeneratorRunner.cs
@@ -15,7 +15,7 @@ namespace Cake.Common.Tools.ReportGenerator
     /// <summary>
     /// ReportGenerator runner.
     /// </summary>
-    public sealed class ReportGeneratorRunner : Tool<ReportGeneratorSettings>
+    internal sealed class ReportGeneratorRunner : Tool<ReportGeneratorSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/ReportUnit/ReportUnitRunner.cs
+++ b/src/Cake.Common/Tools/ReportUnit/ReportUnitRunner.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.ReportUnit
     /// <summary>
     /// ReportUnit runner.
     /// </summary>
-    public sealed class ReportUnitRunner : Tool<ReportUnitSettings>
+    internal sealed class ReportUnitRunner : Tool<ReportUnitSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/Roundhouse/RoundhouseRunner.cs
+++ b/src/Cake.Common/Tools/Roundhouse/RoundhouseRunner.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.Roundhouse
     /// <summary>
     /// The Roundhouse console application runner.
     /// </summary>
-    public sealed class RoundhouseRunner : Tool<RoundhouseSettings>
+    internal sealed class RoundhouseRunner : Tool<RoundhouseSettings>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RoundhouseRunner"/> class.

--- a/src/Cake.Common/Tools/SignTool/SignToolSignRunner.cs
+++ b/src/Cake.Common/Tools/SignTool/SignToolSignRunner.cs
@@ -15,7 +15,7 @@ namespace Cake.Common.Tools.SignTool
     /// <summary>
     /// The SignTool SIGN assembly runner.
     /// </summary>
-    public sealed class SignToolSignRunner : Tool<SignToolSignSettings>
+    internal sealed class SignToolSignRunner : Tool<SignToolSignSettings>
     {
         private readonly ISignToolResolver _resolver;
         private readonly IFileSystem _fileSystem;

--- a/src/Cake.Common/Tools/SpecFlow/StepDefinitionReport/SpecFlowStepDefinitionReporter.cs
+++ b/src/Cake.Common/Tools/SpecFlow/StepDefinitionReport/SpecFlowStepDefinitionReporter.cs
@@ -12,7 +12,7 @@ namespace Cake.Common.Tools.SpecFlow.StepDefinitionReport
     /// <summary>
     /// SpecFlow StepDefinition execution report runner.
     /// </summary>
-    public sealed class SpecFlowStepDefinitionReporter : SpecFlowTool<SpecFlowStepDefinitionReportSettings>
+    internal sealed class SpecFlowStepDefinitionReporter : SpecFlowTool<SpecFlowStepDefinitionReportSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/SpecFlow/TestExecutionReport/SpecFlowTestExecutionReporter.cs
+++ b/src/Cake.Common/Tools/SpecFlow/TestExecutionReport/SpecFlowTestExecutionReporter.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.SpecFlow.TestExecutionReport
     /// <summary>
     /// SpecFlow MSTest execution report runner.
     /// </summary>
-    public sealed class SpecFlowTestExecutionReporter : SpecFlowTool<SpecFlowTestExecutionReportSettings>
+    internal sealed class SpecFlowTestExecutionReporter : SpecFlowTool<SpecFlowTestExecutionReportSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/TextTransform/TextTransformRunner.cs
+++ b/src/Cake.Common/Tools/TextTransform/TextTransformRunner.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.TextTransform
     /// <summary>
     /// The Text Transform runner.
     /// </summary>
-    public sealed class TextTransformRunner : Tool<TextTransformSettings>
+    internal sealed class TextTransformRunner : Tool<TextTransformSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/VSTest/VSTestRunner.cs
+++ b/src/Cake.Common/Tools/VSTest/VSTestRunner.cs
@@ -16,7 +16,7 @@ namespace Cake.Common.Tools.VSTest
     /// The VSTest unit test runner.
     /// Used by Visual Studio 2012 and newer.
     /// </summary>
-    public sealed class VSTestRunner : Tool<VSTestSettings>
+    internal sealed class VSTestRunner : Tool<VSTestSettings>
     {
         private readonly IFileSystem _fileSystem;
         private readonly ICakeEnvironment _environment;

--- a/src/Cake.Common/Tools/VSWhere/All/VSWhereAll.cs
+++ b/src/Cake.Common/Tools/VSWhere/All/VSWhereAll.cs
@@ -12,7 +12,7 @@ namespace Cake.Common.Tools.VSWhere.All
     /// <summary>
     /// The VSWhere tool that finds all instances regardless if they are complete.
     /// </summary>
-    public sealed class VSWhereAll : VSWhereTool<VSWhereAllSettings>
+    internal sealed class VSWhereAll : VSWhereTool<VSWhereAllSettings>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="VSWhereAll"/> class.

--- a/src/Cake.Common/Tools/VSWhere/Latest/VSWhereLatest.cs
+++ b/src/Cake.Common/Tools/VSWhere/Latest/VSWhereLatest.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.VSWhere.Latest
     /// <summary>
     /// The VSWhere tool that returns only the newest version and last installed.
     /// </summary>
-    public sealed class VSWhereLatest : VSWhereTool<VSWhereLatestSettings>
+    internal sealed class VSWhereLatest : VSWhereTool<VSWhereLatestSettings>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="VSWhereLatest"/> class.

--- a/src/Cake.Common/Tools/VSWhere/Legacy/VSWhereLegacy.cs
+++ b/src/Cake.Common/Tools/VSWhere/Legacy/VSWhereLegacy.cs
@@ -12,7 +12,7 @@ namespace Cake.Common.Tools.VSWhere.Legacy
     /// <summary>
     /// The VSWhere tool that finds Visual Studio products.
     /// </summary>
-    public sealed class VSWhereLegacy : VSWhereTool<VSWhereLegacySettings>
+    internal sealed class VSWhereLegacy : VSWhereTool<VSWhereLegacySettings>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="VSWhereLegacy"/> class.

--- a/src/Cake.Common/Tools/VSWhere/Product/VSWhereProduct.cs
+++ b/src/Cake.Common/Tools/VSWhere/Product/VSWhereProduct.cs
@@ -12,7 +12,7 @@ namespace Cake.Common.Tools.VSWhere.Product
     /// <summary>
     /// The VSWhere tool that finds Visual Studio products.
     /// </summary>
-    public sealed class VSWhereProduct : VSWhereTool<VSWhereProductSettings>
+    internal sealed class VSWhereProduct : VSWhereTool<VSWhereProductSettings>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="VSWhereProduct"/> class.

--- a/src/Cake.Common/Tools/WiX/CandleRunner.cs
+++ b/src/Cake.Common/Tools/WiX/CandleRunner.cs
@@ -15,7 +15,7 @@ namespace Cake.Common.Tools.WiX
     /// <summary>
     /// The WiX Candle runner.
     /// </summary>
-    public sealed class CandleRunner : Tool<CandleSettings>
+    internal sealed class CandleRunner : Tool<CandleSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/WiX/Heat/HeatRunner.cs
+++ b/src/Cake.Common/Tools/WiX/Heat/HeatRunner.cs
@@ -15,7 +15,7 @@ namespace Cake.Common.Tools.WiX.Heat
     /// <summary>
     /// The WiX Heat runner.
     /// </summary>
-    public sealed class HeatRunner : Tool<HeatSettings>
+    internal sealed class HeatRunner : Tool<HeatSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/WiX/LightRunner.cs
+++ b/src/Cake.Common/Tools/WiX/LightRunner.cs
@@ -15,7 +15,7 @@ namespace Cake.Common.Tools.WiX
     /// <summary>
     /// The WiX Light runner.
     /// </summary>
-    public sealed class LightRunner : Tool<LightSettings>
+    internal sealed class LightRunner : Tool<LightSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/src/Cake.Common/Tools/XBuild/XBuildRunner.cs
+++ b/src/Cake.Common/Tools/XBuild/XBuildRunner.cs
@@ -16,7 +16,7 @@ namespace Cake.Common.Tools.XBuild
     /// <summary>
     /// The XBuild runner.
     /// </summary>
-    public sealed class XBuildRunner : Tool<XBuildSettings>
+    internal sealed class XBuildRunner : Tool<XBuildSettings>
     {
         private readonly ICakeEnvironment _environment;
         private readonly IFileSystem _fileSystem;

--- a/src/Cake.Common/Tools/XUnit/XUnit2Runner.cs
+++ b/src/Cake.Common/Tools/XUnit/XUnit2Runner.cs
@@ -14,7 +14,7 @@ namespace Cake.Common.Tools.XUnit
     /// <summary>
     /// The xUnit.net v2 test runner.
     /// </summary>
-    public sealed class XUnit2Runner : Tool<XUnit2Settings>
+    internal sealed class XUnit2Runner : Tool<XUnit2Settings>
     {
         private readonly ICakeEnvironment _environment;
         private bool _useX86;

--- a/src/Cake.Common/Tools/XUnit/XUnitRunner.cs
+++ b/src/Cake.Common/Tools/XUnit/XUnitRunner.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Tools.XUnit
     /// <summary>
     /// The xUnit.net (v1) test runner.
     /// </summary>
-    public sealed class XUnitRunner : Tool<XUnitSettings>
+    internal sealed class XUnitRunner : Tool<XUnitSettings>
     {
         private readonly ICakeEnvironment _environment;
 


### PR DESCRIPTION
Currently all tool runner are public. IMHO they should always be called through aliases and since they are sealed it doesn't bring any benefit to have them public.