### PR TITLE
GH1422: Add support for Unicode globbing

### DIFF
--- a/src/Cake.Core.Tests/Fixtures/GlobberFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/GlobberFixture.cs
@@ -64,6 +64,8 @@ namespace Cake.Core.Tests.Fixtures
             FileSystem.CreateDirectory("/Foo/Bar");
             FileSystem.CreateDirectory("/Foo (Bar)");
             FileSystem.CreateDirectory("/Foo@Bar/");
+            FileSystem.CreateDirectory("/嵌套");
+            FileSystem.CreateDirectory("/嵌套/目录");
 
             // Files
             FileSystem.CreateFile("/Working/Foo/Bar/Qux.c");
@@ -79,6 +81,7 @@ namespace Cake.Core.Tests.Fixtures
             FileSystem.CreateFile("/Foo/Bar.baz");
             FileSystem.CreateFile("/Foo (Bar)/Baz.c");
             FileSystem.CreateFile("/Foo@Bar/Baz.c");
+            FileSystem.CreateFile("/嵌套/目录/文件.延期");
         }
 
         public void SetWorkingDirectory(DirectoryPath path)

--- a/src/Cake.Core.Tests/Unit/IO/GlobberTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/GlobberTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using Cake.Core.IO;
 using Cake.Core.Tests.Fixtures;
 using Cake.Testing.Xunit;
@@ -577,6 +578,34 @@ namespace Cake.Core.Tests.Unit.IO
                 Assert.Equal(2, result.Length);
                 AssertEx.ContainsFilePath(result, "/Working/Foo.Bar.Test.dll");
                 AssertEx.ContainsFilePath(result, "/Working/Bar.Qux.Test.dll");
+            }
+
+            [Fact]
+            public void Should_Parse_Glob_Expressions_With_Unicode_Characters_And_Ending_With_Identifier()
+            {
+                // Given
+                var fixture = new GlobberFixture();
+
+                // When
+                var result = fixture.Match("/嵌套/**/文件.延期");
+
+                // Then
+                Assert.Equal(1, result.Length);
+                AssertEx.ContainsFilePath(result, "/嵌套/目录/文件.延期");
+            }
+
+            [Fact]
+            public void Should_Parse_Glob_Expressions_With_Unicode_Characters_And_Not_Ending_With_Identifier()
+            {
+                // Given
+                var fixture = new GlobberFixture();
+
+                // When
+                var result = fixture.Match("/嵌套/**/文件.*");
+
+                // Then
+                Assert.Equal(1, result.Length);
+                AssertEx.ContainsFilePath(result, "/嵌套/目录/文件.延期");
             }
         }
     }

--- a/src/Cake.Core/IO/Globbing/GlobParser.cs
+++ b/src/Cake.Core/IO/Globbing/GlobParser.cs
@@ -40,16 +40,10 @@ namespace Cake.Core.IO.Globbing
             }
 
             // Parse all path segments.
-            while (context.CurrentToken.Kind == GlobTokenKind.PathSeparator)
+            while (context.CurrentToken?.Kind == GlobTokenKind.PathSeparator)
             {
                 context.Accept();
                 items.Add(ParseSegment(context));
-            }
-
-            // Not an end of text token?
-            if (context.CurrentToken.Kind != GlobTokenKind.EndOfText)
-            {
-                throw new InvalidOperationException("Expected EOT");
             }
 
             // Rewrite the items into a linked list.
@@ -134,7 +128,7 @@ namespace Cake.Core.IO.Globbing
             var items = new List<GlobToken>();
             while (true)
             {
-                switch (context.CurrentToken.Kind)
+                switch (context.CurrentToken?.Kind)
                 {
                     case GlobTokenKind.Identifier:
                     case GlobTokenKind.CharacterWildcard:
@@ -144,6 +138,7 @@ namespace Cake.Core.IO.Globbing
                 }
                 break;
             }
+
             return new PathSegment(items, context.Options);
         }
 

--- a/src/Cake.Core/IO/Globbing/GlobParserContext.cs
+++ b/src/Cake.Core/IO/Globbing/GlobParserContext.cs
@@ -28,21 +28,27 @@ namespace Cake.Core.IO.Globbing
             }
         }
 
+        /// <summary>
+        /// Gets the next GlobToken from the context
+        /// </summary>
+        /// <returns>The Peek'd token</returns>
         public GlobToken Peek()
         {
             return _tokenizer.Peek();
         }
 
+        /// <summary>
+        /// Accepts the current GlobToken and loads the next into CurrentToken
+        /// </summary>
         public void Accept()
         {
             CurrentToken = _tokenizer.Scan();
         }
 
-        public void Accept(GlobTokenKind kind)
-        {
-            Accept(new[] { kind });
-        }
-
+        /// <summary>
+        /// Accepts the CurrentToken if it is of the specified TokenKind(s), and fetches the next token.
+        /// </summary>
+        /// <param name="kind">The types of acceptable <see cref="GlobTokenKind"/></param>
         public void Accept(params GlobTokenKind[] kind)
         {
             if (kind.Any(k => k == CurrentToken.Kind))
@@ -50,6 +56,7 @@ namespace Cake.Core.IO.Globbing
                 Accept();
                 return;
             }
+
             throw new InvalidOperationException("Unexpected token kind.");
         }
     }


### PR DESCRIPTION
I've added Unicode support to the Globber by rewriting the `GlobTokenizer`. This fixes https://github.com/cake-build/cake/issues/1422

- Tokens are lazily loaded into a queue
- `GlobTokenizer` now specifies 'non-identifier characters' rather than 'identifier characters'
- Globbing is 15% faster
- Unicode supported