### PR TITLE
ILRepackSettings.Libs should be DirectoryPaths

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/ILRepack/ILRepackRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/ILRepack/ILRepackRunnerTests.cs
@@ -368,13 +368,13 @@ namespace Cake.Common.Tests.Unit.Tools.ILRepack
             {
                 // Given
                 var fixture = new ILRepackRunnerFixture();
-                fixture.Settings.Libs = new List<FilePath> { "/lib1.dll", "/lib2.dll" };
+                fixture.Settings.Libs = new List<DirectoryPath> { "/path1", "/path2" };
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/lib:\"/lib1.dll\" /lib:\"/lib2.dll\" /out:\"/Working/output.exe\" " +
+                Assert.Equal("/lib:\"/path1\" /lib:\"/path2\" /out:\"/Working/output.exe\" " +
                              "\"/Working/input.exe\"", result.Args);
             }
 

--- a/src/Cake.Common/Tools/ILRepack/ILRepackSettings.cs
+++ b/src/Cake.Common/Tools/ILRepack/ILRepackSettings.cs
@@ -118,7 +118,7 @@ namespace Cake.Common.Tools.ILRepack
         /// Gets or sets the paths to search directories for referenced assemblies (can be specified multiple times)
         /// </summary>
         /// <value>The libs.</value>
-        public List<FilePath> Libs { get; set; }
+        public List<DirectoryPath> Libs { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to set all types but the ones from the first assembly 'internal'


### PR DESCRIPTION
When this was originally implemented, it wasn’t very obvious, but ILRepack’s `/lib:<path>` argument should actually be a directory, not a file.

This sheds a _bit_ more light:
https://github.com/gluck/il-repack/blob/master/ILRepack/RepackOptions.cs#L221

This commit fixes up the `ILRepackSettings.Libs` to be the correct type.

This should fix #1720 
