### PR TITLE
GH1798: Make GitVersion tolerate unexpected json

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/GitVersion/GitVersionRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/GitVersion/GitVersionRunnerTests.cs
@@ -215,6 +215,53 @@ namespace Cake.Common.Tests.Unit.Tools.GitVersion
                 // Then
                 Assert.Equal(args, result.Args);
             }
+
+            [Fact]
+            public void Should_Tolerate_Bad_Json_Set()
+            {
+                // Given
+                var fixture = new GitVersionRunnerFixture(
+                    new[]
+                    {
+                        "{",
+                        "  \"Major\":0,",
+                        "  \"Minor\":1,",
+                        "  \"Patch\":1,",
+                        "  \"PreReleaseTag\":\"\",",
+                        "  \"PreReleaseTagWithDash\":\"\",",
+                        "  \"PreReleaseLabel\":\"\",",
+                        "  \"PreReleaseNumber\":\"\",",
+                        "  \"BuildMetaData\":\"\",",
+                        "  \"BuildMetaDataPadded\":\"\",",
+                        "  \"FullBuildMetaData\":\"Branch.master.Sha.f2467748c78b3c8b37972ad0b30df2e15dfbf2cb\",",
+                        "  \"MajorMinorPatch\":\"0.1.1\",",
+                        "  \"SemVer\":\"0.1.1\",",
+                        "  \"LegacySemVer\":\"0.1.1\",",
+                        "  \"LegacySemVerPadded\":\"0.1.1\",",
+                        "  \"AssemblySemVer\":\"0.1.1.0\",",
+                        "  \"FullSemVer\":\"0.1.1\",",
+                        "  \"InformationalVersion\":\"0.1.1+Branch.master.Sha.f2467748c78b3c8b37972ad0b30df2e15dfbf2cb\",",
+                        "  \"BranchName\":\"master\",",
+                        "  \"Sha\":\"f2467748c78b3c8b37972ad0b30df2e15dfbf2cb\",",
+                        "  \"NuGetVersionV2\":\"0.1.1\",",
+                        "  \"NuGetVersion\":\"0.1.1\",",
+                        "  \"CommitsSinceVersionSource\":\"\",",
+                        "  \"CommitsSinceVersionSourcePadded\":\"0002\",",
+                        "  \"CommitDate\":\"2017-09-13\"",
+                        "}"
+                    });
+                fixture.Settings.OutputType = GitVersionOutput.Json;
+
+                // When
+                var result = fixture.RunGitVersion();
+
+                // Then
+                Assert.Equal(0, result.Major);
+                Assert.Equal(1, result.Minor);
+                Assert.Equal(1, result.Minor);
+                Assert.Equal(-1, result.PreReleaseNumber);
+                Assert.Equal(-1, result.CommitsSinceVersionSource);
+            }
         }
     }
 }

--- a/src/Cake.Common/Tools/GitVersion/GitVersionInternal.cs
+++ b/src/Cake.Common/Tools/GitVersion/GitVersionInternal.cs
@@ -1,0 +1,188 @@
+using System.Globalization;
+using System.Runtime.Serialization;
+
+namespace Cake.Common.Tools.GitVersion
+{
+    [DataContract(Name = "GitVersion")]
+    internal class GitVersionInternal
+    {
+        private GitVersion _gitVersion;
+
+        internal GitVersion GitVersion => _gitVersion ?? (_gitVersion = new GitVersion());
+
+        [DataMember]
+        public string Major
+        {
+            get => ToString(GitVersion.Major);
+            set => GitVersion.Major = ToInt(value);
+        }
+
+        [DataMember]
+        public string Minor
+        {
+            get => ToString(GitVersion.Minor);
+            set => GitVersion.Minor = ToInt(value);
+        }
+
+        [DataMember]
+        public string Patch
+        {
+            get => ToString(GitVersion.Patch);
+            set => GitVersion.Patch = ToInt(value);
+        }
+
+        [DataMember]
+        public string PreReleaseTag
+        {
+            get => GitVersion.PreReleaseTag;
+            set => GitVersion.PreReleaseTag = value;
+        }
+
+        [DataMember]
+        public string PreReleaseTagWithDash
+        {
+            get => GitVersion.PreReleaseTagWithDash;
+            set => GitVersion.PreReleaseTagWithDash = value;
+        }
+
+        [DataMember]
+        public string PreReleaseLabel
+        {
+            get => GitVersion.PreReleaseLabel;
+            set => GitVersion.PreReleaseLabel = value;
+        }
+
+        [DataMember]
+        public string PreReleaseNumber
+        {
+            get => ToString(GitVersion.PreReleaseNumber);
+            set => GitVersion.PreReleaseNumber = ToInt(value);
+        }
+
+        [DataMember]
+        public string BuildMetaData
+        {
+            get => GitVersion.BuildMetaData;
+            set => GitVersion.BuildMetaData = value;
+        }
+
+        [DataMember]
+        public string BuildMetaDataPadded
+        {
+            get => GitVersion.BuildMetaDataPadded;
+            set => GitVersion.BuildMetaDataPadded = value;
+        }
+
+        [DataMember]
+        public string FullBuildMetaData
+        {
+            get => GitVersion.FullBuildMetaData;
+            set => GitVersion.FullBuildMetaData = value;
+        }
+
+        [DataMember]
+        public string MajorMinorPatch
+        {
+            get => GitVersion.MajorMinorPatch;
+            set => GitVersion.MajorMinorPatch = value;
+        }
+
+        [DataMember]
+        public string SemVer
+        {
+            get => GitVersion.SemVer;
+            set => GitVersion.SemVer = value;
+        }
+
+        [DataMember]
+        public string LegacySemVer
+        {
+            get => GitVersion.LegacySemVer;
+            set => GitVersion.LegacySemVer = value;
+        }
+
+        [DataMember]
+        public string LegacySemVerPadded
+        {
+            get => GitVersion.LegacySemVerPadded;
+            set => GitVersion.LegacySemVerPadded = value;
+        }
+
+        [DataMember]
+        public string AssemblySemVer
+        {
+            get => GitVersion.AssemblySemVer;
+            set => GitVersion.AssemblySemVer = value;
+        }
+
+        [DataMember]
+        public string FullSemVer
+        {
+            get => GitVersion.FullSemVer;
+            set => GitVersion.FullSemVer = value;
+        }
+
+        [DataMember]
+        public string InformationalVersion
+        {
+            get => GitVersion.InformationalVersion;
+            set => GitVersion.InformationalVersion = value;
+        }
+
+        [DataMember]
+        public string BranchName
+        {
+            get => GitVersion.BranchName;
+            set => GitVersion.BranchName = value;
+        }
+
+        [DataMember]
+        public string Sha
+        {
+            get => GitVersion.Sha;
+            set => GitVersion.Sha = value;
+        }
+
+        [DataMember]
+        public string NuGetVersionV2
+        {
+            get => GitVersion.NuGetVersionV2;
+            set => GitVersion.NuGetVersionV2 = value;
+        }
+
+        [DataMember]
+        public string NuGetVersion
+        {
+            get => GitVersion.NuGetVersionV2;
+            set => GitVersion.NuGetVersionV2 = value;
+        }
+
+        [DataMember]
+        public string CommitsSinceVersionSource
+        {
+            get => ToString(GitVersion.CommitsSinceVersionSource);
+            set => GitVersion.CommitsSinceVersionSource = ToInt(value);
+        }
+
+        [DataMember]
+        public string CommitsSinceVersionSourcePadded
+        {
+            get => GitVersion.CommitsSinceVersionSourcePadded;
+            set => GitVersion.CommitsSinceVersionSourcePadded = value;
+        }
+
+        [DataMember]
+        public string CommitDate
+        {
+            get => GitVersion.CommitsSinceVersionSourcePadded;
+            set => GitVersion.CommitsSinceVersionSourcePadded = value;
+        }
+
+        private static int ToInt(string value) => int.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture,
+            out int numericValue)
+            ? numericValue
+            : -1;
+
+        private static string ToString(int value) => value.ToString(CultureInfo.InvariantCulture);
+    }
+}

--- a/src/Cake.Common/Tools/GitVersion/GitVersionRunner.cs
+++ b/src/Cake.Common/Tools/GitVersion/GitVersionRunner.cs
@@ -58,11 +58,11 @@ namespace Cake.Common.Tools.GitVersion
                 Run(settings, GetArguments(settings), new ProcessSettings { RedirectStandardOutput = true },
                 process => jsonString = string.Join("\n", process.GetStandardOutput()));
 
-                var jsonSerializer = new DataContractJsonSerializer(typeof(GitVersion));
+                var jsonSerializer = new DataContractJsonSerializer(typeof(GitVersionInternal));
 
                 using (var jsonStream = new MemoryStream(Encoding.UTF8.GetBytes(jsonString)))
                 {
-                    return jsonSerializer.ReadObject(jsonStream) as GitVersion;
+                    return (jsonSerializer.ReadObject(jsonStream) as GitVersionInternal)?.GitVersion;
                 }
             }
 


### PR DESCRIPTION
Addresses issue with malformed integers in json by having an internal proxy class accepting all strings and then parsing and passing it down the GitVersion class, it's not super elegant but it does the job, the GitVersion property is lazy loaded because how the DataContractSerializer handles object initilaztion (_it'll otherwise give an null references exception_).
  
* fixes #1798 