### PR TITLE
GH1779: Update xUnit to latest version

### DIFF
--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -22,10 +22,10 @@
   <!-- Global packages -->
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
+    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
     <PackageReference Include="NSubstitute" Version="2.0.2" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta5-build3769" />
   </ItemGroup>
 
   <!-- .NET Framework packages -->

--- a/src/Cake.Common.Tests/Unit/IO/DirectoryAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/DirectoryAliasesTests.cs
@@ -158,7 +158,7 @@ namespace Cake.Common.Tests.Unit.IO
                 DirectoryAliases.CleanDirectory(context, directory.Path, info => !info.Hidden);
 
                 // Then
-                Assert.Equal(1, directory.GetDirectories("*", SearchScope.Recursive).Count());
+                Assert.Single(directory.GetDirectories("*", SearchScope.Recursive));
                 Assert.True(fixture.FileSystem.GetDirectory("/Temp/Hello/Hidden").Exists);
             }
 
@@ -226,7 +226,7 @@ namespace Cake.Common.Tests.Unit.IO
 
                 // Then
                 Assert.True(context.FileSystem.GetDirectory("/Temp").Exists);
-                Assert.Equal(1, directory.GetDirectories("*", SearchScope.Recursive).Count());
+                Assert.Single(directory.GetDirectories("*", SearchScope.Recursive));
                 Assert.True(context.FileSystem.GetDirectory("/Temp/Goodbye").Exists);
             }
         }
@@ -1486,9 +1486,9 @@ namespace Cake.Common.Tests.Unit.IO
                 var directories = DirectoryAliases.GetSubDirectories(context, directoryPath);
 
                 // Then
-                Assert.True(directories.Any(d => d.GetDirectoryName() == "Stuff"));
-                Assert.True(directories.Any(d => d.GetDirectoryName() == "Things"));
-                Assert.False(directories.Any(d => d.GetDirectoryName() == "file1.txt"));
+                Assert.Contains(directories, d => d.GetDirectoryName() == "Stuff");
+                Assert.Contains(directories, d => d.GetDirectoryName() == "Things");
+                Assert.DoesNotContain(directories, d => d.GetDirectoryName() == "file1.txt");
             }
 
             private static void CreateFileStructure(FakeFileSystem ffs)

--- a/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoCreatorTests.cs
+++ b/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoCreatorTests.cs
@@ -116,8 +116,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("using System.Reflection;"));
-                Assert.True(result.Contains("[assembly: AssemblyTitle(\"TheTitle\")]"));
+                Assert.Contains("using System.Reflection;", result);
+                Assert.Contains("[assembly: AssemblyTitle(\"TheTitle\")]", result);
             }
 
             [Fact]
@@ -131,8 +131,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("using System.Reflection;"));
-                Assert.True(result.Contains("[assembly: AssemblyDescription(\"TheDescription\")]"));
+                Assert.Contains("using System.Reflection;", result);
+                Assert.Contains("[assembly: AssemblyDescription(\"TheDescription\")]", result);
             }
 
             [Fact]
@@ -146,8 +146,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("using System.Runtime.InteropServices;"));
-                Assert.True(result.Contains("[assembly: Guid(\"TheGuid\")]"));
+                Assert.Contains("using System.Runtime.InteropServices;", result);
+                Assert.Contains("[assembly: Guid(\"TheGuid\")]", result);
             }
 
             [Fact]
@@ -161,8 +161,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("using System.Reflection;"));
-                Assert.True(result.Contains("[assembly: AssemblyCompany(\"TheCompany\")]"));
+                Assert.Contains("using System.Reflection;", result);
+                Assert.Contains("[assembly: AssemblyCompany(\"TheCompany\")]", result);
             }
 
             [Fact]
@@ -176,8 +176,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("using System.Reflection;"));
-                Assert.True(result.Contains("[assembly: AssemblyProduct(\"TheProduct\")]"));
+                Assert.Contains("using System.Reflection;", result);
+                Assert.Contains("[assembly: AssemblyProduct(\"TheProduct\")]", result);
             }
 
             [Fact]
@@ -191,8 +191,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("using System.Reflection;"));
-                Assert.True(result.Contains("[assembly: AssemblyCopyright(\"TheCopyright\")]"));
+                Assert.Contains("using System.Reflection;", result);
+                Assert.Contains("[assembly: AssemblyCopyright(\"TheCopyright\")]", result);
             }
 
             [Fact]
@@ -206,8 +206,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("using System.Reflection;"));
-                Assert.True(result.Contains("[assembly: AssemblyTrademark(\"TheTrademark\")]"));
+                Assert.Contains("using System.Reflection;", result);
+                Assert.Contains("[assembly: AssemblyTrademark(\"TheTrademark\")]", result);
             }
 
             [Fact]
@@ -221,8 +221,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("using System.Reflection;"));
-                Assert.True(result.Contains("[assembly: AssemblyVersion(\"TheVersion\")]"));
+                Assert.Contains("using System.Reflection;", result);
+                Assert.Contains("[assembly: AssemblyVersion(\"TheVersion\")]", result);
             }
 
             [Fact]
@@ -236,8 +236,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("using System.Reflection;"));
-                Assert.True(result.Contains("[assembly: AssemblyFileVersion(\"TheFileVersion\")]"));
+                Assert.Contains("using System.Reflection;", result);
+                Assert.Contains("[assembly: AssemblyFileVersion(\"TheFileVersion\")]", result);
             }
 
             [Fact]
@@ -251,8 +251,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("using System.Reflection;"));
-                Assert.True(result.Contains("[assembly: AssemblyInformationalVersion(\"TheInformationalVersion\")]"));
+                Assert.Contains("using System.Reflection;", result);
+                Assert.Contains("[assembly: AssemblyInformationalVersion(\"TheInformationalVersion\")]", result);
             }
 
             [Fact]
@@ -266,8 +266,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("using System.Runtime.InteropServices;"));
-                Assert.True(result.Contains("[assembly: ComVisible(true)]"));
+                Assert.Contains("using System.Runtime.InteropServices;", result);
+                Assert.Contains("[assembly: ComVisible(true)]", result);
             }
 
             [Fact]
@@ -281,8 +281,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("using System;"));
-                Assert.True(result.Contains("[assembly: CLSCompliant(true)]"));
+                Assert.Contains("using System;", result);
+                Assert.Contains("[assembly: CLSCompliant(true)]", result);
             }
 
             [Fact]
@@ -296,8 +296,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("using System.Runtime.CompilerServices;"));
-                Assert.True(result.Contains("[assembly: InternalsVisibleTo(\"Assembly1.Tests\")]"));
+                Assert.Contains("using System.Runtime.CompilerServices;", result);
+                Assert.Contains("[assembly: InternalsVisibleTo(\"Assembly1.Tests\")]", result);
             }
 
             [Fact]
@@ -311,10 +311,10 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("using System.Runtime.CompilerServices;"));
-                Assert.True(result.Contains("[assembly: InternalsVisibleTo(\"Assembly1.Tests\")]"));
-                Assert.True(result.Contains("[assembly: InternalsVisibleTo(\"Assembly2.Tests\")]"));
-                Assert.True(result.Contains("[assembly: InternalsVisibleTo(\"Assembly3.Tests\")]"));
+                Assert.Contains("using System.Runtime.CompilerServices;", result);
+                Assert.Contains("[assembly: InternalsVisibleTo(\"Assembly1.Tests\")]", result);
+                Assert.Contains("[assembly: InternalsVisibleTo(\"Assembly2.Tests\")]", result);
+                Assert.Contains("[assembly: InternalsVisibleTo(\"Assembly3.Tests\")]", result);
             }
 
             [Fact]
@@ -328,8 +328,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("using System.Reflection;"));
-                Assert.True(result.Contains("[assembly: AssemblyConfiguration(\"TheConfiguration\")]"));
+                Assert.Contains("using System.Reflection;", result);
+                Assert.Contains("[assembly: AssemblyConfiguration(\"TheConfiguration\")]", result);
             }
 
             [Fact]
@@ -343,8 +343,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("using Test.NameSpace;"));
-                Assert.True(result.Contains("[assembly: TestAttribute(\"TestValue\")]"));
+                Assert.Contains("using Test.NameSpace;", result);
+                Assert.Contains("[assembly: TestAttribute(\"TestValue\")]", result);
             }
         }
     }

--- a/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoCreatorTests_VB.cs
+++ b/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoCreatorTests_VB.cs
@@ -71,8 +71,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("Imports System.Reflection"));
-                Assert.True(result.Contains("<Assembly: AssemblyTitle(\"TheTitle\")>"));
+                Assert.Contains("Imports System.Reflection", result);
+                Assert.Contains("<Assembly: AssemblyTitle(\"TheTitle\")>", result);
             }
 
             [Fact]
@@ -86,8 +86,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("Imports System.Reflection"));
-                Assert.True(result.Contains("<Assembly: AssemblyDescription(\"TheDescription\")>"));
+                Assert.Contains("Imports System.Reflection", result);
+                Assert.Contains("<Assembly: AssemblyDescription(\"TheDescription\")>", result);
             }
 
             [Fact]
@@ -101,8 +101,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("Imports System.Runtime.InteropServices"));
-                Assert.True(result.Contains("<Assembly: Guid(\"TheGuid\")>"));
+                Assert.Contains("Imports System.Runtime.InteropServices", result);
+                Assert.Contains("<Assembly: Guid(\"TheGuid\")>", result);
             }
 
             [Fact]
@@ -116,8 +116,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("Imports System.Reflection"));
-                Assert.True(result.Contains("<Assembly: AssemblyCompany(\"TheCompany\")>"));
+                Assert.Contains("Imports System.Reflection", result);
+                Assert.Contains("<Assembly: AssemblyCompany(\"TheCompany\")>", result);
             }
 
             [Fact]
@@ -131,8 +131,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("Imports System.Reflection"));
-                Assert.True(result.Contains("<Assembly: AssemblyProduct(\"TheProduct\")>"));
+                Assert.Contains("Imports System.Reflection", result);
+                Assert.Contains("<Assembly: AssemblyProduct(\"TheProduct\")>", result);
             }
 
             [Fact]
@@ -146,8 +146,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("Imports System.Reflection"));
-                Assert.True(result.Contains("<Assembly: AssemblyCopyright(\"TheCopyright\")>"));
+                Assert.Contains("Imports System.Reflection", result);
+                Assert.Contains("<Assembly: AssemblyCopyright(\"TheCopyright\")>", result);
             }
 
             [Fact]
@@ -161,8 +161,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("Imports System.Reflection"));
-                Assert.True(result.Contains("<Assembly: AssemblyTrademark(\"TheTrademark\")>"));
+                Assert.Contains("Imports System.Reflection", result);
+                Assert.Contains("<Assembly: AssemblyTrademark(\"TheTrademark\")>", result);
             }
 
             [Fact]
@@ -176,8 +176,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("Imports System.Reflection"));
-                Assert.True(result.Contains("<Assembly: AssemblyVersion(\"TheVersion\")>"));
+                Assert.Contains("Imports System.Reflection", result);
+                Assert.Contains("<Assembly: AssemblyVersion(\"TheVersion\")>", result);
             }
 
             [Fact]
@@ -191,8 +191,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("Imports System.Reflection"));
-                Assert.True(result.Contains("<Assembly: AssemblyFileVersion(\"TheFileVersion\")>"));
+                Assert.Contains("Imports System.Reflection", result);
+                Assert.Contains("<Assembly: AssemblyFileVersion(\"TheFileVersion\")>", result);
             }
 
             [Fact]
@@ -206,8 +206,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("Imports System.Reflection"));
-                Assert.True(result.Contains("<Assembly: AssemblyInformationalVersion(\"TheInformationalVersion\")>"));
+                Assert.Contains("Imports System.Reflection", result);
+                Assert.Contains("<Assembly: AssemblyInformationalVersion(\"TheInformationalVersion\")>", result);
             }
 
             [Fact]
@@ -221,8 +221,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("Imports System.Runtime.InteropServices"));
-                Assert.True(result.Contains("<Assembly: ComVisible(true)>"));
+                Assert.Contains("Imports System.Runtime.InteropServices", result);
+                Assert.Contains("<Assembly: ComVisible(true)>", result);
             }
 
             [Fact]
@@ -236,8 +236,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("Imports System"));
-                Assert.True(result.Contains("<Assembly: CLSCompliant(true)>"));
+                Assert.Contains("Imports System", result);
+                Assert.Contains("<Assembly: CLSCompliant(true)>", result);
             }
 
             [Fact]
@@ -251,8 +251,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("Imports System.Runtime.CompilerServices"));
-                Assert.True(result.Contains("<Assembly: InternalsVisibleTo(\"Assembly1.Tests\")>"));
+                Assert.Contains("Imports System.Runtime.CompilerServices", result);
+                Assert.Contains("<Assembly: InternalsVisibleTo(\"Assembly1.Tests\")>", result);
             }
 
             [Fact]
@@ -266,10 +266,10 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("Imports System.Runtime.CompilerServices"));
-                Assert.True(result.Contains("<Assembly: InternalsVisibleTo(\"Assembly1.Tests\")>"));
-                Assert.True(result.Contains("<Assembly: InternalsVisibleTo(\"Assembly2.Tests\")>"));
-                Assert.True(result.Contains("<Assembly: InternalsVisibleTo(\"Assembly3.Tests\")>"));
+                Assert.Contains("Imports System.Runtime.CompilerServices", result);
+                Assert.Contains("<Assembly: InternalsVisibleTo(\"Assembly1.Tests\")>", result);
+                Assert.Contains("<Assembly: InternalsVisibleTo(\"Assembly2.Tests\")>", result);
+                Assert.Contains("<Assembly: InternalsVisibleTo(\"Assembly3.Tests\")>", result);
             }
 
             [Fact]
@@ -283,8 +283,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("Imports System.Reflection"));
-                Assert.True(result.Contains("<Assembly: AssemblyConfiguration(\"TheConfiguration\")>"));
+                Assert.Contains("Imports System.Reflection", result);
+                Assert.Contains("<Assembly: AssemblyConfiguration(\"TheConfiguration\")>", result);
             }
 
             [Fact]
@@ -298,8 +298,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 var result = fixture.CreateAndReturnContent();
 
                 // Then
-                Assert.True(result.Contains("Imports Test.NameSpace"));
-                Assert.True(result.Contains("<Assembly: TestAttribute(\"TestValue\")>"));
+                Assert.Contains("Imports Test.NameSpace", result);
+                Assert.Contains("<Assembly: TestAttribute(\"TestValue\")>", result);
             }
         }
     }

--- a/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoExtensionTests.cs
+++ b/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoExtensionTests.cs
@@ -21,8 +21,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
             var result = fixture.CreateAndReturnContent();
 
             // Then
-            Assert.True(result.Contains("using Test.NameSpace;"));
-            Assert.True(result.Contains("[assembly: TestAttribute(\"TestValue\")]"));
+            Assert.Contains("using Test.NameSpace;", result);
+            Assert.Contains("[assembly: TestAttribute(\"TestValue\")]", result);
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoExtensionTests_VB.cs
+++ b/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoExtensionTests_VB.cs
@@ -21,8 +21,8 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
             var result = fixture.CreateAndReturnContent();
 
             // Then
-            Assert.True(result.Contains("Imports Test.NameSpace"));
-            Assert.True(result.Contains("<Assembly: TestAttribute(\"TestValue\")>"));
+            Assert.Contains("Imports Test.NameSpace", result);
+            Assert.Contains("<Assembly: TestAttribute(\"TestValue\")>", result);
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Solution/SolutionParserTests.cs
+++ b/src/Cake.Common.Tests/Unit/Solution/SolutionParserTests.cs
@@ -106,7 +106,7 @@ namespace Cake.Common.Tests.Unit.Solution
                 Assert.NotNull(result.Projects);
                 var folders = result.Projects.OfType<SolutionFolder>().ToList();
                 var srcFolder = folders.First(x => x.Name == "src");
-                Assert.Equal(1, srcFolder.Items.Count);
+                Assert.Single(srcFolder.Items);
                 var dummyProject = result.Projects.First(x => x.Name == "dummy");
                 Assert.Contains(dummyProject, srcFolder.Items);
                 Assert.Equal(srcFolder, dummyProject.Parent);

--- a/src/Cake.Common.Tests/Unit/Tools/Fixie/FixieRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Fixie/FixieRunnerTests.cs
@@ -195,9 +195,9 @@ namespace Cake.Common.Tests.Unit.Tools.Fixie
             }
 
             [Theory]
-            [InlineData(true, "on", "\"/Working/Test1.dll\" --TeamCity on")]
-            [InlineData(false, "off", "\"/Working/Test1.dll\" --TeamCity off")]
-            public void Should_Set_TeamCity_Value(bool teamCityOutput, string teamCityValue, string expected)
+            [InlineData(true, "\"/Working/Test1.dll\" --TeamCity on")]
+            [InlineData(false, "\"/Working/Test1.dll\" --TeamCity off")]
+            public void Should_Set_TeamCity_Value(bool teamCityOutput, string expected)
             {
                 // Given
                 var fixture = new FixieRunnerFixture();

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -9,6 +9,8 @@ using Cake.Core.Diagnostics;
 using Cake.Testing;
 using Xunit;
 
+#pragma warning disable xUnit1025 // InlineData should be unique within the Theory it belongs to
+
 namespace Cake.Common.Tests.Unit.Tools.MSBuild
 {
     public sealed class MSBuildRunnerTests
@@ -947,3 +949,5 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
         }
     }
 }
+
+#pragma warning restore xUnit1025 // InlineData should be unique within the Theory it belongs to

--- a/src/Cake.Common.Tests/Unit/Tools/NuGet/Install/NuGetInstallerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NuGet/Install/NuGetInstallerTests.cs
@@ -472,10 +472,10 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Install
             }
 
             [Theory]
-            [InlineData(NuGetVerbosity.Detailed, "detailed", "install \"/Working/packages.config\" -Verbosity detailed -NonInteractive")]
-            [InlineData(NuGetVerbosity.Normal, "normal", "install \"/Working/packages.config\" -Verbosity normal -NonInteractive")]
-            [InlineData(NuGetVerbosity.Quiet, "quiet", "install \"/Working/packages.config\" -Verbosity quiet -NonInteractive")]
-            public void Should_Add_Verbosity_To_Arguments_If_Set(NuGetVerbosity verbosity, string name, string expected)
+            [InlineData(NuGetVerbosity.Detailed, "install \"/Working/packages.config\" -Verbosity detailed -NonInteractive")]
+            [InlineData(NuGetVerbosity.Normal, "install \"/Working/packages.config\" -Verbosity normal -NonInteractive")]
+            [InlineData(NuGetVerbosity.Quiet, "install \"/Working/packages.config\" -Verbosity quiet -NonInteractive")]
+            public void Should_Add_Verbosity_To_Arguments_If_Set(NuGetVerbosity verbosity, string expected)
             {
                 // Given
                 var fixture = new NuGetInstallerFromConfigFixture();

--- a/src/Cake.Common.Tests/Unit/Tools/NuGet/Sources/NuGetSourcesTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NuGet/Sources/NuGetSourcesTests.cs
@@ -37,7 +37,7 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Sources
             {
                 // Given
                 var fixture = new NuGetAddSourceFixture();
-                fixture.Name = string.Empty;
+                fixture.Name = name;
 
                 // When
                 var result = Record.Exception(() => fixture.Run());
@@ -67,7 +67,7 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Sources
             {
                 // Given
                 var fixture = new NuGetAddSourceFixture();
-                fixture.Source = string.Empty;
+                fixture.Source = source;
 
                 // When
                 var result = Record.Exception(() => fixture.Run());
@@ -311,7 +311,7 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Sources
             {
                 // Given
                 var fixture = new NuGetRemoveSourceFixture();
-                fixture.Name = string.Empty;
+                fixture.Name = name;
 
                 // When
                 var result = Record.Exception(() => fixture.Run());
@@ -341,7 +341,7 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Sources
             {
                 // Given
                 var fixture = new NuGetRemoveSourceFixture();
-                fixture.Source = string.Empty;
+                fixture.Source = source;
 
                 // When
                 var result = Record.Exception(() => fixture.Run());
@@ -562,7 +562,7 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Sources
             {
                 // Given
                 var fixture = new NuGetHasSourceFixture();
-                fixture.Source = string.Empty;
+                fixture.Source = source;
 
                 // When
                 var result = Record.Exception(() => fixture.Run());

--- a/src/Cake.Core.Tests/Cake.Core.Tests.csproj
+++ b/src/Cake.Core.Tests/Cake.Core.Tests.csproj
@@ -21,10 +21,10 @@
   <!-- Global packages -->
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
+    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
     <PackageReference Include="NSubstitute" Version="2.0.2" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta5-build3769" />
   </ItemGroup>
 
   <!-- .NET Framework packages -->

--- a/src/Cake.Core.Tests/Unit/ActionTaskTests.cs
+++ b/src/Cake.Core.Tests/Unit/ActionTaskTests.cs
@@ -35,7 +35,7 @@ namespace Cake.Core.Tests.Unit
                 task.AddAction(c => { });
 
                 // Then
-                Assert.Equal(1, task.Actions.Count);
+                Assert.Single(task.Actions);
             }
 
             [Fact]

--- a/src/Cake.Core.Tests/Unit/CakeEngineTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeEngineTests.cs
@@ -54,7 +54,7 @@ namespace Cake.Core.Tests.Unit
                 var result = engine.RegisterTask("task");
 
                 // Then
-                Assert.True(engine.Tasks.Contains(result.Task));
+                Assert.Contains(result.Task, engine.Tasks);
             }
 
             [Fact]
@@ -342,7 +342,7 @@ namespace Cake.Core.Tests.Unit
                     engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
 
                 // Then
-                Assert.True(fixture.Log.Entries.Any(x => x.Message == "Error: Whoops"));
+                Assert.Contains(fixture.Log.Entries, x => x.Message == "Error: Whoops");
             }
 
             [Fact]
@@ -398,7 +398,7 @@ namespace Cake.Core.Tests.Unit
 
                 // Then
                 Assert.False(runTask, "Task A was executed although it shouldn't have been.");
-                Assert.True(fixture.Log.Entries.Any(x => x.Message == "Executing custom setup action..."));
+                Assert.Contains(fixture.Log.Entries, x => x.Message == "Executing custom setup action...");
             }
 
             [Fact]
@@ -440,7 +440,7 @@ namespace Cake.Core.Tests.Unit
                 Assert.NotNull(result);
                 Assert.IsType<InvalidOperationException>(result);
                 Assert.Equal("Fail", result?.Message);
-                Assert.True(fixture.Log.Entries.Any(x => x.Message == "Executing custom teardown action..."));
+                Assert.Contains(fixture.Log.Entries, x => x.Message == "Executing custom teardown action...");
             }
 
             [Fact]
@@ -462,7 +462,7 @@ namespace Cake.Core.Tests.Unit
                 Assert.NotNull(result);
                 Assert.IsType<InvalidOperationException>(result);
                 Assert.Equal("Fail", result?.Message);
-                Assert.True(fixture.Log.Entries.Any(x => x.Message == "Executing custom teardown action..."));
+                Assert.Contains(fixture.Log.Entries, x => x.Message == "Executing custom teardown action...");
             }
 
             [Fact]
@@ -521,7 +521,7 @@ namespace Cake.Core.Tests.Unit
                     engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
 
                 // Then
-                Assert.True(fixture.Log.Entries.Any(x => x.Message.StartsWith("Teardown error:")));
+                Assert.Contains(fixture.Log.Entries, x => x.Message.StartsWith("Teardown error:"));
             }
 
             [Fact]
@@ -559,7 +559,7 @@ namespace Cake.Core.Tests.Unit
                     engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
 
                 // Then
-                Assert.True(fixture.Log.Entries.Any(x => x.Message.StartsWith("Teardown error:")));
+                Assert.Contains(fixture.Log.Entries, x => x.Message.StartsWith("Teardown error:"));
             }
 
             [Fact]
@@ -711,8 +711,8 @@ namespace Cake.Core.Tests.Unit
                 // Then
                 Assert.Equal(new List<string>(), result);
 
-                Assert.True(fixture.Log.Entries.Any(x => x.Message == "Executing custom task setup action (A)..."));
-                Assert.False(fixture.Log.Entries.Any(x => x.Message == "Executing custom task setup action (B)..."));
+                Assert.Contains(fixture.Log.Entries, x => x.Message == "Executing custom task setup action (A)...");
+                Assert.DoesNotContain(fixture.Log.Entries, x => x.Message == "Executing custom task setup action (B)...");
             }
 
             [Fact]
@@ -906,7 +906,7 @@ namespace Cake.Core.Tests.Unit
                 Assert.NotNull(result);
                 Assert.IsType<InvalidOperationException>(result);
                 Assert.Equal("Task Setup: A", result?.Message);
-                Assert.True(fixture.Log.Entries.Any(x => x.Message.StartsWith("Task Teardown error (A):")));
+                Assert.Contains(fixture.Log.Entries, x => x.Message.StartsWith("Task Teardown error (A):"));
             }
 
             [Fact]
@@ -945,7 +945,7 @@ namespace Cake.Core.Tests.Unit
                 Record.Exception(() => engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "A"));
 
                 // Then
-                Assert.True(fixture.Log.Entries.Any(x => x.Message.StartsWith("Task Teardown error (A):")));
+                Assert.Contains(fixture.Log.Entries, x => x.Message.StartsWith("Task Teardown error (A):"));
             }
 
             [Fact]

--- a/src/Cake.Core.Tests/Unit/CakeTaskBuilderExtensionsTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeTaskBuilderExtensionsTests.cs
@@ -175,7 +175,7 @@ namespace Cake.Core.Tests.Unit
                     builder.Does(() => { });
 
                     // Then
-                    Assert.Equal(1, task.Actions.Count);
+                    Assert.Single(task.Actions);
                 }
             }
 
@@ -192,7 +192,7 @@ namespace Cake.Core.Tests.Unit
                     builder.Does(c => { });
 
                     // Then
-                    Assert.Equal(1, task.Actions.Count);
+                    Assert.Single(task.Actions);
                 }
             }
         }
@@ -365,14 +365,14 @@ namespace Cake.Core.Tests.Unit
                 CakeTaskBuilderExtensions.DoesForEach(builder, () => new[] { "a", "b", "c" }, (item) => { });
 
                 // Then
-                Assert.Equal(0, builder.Task.Actions.Count);
-                Assert.Equal(1, builder.Task.DelayedActions.Count);
+                Assert.Empty(builder.Task.Actions);
+                Assert.Single(builder.Task.DelayedActions);
 
                 // When
                 builder.Task.Execute(context);
 
                 // Then
-                Assert.Equal(0, builder.Task.DelayedActions.Count);
+                Assert.Empty(builder.Task.DelayedActions);
                 Assert.Equal(3, builder.Task.Actions.Count);
             }
 
@@ -388,14 +388,14 @@ namespace Cake.Core.Tests.Unit
                 CakeTaskBuilderExtensions.DoesForEach(builder, () => new[] { "a", "b", "c" }, (item, c) => { });
 
                 // Then
-                Assert.Equal(0, builder.Task.Actions.Count);
-                Assert.Equal(1, builder.Task.DelayedActions.Count);
+                Assert.Empty(builder.Task.Actions);
+                Assert.Single(builder.Task.DelayedActions);
 
                 // When
                 builder.Task.Execute(context);
 
                 // Then
-                Assert.Equal(0, builder.Task.DelayedActions.Count);
+                Assert.Empty(builder.Task.DelayedActions);
                 Assert.Equal(3, builder.Task.Actions.Count);
             }
 

--- a/src/Cake.Core.Tests/Unit/Configuration/Parser/ConfigurationTokenizerTests.cs
+++ b/src/Cake.Core.Tests/Unit/Configuration/Parser/ConfigurationTokenizerTests.cs
@@ -20,7 +20,7 @@ namespace Cake.Core.Tests.Unit.Configuration.Parser
                 var result = ConfigurationTokenizer.Tokenize("; Hello World");
 
                 // Then
-                Assert.Equal(0, result.Count);
+                Assert.Empty(result);
             }
 
             [Fact]
@@ -30,7 +30,7 @@ namespace Cake.Core.Tests.Unit.Configuration.Parser
                 var result = ConfigurationTokenizer.Tokenize("[TheSection]");
 
                 // Then
-                Assert.Equal(1, result.Count);
+                Assert.Single(result);
                 Assert.Equal(ConfigurationTokenKind.Section, result[0].Kind);
                 Assert.Equal("TheSection", result[0].Value);
             }

--- a/src/Cake.Core.Tests/Unit/Diagnostics/CakeBuildLogTests.cs
+++ b/src/Cake.Core.Tests/Unit/Diagnostics/CakeBuildLogTests.cs
@@ -27,7 +27,7 @@ namespace Cake.Core.Tests.Unit.Diagnostics
                 log.Write(messageVerbosity, LogLevel.Information, "Hello World");
 
                 // Then
-                Assert.Equal(0, console.Messages.Count);
+                Assert.Empty(console.Messages);
             }
 
             [Theory]
@@ -45,7 +45,7 @@ namespace Cake.Core.Tests.Unit.Diagnostics
                 log.Write(messageVerbosity, LogLevel.Information, "Hello World");
 
                 // Then
-                Assert.Equal(1, console.Messages.Count);
+                Assert.Single(console.Messages);
             }
 
             [Theory]
@@ -63,7 +63,7 @@ namespace Cake.Core.Tests.Unit.Diagnostics
                 log.Write(Verbosity.Diagnostic, logLevel, "Hello World");
 
                 // Then
-                Assert.Equal(1, console.Messages.Count);
+                Assert.Single(console.Messages);
             }
 
             [Theory]
@@ -79,7 +79,7 @@ namespace Cake.Core.Tests.Unit.Diagnostics
                 log.Write(Verbosity.Diagnostic, logLevel, "Hello World");
 
                 // Then
-                Assert.Equal(1, console.ErrorMessages.Count);
+                Assert.Single(console.ErrorMessages);
             }
         }
     }

--- a/src/Cake.Core.Tests/Unit/Diagnostics/FormatParserTests.cs
+++ b/src/Cake.Core.Tests/Unit/Diagnostics/FormatParserTests.cs
@@ -20,7 +20,7 @@ namespace Cake.Core.Tests.Unit.Diagnostics
                 var result = FormatParser.Parse(string.Empty).ToArray();
 
                 // Then
-                Assert.Equal(0, result.Length);
+                Assert.Empty(result);
             }
 
             [Fact]
@@ -30,7 +30,7 @@ namespace Cake.Core.Tests.Unit.Diagnostics
                 var result = FormatParser.Parse("Hello World!").ToArray();
 
                 // Then
-                Assert.Equal(1, result.Length);
+                Assert.Single(result);
                 Assert.IsType<LiteralToken>(result[0]);
                 Assert.Equal("Hello World!", ((LiteralToken)result[0]).Text);
             }
@@ -42,7 +42,7 @@ namespace Cake.Core.Tests.Unit.Diagnostics
                 var result = FormatParser.Parse("{0}").ToArray();
 
                 // Then
-                Assert.Equal(1, result.Length);
+                Assert.Single(result);
                 Assert.IsType<PropertyToken>(result[0]);
                 Assert.Equal(0, ((PropertyToken)result[0]).Position);
             }
@@ -67,7 +67,7 @@ namespace Cake.Core.Tests.Unit.Diagnostics
                 var result = FormatParser.Parse("{0:yyyy-MM-dd}").ToArray();
 
                 // Then
-                Assert.Equal(1, result.Length);
+                Assert.Single(result);
                 Assert.IsType<PropertyToken>(result[0]);
                 Assert.Equal(0, ((PropertyToken)result[0]).Position);
                 Assert.Equal("yyyy-MM-dd", ((PropertyToken)result[0]).Format);

--- a/src/Cake.Core.Tests/Unit/Graph/CakeGraphTests.cs
+++ b/src/Cake.Core.Tests/Unit/Graph/CakeGraphTests.cs
@@ -222,7 +222,7 @@ namespace Cake.Core.Tests.Unit.Graph
                 var result = graph.Traverse("E").ToArray();
 
                 // Then
-                Assert.Equal(0, result.Length);
+                Assert.Empty(result);
             }
 
             [Fact]

--- a/src/Cake.Core.Tests/Unit/IO/FileExtensionsTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/FileExtensionsTests.cs
@@ -157,7 +157,7 @@ namespace Cake.Core.Tests.Unit.IO
                 var result = file.ReadLines(Encoding.UTF8).ToList();
 
                 // Then
-                Assert.Equal(0, result.Count);
+                Assert.Empty(result);
             }
 
             [Fact]
@@ -172,7 +172,7 @@ namespace Cake.Core.Tests.Unit.IO
                 var result = file.ReadLines(Encoding.UTF8).ToList();
 
                 // Then
-                Assert.Equal(1, result.Count);
+                Assert.Single(result);
             }
 
             [Fact]

--- a/src/Cake.Core.Tests/Unit/IO/GlobberTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/GlobberTests.cs
@@ -55,7 +55,7 @@ namespace Cake.Core.Tests.Unit.IO
                     var result = fixture.Match("/Working/Foo/Bar/Qux.c");
 
                     // Then
-                    Assert.Equal(1, result.Length);
+                    Assert.Single(result);
                     AssertEx.ContainsFilePath(result, "C:/Working/Foo/Bar/Qux.c");
                 }
 
@@ -83,7 +83,7 @@ namespace Cake.Core.Tests.Unit.IO
                     var result = fixture.Match("C:/Working/**/qux.c");
 
                     // Then
-                    Assert.Equal(1, result.Length);
+                    Assert.Single(result);
                     Assert.IsType<FilePath>(result[0]);
                     AssertEx.ContainsFilePath(result, "C:/Working/Foo/Bar/Qux.c");
                 }
@@ -98,7 +98,7 @@ namespace Cake.Core.Tests.Unit.IO
                     var result = fixture.Match("C:/Program Files (x86)/Foo.*");
 
                     // Then
-                    Assert.Equal(1, result.Length);
+                    Assert.Single(result);
                     AssertEx.ContainsFilePath(result, "C:/Program Files (x86)/Foo.c");
                 }
 
@@ -112,7 +112,7 @@ namespace Cake.Core.Tests.Unit.IO
                   var result = fixture.Match("C:/Tools & Services/*.dll");
 
                   // Then
-                  Assert.Equal(1, result.Length);
+                  Assert.Single(result);
                   AssertEx.ContainsFilePath(result, "C:/Tools & Services/MyTool.dll");
                 }
 
@@ -126,7 +126,7 @@ namespace Cake.Core.Tests.Unit.IO
                   var result = fixture.Match("C:/Tools + Services/*.dll");
 
                   // Then
-                  Assert.Equal(1, result.Length);
+                  Assert.Single(result);
                   AssertEx.ContainsFilePath(result, "C:/Tools + Services/MyTool.dll");
                 }
 
@@ -140,7 +140,7 @@ namespace Cake.Core.Tests.Unit.IO
                   var result = fixture.Match("C:/Some %2F Directory/*.dll");
 
                   // Then
-                  Assert.Equal(1, result.Length);
+                  Assert.Single(result);
                   AssertEx.ContainsFilePath(result, "C:/Some %2F Directory/MyTool.dll");
                 }
 
@@ -154,7 +154,7 @@ namespace Cake.Core.Tests.Unit.IO
                     var result = fixture.Match("C:/Some ! Directory/*.dll");
 
                     // Then
-                    Assert.Equal(1, result.Length);
+                    Assert.Single(result);
                     AssertEx.ContainsFilePath(result, "C:/Some ! Directory/MyTool.dll");
                 }
 
@@ -168,7 +168,7 @@ namespace Cake.Core.Tests.Unit.IO
                     var result = fixture.Match("C:/Some@Directory/*.dll");
 
                     // Then
-                    Assert.Equal(1, result.Length);
+                    Assert.Single(result);
                     AssertEx.ContainsFilePath(result, "C:/Some@Directory/MyTool.dll");
                 }
             }
@@ -187,7 +187,7 @@ namespace Cake.Core.Tests.Unit.IO
                     var result = fixture.Match("./**/Qux.h", predicate);
 
                     // Then
-                    Assert.Equal(1, result.Length);
+                    Assert.Single(result);
                     AssertEx.ContainsFilePath(result, "/Working/Foo/Bar/Qux.h");
                 }
 
@@ -203,7 +203,7 @@ namespace Cake.Core.Tests.Unit.IO
                     var result = fixture.Match("/Working/Bar/Qux.h", predicate);
 
                     // Then
-                    Assert.Equal(0, result.Length);
+                    Assert.Empty(result);
                 }
 
                 [Fact]
@@ -218,7 +218,7 @@ namespace Cake.Core.Tests.Unit.IO
                     var result = fixture.Match("/Working/Bar", predicate);
 
                     // Then
-                    Assert.Equal(0, result.Length);
+                    Assert.Empty(result);
                 }
             }
 
@@ -245,7 +245,7 @@ namespace Cake.Core.Tests.Unit.IO
                 var result = fixture.Match(string.Empty);
 
                 // Then
-                Assert.Equal(0, result.Length);
+                Assert.Empty(result);
             }
 
             [Fact]
@@ -276,7 +276,7 @@ namespace Cake.Core.Tests.Unit.IO
                 var result = fixture.Match("Foo/Bar/Qux.c");
 
                 // Then
-                Assert.Equal(1, result.Length);
+                Assert.Single(result);
                 AssertEx.ContainsFilePath(result, "/Working/Foo/Bar/Qux.c");
             }
 
@@ -290,7 +290,7 @@ namespace Cake.Core.Tests.Unit.IO
                 var result = fixture.Match("/Working/Foo/../Foo/Bar/Qux.c");
 
                 // Then
-                Assert.Equal(1, result.Length);
+                Assert.Single(result);
                 Assert.IsType<FilePath>(result[0]);
                 AssertEx.ContainsFilePath(result, "/Working/Foo/Bar/Qux.c");
             }
@@ -320,7 +320,7 @@ namespace Cake.Core.Tests.Unit.IO
                 var result = fixture.Match("/Working/Foo/Bar/Qux.c");
 
                 // Then
-                Assert.Equal(1, result.Length);
+                Assert.Single(result);
                 Assert.IsType<FilePath>(result[0]);
                 AssertEx.ContainsFilePath(result, "/Working/Foo/Bar/Qux.c");
             }
@@ -335,7 +335,7 @@ namespace Cake.Core.Tests.Unit.IO
                 var result = fixture.Match("/Working/Foo/Bar");
 
                 // Then
-                Assert.Equal(1, result.Length);
+                Assert.Single(result);
                 AssertEx.ContainsDirectoryPath(result, "/Working/Foo/Bar");
             }
 
@@ -350,7 +350,7 @@ namespace Cake.Core.Tests.Unit.IO
                 var result = fixture.Match("./Bar/Qux.c");
 
                 // Then
-                Assert.Equal(1, result.Length);
+                Assert.Single(result);
                 AssertEx.ContainsFilePath(result, "/Working/Foo/Bar/Qux.c");
             }
 
@@ -365,7 +365,7 @@ namespace Cake.Core.Tests.Unit.IO
                 var result = fixture.Match("./Bar");
 
                 // Then
-                Assert.Equal(1, result.Length);
+                Assert.Single(result);
                 AssertEx.ContainsDirectoryPath(result, "/Working/Foo/Bar");
             }
 
@@ -519,7 +519,7 @@ namespace Cake.Core.Tests.Unit.IO
                 var result = fixture.Match("/Foo/**/Bar.baz");
 
                 // Then
-                Assert.Equal(1, result.Length);
+                Assert.Single(result);
                 AssertEx.ContainsFilePath(result, "/Foo/Bar.baz");
             }
 
@@ -533,7 +533,7 @@ namespace Cake.Core.Tests.Unit.IO
                 var result = fixture.Match("/Foo/**/Bar");
 
                 // Then
-                Assert.Equal(1, result.Length);
+                Assert.Single(result);
                 AssertEx.ContainsDirectoryPath(result, "/Foo/Bar");
             }
 
@@ -547,7 +547,7 @@ namespace Cake.Core.Tests.Unit.IO
                 var result = fixture.Match("/Foo (Bar)/Baz.*");
 
                 // Then
-                Assert.Equal(1, result.Length);
+                Assert.Single(result);
                 AssertEx.ContainsFilePath(result, "/Foo (Bar)/Baz.c");
             }
 
@@ -561,7 +561,7 @@ namespace Cake.Core.Tests.Unit.IO
                 var result = fixture.Match("/Foo@Bar/Baz.*");
 
                 // Then
-                Assert.Equal(1, result.Length);
+                Assert.Single(result);
                 AssertEx.ContainsFilePath(result, "/Foo@Bar/Baz.c");
             }
 
@@ -590,7 +590,7 @@ namespace Cake.Core.Tests.Unit.IO
                 var result = fixture.Match("/嵌套/**/文件.延期");
 
                 // Then
-                Assert.Equal(1, result.Length);
+                Assert.Single(result);
                 AssertEx.ContainsFilePath(result, "/嵌套/目录/文件.延期");
             }
 
@@ -604,7 +604,7 @@ namespace Cake.Core.Tests.Unit.IO
                 var result = fixture.Match("/嵌套/**/文件.*");
 
                 // Then
-                Assert.Equal(1, result.Length);
+                Assert.Single(result);
                 AssertEx.ContainsFilePath(result, "/嵌套/目录/文件.延期");
             }
         }

--- a/src/Cake.Core.Tests/Unit/Scripting/ScriptRunnerTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/ScriptRunnerTests.cs
@@ -377,8 +377,8 @@ namespace Cake.Core.Tests.Unit.Scripting
 
                 // Then
                 AssertEx.IsCakeException(exception, "Errors occured while analyzing script.");
-                Assert.True(fixture.Log.Entries.Any(x => x.Level == LogLevel.Error && x.Message == "/Working/script1.cake:2: Error in script 1"));
-                Assert.True(fixture.Log.Entries.Any(x => x.Level == LogLevel.Error && x.Message == "/Working/script2.cake:7: Error in script 2"));
+                Assert.Contains(fixture.Log.Entries, x => x.Level == LogLevel.Error && x.Message == "/Working/script1.cake:2: Error in script 1");
+                Assert.Contains(fixture.Log.Entries, x => x.Level == LogLevel.Error && x.Message == "/Working/script2.cake:7: Error in script 2");
             }
         }
     }

--- a/src/Cake.Core.Tests/Unit/Text/QuoteAwareStringSplitterTests.cs
+++ b/src/Cake.Core.Tests/Unit/Text/QuoteAwareStringSplitterTests.cs
@@ -22,7 +22,7 @@ namespace Cake.Core.Tests.Unit.Text
                 var result = QuoteAwareStringSplitter.Split(input).ToArray();
 
                 // Then
-                Assert.Equal(0, result.Length);
+                Assert.Empty(result);
             }
 
             [Fact]
@@ -35,7 +35,7 @@ namespace Cake.Core.Tests.Unit.Text
                 var result = QuoteAwareStringSplitter.Split(input).ToArray();
 
                 // Then
-                Assert.Equal(1, result.Length);
+                Assert.Single(result);
                 Assert.Equal("\"C:\\cake-walk\\cake.exe\"", result[0]);
             }
 
@@ -49,7 +49,7 @@ namespace Cake.Core.Tests.Unit.Text
                 var result = QuoteAwareStringSplitter.Split(input).ToArray();
 
                 // Then
-                Assert.Equal(1, result.Length);
+                Assert.Single(result);
                 Assert.Equal("\"C:\\cake walk\\cake.exe\"", result[0]);
             }
 

--- a/src/Cake.NuGet.Tests/Cake.NuGet.Tests.csproj
+++ b/src/Cake.NuGet.Tests/Cake.NuGet.Tests.csproj
@@ -22,12 +22,12 @@
   <!-- Global packages -->
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
+    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
     <PackageReference Include="NSubstitute" Version="2.0.2" />
     <PackageReference Include="NuGet.Frameworks" Version="4.3.0" />
     <PackageReference Include="NuGet.Versioning" Version="4.3.0" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta5-build3769" />
   </ItemGroup>
 
   <!-- .NET Framework packages -->

--- a/src/Cake.NuGet.Tests/Unit/NuGetContentResolverTests.cs
+++ b/src/Cake.NuGet.Tests/Unit/NuGetContentResolverTests.cs
@@ -105,9 +105,9 @@ namespace Cake.NuGet.Tests.Unit
 
                 // Then
                 Assert.Equal(3, files.Count);
-                Assert.True(files.Any(p => p.Path.FullPath == "/Working/tools/Foo/Foo.exe"));
-                Assert.True(files.Any(p => p.Path.FullPath == "/Working/tools/Foo/Bar/Qux.pdb"));
-                Assert.True(files.Any(p => p.Path.FullPath == "/Working/tools/Foo/Foo.XML"));
+                Assert.Contains(files, p => p.Path.FullPath == "/Working/tools/Foo/Foo.exe");
+                Assert.Contains(files, p => p.Path.FullPath == "/Working/tools/Foo/Bar/Qux.pdb");
+                Assert.Contains(files, p => p.Path.FullPath == "/Working/tools/Foo/Foo.XML");
             }
         }
 
@@ -308,7 +308,7 @@ namespace Cake.NuGet.Tests.Unit
                                      "Falling back to using root folder of NuGet package."))
                     .ToList();
 
-                Assert.Equal(1, entries.Count);
+                Assert.Single(entries);
             }
         }
     }

--- a/src/Cake.NuGet.Tests/Unit/NuGetLoadDirectiveProviderTests.cs
+++ b/src/Cake.NuGet.Tests/Unit/NuGetLoadDirectiveProviderTests.cs
@@ -96,7 +96,7 @@ namespace Cake.NuGet.Tests.Unit
                 var result = fixture.Load();
 
                 // Then
-                Assert.Equal(1, result.AnalyzedFiles.Count);
+                Assert.Single(result.AnalyzedFiles);
                 Assert.Equal("/Working/tools/Cake.Recipe/file.cake", result.AnalyzedFiles[0].FullPath);
             }
 

--- a/src/Cake.Testing.Xunit/Cake.Testing.Xunit.csproj
+++ b/src/Cake.Testing.Xunit/Cake.Testing.Xunit.csproj
@@ -12,7 +12,7 @@
 
   <!-- Global packages -->
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
+    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
   </ItemGroup>
 
   <!-- Project references -->

--- a/src/Cake.Tests/Cake.Tests.csproj
+++ b/src/Cake.Tests/Cake.Tests.csproj
@@ -22,10 +22,10 @@
   <!-- Global packages -->
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
+    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
     <PackageReference Include="NSubstitute" Version="2.0.2" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta5-build3769" />
   </ItemGroup>
 
   <!-- .NET Framework packages -->

--- a/src/Cake.Tests/Unit/Arguments/ArgumentParserTests.cs
+++ b/src/Cake.Tests/Unit/Arguments/ArgumentParserTests.cs
@@ -147,7 +147,7 @@ namespace Cake.Tests.Unit.Arguments
                     // Then
                     Assert.NotNull(result);
                     Assert.True(result.HasError);
-                    Assert.True(fixture.Log.Entries.Any(x => x.Message == "Multiple arguments with the same name (unknown)."));
+                    Assert.Contains(fixture.Log.Entries, x => x.Message == "Multiple arguments with the same name (unknown).");
                 }
 
                 [Theory]
@@ -200,7 +200,7 @@ namespace Cake.Tests.Unit.Arguments
 
                     // Then
                     Assert.True(result.HasError);
-                    Assert.True(fixture.Log.Entries.Any(e => e.Message == expected));
+                    Assert.Contains(fixture.Log.Entries, e => e.Message == expected);
                 }
 
                 [Theory]
@@ -386,7 +386,7 @@ namespace Cake.Tests.Unit.Arguments
                     // Then
                     Assert.NotNull(result);
                     Assert.True(result.HasError);
-                    Assert.True(fixture.Log.Entries.Any(x => x.Message == "Multiple arguments with the same name (unknown)."));
+                    Assert.Contains(fixture.Log.Entries, x => x.Message == "Multiple arguments with the same name (unknown).");
                 }
 
                 [Theory]
@@ -432,7 +432,7 @@ namespace Cake.Tests.Unit.Arguments
 
                     // Then
                     Assert.True(result.HasError);
-                    Assert.True(fixture.Log.Entries.Any(e => e.Message == expected));
+                    Assert.Contains(fixture.Log.Entries, e => e.Message == expected);
                 }
 
                 [Theory]

--- a/src/Cake.Tests/Unit/Composition/ContainerBuilderAdapterTests.cs
+++ b/src/Cake.Tests/Unit/Composition/ContainerBuilderAdapterTests.cs
@@ -52,8 +52,8 @@ namespace Cake.Tests.Unit.Composition
 
                 // Then
                 Assert.Equal(2, result.Count);
-                Assert.True(result.Any(instance => instance == instance1));
-                Assert.True(result.Any(instance => instance == instance2));
+                Assert.Contains(result, instance => instance == instance1);
+                Assert.Contains(result, instance => instance == instance2);
             }
 
             [Fact]
@@ -107,8 +107,8 @@ namespace Cake.Tests.Unit.Composition
 
                 // Then
                 Assert.Equal(2, result.Count);
-                Assert.True(result.Any(instance => instance is CakeConsole));
-                Assert.True(result.Any(instance => instance is FakeConsole));
+                Assert.Contains(result, instance => instance is CakeConsole);
+                Assert.Contains(result, instance => instance is FakeConsole);
             }
 
             [Fact]


### PR DESCRIPTION
While working on #1751, I found out that older versions of xUnit don't play well with building with .NET CLI 2.0. This PR updates xUnit to the latest version, in which this problem is fixed. 

In the process, the xunit.analyzers dependency was also updated, which lead to a bunch of compiler warnings which were converted to errors when running the build script. This PR fixes all of those xUnit warnings, thereby making the build pass again. Each fix is in its own, separate commit, to allow for easier reviewing. All fixes were made automatically using the code fix provided by the xunit analyzer.

The one oddity is the xUnit1025 rule, which looks for duplicate theory parameters. It appears that I have found a bug in the analyzer, as it erronously marks different enum values with the same underlying (int) value as duplicates. I've added a `#pragma` to disable this warning in the (one) affected file.

Refs #1779