### PR TITLE
GH1754 - add prerelease flag to VSWhere

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/VSWhere/All/VSWhereAllTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/VSWhere/All/VSWhereAllTests.cs
@@ -169,6 +169,20 @@ namespace Cake.Common.Tests.Unit.Tools.VSWhere.All
                 // Then
                 Assert.Equal("-all -nologo", result.Args);
             }
+
+            [Fact]
+            public void Should_Add_Prerelease_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new VSWhereAllFixture();
+                fixture.Settings.IncludePrerelease = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-all -property installationPath -prerelease -nologo", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/VSWhere/Latest/VSWhereLatestTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/VSWhere/Latest/VSWhereLatestTests.cs
@@ -169,6 +169,20 @@ namespace Cake.Common.Tests.Unit.Tools.VSWhere.Latest
                 // Then
                 Assert.Equal("-latest -nologo", result.Args);
             }
+
+            [Fact]
+            public void Should_Add_Prerelease_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new VSWhereLatestFixture();
+                fixture.Settings.IncludePrerelease = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-latest -property installationPath -prerelease -nologo", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/VSWhere/Legacy/VSWhereLegacyTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/VSWhere/Legacy/VSWhereLegacyTests.cs
@@ -169,6 +169,20 @@ namespace Cake.Common.Tests.Unit.Tools.VSWhere.Legacy
                 // Then
                 Assert.Equal("-legacy -latest -property installationPath -nologo", result.Args);
             }
+
+            [Fact]
+            public void Should_Add_Prerelease_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new VSWhereLegacyFixture();
+                fixture.Settings.IncludePrerelease = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-legacy -property installationPath -prerelease -nologo", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/VSWhere/Product/VSWhereProductTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/VSWhere/Product/VSWhereProductTests.cs
@@ -183,6 +183,20 @@ namespace Cake.Common.Tests.Unit.Tools.VSWhere.Product
                 // Then
                 Assert.Equal("-property installationPath -nologo", result.Args);
             }
+
+            [Fact]
+            public void Should_Add_Prerelease_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new VSWhereProductFixture();
+                fixture.Settings.IncludePrerelease = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-products \"Microsoft.VisualStudio.Product.BuildTools\" -property installationPath -prerelease -nologo", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common/Tools/VSWhere/VSWhereSettings.cs
+++ b/src/Cake.Common/Tools/VSWhere/VSWhereSettings.cs
@@ -27,6 +27,11 @@ namespace Cake.Common.Tools.VSWhere
         public string ReturnProperty { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether VSWhere should include prerelease installations
+        /// </summary>
+        public bool IncludePrerelease { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="VSWhereSettings"/> class.
         /// </summary>
         protected VSWhereSettings()

--- a/src/Cake.Common/Tools/VSWhere/VSWhereTool.cs
+++ b/src/Cake.Common/Tools/VSWhere/VSWhereTool.cs
@@ -93,6 +93,11 @@ namespace Cake.Common.Tools.VSWhere
                 builder.Append(settings.ReturnProperty);
             }
 
+            if (settings.IncludePrerelease)
+            {
+                builder.Append("-prerelease");
+            }
+
             builder.Append("-nologo");
 
             return builder;


### PR DESCRIPTION
As discussed in #1754, this adds a "prerelease" flag.

I think it's more appropriate as an additional flag on the existing VSWhereXXX functionality, but happy to refactor to a VSWherePrerelease or something if that's preferred.