### PR TITLE
GH1665: Implemented NUnit3 params and multiple results

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/NUnit/NUnit3RunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NUnit/NUnit3RunnerTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using Cake.Common.Tests.Fixtures.Tools;
 using Cake.Common.Tools.NUnit;
 using Cake.Core;
@@ -175,7 +176,7 @@ namespace Cake.Common.Tests.Unit.Tools.NUnit
             {
                 // Given
                 var fixture = new NUnit3RunnerFixture();
-                fixture.Settings.Results = "NewResults.xml";
+                fixture.Settings.Results = new[] { new NUnit3Result { FileName = "NewResults.xml" } };
                 fixture.Settings.NoResults = true;
 
                 // When
@@ -191,7 +192,7 @@ namespace Cake.Common.Tests.Unit.Tools.NUnit
             {
                 // Given
                 var fixture = new NUnit3RunnerFixture();
-                fixture.Settings.Results = "NewTestResult.xml";
+                fixture.Settings.Results = new[] { new NUnit3Result { FileName = "NewTestResult.xml" } };
 
                 // When
                 var result = fixture.Run();
@@ -218,9 +219,11 @@ namespace Cake.Common.Tests.Unit.Tools.NUnit
                 fixture.Settings.OutputFile = "stdout.txt";
                 fixture.Settings.ErrorOutputFile = "stderr.txt";
                 fixture.Settings.Full = true;
-                fixture.Settings.Results = "NewTestResult.xml";
-                fixture.Settings.ResultFormat = "nunit2";
-                fixture.Settings.ResultTransform = "nunit2.xslt";
+                fixture.Settings.Results = new[]
+                {
+                    new NUnit3Result { FileName = "NewTestResult.xml", Format = "nunit2", Transform = "nunit2.xslt" },
+                    new NUnit3Result { FileName = "NewTestResult2.xml", Format = "nunit3" }
+                };
                 fixture.Settings.Labels = NUnit3Labels.All;
                 fixture.Settings.TeamCity = true;
                 fixture.Settings.NoHeader = true;
@@ -234,6 +237,12 @@ namespace Cake.Common.Tests.Unit.Tools.NUnit
                 fixture.Settings.DisposeRunners = true;
                 fixture.Settings.ShadowCopy = true;
                 fixture.Settings.Agents = 3;
+                fixture.Settings.Params = new Dictionary<string, string>
+                {
+                    ["one"] = "1",
+                    ["two"] = "2",
+                    ["three"] = "3"
+                };
 
                 // When
                 var result = fixture.Run();
@@ -244,10 +253,14 @@ namespace Cake.Common.Tests.Unit.Tools.NUnit
                         "--stoponerror \"--work=/Working/out\" \"--out=/Working/stdout.txt\" " +
                         "\"--err=/Working/stderr.txt\" --full " +
                         "\"--result=/Working/NewTestResult.xml;format=nunit2;transform=/Working/nunit2.xslt\" " +
+                        "\"--result=/Working/NewTestResult2.xml;format=nunit3\" " +
                         "--labels=All --teamcity --noheader --nocolor --verbose " +
                         "\"--config=Debug\" \"--framework=net3.5\" --x86 " +
                         "--dispose-runners --shadowcopy --agents=3 " +
-                        "--process=InProcess --domain=Single", result.Args);
+                        "--process=InProcess --domain=Single " +
+                        "\"--params=one=1\" " +
+                        "\"--params=two=2\" " +
+                        "\"--params=three=3\"", result.Args);
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/SpecFlow/TestExecutionReport/SpecFlowTestExecutionReporterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/SpecFlow/TestExecutionReport/SpecFlowTestExecutionReporterTests.cs
@@ -304,8 +304,7 @@ namespace Cake.Common.Tests.Unit.Tools.SpecFlow.TestExecutionReport
                 var nUnit3Settings = new NUnit3Settings
                 {
                     ShadowCopy = false,
-                    Results = "/Working/TestResult.xml",
-                    ResultFormat = "nunit2",
+                    Results = new[] { new NUnit3Result { FileName = "/Working/TestResult.xml", Format = "nunit2" } },
                     Labels = NUnit3Labels.All,
                     OutputFile = "/Working/TestResult.txt"
                 };
@@ -360,8 +359,7 @@ namespace Cake.Common.Tests.Unit.Tools.SpecFlow.TestExecutionReport
                 var nUnit3Settings = new NUnit3Settings
                 {
                     ShadowCopy = false,
-                    Results = "/Working/TestResult.xml",
-                    ResultFormat = "nunit2"
+                    Results = new[] { new NUnit3Result { FileName = "/Working/TestResult.xml", Format = "nunit2" } },
                 };
 
                 fixture.Action = context =>
@@ -386,8 +384,7 @@ namespace Cake.Common.Tests.Unit.Tools.SpecFlow.TestExecutionReport
                 var nUnit3Settings = new NUnit3Settings
                 {
                     ShadowCopy = false,
-                    Results = "/Working/TestResult.xml",
-                    ResultFormat = "nunit2",
+                    Results = new[] { new NUnit3Result { FileName = "/Working/TestResult.xml", Format = "nunit2" } },
                     OutputFile = "/Working/TestResult.txt"
                 };
 

--- a/src/Cake.Common/Tools/NUnit/NUnit3Result.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnit3Result.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the.NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.NUnit
+{
+    /// <summary>
+    /// Contains information for the results that should be exported.
+    /// </summary>
+    public sealed class NUnit3Result
+    {
+        /// <summary>
+        /// Gets or sets the name of the XML result file.
+        /// </summary>
+        /// <value>
+        /// The name of the XML result file. Defaults to <c>TestResult.xml</c>.
+        /// </value>
+        public FilePath FileName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the format that the results should be in. <see cref="FileName"/> must be set to
+        /// have any effect. Specify nunit2 to output the results in NUnit 2 xml format.
+        /// nunit3 may be specified for NUnit 3 format, however this is the default. Additional
+        /// formats may be supported in the future, check the NUnit documentation.
+        /// </summary>
+        /// <value>
+        /// The format of the result file. Defaults to <c>nunit3</c>.
+        /// </value>
+        public string Format { get; set; }
+
+        /// <summary>
+        /// Gets or sets the file name of an XSL transform that will be applied to the results.
+        /// </summary>
+        /// <value>
+        /// The name of an XSLT file that will be applied to the results.
+        /// </value>
+        public FilePath Transform { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/NUnit/NUnit3Runner.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnit3Runner.cs
@@ -119,24 +119,27 @@ namespace Cake.Common.Tools.NUnit
                 builder.Append("--full");
             }
 
-            if (settings.Results != null && settings.NoResults)
+            if (HasResults(settings) && settings.NoResults)
             {
                 throw new ArgumentException(
                     GetToolName() + ": You can't specify both a results file and set NoResults to true.");
             }
 
-            if (settings.Results != null)
+            if (HasResults(settings))
             {
-                var results = new StringBuilder(settings.Results.MakeAbsolute(_environment).FullPath);
-                if (settings.ResultFormat != null)
+                foreach (var result in settings.Results)
                 {
-                    results.AppendFormat(";format={0}", settings.ResultFormat);
+                    var resultString = new StringBuilder(result.FileName.MakeAbsolute(_environment).FullPath);
+                    if (result.Format != null)
+                    {
+                        resultString.AppendFormat(";format={0}", result.Format);
+                    }
+                    if (result.Transform != null)
+                    {
+                        resultString.AppendFormat(";transform={0}", result.Transform.MakeAbsolute(_environment).FullPath);
+                    }
+                    builder.AppendQuoted(string.Format(CultureInfo.InvariantCulture, "--result={0}", resultString));
                 }
-                if (settings.ResultTransform != null)
-                {
-                    results.AppendFormat(";transform={0}", settings.ResultTransform.MakeAbsolute(_environment).FullPath);
-                }
-                builder.AppendQuoted(string.Format(CultureInfo.InvariantCulture, "--result={0}", results));
             }
             else if (settings.NoResults)
             {
@@ -209,7 +212,20 @@ namespace Cake.Common.Tools.NUnit
                 builder.Append("--domain=" + settings.AppDomainUsage);
             }
 
+            if (settings.Params != null && settings.Params.Count > 0)
+            {
+                foreach (var param in settings.Params)
+                {
+                    builder.AppendQuoted(string.Format(CultureInfo.InvariantCulture, "--params={0}={1}", param.Key, param.Value));
+                }
+            }
+
             return builder;
+        }
+
+        private bool HasResults(NUnit3Settings settings)
+        {
+            return settings.Results != null && settings.Results.Count > 0;
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/NUnit/NUnit3Settings.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnit3Settings.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
 
@@ -109,31 +110,10 @@ namespace Cake.Common.Tools.NUnit
         public bool Full { get; set; }
 
         /// <summary>
-        /// Gets or sets the name of the XML result file.
+        /// Gets or sets the results that should be saved.
         /// </summary>
-        /// <value>
-        /// The name of the XML result file. Defaults to <c>TestResult.xml</c>.
-        /// </value>
-        public FilePath Results { get; set; }
-
-        /// <summary>
-        /// Gets or sets the format that the results should be in. Results must be set to
-        /// have any effect. Specify nunit2 to output the results in NUnit 2 xml format.
-        /// nunit3 may be specified for NUnit 3 format, however this is the default. Additional
-        /// formats may be supported in the future, check the NUnit documentation.
-        /// </summary>
-        /// <value>
-        /// The format of the result file. Defaults to <c>nunit3</c>.
-        /// </value>
-        public string ResultFormat { get; set; }
-
-        /// <summary>
-        /// Gets or sets the file name of an XSL transform that will be applied to the results.
-        /// </summary>
-        /// <value>
-        /// The name of an XSLT file that will be applied to the results.
-        /// </value>
-        public FilePath ResultTransform { get; set; }
+        /// <value>The package owners.</value>
+        public ICollection<NUnit3Result> Results { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to generate the XML result file.
@@ -250,5 +230,13 @@ namespace Cake.Common.Tools.NUnit
         /// The maximum number of test assembly agents to run at one time.
         /// </value>
         public int? Agents { get; set; }
+
+        /// <summary>
+        /// Gets or sets the params that should be passed to the runner.
+        /// </summary>
+        /// <value>
+        /// List of parametes (key/value) which are passed to the runner.
+        /// </value>
+        public IDictionary<string, string> Params { get; set; }
     }
 }


### PR DESCRIPTION
This is the PR to fix #1665
This is a breaking change.
The ```Results```, ```ResultFormat``` and ```ResultTransform``` are now combined in the ```NUnit3Result``` class and creation looks like:
```csharp
settings.Results = new[]
{
    new NUnit3Result { FileName = "NewTestResult.xml", Format = "nunit2", Transform = "nunit2.xslt" },
    new NUnit3Result { FileName = "NewTestResult2.xml", Format = "nunit3" }
};
```
The parameters can be added like:
```csharp
settings.Params = new Dictionary<string, string>
{
    ["one"] = "1",
    ["two"] = "2",
    ["three"] = "3"
};
```