### PR TITLE
GH1775: Fix CakeScript tool resolution

### DIFF
--- a/src/Cake.Core/Tooling/Tool.cs
+++ b/src/Cake.Core/Tooling/Tool.cs
@@ -266,7 +266,12 @@ namespace Cake.Core.Tooling
             return settings.EnvironmentVariables;
         }
 
-        private FilePath GetToolPath(TSettings settings)
+        /// <summary>
+        /// Gets the resolved tool path.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The resolved tool path.</returns>
+        protected FilePath GetToolPath(TSettings settings)
         {
             if (_tools != null)
             {


### PR DESCRIPTION
* Address Executing assembly issue
* Add support for Cake script on Cake.CoreCLR
* Remove no longer needed special .NET Core ToolPath in integration tests
* fixes #1775