### PR TITLE
GH1746: ScriptAnalyzer will not throw on error

### DIFF
--- a/src/Cake.Core.Tests/Fixtures/ScriptRunnerFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/ScriptRunnerFixture.cs
@@ -28,7 +28,7 @@ namespace Cake.Core.Tests.Fixtures
         public IScriptProcessor ScriptProcessor { get; set; }
         public IScriptConventions ScriptConventions { get; set; }
         public IScriptAliasFinder AliasFinder { get; set; }
-        public ICakeLog Log { get; set; }
+        public FakeLog Log { get; set; }
 
         public IScriptHost Host { get; set; }
         public FilePath Script { get; set; }
@@ -50,7 +50,7 @@ namespace Cake.Core.Tests.Fixtures
 
             Configuration = Substitute.For<ICakeConfiguration>();
             AliasFinder = Substitute.For<IScriptAliasFinder>();
-            Log = Substitute.For<ICakeLog>();
+            Log = new FakeLog();
 
             Session = Substitute.For<IScriptSession>();
             ArgumentDictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);

--- a/src/Cake.Core.Tests/Unit/Scripting/Analysis/ScriptAnalyzerResultTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/Analysis/ScriptAnalyzerResultTests.cs
@@ -107,6 +107,33 @@ namespace Cake.Core.Tests.Unit.Scripting.Analysis
                 Assert.Contains(result.Tools, package => package.OriginalString == "nuget:?package=First.Package");
                 Assert.Contains(result.Tools, package => package.OriginalString == "nuget:?package=Second.Package");
             }
+
+            [Fact]
+            public void Should_Set_Succeeded_To_False_If_Any_Errors()
+            {
+                // Given
+                var script = new ScriptInformation("./build.cake");
+                var error = new ScriptAnalyzerError("./build.cake", 1, "error message");
+
+                // When
+                var result = new ScriptAnalyzerResult(script, new List<string>(), new List<ScriptAnalyzerError> { error });
+
+                // Then
+                Assert.False(result.Succeeded);
+            }
+
+            [Fact]
+            public void Should_Set_Succeeded_To_True_If_Not_Any_Errors()
+            {
+                // Given
+                var script = new ScriptInformation("./build.cake");
+
+                // When
+                var result = new ScriptAnalyzerResult(script, new List<string>(), new List<ScriptAnalyzerError>());
+
+                // Then
+                Assert.True(result.Succeeded);
+            }
         }
     }
 }

--- a/src/Cake.Core.Tests/Unit/Scripting/Analysis/ScriptAnalyzerTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/Analysis/ScriptAnalyzerTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
+using Cake.Core.Scripting.Processors.Loading;
 using Cake.Core.Tests.Fixtures;
 using Xunit;
 
@@ -71,17 +72,18 @@ namespace Cake.Core.Tests.Unit.Scripting.Analysis
             }
 
             [Fact]
-            public void Should_Throw_If_Script_Was_Not_Found()
+            public void Should_Return_Error_If_Script_Was_Not_Found()
             {
                 // Given
                 var fixture = new ScriptAnalyzerFixture();
 
                 // When
-                var result = Record.Exception(() => fixture.Analyze("/Working/notfound.cake"));
+                var result = fixture.Analyze("/Working/notfound.cake");
 
                 // Then
-                Assert.IsType<CakeException>(result);
-                Assert.Equal("Could not find script '/Working/notfound.cake'.", result?.Message);
+                Assert.False(result.Succeeded);
+                Assert.Equal(1, result.Errors.Count);
+                Assert.Equal("Could not find script '/Working/notfound.cake'.", result.Errors[0].Message);
             }
 
             [Fact]
@@ -323,6 +325,49 @@ namespace Cake.Core.Tests.Unit.Scripting.Analysis
                 Assert.Equal(2, result.Lines.Count);
                 Assert.Equal(result.Lines[0], "#line 1 \"/Working/script.cake\"");
                 Assert.Equal(result.Lines[1], @"if (System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Break(); }");
+            }
+
+            [Fact]
+            public void Should_Log_Error_Location()
+            {
+                // Given
+                var fixture = new ScriptAnalyzerFixture();
+                fixture.Providers.Add(new FileLoadDirectiveProvider());
+                fixture.GivenScriptExist("/Working/script.cake", "#load \"local:?pat\"");
+
+                // When
+                var result = fixture.Analyze("/Working/script.cake");
+
+                // Then
+                Assert.Equal(2, result.Lines.Count);
+                Assert.Equal("#line 1 \"/Working/script.cake\"", result.Lines[0]);
+                Assert.Equal("// #load \"local:?pat\"", result.Lines[1]);
+                Assert.False(result.Succeeded);
+                Assert.Equal(1, result.Errors.Count);
+                Assert.Equal("/Working/script.cake", result.Errors[0].File.FullPath);
+                Assert.Equal(1, result.Errors[0].Line);
+                Assert.Equal("Query string for #load is missing parameter 'path'.", result.Errors[0].Message);
+            }
+
+            [Fact]
+            public void Should_Log_Error_Location_In_Loaded_Script()
+            {
+                // Given
+                var fixture = new ScriptAnalyzerFixture();
+                fixture.Providers.Add(new FileLoadDirectiveProvider());
+                fixture.GivenScriptExist("/Working/script.cake", "#load \"local:?path=script2.cake\"");
+                fixture.GivenScriptExist("/Working/script2.cake", "\n#load \"local:?path=1&path=2\"");
+
+                // When
+                var result = fixture.Analyze("/Working/script.cake");
+
+                // Then
+                Assert.Equal(6, result.Lines.Count);
+                Assert.False(result.Succeeded);
+                Assert.Equal(1, result.Errors.Count);
+                Assert.Equal("/Working/script2.cake", result.Errors[0].File.FullPath);
+                Assert.Equal(2, result.Errors[0].Line);
+                Assert.Equal("Query string for #load contains more than one parameter 'path'.", result.Errors[0].Message);
             }
         }
     }

--- a/src/Cake.Core/Scripting/Analysis/IScriptAnalyzerContext.cs
+++ b/src/Cake.Core/Scripting/Analysis/IScriptAnalyzerContext.cs
@@ -33,5 +33,11 @@ namespace Cake.Core.Scripting.Analysis
         /// </summary>
         /// <param name="line">The script line to add.</param>
         void AddScriptLine(string line);
+
+        /// <summary>
+        /// Adds a script error to the result.
+        /// </summary>
+        /// <param name="error">The script error to add.</param>
+        void AddScriptError(string error);
     }
 }

--- a/src/Cake.Core/Scripting/Analysis/ScriptAnalyzer.cs
+++ b/src/Cake.Core/Scripting/Analysis/ScriptAnalyzer.cs
@@ -92,7 +92,8 @@ namespace Cake.Core.Scripting.Analysis
             // Create and return the results.
             return new ScriptAnalyzerResult(
                 context.Current,
-                context.Lines);
+                context.Lines,
+                context.Errors);
         }
 
         [SuppressMessage("ReSharper", "ConvertIfStatementToConditionalTernaryExpression")]

--- a/src/Cake.Core/Scripting/Analysis/ScriptAnalyzerError.cs
+++ b/src/Cake.Core/Scripting/Analysis/ScriptAnalyzerError.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Core.IO;
+
+namespace Cake.Core.Scripting.Analysis
+{
+    /// <summary>
+    /// Represents a script analysis error.
+    /// </summary>
+    public sealed class ScriptAnalyzerError
+    {
+        /// <summary>
+        /// Gets the file containing the error.
+        /// </summary>
+        public FilePath File { get; }
+
+        /// <summary>
+        /// Gets the line number for the error.
+        /// </summary>
+        public int Line { get; }
+
+        /// <summary>
+        /// Gets the error message.
+        /// </summary>
+        public string Message { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScriptAnalyzerError"/> class.
+        /// </summary>
+        /// <param name="file">The file containing the error.</param>
+        /// <param name="line">The line number for the error.</param>
+        /// <param name="message">The error message.</param>
+        public ScriptAnalyzerError(FilePath file, int line, string message)
+        {
+            if (file == null)
+            {
+                throw new ArgumentNullException(nameof(file));
+            }
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            File = file;
+            Line = line;
+            Message = message;
+        }
+    }
+}

--- a/src/Cake.Core/Scripting/Analysis/ScriptAnalyzerResult.cs
+++ b/src/Cake.Core/Scripting/Analysis/ScriptAnalyzerResult.cs
@@ -60,11 +60,22 @@ namespace Cake.Core.Scripting.Analysis
         public HashSet<PackageReference> Tools { get; }
 
         /// <summary>
+        /// Gets a value indicating whether to analysis succeded without errors.
+        /// </summary>
+        public bool Succeeded { get; }
+
+        /// <summary>
+        /// Gets the list of analyzer errors.
+        /// </summary>
+        public IReadOnlyList<ScriptAnalyzerError> Errors { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ScriptAnalyzerResult"/> class.
         /// </summary>
         /// <param name="script">The script.</param>
         /// <param name="lines">The merged script lines.</param>
-        public ScriptAnalyzerResult(IScriptInformation script, IReadOnlyList<string> lines)
+        /// <param name="errors">The analyzer errors.</param>
+        public ScriptAnalyzerResult(IScriptInformation script, IReadOnlyList<string> lines, IReadOnlyList<ScriptAnalyzerError> errors = null)
         {
             Script = script;
             Lines = lines;
@@ -73,9 +84,11 @@ namespace Cake.Core.Scripting.Analysis
             _usingAliases = new HashSet<string>(Collect(script, i => i.UsingAliases));
             Tools = new HashSet<PackageReference>(Collect(script, i => i.Tools));
             Addins = new HashSet<PackageReference>(Collect(script, i => i.Addins));
+            Errors = errors ?? new List<ScriptAnalyzerError>(0);
+            Succeeded = Errors.Count == 0;
         }
 
-        private IEnumerable<T> Collect<T>(IScriptInformation script, Func<IScriptInformation, IEnumerable<T>> collector)
+        private static IEnumerable<T> Collect<T>(IScriptInformation script, Func<IScriptInformation, IEnumerable<T>> collector)
         {
             var stack = new Stack<IScriptInformation>();
             stack.Push(script);

--- a/src/Cake.Core/Scripting/Processors/UriDirectiveProcessor.cs
+++ b/src/Cake.Core/Scripting/Processors/UriDirectiveProcessor.cs
@@ -37,8 +37,16 @@ namespace Cake.Core.Scripting.Processors
                         var uri = ParseUriFromTokens(tokens);
                         if (uri != null)
                         {
-                            // Add the URI to the context.
-                            AddToContext(context, uri);
+                            try
+                            {
+                                // Add the URI to the context.
+                                AddToContext(context, uri);
+                            }
+                            catch (Exception e)
+                            {
+                                // Add any errors to context
+                                context.AddScriptError(e.Message);
+                            }
 
                             // Return success.
                             return true;

--- a/src/Cake.Core/Scripting/ScriptRunner.cs
+++ b/src/Cake.Core/Scripting/ScriptRunner.cs
@@ -131,6 +131,17 @@ namespace Cake.Core.Scripting
             _log.Verbose("Analyzing build script...");
             var result = _analyzer.Analyze(scriptPath.GetFilename());
 
+            // Log all errors and throw
+            if (!result.Succeeded)
+            {
+                foreach (var error in result.Errors)
+                {
+                    var format = $"{error.File.MakeAbsolute(_environment).FullPath}:{error.Line}: {{0}}";
+                    _log.Error(format, error.Message);
+                }
+                throw new CakeException("Errors occured while analyzing script.");
+            }
+
             // Install tools.
             _log.Verbose("Processing build script...");
             var toolsPath = GetToolPath(scriptPath.GetDirectory());


### PR DESCRIPTION
- ScriptAnalyzer will not throw on error. Instead the result will
indicate if analysis succeeded or not. A list of errors is also present
in the analyzer result.
- Fixes #1746