### PR TITLE
GH1674: MSBuild - Made LogFile a FilePath, use absolute path when using the runner

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -866,7 +866,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 // When
                 var result = fixture.Run();
                 // Then
-                Assert.Equal(@"/v:normal /target:Build /fl /flp:logfile=A;Encoding=E;Verbosity=Diagnostic /fl1 /flp1:Append;PerformanceSummary;NoSummary;ErrorsOnly;NoItemAndPropertyList;ShowCommandLine;ShowTimestamp;ShowEventId;Verbosity=Minimal /fl2 /flp2:WarningsOnly;Verbosity=Normal /fl3 /flp3:Verbosity=Quiet /fl4 /flp4:Verbosity=Verbose /fl5 /fl6 ""/Working/src/Solution.sln""", result.Args);
+                Assert.Equal(@"/v:normal /target:Build /fl /flp:logfile=""/Working/A"";Encoding=E;Verbosity=Diagnostic /fl1 /flp1:Append;PerformanceSummary;NoSummary;ErrorsOnly;NoItemAndPropertyList;ShowCommandLine;ShowTimestamp;ShowEventId;Verbosity=Minimal /fl2 /flp2:WarningsOnly;Verbosity=Normal /fl3 /flp3:Verbosity=Quiet /fl4 /flp4:Verbosity=Verbose /fl5 /fl6 ""/Working/src/Solution.sln""", result.Args);
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsExtensionsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsExtensionsTests.cs
@@ -381,7 +381,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 Assert.Equal(2, loggers.Length);
                 Assert.Equal(fileLogger, loggers[0]);
                 Assert.Equal(fileLogger2, loggers[1]);
-                Assert.Equal("A", loggers[1].LogFile);
+                Assert.Equal("A", loggers[1].LogFile.FullPath);
             }
 
             [Fact]

--- a/src/Cake.Common/Tools/MSBuild/MSBuildFileLogger.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildFileLogger.cs
@@ -4,7 +4,9 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Cake.Core;
 using Cake.Core.Diagnostics;
+using Cake.Core.IO;
 
 namespace Cake.Common.Tools.MSBuild
 {
@@ -65,7 +67,7 @@ namespace Cake.Common.Tools.MSBuild
         /// Gets or sets LogFile. The path to the log file into which the build log is written.
         /// An empty string will use msbuild.log.
         /// </summary>
-        public string LogFile { get; set; }
+        public FilePath LogFile { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the build log is appended to the log file or overwrites it. When true, the build log is appended to the log file.
@@ -80,11 +82,12 @@ namespace Cake.Common.Tools.MSBuild
         /// <summary>
         /// Process the file logger config and return parameters as a string.
         /// </summary>
+        /// <param name="environment">The environment.</param>
         /// <returns>The parameters separated by semi-colons.</returns>
-        public string GetParameters()
+        public string GetParameters(ICakeEnvironment environment)
         {
             var parameters = new List<string>();
-            parameters.Add(!string.IsNullOrWhiteSpace(LogFile) ? $"logfile={LogFile}" : null);
+            parameters.Add(LogFile != null ? $"logfile={LogFile.MakeAbsolute(environment).FullPath.Quote()}" : null);
             parameters.Add(!string.IsNullOrWhiteSpace(Encoding) ? $"Encoding={Encoding}" : null);
             parameters.Add(AppendToLogFile ? "Append" : null);
             parameters.Add(PerformanceSummaryEnabled ? "PerformanceSummary" : null);

--- a/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
@@ -141,7 +141,7 @@ namespace Cake.Common.Tools.MSBuild
             return builder;
         }
 
-        private static string GetLoggerArgument(int index, MSBuildFileLogger logger)
+        private string GetLoggerArgument(int index, MSBuildFileLogger logger)
         {
             if (index >= 10)
             {
@@ -151,7 +151,7 @@ namespace Cake.Common.Tools.MSBuild
             var counter = index == 0 ? string.Empty : index.ToString();
             var argument = $"/fl{counter}";
 
-            var parameters = logger.GetParameters();
+            var parameters = logger.GetParameters(_environment);
             if (!string.IsNullOrWhiteSpace(parameters))
             {
                 argument = $"{argument} /flp{counter}:{parameters}";


### PR DESCRIPTION
This PR will solve #1674. It is partially a breaking change (since a FilePath is implicitly created when assigning a string).