### PR TITLE
[WIP review request] GH1770: Module attributes adding script namespaces and assemblies

### DIFF
--- a/src/Cake.Core.Tests/Fixtures/ScriptRunnerFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/ScriptRunnerFixture.cs
@@ -27,6 +27,7 @@ namespace Cake.Core.Tests.Fixtures
         public IScriptAnalyzer ScriptAnalyzer { get; set; }
         public IScriptProcessor ScriptProcessor { get; set; }
         public IScriptConventions ScriptConventions { get; set; }
+        public IScriptConfiguration ScriptConfiguration { get; set; }
         public IScriptAliasFinder AliasFinder { get; set; }
         public FakeLog Log { get; set; }
 
@@ -60,6 +61,7 @@ namespace Cake.Core.Tests.Fixtures
             ScriptAnalyzer = new ScriptAnalyzer(FileSystem, Environment, Log, new[] { new FileLoadDirectiveProvider() });
             ScriptProcessor = Substitute.For<IScriptProcessor>();
             ScriptConventions = new ScriptConventions(FileSystem, AssemblyLoader);
+            ScriptConfiguration = new ScriptConfiguration();
 
             var context = Substitute.For<ICakeContext>();
             context.Environment.Returns(c => Environment);
@@ -72,7 +74,7 @@ namespace Cake.Core.Tests.Fixtures
         {
             return new ScriptRunner(Environment, Log, Configuration, Engine,
                 AliasFinder, ScriptAnalyzer, ScriptProcessor,
-                ScriptConventions, AssemblyLoader);
+                ScriptConventions, ScriptConfiguration, AssemblyLoader);
         }
     }
 }

--- a/src/Cake.Core.Tests/Unit/Annotations/CakeNamespaceImportAttributeTests.cs
+++ b/src/Cake.Core.Tests/Unit/Annotations/CakeNamespaceImportAttributeTests.cs
@@ -17,7 +17,7 @@ namespace Cake.Core.Tests.Unit.Annotations
             public void Should_Throw_If_Namespace_Is_Null()
             {
                 // Given, When
-                var result = Record.Exception(() => new CakeNamespaceImportAttribute(null));
+                var result = Record.Exception(() => new CakeNamespaceImportAttribute((string)null));
 
                 // Then
                 AssertEx.IsArgumentNullException(result, "namespace");

--- a/src/Cake.Core.Tests/Unit/Annotations/CakeNamespaceImportAttributeTests.cs
+++ b/src/Cake.Core.Tests/Unit/Annotations/CakeNamespaceImportAttributeTests.cs
@@ -3,14 +3,61 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using Cake.Core.Annotations;
+using Cake.Core.IO;
+using Cake.Core.Packaging;
+using Cake.Core.Scripting;
+using Cake.Core.Tests.Fixtures;
+using Cake.Testing;
+using NSubstitute;
 using Xunit;
+
+[assembly: CakeNamespaceImport("assembly-level namespace import 1")]
+[assembly: CakeNamespaceImport("assembly-level namespace import 2")]
 
 namespace Cake.Core.Tests.Unit.Annotations
 {
-    public sealed class CakeNamespaceImportAttributeTests
+    [CakeNamespaceImport("class-level namespace import 1")]
+    [CakeNamespaceImport("class-level namespace import 2")]
+    public static class CakeNamespaceImportAttributeTests
     {
+        [CakeMethodAlias]
+        [CakeNamespaceImport("method-level namespace import 1")]
+        [CakeNamespaceImport("method-level namespace import 2")]
+        public static void DummyAlias(this ICakeContext context)
+        {
+        }
+
+        [Theory]
+        [InlineData("method")]
+        [InlineData("class")]
+        [InlineData("assembly")]
+        public static void Imports_from_addin_into_session(string level)
+        {
+            var fixture = new ScriptRunnerFixture();
+            fixture.AliasFinder = new ScriptAliasFinder(fixture.Log);
+
+            // Necessary because the ScriptConventions class starts returning null in the assemblies list
+            // when it uses a test double assembly loader and tries to load System.Runtime
+            fixture.ScriptConventions = Substitute.For<IScriptConventions>();
+            fixture.ScriptConventions.GetDefaultAssemblies(Arg.Any<DirectoryPath>()).Returns(Array.Empty<Assembly>());
+
+            var thisAssembly = typeof(CakeNamespaceImportAttributeTests).GetTypeInfo().Assembly;
+            var thisAssemblyPath = new FilePath(thisAssembly.Location);
+            fixture.FileSystem.CreateFile(thisAssemblyPath);
+            fixture.AssemblyLoader.Load(Arg.Is<FilePath>(v => v.FullPath == thisAssemblyPath.FullPath), Arg.Any<bool>()).Returns(thisAssembly);
+
+            fixture.ScriptProcessor.InstallAddins(Arg.Any<IReadOnlyCollection<PackageReference>>(), Arg.Any<DirectoryPath>())
+                .Returns(new[] { thisAssemblyPath });
+
+            fixture.CreateScriptRunner().Run(fixture.Host, fixture.Script, fixture.ArgumentDictionary);
+
+            fixture.Session.Received().ImportNamespace($"{level}-level namespace import 1");
+            fixture.Session.Received().ImportNamespace($"{level}-level namespace import 2");
+        }
+
         public sealed class TheConstructor
         {
             [Fact]

--- a/src/Cake.Core/Annotations/CakeAssemblyReferenceAttribute.cs
+++ b/src/Cake.Core/Annotations/CakeAssemblyReferenceAttribute.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Cake.Core.Annotations
+{
+    /// <summary>
+    /// Causes an assembly to be referenced by scripts.
+    /// Can be applied to module assemblies.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    public sealed class CakeAssemblyReferenceAttribute : Attribute
+    {
+        /// <summary>
+        /// Gets the namespace.
+        /// </summary>
+        public string AssemblyName { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CakeAssemblyReferenceAttribute"/> class.
+        /// </summary>
+        /// <param name="assemblyName">The name of the assembly to reference in scripts.</param>
+        public CakeAssemblyReferenceAttribute(string assemblyName)
+        {
+            AssemblyName = assemblyName ?? throw new ArgumentNullException(nameof(assemblyName));
+        }
+    }
+}

--- a/src/Cake.Core/Annotations/CakeAssemblyReferenceAttribute.cs
+++ b/src/Cake.Core/Annotations/CakeAssemblyReferenceAttribute.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Reflection;
 
 namespace Cake.Core.Annotations
 {
@@ -14,7 +15,7 @@ namespace Cake.Core.Annotations
     public sealed class CakeAssemblyReferenceAttribute : Attribute
     {
         /// <summary>
-        /// Gets the namespace.
+        /// Gets the assembly name.
         /// </summary>
         public string AssemblyName { get; }
 
@@ -25,6 +26,15 @@ namespace Cake.Core.Annotations
         public CakeAssemblyReferenceAttribute(string assemblyName)
         {
             AssemblyName = assemblyName ?? throw new ArgumentNullException(nameof(assemblyName));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CakeAssemblyReferenceAttribute"/> class.
+        /// </summary>
+        /// <param name="assemblyOfType">A type whose assembly to reference in scripts.</param>
+        public CakeAssemblyReferenceAttribute(Type assemblyOfType)
+            : this((assemblyOfType ?? throw new ArgumentNullException(nameof(assemblyOfType))).GetTypeInfo().Assembly.FullName)
+        {
         }
     }
 }

--- a/src/Cake.Core/Annotations/CakeNamespaceImportAttribute.cs
+++ b/src/Cake.Core/Annotations/CakeNamespaceImportAttribute.cs
@@ -24,11 +24,7 @@ namespace Cake.Core.Annotations
         /// <param name="namespace">The namespace to import into scripts.</param>
         public CakeNamespaceImportAttribute(string @namespace)
         {
-            if (@namespace == null)
-            {
-                throw new ArgumentNullException(nameof(@namespace));
-            }
-            Namespace = @namespace;
+            Namespace = @namespace ?? throw new ArgumentNullException(nameof(@namespace));
         }
     }
 }

--- a/src/Cake.Core/Annotations/CakeNamespaceImportAttribute.cs
+++ b/src/Cake.Core/Annotations/CakeNamespaceImportAttribute.cs
@@ -26,5 +26,14 @@ namespace Cake.Core.Annotations
         {
             Namespace = @namespace ?? throw new ArgumentNullException(nameof(@namespace));
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CakeNamespaceImportAttribute"/> class.
+        /// </summary>
+        /// <param name="namespaceOfType">A type whose namespace to import into scripts.</param>
+        public CakeNamespaceImportAttribute(Type namespaceOfType)
+            : this((namespaceOfType ?? throw new ArgumentNullException(nameof(namespaceOfType))).Namespace)
+        {
+        }
     }
 }

--- a/src/Cake.Core/Annotations/CakeNamespaceImportAttribute.cs
+++ b/src/Cake.Core/Annotations/CakeNamespaceImportAttribute.cs
@@ -7,9 +7,8 @@ using System;
 namespace Cake.Core.Annotations
 {
     /// <summary>
-    /// An attribute used to hint Cake about additional namespaces that need
-    /// to be imported for an alias to work. This attribute can mark an
-    /// extension method, the extension method class, or the assembly to provide a global set of imports
+    /// Causes a namespace to be imported by scripts.
+    /// Can be applied to addin and module assemblies, as well as alias methods and classes in addin assemblies.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
     public sealed class CakeNamespaceImportAttribute : Attribute
@@ -17,13 +16,12 @@ namespace Cake.Core.Annotations
         /// <summary>
         /// Gets the namespace.
         /// </summary>
-        /// <value>The namespace.</value>
         public string Namespace { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CakeNamespaceImportAttribute"/> class.
         /// </summary>
-        /// <param name="namespace">The namespace.</param>
+        /// <param name="namespace">The namespace to import into scripts.</param>
         public CakeNamespaceImportAttribute(string @namespace)
         {
             if (@namespace == null)

--- a/src/Cake.Core/Scripting/IScriptConfiguration.cs
+++ b/src/Cake.Core/Scripting/IScriptConfiguration.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Cake.Core.Scripting
+{
+    /// <summary>
+    /// Provides the ability to configure the script via IoC.
+    /// </summary>
+    public interface IScriptConfiguration
+    {
+        /// <summary>
+        /// Gets additional namespaces to be imported in the script.
+        /// </summary>
+        IReadOnlyList<string> Namespaces { get; }
+
+        /// <summary>
+        /// Gets additional assembly names to be referenced by the script.
+        /// </summary>
+        IReadOnlyList<string> AssemblyNames { get; }
+    }
+}

--- a/src/Cake.Core/Scripting/ScriptConfiguration.cs
+++ b/src/Cake.Core/Scripting/ScriptConfiguration.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Cake.Core.Scripting
+{
+    /// <summary>
+    /// Provides the ability to configure the script via IoC.
+    /// </summary>
+    public sealed class ScriptConfiguration : IScriptConfiguration
+    {
+        private readonly List<string> scriptNamespaces = new List<string>();
+        private readonly List<string> scriptAssemblyNames = new List<string>();
+
+        /// <summary>
+        /// Adds a namespace to import in the script.
+        /// </summary>
+        /// <param name="namespace">The namespace to import in the script.</param>
+        public void AddScriptNamespace(string @namespace) => scriptNamespaces.Add(@namespace);
+
+        /// <summary>
+        /// Adds an assembly name to reference in the script.
+        /// </summary>
+        /// <param name="assemblyName">The assembly name to reference in the script.</param>
+        public void AddScriptAssembly(string assemblyName) => scriptAssemblyNames.Add(assemblyName);
+
+        IReadOnlyList<string> IScriptConfiguration.Namespaces => scriptNamespaces;
+
+        IReadOnlyList<string> IScriptConfiguration.AssemblyNames => scriptAssemblyNames;
+    }
+}

--- a/src/Cake/Composition/ModuleLoader.cs
+++ b/src/Cake/Composition/ModuleLoader.cs
@@ -5,33 +5,22 @@
 using System;
 using System.Collections.Generic;
 using Autofac;
-using Cake.Core;
 using Cake.Core.Composition;
-using Cake.Core.Configuration;
 using Cake.Core.Diagnostics;
-using Cake.Core.IO;
 
 namespace Cake.Composition
 {
     internal sealed class ModuleLoader
     {
-        private readonly ModuleSearcher _searcher;
         private readonly ICakeLog _log;
-        private readonly ICakeConfiguration _configuration;
-        private readonly ICakeEnvironment _environment;
 
-        public ModuleLoader(ModuleSearcher searcher, ICakeLog log, ICakeConfiguration configuration, ICakeEnvironment environment)
+        public ModuleLoader(ICakeLog log)
         {
-            _searcher = searcher;
             _log = log;
-            _configuration = configuration;
-            _environment = environment;
         }
 
-        public void LoadModules(IContainer container, CakeOptions options)
+        public void LoadModules(IContainer container, IReadOnlyList<Type> moduleTypes)
         {
-            var root = GetModulePath(options.Script.GetDirectory());
-            var moduleTypes = _searcher.Search(root);
             if (moduleTypes.Count > 0)
             {
                 using (var temporaryContainer = container.BeginLifetimeScope())
@@ -48,29 +37,6 @@ namespace Cake.Composition
                     builder.Update(container);
                 }
             }
-        }
-
-        private DirectoryPath GetToolPath(DirectoryPath root)
-        {
-            var toolPath = _configuration.GetValue(Constants.Paths.Tools);
-            if (!string.IsNullOrWhiteSpace(toolPath))
-            {
-                return new DirectoryPath(toolPath).MakeAbsolute(_environment);
-            }
-
-            return root.Combine("tools");
-        }
-
-        private DirectoryPath GetModulePath(DirectoryPath root)
-        {
-            var modulePath = _configuration.GetValue(Constants.Paths.Modules);
-            if (!string.IsNullOrWhiteSpace(modulePath))
-            {
-                return new DirectoryPath(modulePath).MakeAbsolute(_environment);
-            }
-
-            var toolPath = GetToolPath(root);
-            return toolPath.Combine("Modules").Collapse();
         }
 
         private void RegisterExternalModules(IEnumerable<Type> moduleTypes, ILifetimeScope scope)

--- a/src/Cake/Modules/CakeModule.cs
+++ b/src/Cake/Modules/CakeModule.cs
@@ -10,6 +10,7 @@ using Cake.Core;
 using Cake.Core.Composition;
 using Cake.Core.Configuration;
 using Cake.Core.Diagnostics;
+using Cake.Core.Scripting;
 using Cake.Diagnostics;
 using Cake.Scripting;
 
@@ -31,6 +32,7 @@ namespace Cake.Modules
             // Modules
             registrar.RegisterType<ModuleSearcher>().Singleton();
             registrar.RegisterType<ModuleLoader>().Singleton();
+            registrar.RegisterType<ScriptConfiguration>().AsSelf().As<IScriptConfiguration>().Singleton();
 
             // Configuration
             registrar.RegisterType<CakeConfigurationProvider>().Singleton();

--- a/src/Cake/Program.cs
+++ b/src/Cake/Program.cs
@@ -12,6 +12,7 @@ using Cake.Core;
 using Cake.Core.Configuration;
 using Cake.Core.Diagnostics;
 using Cake.Core.Modules;
+using Cake.Core.Scripting;
 using Cake.Core.Text;
 using Cake.Modules;
 using Cake.NuGet;
@@ -70,7 +71,7 @@ namespace Cake
                     // Load all modules.
                     var moduleSearcher = container.Resolve<ModuleSearcher>();
                     var moduleLoader = container.Resolve<ModuleLoader>();
-                    moduleLoader.LoadModules(container, moduleSearcher.Search(options));
+                    moduleLoader.LoadModules(moduleSearcher.Search(options), container, container.Resolve<ScriptConfiguration>());
 
                     // Resolve and run the application.
                     var application = container.Resolve<CakeApplication>();

--- a/src/Cake/Program.cs
+++ b/src/Cake/Program.cs
@@ -68,8 +68,9 @@ namespace Cake
                     builder.Update(container);
 
                     // Load all modules.
-                    var loader = container.Resolve<ModuleLoader>();
-                    loader.LoadModules(container, options);
+                    var moduleSearcher = container.Resolve<ModuleSearcher>();
+                    var moduleLoader = container.Resolve<ModuleLoader>();
+                    moduleLoader.LoadModules(container, moduleSearcher.Search(options));
 
                     // Resolve and run the application.
                     var application = container.Resolve<CakeApplication>();


### PR DESCRIPTION
Please do not merge yet.

Closes #1770. I offered to add the assembly attributes to add namespaces and assembly references to the script from a module, as @patriksvensson wanted.

Implementation was very easy, but writing tests is not and I'd like guidance on the best way to do that.
Walking through the commits:

 - First three commits created the API shape discussed in #1770

 - Fourth commit added a test ensuring the **existing** addin namespace import was working. You didn't seem to have a test for this. Please especially review this one because I want feedback on the style of testing. (https://github.com/cake-build/cake/commit/5098fb7f610bb6bdefe976e0eab05a989d27f434)

 - Fifth commit decouples the module loader from the module searcher ahead of time for testing purposes- I wanted to be able to test code in the module loader without involving the searcher to make sure namespaces and assemblies would be imported

 - Sixth commit actually implements the new API.

 - Now I'm stuck. I want to test loading a module in the context of a `ScriptRunnerFixture` so that I can duplicate the test in https://github.com/cake-build/cake/commit/5098fb7f610bb6bdefe976e0eab05a989d27f434. But that requires referencing both Cake and Autofac from Cake.Core.Tests. If I put the test in Cake.Tests, I lose access to `ScriptRunnerFixture`. How would you go about testing this?

Thanks!

