### PR TITLE
GH1537: Refactor XmlPeek alias to use XPathNavigator

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/XmlPeekAliasesFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/XmlPeekAliasesFixture.cs
@@ -43,6 +43,11 @@ namespace Cake.Common.Tests.Fixtures
            Context.Log.Returns(FakeLog);
        }
 
+       public void SetContent(string xml)
+       {
+           var file = ((FakeFileSystem)FileSystem).GetFile(XmlPath).SetContent(xml);
+       }
+
        public string Peek(string xpath)
        {
            return XmlPeekAliases.XmlPeek(Context, XmlPath, xpath, Settings);

--- a/src/Cake.Common.Tests/Properties/Resources.Designer.cs
+++ b/src/Cake.Common.Tests/Properties/Resources.Designer.cs
@@ -582,6 +582,14 @@ namespace Cake.Common.Tests.Properties {
             }
         }
 
+        public static string XmlPeek_Xml_With_Namespace
+        {
+            get
+            {
+                return ResourceManager.GetString("XmlPeek_Xml_With_Namespace", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///    Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
         ///&lt;!DOCTYPE plist PUBLIC &quot;-//Apple//DTD PLIST 1.0//EN&quot; &quot;http://www.apple.com/DTDs/PropertyList-1.0.dtd&quot;&gt;

--- a/src/Cake.Common.Tests/Properties/Resources.resx
+++ b/src/Cake.Common.Tests/Properties/Resources.resx
@@ -1012,4 +1012,19 @@ Imports System.Runtime.CompilerServices;
 '&lt;Assembly: AssemblyDelaySign(false)&gt;
 '&lt;Assembly: AssemblyKeyFile("")&gt;</value>
   </data>
+  <data name="XmlPeek_Xml_With_Namespace" xml:space="preserve">
+    <value>&lt;?xml version="1.0" encoding="utf-8"?&gt;
+&lt;Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"&gt;
+  &lt;PropertyGroup&gt;
+    &lt;WebPublishMethod&gt;FileSystem&lt;/WebPublishMethod&gt;
+    &lt;LastUsedBuildConfiguration&gt;DeploymentTemplate&lt;/LastUsedBuildConfiguration&gt;
+    &lt;LastUsedPlatform&gt;Any CPU&lt;/LastUsedPlatform&gt;
+    &lt;SiteUrlToLaunchAfterPublish /&gt;
+    &lt;LaunchSiteAfterPublish&gt;True&lt;/LaunchSiteAfterPublish&gt;
+    &lt;ExcludeApp_Data&gt;False&lt;/ExcludeApp_Data&gt;
+    &lt;publishUrl&gt;C:\Deployment\DeploymentTemplate\WebApi&lt;/publishUrl&gt;
+    &lt;DeleteExistingFiles&gt;False&lt;/DeleteExistingFiles&gt;
+  &lt;/PropertyGroup&gt;
+&lt;/Project&gt;</value>
+  </data>
 </root>

--- a/src/Cake.Common.Tests/Unit/XML/XmlPeekAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/XML/XmlPeekAliasesTests.cs
@@ -96,6 +96,34 @@ namespace Cake.Common.Tests.Unit.XML
             }
 
             [Fact]
+            public void Should_Get_Element_Value()
+            {
+                // Given
+                var fixture = new XmlPeekAliasesFixture();
+
+                // When
+                var result = fixture.Peek("/configuration/test");
+
+                // Then
+                Assert.Equal("test value", result);
+            }
+
+            [Fact]
+            public void Should_Get_Element_Value_With_Namespace()
+            {
+                // Given
+                var fixture = new XmlPeekAliasesFixture();
+                fixture.SetContent(Properties.Resources.XmlPeek_Xml_With_Namespace);
+                fixture.Settings.Namespaces.Add("msbuild", "http://schemas.microsoft.com/developer/msbuild/2003");
+
+                // When
+                var result = fixture.Peek("/msbuild:Project/msbuild:PropertyGroup/msbuild:publishUrl");
+
+                // Then
+                Assert.Equal("C:\\Deployment\\DeploymentTemplate\\WebApi", result);
+            }
+
+            [Fact]
             public void Should_Get_Node_Value_From_File_With_Dtd()
             {
                 // Given

--- a/src/Cake.Common/Xml/XmlPeekAliases.cs
+++ b/src/Cake.Common/Xml/XmlPeekAliases.cs
@@ -132,14 +132,15 @@ namespace Cake.Common.Xml
             document.PreserveWhitespace = settings.PreserveWhitespace;
             document.Load(source);
 
-            var namespaceManager = new XmlNamespaceManager(document.NameTable);
+            var navigator = document.CreateNavigator();
+            var namespaceManager = new XmlNamespaceManager(navigator.NameTable);
+
             foreach (var xmlNamespace in settings.Namespaces)
             {
                 namespaceManager.AddNamespace(xmlNamespace.Key /* Prefix */, xmlNamespace.Value /* URI */);
             }
 
-            var node = document.SelectSingleNode(xpath, namespaceManager);
-
+            var node = navigator.SelectSingleNode(xpath, namespaceManager);
             return node?.Value;
         }
 


### PR DESCRIPTION
This is the revised `XmlPeek` alias to address the issues described in  GH1537.
The PR is drafted from the code sample provided in the original issue nearly 1:1 with a couple of small optimizations; from reflecting the `XmlDocument` and `XPathNavigator` source, it appears that the extra `null` checks are extraneous.  I can revise accordingly if that's understood to be incorrect or otherwise desirable.

Overall, I added the test coverage given the existing sample content and also included the sample document as provided for posterity/regression.