### PR TITLE
GH1738: NuGetInstaller resolves correct files when package has dependencies

### DIFF
--- a/src/Cake.NuGet.Tests/Unit/NuGetPackageInstallerTests.cs
+++ b/src/Cake.NuGet.Tests/Unit/NuGetPackageInstallerTests.cs
@@ -4,6 +4,7 @@
 
 #if !NETCORE
 using System.Collections.Generic;
+using System.Linq;
 using Cake.Core.IO;
 using Cake.Core.Packaging;
 using Cake.NuGet.Tests.Fixtures;
@@ -342,6 +343,28 @@ namespace Cake.NuGet.Tests.Unit
                     Verbosity.Diagnostic, LogLevel.Debug,
                     "Package {0} has already been installed.",
                     "Cake.Foo");
+            }
+
+            [Fact]
+            public void Should_Return_Correct_Files_When_Resource_Has_Dependencies()
+            {
+                // Given
+                var fixture = new NuGetPackageInstallerFixture();
+                fixture.FileSystem.CreateFile("/Working/nuget/cake.foo.1.2.3/Cake.Abc/Cake.Abc.dll");
+                fixture.FileSystem.CreateFile("/Working/nuget/cake.foo.1.2.3/Cake.Foo/Cake.Foo.dll");
+                fixture.FileSystem.CreateFile("/Working/nuget/cake.foo.1.2.3/Cake.Xyz/Cake.Xyz.dll");
+                fixture.ContentResolver.GetFiles(
+                        Arg.Any<DirectoryPath>(), Arg.Any<PackageReference>(), Arg.Any<PackageType>())
+                    .Returns(new List<IFile> { Substitute.For<IFile>() });
+
+                // When
+                var result = fixture.Install();
+
+                // Then
+                fixture.ContentResolver.Received(1).GetFiles(
+                    Arg.Is<DirectoryPath>(x => x.FullPath.Equals("/Working/nuget/cake.foo.1.2.3/Cake.Foo")),
+                    fixture.Package,
+                    PackageType.Addin);
             }
         }
     }

--- a/src/Cake.NuGet/NuGetPackageInstaller.cs
+++ b/src/Cake.NuGet/NuGetPackageInstaller.cs
@@ -136,7 +136,7 @@ namespace Cake.NuGet
             }
 
             // Package already exist?
-            var packagePath = GetPackagePath(root);
+            var packagePath = GetPackagePath(root, package.Package);
             if (packagePath != null)
             {
                 // Fetch available content from disc.
@@ -152,7 +152,7 @@ namespace Cake.NuGet
             InstallPackage(package, path);
 
             // Try locating the install folder again.
-            packagePath = GetPackagePath(root);
+            packagePath = GetPackagePath(root, package.Package);
 
             // Get the files.
             var result = _contentResolver.GetFiles(packagePath, package, type);
@@ -173,10 +173,10 @@ namespace Cake.NuGet
             return result;
         }
 
-        private static DirectoryPath GetPackagePath(IDirectory root)
+        private static DirectoryPath GetPackagePath(IDirectory root, string package)
         {
             var directories = root.GetDirectories("*", SearchScope.Current).ToArray();
-            return directories.FirstOrDefault()?.Path;
+            return directories.FirstOrDefault(p => p.Path.GetDirectoryName().Equals(package, StringComparison.OrdinalIgnoreCase))?.Path;
         }
 
         private static DirectoryPath GetPackagePath(DirectoryPath root, PackageReference package)


### PR DESCRIPTION
- Fixes #1738
