### PR TITLE
Obsolete unused NUnit3 arguments

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/NUnit/NUnit3RunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NUnit/NUnit3RunnerTests.cs
@@ -218,7 +218,9 @@ namespace Cake.Common.Tests.Unit.Tools.NUnit
                 fixture.Settings.Work = "out";
                 fixture.Settings.OutputFile = "stdout.txt";
                 fixture.Settings.ErrorOutputFile = "stderr.txt";
+                #pragma warning disable 0618
                 fixture.Settings.Full = true;
+                #pragma warning restore 0618
                 fixture.Settings.Results = new[]
                 {
                     new NUnit3Result { FileName = "NewTestResult.xml", Format = "nunit2", Transform = "nunit2.xslt" },
@@ -228,7 +230,9 @@ namespace Cake.Common.Tests.Unit.Tools.NUnit
                 fixture.Settings.TeamCity = true;
                 fixture.Settings.NoHeader = true;
                 fixture.Settings.NoColor = true;
+                #pragma warning disable 0618
                 fixture.Settings.Verbose = true;
+                #pragma warning restore 0618
                 fixture.Settings.Configuration = "Debug";
                 fixture.Settings.Process = NUnit3ProcessOption.InProcess;
                 fixture.Settings.AppDomainUsage = NUnit3AppDomainUsage.Single;

--- a/src/Cake.Common/Tools/NUnit/NUnit3Runner.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnit3Runner.cs
@@ -114,10 +114,12 @@ namespace Cake.Common.Tools.NUnit
                 builder.AppendQuoted(string.Format(CultureInfo.InvariantCulture, "--err={0}", settings.ErrorOutputFile.MakeAbsolute(_environment).FullPath));
             }
 
+            #pragma warning disable 0618
             if (settings.Full)
             {
                 builder.Append("--full");
             }
+            #pragma warning restore 0618
 
             if (HasResults(settings) && settings.NoResults)
             {
@@ -166,10 +168,12 @@ namespace Cake.Common.Tools.NUnit
                 builder.Append("--nocolor");
             }
 
+            #pragma warning disable 0618
             if (settings.Verbose)
             {
                 builder.Append("--verbose");
             }
+            #pragma warning restore 0618
 
             if (settings.Configuration != null)
             {

--- a/src/Cake.Common/Tools/NUnit/NUnit3Settings.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnit3Settings.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
-using System;
 
 namespace Cake.Common.Tools.NUnit
 {

--- a/src/Cake.Common/Tools/NUnit/NUnit3Settings.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnit3Settings.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
+using System;
 
 namespace Cake.Common.Tools.NUnit
 {
@@ -107,6 +108,7 @@ namespace Cake.Common.Tools.NUnit
         /// <c>true</c> if a full report of test results should be printed;
         /// otherwise, <c>false</c>.
         /// </value>
+        [Obsolete("This argument was removed from NUnit3", false)]
         public bool Full { get; set; }
 
         /// <summary>
@@ -162,6 +164,7 @@ namespace Cake.Common.Tools.NUnit
         /// <value>
         /// <c>true</c> shows additional information as the tests run; otherwise, <c>false</c>.
         /// </value>
+        [Obsolete("This argument was removed from NUnit3", false)]
         public bool Verbose { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Closes #1651, NUnit3 [removed](https://github.com/nunit/nunit-console/issues/99) the `verbose` and `full` attributes.

I just added the `Obsolete` attributes to them.