### PR TITLE
GH1625 Escape comma and semicolon in msbuild property values

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -928,6 +928,22 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 // Then
                 Assert.Equal("/v:normal /target:Build /bl:mylog.binlog;ProjectImports=ZipFile \"C:/Working/src/Solution.sln\"", result.Args);
             }
+
+            [Theory]
+            [InlineData("Value1,Value2", "/v:normal /p:Property=Value1%2CValue2 /target:Build \"C:/Working/src/Solution.sln\"")]
+            [InlineData("Value1;Value2", "/v:normal /p:Property=Value1%3BValue2 /target:Build \"C:/Working/src/Solution.sln\"")]
+            public void Should_Escape_Special_Characters_In_Property_Value(string propertyValue, string expected)
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows);
+                fixture.Settings.WithProperty("Property", propertyValue);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
@@ -232,9 +232,15 @@ namespace Cake.Common.Tools.MSBuild
             {
                 foreach (var propertyValue in properties[propertyKey])
                 {
-                    yield return string.Concat("/p:", propertyKey, "=", propertyValue);
+                    yield return string.Concat("/p:", propertyKey, "=", EscapeSpecialCharacters(propertyValue));
                 }
             }
+        }
+
+        private static string EscapeSpecialCharacters(string value)
+        {
+            return value.Replace(",", "%2C")
+                .Replace(";", "%3B");
         }
 
         /// <summary>


### PR DESCRIPTION
Replace comma and semicolon in msbuild properties values by hex equivalent to fix issue #1625 
