### PR TITLE
GH1831: Verify CurrentToken is not null before checking Kind property

### DIFF
--- a/src/Cake.Core.Tests/Unit/IO/GlobberTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/GlobberTests.cs
@@ -249,6 +249,19 @@ namespace Cake.Core.Tests.Unit.IO
             }
 
             [Fact]
+            public void Should_Return_Empty_Result_If_Pattern_Is_Invalid()
+            {
+                // Given
+                var fixture = new GlobberFixture();
+
+                // When
+                var result = fixture.Match("pattern/");
+
+                // Then
+                Assert.Empty(result);
+            }
+
+            [Fact]
             public void Can_Traverse_Recursively()
             {
                 // Given

--- a/src/Cake.Core/IO/Globbing/GlobParser.cs
+++ b/src/Cake.Core/IO/Globbing/GlobParser.cs
@@ -109,17 +109,17 @@ namespace Cake.Core.IO.Globbing
 
         private static GlobNode ParseSegment(GlobParserContext context)
         {
-            if (context.CurrentToken.Kind == GlobTokenKind.DirectoryWildcard)
+            if (context.CurrentToken?.Kind == GlobTokenKind.DirectoryWildcard)
             {
                 context.Accept();
                 return new RecursiveWildcardSegment();
             }
-            if (context.CurrentToken.Kind == GlobTokenKind.Parent)
+            if (context.CurrentToken?.Kind == GlobTokenKind.Parent)
             {
                 context.Accept();
                 return new ParentSegment();
             }
-            if (context.CurrentToken.Kind == GlobTokenKind.Current)
+            if (context.CurrentToken?.Kind == GlobTokenKind.Current)
             {
                 context.Accept();
                 return new CurrentSegment();


### PR DESCRIPTION
For #1831 

Discussed briefly in the CAKE gitter. This should be a better place for any discussions if they are needed.