### PR TITLE
GH1773: Fix NuGetHasSource ArgumentCustomization & add ConfigFile to NuGetSourcesSettings

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/NuGet/Sources/NuGetSourcesTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NuGet/Sources/NuGetSourcesTests.cs
@@ -271,6 +271,21 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Sources
                 Assert.Equal("sources Add -Name \"name\" -Source \"source\" " +
                              "-NonInteractive -StorePasswordInClearText", result.Args);
             }
+
+            [Fact]
+            public void Should_Add_ConfigFile_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new NuGetAddSourceFixture();
+                fixture.Settings.ConfigFile = "./src/NuGet.config";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("sources Add -Name \"name\" -Source \"source\" " +
+                             "-ConfigFile \"src/NuGet.config\" -NonInteractive", result.Args);
+            }
         }
 
         public sealed class TheRemoveSourceMethod
@@ -506,6 +521,22 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Sources
                 Assert.Equal("sources Remove -Name \"name\" " +
                              "-Source \"source\" -NonInteractive", result.Args);
             }
+
+            [Fact]
+            public void Should_Add_ConfigFile_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new NuGetRemoveSourceFixture();
+                fixture.GivenExistingSource();
+                fixture.Settings.ConfigFile = "./src/NuGet.config";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("sources Remove -Name \"name\" -Source \"source\" " +
+                             "-ConfigFile \"src/NuGet.config\" -NonInteractive", result.Args);
+            }
         }
 
         public sealed class TheHasSourceMethod
@@ -552,6 +583,47 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Sources
 
                 // Then
                 AssertEx.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new NuGetHasSourceFixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("sources List -NonInteractive", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_ConfigFile_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new NuGetHasSourceFixture();
+                fixture.Settings.ConfigFile = "./src/NuGet.config";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("sources List -ConfigFile \"src/NuGet.config\" -NonInteractive", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Argument_Customization()
+            {
+                // Given
+                var fixture = new NuGetHasSourceFixture();
+                fixture.Settings.ArgumentCustomization = arg => arg.Append("-Foo");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("sources List -NonInteractive -Foo", result.Args);
             }
         }
     }

--- a/src/Cake.Common/Tools/NuGet/Sources/NuGetSources.cs
+++ b/src/Cake.Common/Tools/NuGet/Sources/NuGetSources.cs
@@ -133,16 +133,33 @@ namespace Cake.Common.Tools.NuGet.Sources
 
             var processSettings = new ProcessSettings
             {
-                Arguments = "sources List",
                 RedirectStandardOutput = true
             };
 
             var result = false;
-            Run(settings, null,  processSettings,
+
+            Run(settings, GetHasArguments(settings),  processSettings,
                 process => result = process.GetStandardOutput().Any(line => line.TrimStart() == source));
 
             // Return whether or not the source exist.
             return result;
+        }
+
+        private static ProcessArgumentBuilder GetHasArguments(NuGetSourcesSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("sources List");
+
+            if (settings.ConfigFile != null)
+            {
+                builder.Append("-ConfigFile");
+                builder.AppendQuoted(settings.ConfigFile.FullPath);
+            }
+
+            builder.Append("-NonInteractive");
+
+            return builder;
         }
 
         private static ProcessArgumentBuilder GetAddArguments(string name, string source, NuGetSourcesSettings settings)
@@ -208,6 +225,12 @@ namespace Cake.Common.Tools.NuGet.Sources
             {
                 builder.Append("-Verbosity");
                 builder.Append(settings.Verbosity.Value.ToString().ToLowerInvariant());
+            }
+
+            if (settings.ConfigFile != null)
+            {
+                builder.Append("-ConfigFile");
+                builder.AppendQuoted(settings.ConfigFile.FullPath);
             }
 
             builder.Append("-NonInteractive");

--- a/src/Cake.Common/Tools/NuGet/Sources/NuGetSourcesSettings.cs
+++ b/src/Cake.Common/Tools/NuGet/Sources/NuGetSourcesSettings.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Core.IO;
 using Cake.Core.Tooling;
 
 namespace Cake.Common.Tools.NuGet.Sources
@@ -44,5 +45,10 @@ namespace Cake.Common.Tools.NuGet.Sources
         /// <c>true</c> if password is stored as unencrypted; otherwise, <c>false</c>.
         /// </value>
         public bool StorePasswordInClearText { get; set; }
+
+        /// <summary>
+        /// Gets or sets the location of the NuGet configuration file. If not specified, file %AppData%\NuGet\NuGet.config is used as configuration file.
+        /// </summary>
+        public FilePath ConfigFile { get; set; }
     }
 }

--- a/tests/integration/Cake.Common/Tools/NuGet/NuGetAliases.cake
+++ b/tests/integration/Cake.Common/Tools/NuGet/NuGetAliases.cake
@@ -1,0 +1,110 @@
+#load "./../../../utilities/xunit.cake"
+#load "./../../../utilities/paths.cake"
+
+FilePath NuGetAliasesConfigFile = null;
+Task("Cake.Common.Tools.NuGet.NuGetAliases.Setup")
+    .Does(() =>
+{
+    var sourcePath = Paths.Resources.Combine("./Cake.Common/Tools/NuGet");
+    var targetPath = Paths.Temp.Combine("./Cake.Common/Tools/NuGet");
+    EnsureDirectoryExist(targetPath.Combine("../").Collapse());
+    CopyDirectory(sourcePath, targetPath);
+    NuGetAliasesConfigFile = targetPath.CombineWithFilePath("NuGet.config");
+});
+
+Task("Cake.Common.Tools.NuGet.NuGetAliases.NuGetAddSource")
+    .IsDependentOn("Cake.Common.Tools.NuGet.NuGetAliases.Setup")
+    .Does(() =>
+{
+    // Given
+    var name = "TestSource";
+    var source = "https://contoso.com/packages/";
+    var settings = new NuGetSourcesSettings {
+            ConfigFile = NuGetAliasesConfigFile
+        };
+
+    // When
+    NuGetAddSource(
+        name,
+        source,
+        settings
+        );
+});
+
+Task("Cake.Common.Tools.NuGet.NuGetAliases.NuGetHasSource")
+    .IsDependentOn("Cake.Common.Tools.NuGet.NuGetAliases.NuGetAddSource")
+    .Does(() =>
+{
+    // Given
+    var source = "https://contoso.com/packages/";
+    var settings = new NuGetSourcesSettings {
+            ConfigFile = NuGetAliasesConfigFile
+        };
+
+    // When
+    var result = NuGetHasSource(
+        source,
+        settings
+        );
+
+    // Then
+    Assert.True(result);
+});
+
+Task("Cake.Common.Tools.NuGet.NuGetAliases.NuGetHasSource.ArgumentCustomization")
+    .IsDependentOn("Cake.Common.Tools.NuGet.NuGetAliases.NuGetAddSource")
+    .Does(() =>
+{
+    // Given
+    var source = "https://contoso.com/packages/";
+    var settings = new NuGetSourcesSettings {
+            ArgumentCustomization = args => args.Append("-ConfigFile").AppendQuoted(NuGetAliasesConfigFile.FullPath)
+        };
+
+    // When
+    var result = NuGetHasSource(
+        source,
+        settings
+        );
+
+    // Then
+    Assert.True(result);
+});
+
+Task("Cake.Common.Tools.NuGet.NuGetAliases.NuGetRemoveSource")
+    .IsDependentOn("Cake.Common.Tools.NuGet.NuGetAliases.NuGetHasSource")
+    .IsDependentOn("Cake.Common.Tools.NuGet.NuGetAliases.NuGetHasSource.ArgumentCustomization")
+    .Does(() =>
+{
+    // Given
+    var name = "TestSource";
+    var source = "https://contoso.com/packages/";
+    var settings = new NuGetSourcesSettings {
+            ConfigFile = NuGetAliasesConfigFile
+        };
+
+    // When
+    NuGetRemoveSource(
+        name,
+        source,
+        settings
+        );
+
+    var result = NuGetHasSource(
+        source,
+        settings
+        );
+
+    // Then
+    Assert.False(result);
+
+});
+
+var nugetAliasesTask = Task("Cake.Common.Tools.NuGet.NuGetAliases");
+if (!Context.Environment.Runtime.IsCoreClr || !Context.IsRunningOnUnix())
+{
+    nugetAliasesTask
+        .IsDependentOn("Cake.Common.Tools.NuGet.NuGetAliases.NuGetAddSource")
+        .IsDependentOn("Cake.Common.Tools.NuGet.NuGetAliases.NuGetHasSource")
+        .IsDependentOn("Cake.Common.Tools.NuGet.NuGetAliases.NuGetRemoveSource");
+}

--- a/tests/integration/build.cake
+++ b/tests/integration/build.cake
@@ -18,6 +18,7 @@
 #load "./Cake.Common/Text/TextTransformationAliases.cake"
 #load "./Cake.Common/Tools/Cake/CakeAliases.cake"
 #load "./Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cake"
+#load "./Cake.Common/Tools/NuGet/NuGetAliases.cake"
 #load "./Cake.Core/Scripting/LoadDirective.cake"
 #load "./Cake.Core/Tooling/ToolLocator.cake"
 #load "./Cake.Core/CakeAliases.cake"
@@ -61,7 +62,8 @@ Task("Cake.Common")
     .IsDependentOn("Cake.Common.Solution.Project.XmlDoc.XmlDocAliases")
     .IsDependentOn("Cake.Common.Text.TextTransformationAliases")
     .IsDependentOn("Cake.Common.Tools.Cake.CakeAliases")
-    .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases");
+    .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases")
+    .IsDependentOn("Cake.Common.Tools.NuGet.NuGetAliases");
 
 Task("Run-All-Tests")
     .IsDependentOn("Cake.Core")

--- a/tests/integration/resources/Cake.Common/Tools/NuGet/NuGet.config
+++ b/tests/integration/resources/Cake.Common/Tools/NuGet/NuGet.config
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <config>
+        <add key="repositoryPath" value="temp\Cake.Common\Tools\NuGet\Packages" />
+    </config>
+
+    <packageRestore>
+        <add key="enabled" value="True" />
+        <add key="automatic" value="True" />
+    </packageRestore>
+
+    <packageSources>
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    </packageSources>
+
+    <packageSourceCredentials />
+
+    <disabledPackageSources />
+
+    <apikeys/>
+</configuration>


### PR DESCRIPTION
* Addresses issue with ArgumentCustomization not being used with NuGetHasSource 
* Adds ConfigFile to NuGetSourcesSettings so one can work against custom NuGet.config
* Adds NuGetSourcesSettings  ConfigFile unit tests
* Adds ArgumentCustomization unit test for NuGetHasSource 
* Adds NuGet sources integration tests (_.NET Core on posix excluded as nuget.exe won't run ootb there_)
* Adds NonInteractive which was missing from NuGetHasSource (user input no good in build scripts 😎 )
* Fixes #1773 