### PR TITLE
Added new extension method DoesForEach

### DIFF
--- a/src/Cake.Core.Tests/Unit/ActionTaskTests.cs
+++ b/src/Cake.Core.Tests/Unit/ActionTaskTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using Cake.Core.Tests.Fixtures;
 using Xunit;
 
 namespace Cake.Core.Tests.Unit
@@ -34,6 +36,71 @@ namespace Cake.Core.Tests.Unit
 
                 // Then
                 Assert.Equal(1, task.Actions.Count);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Builder_Is_Null()
+            {
+                // Given, When
+                var result = Record.Exception(() => CakeTaskBuilderExtensions.DeferOnError(null));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "builder");
+            }
+
+            [Fact]
+            public void Should_Throw_On_First_Failed_Action()
+            {
+                // Given
+                var task = new ActionTask("task");
+                var context = new CakeContextFixture().CreateContext();
+
+                // When
+                task.Actions.Add((c) => throw new NotImplementedException());
+                task.Actions.Add((c) => throw new NotSupportedException());
+                task.Actions.Add((c) => throw new OutOfMemoryException());
+                var result = Record.Exception(() => task.Execute(context));
+
+                // Then
+                Assert.IsType<NotImplementedException>(result);
+            }
+
+            [Fact]
+            public void Should_Aggregate_Exceptions_From_Actions()
+            {
+                // Given
+                var task = new ActionTask("task");
+                var context = new CakeContextFixture().CreateContext();
+
+                // When
+                task.Actions.Add((c) => throw new NotImplementedException());
+                task.Actions.Add((c) => throw new NotSupportedException());
+                task.Actions.Add((c) => throw new OutOfMemoryException());
+                task.SetDeferExceptions(true);
+                var result = Record.Exception(() => task.Execute(context));
+
+                // Then
+                Assert.IsType<AggregateException>(result);
+                var ex = result as AggregateException;
+                Assert.Contains(ex.InnerExceptions, x => x.GetType() == typeof(NotImplementedException));
+                Assert.Contains(ex.InnerExceptions, x => x.GetType() == typeof(NotSupportedException));
+                Assert.Contains(ex.InnerExceptions, x => x.GetType() == typeof(OutOfMemoryException));
+            }
+
+            [Fact]
+            public void Should_Only_Aggregate_Exceptions_When_There_Are_Many()
+            {
+                // Given
+                var task = new ActionTask("task");
+                var context = new CakeContextFixture().CreateContext();
+
+                // When
+                task.Actions.Add((c) => throw new NotImplementedException());
+                task.SetDeferExceptions(true);
+                var result = Record.Exception(() => task.Execute(context));
+
+                // Then
+                Assert.IsType<NotImplementedException>(result);
             }
         }
     }

--- a/src/Cake.Core/CakeTaskBuilderExtensions.cs
+++ b/src/Cake.Core/CakeTaskBuilderExtensions.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Cake.Core
 {
@@ -145,6 +147,97 @@ namespace Cake.Core
             }
 
             builder.Task.AddAction(action);
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds an action to be executed foreach item in the list.
+        /// </summary>
+        /// <typeparam name="TItem">The item type.</typeparam>
+        /// <param name="builder">The task builder.</param>
+        /// <param name="items">The items.</param>
+        /// <param name="action">The action.</param>
+        /// <returns>The same <see cref="CakeTaskBuilder{ActionTask}"/> instance so that multiple calls can be chained.</returns>
+        public static CakeTaskBuilder<ActionTask> DoesForEach<TItem>(this CakeTaskBuilder<ActionTask> builder, IEnumerable<TItem> items, Action<TItem> action)
+        {
+            return DoesForEach(builder, items, (item, context) => action(item));
+        }
+
+        /// <summary>
+        /// Adds an action to be executed foreach item in the list.
+        /// </summary>
+        /// <typeparam name="TItem">The item type.</typeparam>
+        /// <param name="builder">The task builder.</param>
+        /// <param name="items">The items.</param>
+        /// <param name="action">The action.</param>
+        /// <returns>The same <see cref="CakeTaskBuilder{ActionTask}"/> instance so that multiple calls can be chained.</returns>
+        public static CakeTaskBuilder<ActionTask> DoesForEach<TItem>(this CakeTaskBuilder<ActionTask> builder, IEnumerable<TItem> items, Action<TItem, ICakeContext> action)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            foreach (var item in items)
+            {
+                builder.Task.AddAction(context => action(item, context));
+            }
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds an action to be executed foreach item returned by the items function.
+        /// This method will be executed the first time the task is executed.
+        /// </summary>
+        /// <typeparam name="TItem">The item type.</typeparam>
+        /// <param name="builder">The task builder.</param>
+        /// <param name="itemsFunc">The items.</param>
+        /// <param name="action">The action.</param>
+        /// <returns>The same <see cref="CakeTaskBuilder{ActionTask}"/> instance so that multiple calls can be chained.</returns>
+        public static CakeTaskBuilder<ActionTask> DoesForEach<TItem>(this CakeTaskBuilder<ActionTask> builder, Func<IEnumerable<TItem>> itemsFunc, Action<TItem> action)
+        {
+            return DoesForEach(builder, itemsFunc, (i, c) => action(i));
+        }
+
+        /// <summary>
+        /// Adds an action to be executed foreach item returned by the items function.
+        /// This method will be executed the first time the task is executed.
+        /// </summary>
+        /// <typeparam name="TItem">The item type.</typeparam>
+        /// <param name="builder">The task builder.</param>
+        /// <param name="itemsFunc">The items.</param>
+        /// <param name="action">The action.</param>
+        /// <returns>The same <see cref="CakeTaskBuilder{ActionTask}"/> instance so that multiple calls can be chained.</returns>
+        public static CakeTaskBuilder<ActionTask> DoesForEach<TItem>(this CakeTaskBuilder<ActionTask> builder, Func<IEnumerable<TItem>> itemsFunc, Action<TItem, ICakeContext> action)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.Task.AddDelayedAction(() =>
+            {
+                foreach (var item in itemsFunc())
+                {
+                    builder.Task.AddAction(context => action(item, context));
+                }
+            });
+            return builder;
+        }
+
+        /// <summary>
+        /// Defers all exceptions until after all actions for this task have completed
+        /// </summary>
+        /// <param name="builder">The task builder.</param>
+        /// <returns>The same <see cref="CakeTaskBuilder{ActionTask}"/> instance so that multiple calls can be chained.</returns>
+        public static CakeTaskBuilder<ActionTask> DeferOnError(this CakeTaskBuilder<ActionTask> builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.Task.SetDeferExceptions(true);
             return builder;
         }
 

--- a/tests/integration/Cake.Core/CakeAliases.cake
+++ b/tests/integration/Cake.Core/CakeAliases.cake
@@ -1,0 +1,68 @@
+var cakeCoreCakeAliasesDoesForEachTestFiles = Paths.Resources.Combine("./Cake.Core/testfile*.txt");
+
+var cakeCoreCakeAliasesDoesForEachOkCount = 0;
+Task("Cake.Core.CakeAliases.DoesForEach.Ok")
+    .DoesForEach(cakeCoreCakeAliasesDoesForEachTestFiles, (file) =>
+{
+    // Given
+    cakeCoreCakeAliasesDoesForEachOkCount++;
+
+    // When
+    Assert.StartsWith(file, "Test core file");
+})
+.Finally(() => {
+    // Then
+    Assert.Equal(cakeCoreCakeAliasesDoesForEachOkCount, 3);
+});
+
+var cakeCoreCakeAliasesDoesForEachNotOkCount = 0;
+Task("Cake.Core.CakeAliases.DoesForEach.NotOk")
+    .DeferExceptions()
+    .DoesForEach(cakeCoreCakeAliasesDoesForEachTestFiles, (file) =>
+{
+    // Given
+    cakeCoreCakeAliasesDoesForEachNotOkCount++;
+
+    // When
+    throw new Exception(file);
+})
+.Finally(() => {
+    // Then
+    Assert.Equal(cakeCoreCakeAliasesDoesForEachNotOkCount, 3);
+});
+
+var cakeCoreCakeAliasesDoesForEachFuncOkCount = 0;
+Task("Cake.Core.CakeAliases.DoesForEach.Func.Ok")
+    .DoesForEach(() => cakeCoreCakeAliasesDoesForEachTestFiles, (file) =>
+{
+    // Given
+    cakeCoreCakeAliasesDoesForEachFuncOkCount++;
+
+    // When
+    Assert.StartsWith(file, "Test core file");
+})
+.Finally(() => {
+    // Then
+    Assert.Equal(cakeCoreCakeAliasesDoesForEachFuncOkCount, 3);
+});
+
+var cakeCoreCakeAliasesDoesForEachFuncNotOkCount = 0;
+Task("Cake.Core.CakeAliases.DoesForEach.Func.NotOk")
+    .DoesForEach(() => cakeCoreCakeAliasesDoesForEachTestFiles, (file) =>
+{
+    // Given
+    cakeCoreCakeAliasesDoesForEachFuncNotOkCount++;
+
+    // When
+    throw new Exception(file);
+})
+.Finally(() => {
+    // Then
+    Assert.Equal(cakeCoreCakeAliasesDoesForEachFuncNotOkCount, 1);
+});
+
+Task("Cake.Core.CakeAliases")
+    .IsDependentOn("Cake.Core.CakeAliases.DoesForEach.Ok")
+    .IsDependentOn("Cake.Core.CakeAliases.DoesForEach.NotOk")
+    .IsDependentOn("Cake.Core.CakeAliases.DoesForEach.Func.Ok")
+    .IsDependentOn("Cake.Core.CakeAliases.DoesForEach.Func.NotOk");

--- a/tests/integration/build.cake
+++ b/tests/integration/build.cake
@@ -20,6 +20,7 @@
 #load "./Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cake"
 #load "./Cake.Core/Scripting/LoadDirective.cake"
 #load "./Cake.Core/Tooling/ToolLocator.cake"
+#load "./Cake.Core/CakeAliases.cake"
 
 //////////////////////////////////////////////////
 // ARGUMENTS
@@ -42,7 +43,8 @@ Setup(ctx =>
 
 Task("Cake.Core")
     .IsDependentOn("Cake.Core.Scripting.LoadDirective")
-    .IsDependentOn("Cake.Core.Tooling.ToolLocator");
+    .IsDependentOn("Cake.Core.Tooling.ToolLocator")
+    .IsDependentOn("Cake.Core.CakeAliases");
 
 Task("Cake.Common")
     .IsDependentOn("Cake.Common.ArgumentAliases")

--- a/tests/integration/resources/Cake.Core/testfile1.txt
+++ b/tests/integration/resources/Cake.Core/testfile1.txt
@@ -1,0 +1,1 @@
+Test core file 1!

--- a/tests/integration/resources/Cake.Core/testfile2.txt
+++ b/tests/integration/resources/Cake.Core/testfile2.txt
@@ -1,0 +1,1 @@
+Test core file 2!

--- a/tests/integration/resources/Cake.Core/testfile3.txt
+++ b/tests/integration/resources/Cake.Core/testfile3.txt
@@ -1,0 +1,1 @@
+Test core file 3!


### PR DESCRIPTION
This adds two new extension methods for `ActionTask`
* `DoesForEach`
* `DeferOnError`

`DoesForEach` allows a collection of items, or a delegate that returns a collection of items, to be added as actions to a given task.  In the case of the delegate returning a collection, the delegate is only executed when the task is executed.  This allows the task to look up items that don't exist when the script is first run, such as build artifacts.

`DeferOnError` allows a given task the ability to defer all exceptions until the end of the task execution.  This way tasks can run all actions to completion before failing.  This can have some value when you work with something like multiple unit test projects, or multiple publishes.  You can see the output of the entire task, and not just where it failed.

Also makes some changes to `ActionTask`, I'm not sure if I should or not.  The reason I did make the changes was so that these two new extension methods work correctly in more scenarios.  One such case would have been given:

```csharp
Task("Awesome")
    .Does(() => { throw new Exception(); })
    .DoesForEach(GetFiles("**/*.txt"), (file) => { // My cool file action })
    .DeferOnError();
```

This way all the actions would execute, not just the action before the actions contained in `DoesForEach`.

Related: #1761