### PR TITLE
GH1734: Add GitLink 3 aliases

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/GitLink3Fixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/GitLink3Fixture.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.GitLink;
+using Cake.Core.IO;
+using Cake.Testing.Fixtures;
+
+namespace Cake.Common.Tests.Fixtures.Tools
+{
+    internal sealed class GitLink3Fixture : ToolFixture<GitLink3Settings>
+    {
+        public FilePath PdbFilePath { get; set; }
+
+        public GitLink3Fixture()
+            : base("gitlink.exe")
+        {
+            PdbFilePath = new FilePath("c:/temp/my.pdb");
+        }
+
+        protected override void RunTool()
+        {
+            var tool = new GitLink3Runner(FileSystem, Environment, ProcessRunner, Tools);
+            tool.Run(PdbFilePath, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/GitLink/Gitlink3RunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/GitLink/Gitlink3RunnerTests.cs
@@ -1,0 +1,160 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tests.Fixtures.Tools;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Testing;
+using Cake.Testing.Xunit;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.GitLink
+{
+    public sealed class Gitlink3RunnerTests
+    {
+        public sealed class TheRunMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Pdb_Path_Is_Null()
+            {
+                // Given
+                var fixture = new GitLink3Fixture();
+                fixture.PdbFilePath = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "pdbFile");
+            }
+
+            [Fact]
+            public void Should_Find_GitLink_Runner()
+            {
+                // Given
+                var fixture = new GitLink3Fixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/Working/tools/gitlink.exe", result.Path.FullPath);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new GitLink3Fixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("GitLink: Process was not started.", result?.Message);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new GitLink3Fixture();
+                fixture.GivenProcessExitsWithCode(1);
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("GitLink: Process returned an error (exit code 1).", result?.Message);
+            }
+
+            [Fact]
+            public void Should_Use_Provided_Pdb_File_Path_In_Process_Arguments()
+            {
+                // Given
+                var fixture = new GitLink3Fixture();
+                fixture.PdbFilePath = "source/my.pdb";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("\"/Working/source/my.pdb\"", result.Args);
+            }
+
+            [WindowsFact]
+            public void Should_Set_RepositoryUrl()
+            {
+                // Given
+                var fixture = new GitLink3Fixture();
+                fixture.Settings.RepositoryUrl = "http://mydomain.com";
+
+                // Then
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-u \"http://mydomain.com\" \"c:/temp/my.pdb\"", result.Args);
+            }
+
+            [WindowsFact]
+            public void Should_Set_ShaHash()
+            {
+                // Given
+                var fixture = new GitLink3Fixture();
+                fixture.Settings.ShaHash = "abcdef";
+
+                // Then
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("--commit \"abcdef\" \"c:/temp/my.pdb\"", result.Args);
+            }
+
+            [WindowsFact]
+            public void Should_Set_BaseDirectory()
+            {
+                // Given
+                var fixture = new GitLink3Fixture();
+                fixture.Settings.BaseDir = DirectoryPath.FromString("pdb/");
+
+                // Then
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("--baseDir \"/Working/pdb\" \"c:/temp/my.pdb\"", result.Args);
+            }
+
+            [WindowsFact]
+            public void Should_Set_PowerShell_Switch()
+            {
+                // Given
+                var fixture = new GitLink3Fixture();
+                fixture.Settings.UsePowerShell = true;
+
+                // Then
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-m Powershell \"c:/temp/my.pdb\"", result.Args);
+            }
+
+            [WindowsFact]
+            public void Should_Set_SkipVerify_Switch()
+            {
+                // Given
+                var fixture = new GitLink3Fixture();
+                fixture.Settings.SkipVerify = true;
+
+                // Then
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-s \"c:/temp/my.pdb\"", result.Args);
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Tools/GitLink/GitLink3Aliases.cs
+++ b/src/Cake.Common/Tools/GitLink/GitLink3Aliases.cs
@@ -1,0 +1,114 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.GitLink
+{
+    /// <summary>
+    /// <para>Contains functionality related to <see href="https://github.com/gittools/gitlink">GitLink</see> version 3.</para>
+    /// <para>
+    /// In order to use the commands for this alias, include the following in your build.cake file to download and
+    /// install from NuGet.org, or specify the ToolPath within the <see cref="GitLink3Settings" /> class:
+    /// <code>
+    /// #tool "nuget:?package=gitlink"
+    /// </code>
+    /// </para>
+    /// </summary>
+    [CakeAliasCategory("GitLink v3")]
+    public static class GitLink3Aliases
+    {
+        /// <summary>
+        /// Update the pdb file to link all sources.
+        /// This will allow anyone to step through the source code while debugging without a symbol source server.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="pdbFilePath">The PDB File to analyze.</param>
+        /// <example>
+        /// <code>
+        /// GitLink3("C:/temp/solution/bin/my.pdb");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static void GitLink3(this ICakeContext context, FilePath pdbFilePath)
+        {
+            GitLink3(context, pdbFilePath, new GitLink3Settings());
+        }
+
+        /// <summary>
+        /// Update the pdb file to link all sources.
+        /// This will allow anyone to step through the source code while debugging without a symbol source server.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="pdbFilePath">The PDB File to analyze.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// GitLink3("C:/temp/solution/bin/my.pdb", new GitLink3Settings {
+        ///     RepositoryUrl = "http://mydomain.com",
+        ///     ShaHash       = "abcdef"
+        /// });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static void GitLink3(this ICakeContext context, FilePath pdbFilePath, GitLink3Settings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var runner = new GitLink3Runner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            runner.Run(pdbFilePath, settings);
+        }
+
+        /// <summary>
+        /// Update the pdb files to link all sources.
+        /// This will allow anyone to step through the source code while debugging without a symbol source server.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="pdbFiles">The PDB File collection to analyze.</param>
+        /// <example>
+        /// <code>
+        /// GitLink3("C:/temp/solution/bin/**/*.pdb");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static void GitLink3(this ICakeContext context, IEnumerable<FilePath> pdbFiles)
+        {
+            GitLink3(context, pdbFiles, new GitLink3Settings());
+        }
+
+        /// <summary>
+        /// Update the pdb files to link all sources.
+        /// This will allow anyone to step through the source code while debugging without a symbol source server.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="pdbFiles">The PDB File collection to analyze.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// GitLink3("C:/temp/solution/bin/**/*.pdb", new GitLink3Settings {
+        ///     RepositoryUrl = "http://mydomain.com",
+        ///     ShaHash       = "abcdef"
+        /// });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static void GitLink3(this ICakeContext context, IEnumerable<FilePath> pdbFiles, GitLink3Settings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var runner = new GitLink3Runner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            runner.Run(pdbFiles, settings);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/GitLink/GitLink3Runner.cs
+++ b/src/Cake.Common/Tools/GitLink/GitLink3Runner.cs
@@ -1,0 +1,135 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.GitLink
+{
+    /// <summary>
+    /// GitLink runner
+    /// </summary>
+    public sealed class GitLink3Runner : Tool<GitLink3Settings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GitLink3Runner"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="tools">The tool locator.</param>
+        public GitLink3Runner(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IToolLocator tools) : base(fileSystem, environment, processRunner, tools)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Update pdb file to link all sources
+        /// </summary>
+        /// <param name="pdbFile">The path to the pdb file to link.</param>
+        /// <param name="settings">The settings.</param>
+        public void Run(FilePath pdbFile, GitLink3Settings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            if (pdbFile == null)
+            {
+                throw new ArgumentNullException(nameof(pdbFile));
+            }
+
+            Run(settings, GetArguments(pdbFile, settings));
+        }
+
+        /// <summary>
+        /// Update pdb files to link all sources
+        /// </summary>
+        /// <param name="pdbFiles">The file path collection for the pdb files to link.</param>
+        /// <param name="settings">The settings.</param>
+        public void Run(IEnumerable<FilePath> pdbFiles, GitLink3Settings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            if (pdbFiles == null)
+            {
+                throw new ArgumentNullException(nameof(pdbFiles));
+            }
+
+            foreach (var pdbFile in pdbFiles)
+            {
+                Run(settings, GetArguments(pdbFile, settings));
+            }
+        }
+
+        private ProcessArgumentBuilder GetArguments(FilePath pdbFilePath, GitLink3Settings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            if (!string.IsNullOrWhiteSpace(settings.RepositoryUrl))
+            {
+                builder.Append("-u");
+                builder.AppendQuoted(settings.RepositoryUrl);
+            }
+
+            if (!string.IsNullOrWhiteSpace(settings.ShaHash))
+            {
+                builder.Append("--commit");
+                builder.AppendQuoted(settings.ShaHash);
+            }
+
+            if (settings.UsePowerShell)
+            {
+                builder.Append("-m");
+                builder.Append("Powershell");
+            }
+
+            if (settings.SkipVerify)
+            {
+                builder.Append("-s");
+            }
+
+            if (settings.BaseDir != null)
+            {
+                builder.Append("--baseDir");
+                builder.AppendQuoted(settings.BaseDir.MakeAbsolute(_environment).FullPath);
+            }
+
+            builder.AppendQuoted(pdbFilePath.MakeAbsolute(_environment).FullPath);
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Gets the name of the tool.
+        /// </summary>
+        /// <returns>The name of the tool.</returns>
+        protected override string GetToolName()
+        {
+            return "GitLink";
+        }
+
+        /// <summary>
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return new[] { "gitlink.exe" };
+        }
+    }
+}

--- a/src/Cake.Common/Tools/GitLink/GitLink3Settings.cs
+++ b/src/Cake.Common/Tools/GitLink/GitLink3Settings.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.GitLink
+{
+    /// <summary>
+    /// Contains settings used by <see cref="GitLink3Runner"/> .
+    /// </summary>
+    public sealed class GitLink3Settings : ToolSettings
+    {
+        /// <summary>
+        /// Gets or sets the Url to remote git repository.
+        /// </summary>
+        public string RepositoryUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the SHA-1 hash of the git commit to be used.
+        /// </summary>
+        public string ShaHash { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the root of the git repository
+        /// </summary>
+        public DirectoryPath BaseDir { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the Use PowerShell Command option should be enabled.
+        /// This option will use PowerShell instead of HTTP in SRCSRV to retreive the source code.
+        /// </summary>
+        public bool UsePowerShell { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the Skip Verify option should be enabled.
+        /// This option indicates whether verification of all source files are available in source control.
+        /// </summary>
+        public bool SkipVerify { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/GitLink/GitLinkAliases.cs
+++ b/src/Cake.Common/Tools/GitLink/GitLinkAliases.cs
@@ -15,7 +15,7 @@ namespace Cake.Common.Tools.GitLink
     /// In order to use the commands for this alias, include the following in your build.cake file to download and
     /// install from NuGet.org, or specify the ToolPath within the <see cref="GitLinkSettings" /> class:
     /// <code>
-    /// #tool "nuget:?package=gitlink"
+    /// #tool "nuget:?package=gitlink&amp;version=2.4.0"
     /// </code>
     /// </para>
     /// </summary>
@@ -34,7 +34,6 @@ namespace Cake.Common.Tools.GitLink
         /// </code>
         /// </example>
         [CakeMethodAlias]
-        [CakeAliasCategory("GitLink")]
         public static void GitLink(this ICakeContext context, DirectoryPath repositoryRootPath)
         {
             GitLink(context, repositoryRootPath, new GitLinkSettings());
@@ -57,7 +56,6 @@ namespace Cake.Common.Tools.GitLink
         /// </code>
         /// </example>
         [CakeMethodAlias]
-        [CakeAliasCategory("GitLink")]
         public static void GitLink(this ICakeContext context, DirectoryPath repositoryRootPath, GitLinkSettings settings)
         {
             if (context == null)


### PR DESCRIPTION
This Pull Request relates to https://github.com/cake-build/cake/issues/1734 and updates the GitLink tool to reflect the major restructure that was done in GitLink 3.0.0.

Instead of taking a solution directory, the new GitLink tool takes singular pdb files and patches them. I've added a helper alias to allow passing a FilePathCollection to allow globbing.