### PR TITLE
GH1989: Removed unnecessary parameter

### DIFF
--- a/src/Cake.Core/IO/Path.cs
+++ b/src/Cake.Core/IO/Path.cs
@@ -71,7 +71,7 @@ namespace Cake.Core.IO
             }
 
             // Remove trailing slashes.
-            FullPath = FullPath.TrimEnd('/', '\\');
+            FullPath = FullPath.TrimEnd('/');
 
             if (FullPath.EndsWith(":", StringComparison.OrdinalIgnoreCase))
             {


### PR DESCRIPTION
I removed the forward slash parameter because it's unnecessary because line #64 that replaces all forward slashes with backslashes. Hardly a critical bug, but as I was studying the code, saw it, and thought I'd comment. The code was introduced in commit ce0c04e3 on 6/9/2014.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over CONTRIBUTING - https://github.com/cake-build/cake/blob/develop/CONTRIBUTING.md. We provide VERY defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - You are not submitting a pull request from your MASTER branch.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
