### PR TITLE
GH1607: Make ToolResolutionStrategy more resilient to exceptions 

### DIFF
--- a/src/Cake.Core/Tooling/ToolResolutionStrategy.cs
+++ b/src/Cake.Core/Tooling/ToolResolutionStrategy.cs
@@ -118,9 +118,15 @@ namespace Cake.Core.Tooling
                 foreach (var pathDir in _path)
                 {
                     var file = pathDir.CombineWithFilePath(tool);
-                    if (_fileSystem.Exist(file))
+                    try
                     {
-                        return file.MakeAbsolute(_environment);
+                        if (_fileSystem.Exist(file))
+                        {
+                            return file.MakeAbsolute(_environment);
+                        }
+                    }
+                    catch
+                    {
                     }
                 }
 


### PR DESCRIPTION
This addresses the failures described in GH-1607 by surrounding the attempt to access the file system (and consequently any `IFileSystem` implementation being registered via module) with a `try/catch` to suppress any errors that may be environmental so as to fully iterate the paths represented in the PATH environment variable.