### PR TITLE
GH1533: Added support for dotnet vstest inline with Tooling v1.0

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/DotNetCore/VSTest/DotNetCoreVSTesterFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/DotNetCore/VSTest/DotNetCoreVSTesterFixture.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Cake.Common.Tools.DotNetCore.VSTest;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tests.Fixtures.Tools.DotNetCore.VSTest
+{
+    internal sealed class DotNetCoreVSTesterFixture : DotNetCoreFixture<DotNetCoreVSTestSettings>
+    {
+        public ICollection<FilePath> TestFiles { get; set; }
+
+        protected override void RunTool()
+        {
+            var tool = new DotNetCoreVSTester(FileSystem, Environment, ProcessRunner, Tools);
+            tool.Test(TestFiles, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/VSTest/DotNetCoreVSTesterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/VSTest/DotNetCoreVSTesterTests.cs
@@ -1,0 +1,370 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tests.Fixtures.Tools.DotNetCore.VSTest;
+using Cake.Common.Tools.DotNetCore.VSTest;
+using Cake.Common.Tools.VSTest;
+using Cake.Core.IO;
+using Cake.Testing;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.DotNetCore.VSTest
+{
+    public sealed class DotNetCoreVSTesterTests
+    {
+        public sealed class TheTestMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new DotNetCoreVSTesterFixture
+                {
+                    TestFiles = new[] { (FilePath)"./test/unit.tests.csproj" },
+                    Settings = null
+                };
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new DotNetCoreVSTesterFixture { TestFiles = new[] { (FilePath)"./test/unit.tests.csproj" } };
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new DotNetCoreVSTesterFixture { TestFiles = new[] { (FilePath)"./test/unit.tests.csproj" } };
+                fixture.GivenProcessExitsWithCode(1);
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new DotNetCoreVSTesterFixture { TestFiles = new[] { (FilePath)"./test/unit.tests.csproj" } };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("vstest \"/Working/test/unit.tests.csproj\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Multiple_Test_File_Arguments()
+            {
+                // Given
+                var fixture = new DotNetCoreVSTesterFixture
+                {
+                    TestFiles = new[]
+                    {
+                        (FilePath)"./test1/unit.tests.csproj",
+                        (FilePath)"./test2/unit.tests.csproj",
+                        (FilePath)"./test3/unit.tests.csproj",
+                    }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("vstest \"/Working/test1/unit.tests.csproj\" \"/Working/test2/unit.tests.csproj\" \"/Working/test3/unit.tests.csproj\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Quote_Test_File_Path()
+            {
+                // Given
+                var fixture = new DotNetCoreVSTesterFixture { TestFiles = new[] { (FilePath)"./test/cake unit tests/cake core tests.csproj" } };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("vstest \"/Working/test/cake unit tests/cake core tests.csproj\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Settings_Argument()
+            {
+                // Given
+                var fixture = new DotNetCoreVSTesterFixture
+                {
+                    TestFiles = new[] { (FilePath)"./test/unit.tests.csproj" },
+                    Settings = new DotNetCoreVSTestSettings
+                    {
+                        Settings = "./test/demo.runsettings"
+                    }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("vstest \"/Working/test/unit.tests.csproj\" --Settings:\"/Working/test/demo.runsettings\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Tests_Argument()
+            {
+                // Given
+                var fixture = new DotNetCoreVSTesterFixture
+                {
+                    TestFiles = new[] { (FilePath)"./test/unit.tests.csproj" },
+                    Settings = new DotNetCoreVSTestSettings
+                    {
+                        TestsToRun = new[] { "TestMethod1", "TestMethod2" }
+                    }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("vstest \"/Working/test/unit.tests.csproj\" --Tests:TestMethod1,TestMethod2", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_TestAdapter_Argument()
+            {
+                // Given
+                var fixture = new DotNetCoreVSTesterFixture
+                {
+                    TestFiles = new[] { (FilePath)"./test/unit.tests.csproj" },
+                    Settings = new DotNetCoreVSTestSettings
+                    {
+                        TestAdapterPath = @"/Working/custom-test-adapter"
+                    }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("vstest \"/Working/test/unit.tests.csproj\" --TestAdapterPath:\"/Working/custom-test-adapter\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Platform_Argument()
+            {
+                // Given
+                var fixture = new DotNetCoreVSTesterFixture
+                {
+                    TestFiles = new[] { (FilePath)"./test/unit.tests.csproj" },
+                    Settings = new DotNetCoreVSTestSettings
+                    {
+                        Platform = VSTestPlatform.x64
+                    }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("vstest \"/Working/test/unit.tests.csproj\" --Platform:x64", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Framework_Argument()
+            {
+                // Given
+                var fixture = new DotNetCoreVSTesterFixture
+                {
+                    TestFiles = new[] { (FilePath)"./test/unit.tests.csproj" },
+                    Settings = new DotNetCoreVSTestSettings
+                    {
+                        Framework = "dnxcore50"
+                    }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("vstest \"/Working/test/unit.tests.csproj\" --Framework:dnxcore50", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Parallel_Argument()
+            {
+                // Given
+                var fixture = new DotNetCoreVSTesterFixture
+                {
+                    TestFiles = new[] { (FilePath)"./test/unit.tests.csproj" },
+                    Settings = new DotNetCoreVSTestSettings
+                    {
+                        Parallel = true
+                    }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("vstest \"/Working/test/unit.tests.csproj\" --Parallel", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_TestCaseFilter_Argument()
+            {
+                // Given
+                var fixture = new DotNetCoreVSTesterFixture
+                {
+                    TestFiles = new[] { (FilePath)"./test/unit.tests.csproj" },
+                    Settings = new DotNetCoreVSTestSettings
+                    {
+                        TestCaseFilter = "FullyQualifiedName~Cake.Common.Core.DotNetCore"
+                    }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("vstest \"/Working/test/unit.tests.csproj\" --TestCaseFilter:\"FullyQualifiedName~Cake.Common.Core.DotNetCore\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Logger_Argument()
+            {
+                // Given
+                var fixture = new DotNetCoreVSTesterFixture
+                {
+                    TestFiles = new[] { (FilePath)"./test/unit.tests.csproj" },
+                    Settings = new DotNetCoreVSTestSettings
+                    {
+                        Logger = @"trx;LogFileName=/Working/logfile.trx"
+                    }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("vstest \"/Working/test/unit.tests.csproj\" --logger:\"trx;LogFileName=/Working/logfile.trx\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_ParentProcessId_Argument()
+            {
+                // Given
+                var fixture = new DotNetCoreVSTesterFixture
+                {
+                    TestFiles = new[] { (FilePath)"./test/unit.tests.csproj" },
+                    Settings = new DotNetCoreVSTestSettings
+                    {
+                        ParentProcessId = @"100"
+                    }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("vstest \"/Working/test/unit.tests.csproj\" --ParentProcessId:100", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Port_Argument()
+            {
+                // Given
+                var fixture = new DotNetCoreVSTesterFixture
+                {
+                    TestFiles = new[] { (FilePath)"./test/unit.tests.csproj" },
+                    Settings = new DotNetCoreVSTestSettings
+                    {
+                        Port = 8000
+                    }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("vstest \"/Working/test/unit.tests.csproj\" --Port:8000", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Diag_Argument()
+            {
+                // Given
+                var fixture = new DotNetCoreVSTesterFixture
+                {
+                    TestFiles = new[] { (FilePath)"./test/unit.tests.csproj" },
+                    Settings = new DotNetCoreVSTestSettings
+                    {
+                        DiagnosticFile = "./artifacts/logging/diagnostics.txt"
+                    }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("vstest \"/Working/test/unit.tests.csproj\" --Diag:\"/Working/artifacts/logging/diagnostics.txt\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Extra_Argument()
+            {
+                // Given
+                var fixture = new DotNetCoreVSTesterFixture
+                {
+                    TestFiles = new[] { (FilePath)"./test/unit.tests.csproj" },
+                    Settings = new DotNetCoreVSTestSettings
+                    {
+                        Arguments =
+                        {
+                            { "Arg1", "Value1" },
+                            { "Arg2", "Value2" },
+                        }
+                    }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("vstest \"/Working/test/unit.tests.csproj\" Arg1=\"Value1\" Arg2=\"Value2\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Host_Arguments()
+            {
+                // Given
+                var fixture = new DotNetCoreVSTesterFixture { TestFiles = new[] { (FilePath)"./test/unit.tests.csproj" } };
+                fixture.Settings.DiagnosticOutput = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("--diagnostics vstest \"/Working/test/unit.tests.csproj\"", result.Args);
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using Cake.Common.IO;
 using Cake.Common.Tools.DotNetCore.Build;
 using Cake.Common.Tools.DotNetCore.Clean;
 using Cake.Common.Tools.DotNetCore.Execute;
@@ -14,6 +16,7 @@ using Cake.Common.Tools.DotNetCore.Publish;
 using Cake.Common.Tools.DotNetCore.Restore;
 using Cake.Common.Tools.DotNetCore.Run;
 using Cake.Common.Tools.DotNetCore.Test;
+using Cake.Common.Tools.DotNetCore.VSTest;
 using Cake.Core;
 using Cake.Core.Annotations;
 using Cake.Core.IO;
@@ -936,6 +939,119 @@ namespace Cake.Common.Tools.DotNetCore
 
             var builder = new DotNetCoreMSBuildBuilder(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             builder.Build(projectOrDirectory, settings);
+        }
+
+        /// <summary>
+        /// Test one or more projects specified by a path or glob pattern using the VS Test host runner.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="testFile">A path to the test file or glob for one or more test files.</param>
+        /// <example>
+        /// <para>Specify the path to the .csproj file in the test project</para>
+        /// <code>
+        ///     DotNetCoreTest("./test/Project.Tests/Project.Tests.csproj");
+        /// </code>
+        /// <para>You could also specify a glob pattern to run multiple test projects.</para>
+        /// <code>
+        ///     DotNetCoreTest("./**/*.Tests.csproj");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Test")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.VSTest")]
+        public static void DotNetCoreVSTest(this ICakeContext context, string testFile) => context.DotNetCoreVSTest(testFile, null);
+
+        /// <summary>
+        /// Test one or more projects specified by a path or glob pattern with settings using the VS Test host runner.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="testFile">A path to the test file or glob for one or more test files.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <para>Specify the path to the .csproj file in the test project</para>
+        /// <code>
+        ///     var settings = new DotNetCoreTestSettings
+        ///     {
+        ///         Framework = "FrameworkCore10",
+        ///         Platform = "x64"
+        ///     };
+        ///
+        ///     DotNetCoreTest("./test/Project.Tests/Project.Tests.csproj", settings);
+        /// </code>
+        /// <para>You could also specify a glob pattern to run multiple test projects.</para>
+        /// <code>
+        ///     var settings = new DotNetCoreTestSettings
+        ///     {
+        ///         Framework = "FrameworkCore10",
+        ///         Platform = "x64",
+        ///         Parallel = true
+        ///     };
+        ///
+        ///     DotNetCoreTest("./**/*.Tests.csproj", settings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Test")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.VSTest")]
+        public static void DotNetCoreVSTest(this ICakeContext context, string testFile, DotNetCoreVSTestSettings settings)
+        {
+            var testFiles = context.GetFiles(testFile);
+
+            context.DotNetCoreVSTest(testFiles, settings);
+        }
+
+        /// <summary>
+        /// Test one or more specified projects with settings using the VS Test host runner.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="testFiles">The project paths to test.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        ///     var settings = new DotNetCoreTestSettings
+        ///     {
+        ///         Framework = "FrameworkCore10",
+        ///         Platform = "x64"
+        ///     };
+        ///
+        ///     DotNetCoreTest(new[] { (FilePath)"./Test/Cake.Common.Tests.csproj" }, settings);
+        /// </code>
+        /// <para>You could also specify a task that runs multiple test projects.</para>
+        /// <para>Cake task:</para>
+        /// <code>
+        /// Task("Test")
+        ///     .Does(() =>
+        /// {
+        ///     var settings = new DotNetCoreTestSettings
+        ///     {
+        ///         Framework = "FrameworkCore10",
+        ///         Platform = "x64",
+        ///         Parallel = true
+        ///     };
+        ///
+        ///     var projectFiles = GetFiles("./test/**/*.csproj");
+        ///
+        ///     DotNetCoreTest(projectFiles, settings);
+        /// });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Test")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.VSTest")]
+        public static void DotNetCoreVSTest(this ICakeContext context, IEnumerable<FilePath> testFiles, DotNetCoreVSTestSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (settings == null)
+            {
+                settings = new DotNetCoreVSTestSettings();
+            }
+
+            var tester = new DotNetCoreVSTester(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            tester.Test(testFiles, settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/VSTest/DotNetCoreVSTestSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/VSTest/DotNetCoreVSTestSettings.cs
@@ -1,0 +1,95 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Cake.Common.Tools.VSTest;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotNetCore.VSTest
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetCoreVSTester" />.
+    /// </summary>
+    public sealed class DotNetCoreVSTestSettings : DotNetCoreSettings
+    {
+        /// <summary>
+        /// Gets or sets the settings file to use when running tests.
+        /// </summary>
+        public FilePath Settings { get; set; }
+
+        /// <summary>
+        /// Gets or sets the a list tests to run.
+        /// </summary>
+        public ICollection<string> TestsToRun { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to use for the custom test adapter in the test run.
+        /// </summary>
+        public DirectoryPath TestAdapterPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the target platform architecture to be used for test execution.
+        /// </summary>
+        public VSTestPlatform Platform { get; set; }
+
+        /// <summary>
+        /// Gets or sets specific .Net Framework version to be used for test execution.
+        /// </summary>
+        /// <remarks>
+        /// Valid values are ".NETFramework,Version=v4.6", ".NETCoreApp,Version=v1.0" etc.
+        /// Other supported values are Framework35, Framework40, Framework45 and FrameworkCore10.
+        /// </remarks>
+        public string Framework { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the tests should be executed in parallel.
+        /// </summary>
+        /// <remarks>
+        /// By default up to all available cores on the machine may be used. The number of cores to use may be configured using a settings file.
+        /// </remarks>
+        public bool Parallel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the filter expression to run test that match.
+        /// </summary>
+        /// <remarks>
+        /// For more information on filtering support, see https://aka.ms/vstest-filtering
+        /// </remarks>
+        public string TestCaseFilter { get; set; }
+
+        /// <summary>
+        /// Gets or sets a logger for test results.
+        /// </summary>
+        public string Logger { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Process Id of the Parent Process responsible for launching current process.
+        /// </summary>
+        public string ParentProcessId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Port for socket connection and receiving the event messages.
+        /// </summary>
+        public int? Port { get; set; }
+
+        /// <summary>
+        /// Gets or sets a file to write diagnostic messages to.
+        /// </summary>
+        public FilePath DiagnosticFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets a list of extra arguments that should be passed to adapter.
+        /// </summary>
+        public IDictionary<string, string> Arguments { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotNetCoreVSTestSettings"/> class.
+        /// </summary>
+        public DotNetCoreVSTestSettings()
+        {
+            TestsToRun = new List<string>();
+            Arguments = new Dictionary<string, string>();
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/VSTest/DotNetCoreVSTester.cs
+++ b/src/Cake.Common/Tools/DotNetCore/VSTest/DotNetCoreVSTester.cs
@@ -1,0 +1,145 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cake.Common.Tools.VSTest;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.DotNetCore.VSTest
+{
+    /// <summary>
+    /// .NET Core VSTest tester.
+    /// </summary>
+    public sealed class DotNetCoreVSTester : DotNetCoreTool<DotNetCoreVSTestSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotNetCoreVSTester" /> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="tools">The tool locator.</param>
+        public DotNetCoreVSTester(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IToolLocator tools) : base(fileSystem, environment, processRunner, tools)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Tests the project using the specified path with arguments and settings.
+        /// </summary>
+        /// <param name="testFiles">A list of test files to run.</param>
+        /// <param name="settings">The settings.</param>
+        public void Test(IEnumerable<FilePath> testFiles, DotNetCoreVSTestSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            if (testFiles == null || !testFiles.Any())
+            {
+                throw new ArgumentNullException(nameof(testFiles));
+            }
+
+            RunCommand(settings, GetArguments(testFiles, settings));
+        }
+
+        private ProcessArgumentBuilder GetArguments(IEnumerable<FilePath> testFiles, DotNetCoreVSTestSettings settings)
+        {
+            var builder = CreateArgumentBuilder(settings);
+
+            builder.Append("vstest");
+
+            // Specific path?
+            foreach (var testFile in testFiles)
+            {
+                builder.AppendQuoted(testFile.MakeAbsolute(_environment).FullPath);
+            }
+
+            // Settings
+            if (settings.Settings != null)
+            {
+                builder.AppendSwitchQuoted("--Settings", ":", settings.Settings.MakeAbsolute(_environment).FullPath);
+            }
+
+            // Tests to run
+            if (settings.TestsToRun.Any())
+            {
+                builder.AppendSwitch("--Tests", ":", string.Join(",", settings.TestsToRun));
+            }
+
+            // Path to custom test adapter
+            if (settings.TestAdapterPath != null)
+            {
+                builder.AppendSwitchQuoted("--TestAdapterPath", ":", settings.TestAdapterPath.MakeAbsolute(_environment).FullPath);
+            }
+
+            // Platform architecture to execute tests on
+            if (settings.Platform != VSTestPlatform.Default)
+            {
+                builder.AppendSwitch("--Platform", ":", settings.Platform.ToString());
+            }
+
+            // Target Framework
+            if (!string.IsNullOrWhiteSpace(settings.Framework))
+            {
+                builder.AppendSwitch("--Framework", ":", settings.Framework);
+            }
+
+            // Run tests in parallel?
+            if (settings.Parallel)
+            {
+                builder.Append("--Parallel");
+            }
+
+            // Test Case Filter
+            if (!string.IsNullOrWhiteSpace(settings.TestCaseFilter))
+            {
+                builder.AppendSwitchQuoted("--TestCaseFilter", ":", settings.TestCaseFilter);
+            }
+
+            // Logger
+            if (!string.IsNullOrWhiteSpace(settings.Logger))
+            {
+                builder.AppendSwitchQuoted("--logger", ":", settings.Logger);
+            }
+
+            // Parent Process Id?
+            if (!string.IsNullOrWhiteSpace(settings.ParentProcessId))
+            {
+                builder.AppendSwitch("--ParentProcessId", ":", settings.ParentProcessId);
+            }
+
+            // Port?
+            if (settings.Port.HasValue)
+            {
+                builder.AppendSwitch("--Port", ":", settings.Port.Value.ToString());
+            }
+
+            // Write to Diagnostic file?
+            if (settings.DiagnosticFile != null)
+            {
+                builder.AppendSwitchQuoted("--Diag", ":", settings.DiagnosticFile.MakeAbsolute(_environment).FullPath);
+            }
+
+            // Extra arguments
+            foreach (var argument in settings.Arguments)
+            {
+                builder.AppendSwitchQuoted(argument.Key, "=", argument.Value);
+            }
+
+            return builder;
+        }
+    }
+}


### PR DESCRIPTION
* add alias and related files to support dotnet vstest for v1.0.4 of command line tools
* unit tests

See #1533 for more info