### PR TITLE
Fix bug #1679 : Cake on dotnet core doesn't load reference dll correctly if referenced from a subdirectory

### DIFF
--- a/src/Cake.Core/Polyfill/AssemblyHelper.cs
+++ b/src/Cake.Core/Polyfill/AssemblyHelper.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.IO;
 using System.Reflection;
 using Cake.Core.IO;
 using Cake.Core.Reflection;
@@ -20,7 +21,7 @@ namespace Cake.Core.Polyfill
 #endif
         }
 
-        public static Assembly LoadAssembly(IFileSystem fileSystem, FilePath path)
+        public static Assembly LoadAssembly(ICakeEnvironment environment, IFileSystem fileSystem, FilePath path)
         {
 #if NETCORE
             if (path == null)
@@ -35,7 +36,7 @@ namespace Cake.Core.Polyfill
             }
 
             var loader = new CakeAssemblyLoadContext(fileSystem, path.GetDirectory());
-            return loader.LoadFromAssemblyPath(path.FullPath);
+            return loader.LoadFromAssemblyPath(path.MakeAbsolute(environment).FullPath);
 #else
             return Assembly.LoadFrom(path.FullPath);
 #endif

--- a/src/Cake.Core/Reflection/AssemblyLoader.cs
+++ b/src/Cake.Core/Reflection/AssemblyLoader.cs
@@ -11,11 +11,13 @@ namespace Cake.Core.Reflection
 {
     internal sealed class AssemblyLoader : IAssemblyLoader
     {
+        private readonly ICakeEnvironment _environment;
         private readonly IFileSystem _fileSystem;
         private readonly AssemblyVerifier _verifier;
 
-        public AssemblyLoader(IFileSystem fileSystem, AssemblyVerifier verifier)
+        public AssemblyLoader(ICakeEnvironment environment, IFileSystem fileSystem, AssemblyVerifier verifier)
         {
+            _environment = environment;
             _fileSystem = fileSystem;
             _verifier = verifier;
         }
@@ -32,7 +34,7 @@ namespace Cake.Core.Reflection
 
         public Assembly Load(FilePath path, bool verify)
         {
-            var assembly = AssemblyHelper.LoadAssembly(_fileSystem, path);
+            var assembly = AssemblyHelper.LoadAssembly(_environment, _fileSystem, path);
             if (verify)
             {
                 _verifier.Verify(assembly);


### PR DESCRIPTION
This PR fix the bug #1679 by using ```path.MakeAbsolute(env)``` 
