### PR TITLE
Fixed typo in installer scripts

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -111,7 +111,7 @@ if (!(Test-Path $CakePath)) {
     Write-Host "Installing Cake..."
     Invoke-Expression "&`"$NugetPath`" install Cake -Version $CakeVersion -OutputDirectory `"$ToolPath`"" | Out-Null;
     if ($LASTEXITCODE -ne 0) {
-        Throw "An error occured while restoring Cake from NuGet."
+        Throw "An error occurred while restoring Cake from NuGet."
     }
 }
 

--- a/build.sh
+++ b/build.sh
@@ -65,7 +65,7 @@ if [ ! -f "$NUGET_EXE" ]; then
     echo "Downloading NuGet..."
     curl -Lsfo "$NUGET_EXE" $NUGET_URL
     if [ $? -ne 0 ]; then
-        echo "An error occured while downloading nuget.exe."
+        echo "An error occurred while downloading nuget.exe."
         exit 1
     fi
 fi


### PR DESCRIPTION
This PR fixes a typo in PowerShell and bash scripts. The typo is `occured` instead of `occurred`.