### PR TITLE
GH1838: Add reference to nuget dependencies

### DIFF
--- a/src/Cake.NuGet/Install/NuGetFolderProject.cs
+++ b/src/Cake.NuGet/Install/NuGetFolderProject.cs
@@ -105,7 +105,7 @@ namespace Cake.NuGet.Install
                         continue;
                     }
 
-                    var dependencyInstallPath = new DirectoryPath(_pathResolver.GetInstallPath(package));
+                    var dependencyInstallPath = new DirectoryPath(_pathResolver.GetInstallPath(dependency));
 
                     if (!_fileSystem.Exist(dependencyInstallPath))
                     {


### PR DESCRIPTION
This fixes #1838

I think that simply the wrong package identity was used here.  Instead of `package` which is the identity of the package we are evaluating dependencies for, the `dependency` instance should be used instead which will give us the correct path to the actual libraries in the dependency package.

Using `dependency` just caused the actual main package to have multiple duplicate references added.