### PR TITLE
(build) Target net461 for cake.exe and update NuGet dependencies

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -159,7 +159,7 @@ Task("Copy-Files")
     // .NET 4.6
     DotNetCorePublish("./src/Cake", new DotNetCorePublishSettings
     {
-        Framework = "net46",
+        Framework = "net461",
         VersionSuffix = parameters.Version.DotNetAsterix,
         Configuration = parameters.Configuration,
         OutputDirectory = parameters.Paths.Directories.ArtifactsBinFullFx,
@@ -180,7 +180,7 @@ Task("Copy-Files")
     CopyFileToDirectory("./LICENSE", parameters.Paths.Directories.ArtifactsBinNetCore);
 
     // Copy Cake.XML (since publish does not do this anymore)
-    CopyFileToDirectory("./src/Cake/bin/" + parameters.Configuration + "/net46/Cake.xml", parameters.Paths.Directories.ArtifactsBinFullFx);
+    CopyFileToDirectory("./src/Cake/bin/" + parameters.Configuration + "/net461/Cake.xml", parameters.Paths.Directories.ArtifactsBinFullFx);
     CopyFileToDirectory("./src/Cake/bin/" + parameters.Configuration + "/netcoreapp1.0/Cake.xml", parameters.Paths.Directories.ArtifactsBinNetCore);
 });
 

--- a/build/paths.cake
+++ b/build/paths.cake
@@ -24,13 +24,13 @@ public class BuildPaths
 
         var artifactsDir = (DirectoryPath)(context.Directory("./artifacts") + context.Directory("v" + semVersion));
         var artifactsBinDir = artifactsDir.Combine("bin");
-        var artifactsBinFullFx = artifactsBinDir.Combine("net46");
+        var artifactsBinFullFx = artifactsBinDir.Combine("net461");
         var artifactsBinNetCore = artifactsBinDir.Combine("netcoreapp1.0");
         var testResultsDir = artifactsDir.Combine("test-results");
         var nugetRoot = artifactsDir.Combine("nuget");
 
         var zipArtifactPathCoreClr = artifactsDir.CombineWithFilePath("Cake-bin-coreclr-v" + semVersion + ".zip");
-        var zipArtifactPathDesktop = artifactsDir.CombineWithFilePath("Cake-bin-net46-v" + semVersion + ".zip");
+        var zipArtifactPathDesktop = artifactsDir.CombineWithFilePath("Cake-bin-net461-v" + semVersion + ".zip");
 
         var testCoverageOutputFilePath = testResultsDir.CombineWithFilePath("OpenCover.xml");
 

--- a/src/Cake.Core.Tests/Unit/CakeRuntimeTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeRuntimeTests.cs
@@ -22,7 +22,7 @@ namespace Cake.Core.Tests.Unit
                 var framework = runtime.TargetFramework;
 
                 // Then
-                Assert.Equal(".NETFramework,Version=v4.6", framework.FullName);
+                Assert.Equal(".NETFramework,Version=v4.6.1", framework.FullName);
             }
 
             [RuntimeFact(TestRuntime.CoreClr)]

--- a/src/Cake.Core/Polyfill/EnvironmentHelper.cs
+++ b/src/Cake.Core/Polyfill/EnvironmentHelper.cs
@@ -90,7 +90,7 @@ namespace Cake.Core.Polyfill
 #if NETCORE
             return new FrameworkName(".NETStandard,Version=v1.6");
 #else
-            return new FrameworkName(".NETFramework,Version=v4.6");
+            return new FrameworkName(".NETFramework,Version=v4.6.1");
 #endif
         }
     }

--- a/src/Cake.NuGet.Tests/Cake.NuGet.Tests.csproj
+++ b/src/Cake.NuGet.Tests/Cake.NuGet.Tests.csproj
@@ -25,7 +25,8 @@
     <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
     <PackageReference Include="NSubstitute" Version="2.0.2" />
-    <PackageReference Include="NuGet.Client" Version="4.0.0" />
+    <PackageReference Include="NuGet.Frameworks" Version="4.3.0" />
+    <PackageReference Include="NuGet.Versioning" Version="4.3.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
   </ItemGroup>
 

--- a/src/Cake.NuGet.Tests/Unit/NuGetContentResolverTests.cs
+++ b/src/Cake.NuGet.Tests/Unit/NuGetContentResolverTests.cs
@@ -129,7 +129,7 @@ namespace Cake.NuGet.Tests.Unit
 
             [Theory]
             [InlineData(".NETStandard,Version=v1.6", "netstandard1.6")]
-            [InlineData(".NETFramework,Version=v4.6", "net46")]
+            [InlineData(".NETFramework,Version=v4.6.1", "net461")]
             public void Should_Return_Exact_Framework_If_Possible(string framework, string expected)
             {
                 // Given
@@ -139,6 +139,7 @@ namespace Cake.NuGet.Tests.Unit
                 fixture.CreateCLRAssembly("/Working/lib/net452/file.dll");
                 fixture.CreateCLRAssembly("/Working/lib/net46/file.dll");
                 fixture.CreateCLRAssembly("/Working/lib/net461/file.dll");
+                fixture.CreateCLRAssembly("/Working/lib/net462/file.dll");
                 fixture.CreateCLRAssembly("/Working/lib/netstandard1.5/file.dll");
                 fixture.CreateCLRAssembly("/Working/lib/netstandard1.6/file.dll");
 
@@ -152,7 +153,7 @@ namespace Cake.NuGet.Tests.Unit
 
             [Theory]
             [InlineData(".NETStandard,Version=v1.6", "netstandard1.5")]
-            [InlineData(".NETFramework,Version=v4.6", "net452")]
+            [InlineData(".NETFramework,Version=v4.6.1", "net452")]
             public void Should_Return_Nearest_Compatible_Framework_If_An_Exact_Match_Is_Not_Possible(string framework, string expected)
             {
                 // Given
@@ -160,7 +161,7 @@ namespace Cake.NuGet.Tests.Unit
                 fixture.CreateCLRAssembly("/Working/lib/net45/file.dll");
                 fixture.CreateCLRAssembly("/Working/lib/net451/file.dll");
                 fixture.CreateCLRAssembly("/Working/lib/net452/file.dll");
-                fixture.CreateCLRAssembly("/Working/lib/net461/file.dll");
+                fixture.CreateCLRAssembly("/Working/lib/net462/file.dll");
                 fixture.CreateCLRAssembly("/Working/lib/netstandard1.5/file.dll");
 
                 // When
@@ -173,15 +174,14 @@ namespace Cake.NuGet.Tests.Unit
 
             [Theory]
             [InlineData(".NETStandard,Version=v1.6")]
-            [InlineData(".NETFramework,Version=v4.6")]
+            [InlineData(".NETFramework,Version=v4.6.1")]
             public void Should_Return_Empty_Result_If_Any_Match_Is_Not_Possible(string framework)
             {
                 // Given
                 var fixture = new NuGetAddinContentResolverFixture(framework);
 
-                fixture.CreateCLRAssembly("/Working/lib/net461/file.dll");
                 fixture.CreateCLRAssembly("/Working/lib/net462/file.dll");
-                fixture.CreateCLRAssembly("/Working/lib/netstandard2.0/file.dll");
+                fixture.CreateCLRAssembly("/Working/lib/netstandard2.2/file.dll");
 
                 // When
                 var result = fixture.GetFiles();
@@ -194,18 +194,19 @@ namespace Cake.NuGet.Tests.Unit
             public void Should_Return_Compatible_Netstandard_If_An_Exact_Match_Is_Not_Possible()
             {
                 // Given
-                var fixture = new NuGetAddinContentResolverFixture(".NETFramework,Version=v4.6");
+                var fixture = new NuGetAddinContentResolverFixture(".NETFramework,Version=v4.6.1");
 
                 fixture.CreateCLRAssembly("/Working/lib/netstandard1.0/file.dll");
                 fixture.CreateCLRAssembly("/Working/lib/netstandard1.3/file.dll");
-                fixture.CreateCLRAssembly("/Working/lib/netstandard2.0/file.dll");
+                fixture.CreateCLRAssembly("/Working/lib/netstandard1.6/file.dll");
+                fixture.CreateCLRAssembly("/Working/lib/netstandard2.1/file.dll");
 
                 // When
                 var result = fixture.GetFiles();
 
                 // Then
                 Assert.Equal(1, result.Count);
-                Assert.Equal($"/Working/lib/netstandard1.3/file.dll", result.ElementAt(0).Path.FullPath);
+                Assert.Equal($"/Working/lib/netstandard1.6/file.dll", result.ElementAt(0).Path.FullPath);
             }
 
             [Fact]
@@ -227,7 +228,7 @@ namespace Cake.NuGet.Tests.Unit
 
             [Theory]
             [InlineData(".NETStandard,Version=v1.6")]
-            [InlineData(".NETFramework,Version=v4.6")]
+            [InlineData(".NETFramework,Version=v4.6.1")]
             public void Should_Return_Files_When_Located_In_Root(string framework)
             {
                 // Given
@@ -249,13 +250,13 @@ namespace Cake.NuGet.Tests.Unit
 
             [Theory]
             [InlineData(".NETStandard,Version=v1.6", "netstandard1.6")]
-            [InlineData(".NETFramework,Version=v4.6", "net46")]
+            [InlineData(".NETFramework,Version=v4.6.1", "net461")]
             public void Should_Return_Exact_Framework_Even_Though_Files_Located_In_Root(string framework, string expected)
             {
                 // Given
                 var fixture = new NuGetAddinContentResolverFixture(framework);
 
-                fixture.CreateCLRAssembly("/Working/lib/net46/file.dll");
+                fixture.CreateCLRAssembly("/Working/lib/net461/file.dll");
                 fixture.CreateCLRAssembly("/Working/lib/netstandard1.6/file.dll");
                 fixture.CreateCLRAssembly("/Working/file.dll");
 
@@ -269,14 +270,13 @@ namespace Cake.NuGet.Tests.Unit
 
             [Theory]
             [InlineData(".NETStandard,Version=v1.6")]
-            [InlineData(".NETFramework,Version=v4.6")]
+            [InlineData(".NETFramework,Version=v4.6.1")]
             public void Should_Return_From_Root_If_No_Compatible_Framework_Found(string framework)
             {
                 // Given
                 var fixture = new NuGetAddinContentResolverFixture(framework);
 
-                fixture.CreateCLRAssembly("/Working/lib/net461/file.dll");
-                fixture.CreateCLRAssembly("/Working/lib/netstandard2.0/file.dll");
+                fixture.CreateCLRAssembly("/Working/lib/net462/file.dll");
                 fixture.CreateCLRAssembly("/Working/file.dll");
 
                 // When
@@ -289,7 +289,7 @@ namespace Cake.NuGet.Tests.Unit
 
             [Theory]
             [InlineData(".NETStandard,Version=v1.6")]
-            [InlineData(".NETFramework,Version=v4.6")]
+            [InlineData(".NETFramework,Version=v4.6.1")]
             public void Should_Log_Warning_For_Files_Located_In_Root(string framework)
             {
                 // Given

--- a/src/Cake.NuGet/Cake.NuGet.csproj
+++ b/src/Cake.NuGet/Cake.NuGet.csproj
@@ -23,7 +23,8 @@
 
   <!-- Global packages -->
   <ItemGroup>
-    <PackageReference Include="NuGet.Client" Version="4.0.0" />
+    <PackageReference Include="NuGet.Frameworks" Version="4.3.0" />
+    <PackageReference Include="NuGet.Versioning" Version="4.3.0" />
   </ItemGroup>
 
   <!-- .NET Framework packages -->

--- a/src/Cake.Tests/Cake.Tests.csproj
+++ b/src/Cake.Tests/Cake.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>Cake.Tests</AssemblyName>
-    <TargetFrameworks>net46;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp1.0</TargetFrameworks>
     <PlatformTarget>AnyCpu</PlatformTarget>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsCakeTestProject>true</IsCakeTestProject>
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <!-- .NET Framework packages -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System" />
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Cake/Cake.csproj
+++ b/src/Cake/Cake.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>Cake</AssemblyName>
-    <TargetFrameworks>net46;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp1.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <PlatformTarget>AnyCpu</PlatformTarget>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <!-- .NET Framework packages -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="Autofac" Version="3.5.2" />
     <Reference Include="System" />
     <Reference Include="System.IO" />

--- a/src/Shared.msbuild
+++ b/src/Shared.msbuild
@@ -21,11 +21,6 @@
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.6.0</NetStandardImplicitPackageVersion>
   </PropertyGroup>
 
-  <!-- Runtime identifiers for standalone build -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46'">
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;fedora.24-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>
-  </PropertyGroup>
-
   <!-- Global solution information -->
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)SolutionInfo.cs" />


### PR DESCRIPTION
- Cake.exe can now load netstandard1.x and netstandard2.0 libraries

@cake-build/cake-team I will try running some integration tests now locally and try this out. @devlead could you at some point start integration tests on CI servers. @Redth could you take this for a spin, at least in Unit Tests, `netstandard1.x` and `netstandard2.0` should be picked up by `NuGetContentResolver` now.