### PR TITLE
GH1988: Fix writing start and end progress messages

### DIFF
--- a/src/Cake.Common/Build/TeamCity/TeamCityProvider.cs
+++ b/src/Cake.Common/Build/TeamCity/TeamCityProvider.cs
@@ -134,7 +134,7 @@ namespace Cake.Common.Build.TeamCity
         /// <param name="message">Build log message.</param>
         public void WriteStartProgress(string message)
         {
-            WriteServiceMessage("progressStart", "message", message);
+            WriteServiceMessage("progressStart", message);
         }
 
         /// <summary>
@@ -143,7 +143,7 @@ namespace Cake.Common.Build.TeamCity
         /// <param name="message">Build log message.</param>
         public void WriteEndProgress(string message)
         {
-            WriteServiceMessage("progressFinish", "message", message);
+            WriteServiceMessage("progressFinish", message);
         }
 
         /// <summary>


### PR DESCRIPTION
According to the [docs](https://confluence.jetbrains.com/display/TCD10/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-progressReportingReportingBuildProgress) there is no property "message" for "progressStart" and "progressFinish".
