### PR TITLE
Fix the contribution-guidelines link again

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ chmod +x build.sh
 
 So you’re thinking about contributing to Cake? Great! It’s **really** appreciated.
 
-Make sure you've read the [contribution guidelines](http://cakebuild.net/docs/contributing/contribution-guidelines/) before sending that epic pull request. You'll also need to sign the [contribution license agreement](https://cla2.dotnetfoundation.org/) (CLA) for anything other than a trivial change.  **NOTE:** The .NET Foundation CLA Bot will provide a link to this CLA within the PR that you submit if it is deemed as required.
+Make sure you've read the [contribution guidelines](http://cakebuild.net/docs/contributing/contribution-guidelines) before sending that epic pull request. You'll also need to sign the [contribution license agreement](https://cla2.dotnetfoundation.org/) (CLA) for anything other than a trivial change.  **NOTE:** The .NET Foundation CLA Bot will provide a link to this CLA within the PR that you submit if it is deemed as required.
 
 * Fork the repository.
 * Create a branch to work in.


### PR DESCRIPTION
Looks like the link I changed in https://github.com/cake-build/cake/pull/1604 wasn't quite right. This removes the trailing slash which broke the link. Actually tested it this time!