### PR TITLE
GH1620: Improve documentation for RedirectStandardError and RedirectStandardOutput

### DIFF
--- a/src/Cake.Core/IO/ProcessSettings.cs
+++ b/src/Cake.Core/IO/ProcessSettings.cs
@@ -24,15 +24,15 @@ namespace Cake.Core.IO
         public DirectoryPath WorkingDirectory { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the error output of an application is written to the <see cref="P:System.Diagnostics.Process.StandardError"/> stream.
+        /// Gets or sets a value indicating whether the error output of an application is written to the standard error stream.
         /// </summary>
-        /// <value>true if error output should be written to <see cref="P:System.Diagnostics.Process.StandardError"/>; otherwise, false. The default is false.</value>
+        /// <value>true if error output should be redirected; false if error output should be written to the standard error stream. The default is false.</value>
         public bool RedirectStandardError { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the output of an application is written to the <see cref="P:System.Diagnostics.Process.StandardOutput"/> stream.
+        /// Gets or sets a value indicating whether the output of an application is written to the standard output stream.
         /// </summary>
-        /// <value>true if output should be written to <see cref="P:System.Diagnostics.Process.StandardOutput"/>; otherwise, false. The default is false.</value>
+        /// <value>true if output should be redirected; false if output should be written to the standard output stream. The default is false.</value>
         public bool RedirectStandardOutput { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Documentation for `ProcessSettings.RedirectStandardError` and `ProcessSettings.RedirectStandardOutput` seems to be just a copy from `ProcessStartInfo` documentation on MSDN, which is misleading in the context of the `ProcessSettings` class.