### PR TITLE
Update nuget license url

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Cake is provided as-is under the MIT license. For more information see [LICENSE]
 * For Roslyn, see https://github.com/dotnet/roslyn/blob/master/License.txt
 * For Mono.CSharp, see https://github.com/mono/mono/blob/master/mcs/LICENSE
 * For Autofac, see https://github.com/autofac/Autofac/blob/master/LICENSE
-* For NuGet.Core, see https://nuget.codeplex.com/license
+* For NuGet.Core, see https://github.com/NuGet/Home/blob/dev/LICENSE.txt
 
 ## Thanks
 


### PR DESCRIPTION
I only updated the url of the nuget license on the README.md
