### PR TITLE
GH1818: Support task dependees (reverse dependencies)

### DIFF
--- a/src/Cake.Core.Tests/Unit/CakeEngineTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeEngineTests.cs
@@ -150,15 +150,19 @@ namespace Cake.Core.Tests.Unit
                 engine.RegisterTask("A").Does(() => result.Add("A"));
                 engine.RegisterTask("B").IsDependentOn("A").Does(() => result.Add("B"));
                 engine.RegisterTask("C").IsDependentOn("B").Does(() => result.Add("C"));
+                engine.RegisterTask("D").IsDependentOn("C").IsDependeeOf("E").Does(() => { result.Add("D"); });
+                engine.RegisterTask("E").Does(() => { result.Add("E"); });
 
                 // When
-                engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "C");
+                engine.RunTarget(fixture.Context, fixture.ExecutionStrategy, "E");
 
                 // Then
-                Assert.Equal(3, result.Count);
+                Assert.Equal(5, result.Count);
                 Assert.Equal("A", result[0]);
                 Assert.Equal("B", result[1]);
                 Assert.Equal("C", result[2]);
+                Assert.Equal("D", result[3]);
+                Assert.Equal("E", result[4]);
             }
 
             [Fact]

--- a/src/Cake.Core.Tests/Unit/CakeTaskBuilderExtensionsTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeTaskBuilderExtensionsTests.cs
@@ -25,70 +25,88 @@ namespace Cake.Core.Tests.Unit
                 // Then
                 Assert.Equal(1, task.Dependencies.Count);
             }
+
+            public sealed class OnMethodTaskBuilder
+            {
+                [Fact]
+                public void Should_Add_Dependency_To_Task()
+                {
+                    // Given
+                    var parentTask = new ActionTask("parent");
+                    var childTask = new ActionTask("child");
+                    var builder = new CakeTaskBuilder<ActionTask>(parentTask);
+                    var cakeTaskBuilder = new CakeTaskBuilder<ActionTask>(childTask);
+
+                    // When
+                    builder.IsDependentOn(cakeTaskBuilder);
+
+                    // Then
+                    Assert.Equal(1, parentTask.Dependencies.Count);
+                }
+
+                [Fact]
+                public void Should_Add_Dependency_To_Task_With_Correct_Name()
+                {
+                    // Given
+                    var parentTask = new ActionTask("parent");
+                    var childTask = new ActionTask("child");
+                    var builder = new CakeTaskBuilder<ActionTask>(parentTask);
+                    var childTaskBuilder = new CakeTaskBuilder<ActionTask>(childTask);
+
+                    // When
+                    builder.IsDependentOn(childTaskBuilder);
+
+                    // Then
+                    Assert.Equal(parentTask.Dependencies[0].Name, childTaskBuilder.Task.Name);
+                }
+
+                [Fact]
+                public void Should_Throw_If_Builder_Is_Null()
+                {
+                    // Given
+                    var childTask = new ActionTask("child");
+                    CakeTaskBuilder<ActionTask> builder = null;
+                    var childTaskBuilder = new CakeTaskBuilder<ActionTask>(childTask);
+
+                    // When
+                    var result = Record.Exception(() => builder.IsDependentOn(childTaskBuilder));
+
+                    // Then
+                    AssertEx.IsArgumentNullException(result, "builder");
+                }
+
+                [Fact]
+                public void Should_Throw_If_OtherBuilder_Is_Null()
+                {
+                    // Given
+                    var parentTask = new ActionTask("parent");
+                    var builder = new CakeTaskBuilder<ActionTask>(parentTask);
+                    CakeTaskBuilder<ActionTask> childTaskBuilder = null;
+
+                    // When
+                    var result = Record.Exception(() => builder.IsDependentOn(childTaskBuilder));
+
+                    // Then
+                    AssertEx.IsArgumentNullException(result, "other");
+                }
+            }
         }
 
-        public sealed class TheIsDependentOnMethodTaskBuilder
+        public sealed class TheIsDependeeOfMethod
         {
             [Fact]
-            public void Should_Add_Dependency_To_Task()
+            public void Should_Add_Dependee_To_Task()
             {
                 // Given
-                var parentTask = new ActionTask("parent");
-                var childTask = new ActionTask("child");
-                var builder = new CakeTaskBuilder<ActionTask>(parentTask);
-                var cakeTaskBuilder = new CakeTaskBuilder<ActionTask>(childTask);
+                var task = new ActionTask("task");
+                var builder = new CakeTaskBuilder<ActionTask>(task);
 
                 // When
-                builder.IsDependentOn(cakeTaskBuilder);
+                builder.IsDependeeOf("other");
 
                 // Then
-                Assert.Equal(1, parentTask.Dependencies.Count);
-            }
-
-            [Fact]
-            public void Should_Add_Dependency_To_Task_With_Correct_Name()
-            {
-                // Given
-                var parentTask = new ActionTask("parent");
-                var childTask = new ActionTask("child");
-                var builder = new CakeTaskBuilder<ActionTask>(parentTask);
-                var childTaskBuilder = new CakeTaskBuilder<ActionTask>(childTask);
-
-                // When
-                builder.IsDependentOn(childTaskBuilder);
-
-                // Then
-                Assert.Equal(parentTask.Dependencies[0], childTaskBuilder.Task.Name);
-            }
-
-            [Fact]
-            public void Should_Throw_If_Builder_Is_Null()
-            {
-                // Given
-                var childTask = new ActionTask("child");
-                CakeTaskBuilder<ActionTask> builder = null;
-                var childTaskBuilder = new CakeTaskBuilder<ActionTask>(childTask);
-
-                // When
-                var result = Record.Exception(() => builder.IsDependentOn(childTaskBuilder));
-
-                // Then
-                AssertEx.IsArgumentNullException(result, "builder");
-            }
-
-            [Fact]
-            public void Should_Throw_If_OtherBuilder_Is_Null()
-            {
-                // Given
-                var parentTask = new ActionTask("parent");
-                var builder = new CakeTaskBuilder<ActionTask>(parentTask);
-                CakeTaskBuilder<ActionTask> childTaskBuilder = null;
-
-                // When
-                var result = Record.Exception(() => builder.IsDependentOn(childTaskBuilder));
-
-                // Then
-                AssertEx.IsArgumentNullException(result, "other");
+                Assert.Equal(1, task.Dependees.Count);
+                Assert.Equal("other", task.Dependees[0].Name);
             }
         }
 
@@ -278,7 +296,8 @@ namespace Cake.Core.Tests.Unit
             public void Should_Throw_If_Builder_Is_Null()
             {
                 // Given, When
-                var result = Record.Exception(() => CakeTaskBuilderExtensions.ReportError<ActionTask>(null, exception => { }));
+                var result = Record.Exception(() =>
+                    CakeTaskBuilderExtensions.ReportError<ActionTask>(null, exception => { }));
 
                 // Then
                 AssertEx.IsArgumentNullException(result, "builder");
@@ -319,7 +338,8 @@ namespace Cake.Core.Tests.Unit
             public void Should_Throw_If_Builder_Is_Null()
             {
                 // Given, When
-                var result = Record.Exception(() => CakeTaskBuilderExtensions.DoesForEach(null, new string[0], exception => { }));
+                var result = Record.Exception(() =>
+                    CakeTaskBuilderExtensions.DoesForEach(null, new string[0], exception => { }));
 
                 // Then
                 AssertEx.IsArgumentNullException(result, "builder");
@@ -408,7 +428,8 @@ namespace Cake.Core.Tests.Unit
                 var context = new CakeContextFixture().CreateContext();
 
                 // When
-                CakeTaskBuilderExtensions.DoesForEach(builder, () => new[] { "a", "b", "c" }, (item, c) => throw new NotImplementedException());
+                CakeTaskBuilderExtensions.DoesForEach(builder, () => new[] { "a", "b", "c" },
+                    (item, c) => throw new NotImplementedException());
                 var result = Record.Exception(() => builder.Task.Execute(context));
 
                 // Then

--- a/src/Cake.Core.Tests/Unit/CakeTaskTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeTaskTests.cs
@@ -51,7 +51,7 @@ namespace Cake.Core.Tests.Unit
 
                 // Then
                 Assert.Equal(1, task.Dependencies.Count);
-                Assert.Equal("other", task.Dependencies[0]);
+                Assert.Equal("other", task.Dependencies[0].Name);
             }
 
             [Fact]
@@ -67,6 +67,38 @@ namespace Cake.Core.Tests.Unit
                 // Then
                 Assert.IsType<CakeException>(result);
                 Assert.Equal("The task 'task' already have a dependency on 'other'.", result?.Message);
+            }
+        }
+
+        public sealed class TheAddReverseDependencyMethod
+        {
+            [Fact]
+            public void Should_Add_Dependency_If_Not_Already_Present()
+            {
+                // Given
+                var task = new ActionTask("task");
+
+                // When
+                task.AddReverseDependency("other");
+
+                // Then
+                Assert.Equal(1, task.Dependees.Count);
+                Assert.Equal("other", task.Dependees[0].Name);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Dependency_Already_Exist()
+            {
+                // Given
+                var task = new ActionTask("task");
+                task.AddReverseDependency("other");
+
+                // When
+                var result = Record.Exception(() => task.AddReverseDependency("other"));
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("The task 'task' already is a dependee of 'other'.", result?.Message);
             }
         }
 
@@ -247,7 +279,7 @@ namespace Cake.Core.Tests.Unit
             Assert.IsAssignableFrom<ICakeTaskInfo>(task);
             Assert.Equal("task", result.Name);
             Assert.Equal("my description", result.Description);
-            Assert.Equal(new[] { "dependency1", "dependency2" }, result.Dependencies.ToArray());
+            Assert.Equal(new[] { "dependency1", "dependency2" }, result.Dependencies.Select(x => x.Name).ToArray());
         }
     }
 }

--- a/src/Cake.Core/Cake.Core.csproj
+++ b/src/Cake.Core/Cake.Core.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <AssemblyName>Cake.Core</AssemblyName>
     <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
@@ -7,15 +6,12 @@
     <PlatformTarget>AnyCpu</PlatformTarget>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
-
   <!-- Package specific metadata -->
   <PropertyGroup>
     <Description>The Cake core library.</Description>
   </PropertyGroup>
-
   <!-- Import shared functionality -->
   <Import Project="..\Shared.msbuild" />
-
   <!-- .NET Core packages -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />
@@ -24,7 +20,6 @@
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.1" />
   </ItemGroup>
-
   <!-- .NET Framework packages -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
@@ -33,9 +28,7 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-
 </Project>

--- a/src/Cake.Core/CakeTaskBuilderExtensions.cs
+++ b/src/Cake.Core/CakeTaskBuilderExtensions.cs
@@ -46,15 +46,33 @@ namespace Cake.Core
         {
             if (builder == null)
             {
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             }
-
             if (other == null)
             {
-                throw new ArgumentNullException("other");
+                throw new ArgumentNullException(nameof(other));
             }
 
             builder.Task.AddDependency(other.Task.Name);
+            return builder;
+        }
+
+        /// <summary>
+        /// Makes the task a dependency of another task.
+        /// </summary>
+        /// <typeparam name="T">The task type.</typeparam>
+        /// <param name="builder">The task builder.</param>
+        /// <param name="name">The name of the task the current task will be a dependency of.</param>
+        /// <returns>The same <see cref="CakeTaskBuilder{T}"/> instance so that multiple calls can be chained.</returns>
+        public static CakeTaskBuilder<T> IsDependeeOf<T>(this CakeTaskBuilder<T> builder, string name)
+            where T : CakeTask
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.Task.AddReverseDependency(name);
             return builder;
         }
 

--- a/src/Cake.Core/CakeTaskDependency.cs
+++ b/src/Cake.Core/CakeTaskDependency.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Cake.Core
+{
+    /// <summary>
+    /// Represents a task dependency.
+    /// </summary>
+    public sealed class CakeTaskDependency
+    {
+        /// <summary>
+        /// Gets the name of the dependency.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether or not the dependency is required.
+        /// </summary>
+        public bool Required { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CakeTaskDependency"/> class.
+        /// </summary>
+        /// <param name="name">The name of the task.</param>
+        /// <param name="required">Whether or not the dependency is required.</param>
+        public CakeTaskDependency(string name, bool required)
+        {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            Required = required;
+        }
+    }
+}

--- a/src/Cake.Core/Graph/CakeGraphBuilder.cs
+++ b/src/Cake.Core/Graph/CakeGraphBuilder.cs
@@ -20,14 +20,36 @@ namespace Cake.Core.Graph
             {
                 foreach (var dependency in task.Dependencies)
                 {
-                    if (!graph.Exist(dependency))
+                    if (!graph.Exist(dependency.Name))
                     {
-                        const string format = "Task '{0}' is dependent on task '{1}' which does not exist.";
-                        var message = string.Format(CultureInfo.InvariantCulture, format, task.Name, dependency);
-                        throw new CakeException(message);
+                        if (dependency.Required)
+                        {
+                            const string format = "Task '{0}' is dependent on task '{1}' which does not exist.";
+                            var message = string.Format(CultureInfo.InvariantCulture, format, task.Name, dependency.Name);
+                            throw new CakeException(message);
+                        }
                     }
+                    else
+                    {
+                        graph.Connect(dependency.Name, task.Name);
+                    }
+                }
 
-                    graph.Connect(dependency, task.Name);
+                foreach (var dependency in task.Dependees)
+                {
+                    if (!graph.Exist(dependency.Name))
+                    {
+                        if (dependency.Required)
+                        {
+                            const string format = "Task '{0}' has specified that it's a dependency for task '{1}' which does not exist.";
+                            var message = string.Format(CultureInfo.InvariantCulture, format, task.Name, dependency.Name);
+                            throw new CakeException(message);
+                        }
+                    }
+                    else
+                    {
+                        graph.Connect(task.Name, dependency.Name);
+                    }
                 }
             }
             return graph;

--- a/src/Cake.Core/ICakeTaskInfo.cs
+++ b/src/Cake.Core/ICakeTaskInfo.cs
@@ -27,6 +27,12 @@ namespace Cake.Core
         /// Gets the task's dependencies.
         /// </summary>
         /// <value>The task's dependencies.</value>
-        IReadOnlyList<string> Dependencies { get; }
+        IReadOnlyList<CakeTaskDependency> Dependencies { get; }
+
+        /// <summary>
+        /// Gets the tasks that the task want to be a dependency of.
+        /// </summary>
+        /// <value>The tasks that the task want to be a dependency of.</value>
+        IReadOnlyList<CakeTaskDependency> Dependees { get; }
     }
 }

--- a/src/Cake.Testing.Xunit/Cake.Testing.Xunit.csproj
+++ b/src/Cake.Testing.Xunit/Cake.Testing.Xunit.csproj
@@ -1,30 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <AssemblyName>Cake.Testing.Xunit</AssemblyName>
     <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
     <OutputType>Library</OutputType>
     <PlatformTarget>AnyCpu</PlatformTarget>
   </PropertyGroup>
-
   <!-- Import shared functionality -->
   <Import Project="..\Shared.msbuild" />
-
   <!-- Global packages -->
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
   </ItemGroup>
-
   <!-- Project references -->
   <ItemGroup>
     <ProjectReference Include="..\Cake.Core\Cake.Core.csproj" />
   </ItemGroup>
-
   <!-- .NET Framework packages -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="System.Runtime" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
* Added support for reverse dependencies.
* Dependencies can now be optional.

```csharp
Task("A");
Task("B").IsDependentOn("A", required: true);
Task("C").IsDependentOn("B").IsDependeeOf("D");
Task("D").IsDependeeOf("E", required: false);

RunTarget("D");
```

Fixes #1818