### PR TITLE
Fixes StyleCop issues

### DIFF
--- a/src/Cake.Common/Tools/MSBuild/MSBuildBinaryLogSettings.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildBinaryLogSettings.cs
@@ -16,17 +16,17 @@ namespace Cake.Common.Tools.MSBuild
     public class MSBuildBinaryLogSettings
     {
         /// <summary>
-        /// Should binary logging be enabled
+        /// Gets or sets a value indicating whether binary logging should be enabled.
         /// </summary>
         public bool Enabled { get; set; }
 
         /// <summary>
-        /// Output filename (optional)
+        /// Gets or sets the output filename.
         /// </summary>
         public string FileName { get; set; }
 
         /// <summary>
-        /// What source files should be included in the log
+        /// Gets or sets what source files should be included in the log.
         /// </summary>
         public MSBuildBinaryLogImports Imports { get; set; }
     }

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverSettings.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverSettings.cs
@@ -67,7 +67,7 @@ namespace Cake.Common.Tools.OpenCover
         public bool MergeOutput { get; set; }
 
         /// <summary>
-        /// Gets or sets a list of directories where assemblies being loaded from will be ignored.
+        /// Gets a list of directories where assemblies being loaded from will be ignored.
         /// </summary>
         public ISet<DirectoryPath> ExcludeDirectories => _excludeDirectories;
 
@@ -77,23 +77,23 @@ namespace Cake.Common.Tools.OpenCover
         public OpenCoverLogLevel LogLevel { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating to merge the coverage results for an assembly
+        /// Gets or sets a value indicating whether to merge the coverage results for an assembly
         /// regardless of where it was loaded assuming it has the same file-hash in each location.
         /// </summary>
         public bool MergeByHash { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating if the default filters should be applied or not.
+        /// Gets or sets a value indicating whether the default filters should be applied or not.
         /// </summary>
         public bool NoDefaultFilters { get; set; }
 
         /// <summary>
-        /// Gets or sets a list of directories with alternative locations to look for PDBs.
+        /// Gets a list of directories with alternative locations to look for PDBs.
         /// </summary>
         public ISet<DirectoryPath> SearchDirectories => _searchDirectories;
 
         /// <summary>
-        /// Gets or sets a value indicating if the value provided in the target parameter
+        /// Gets or sets a value indicating whether if the value provided in the target parameter
         /// is the name of a service rather than a name of a process.
         /// </summary>
         public bool IsService { get; set; }

--- a/src/Cake.Core/Cake.Core.csproj
+++ b/src/Cake.Core/Cake.Core.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <AssemblyName>Cake.Core</AssemblyName>
     <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
@@ -6,12 +7,15 @@
     <PlatformTarget>AnyCpu</PlatformTarget>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
   <!-- Package specific metadata -->
   <PropertyGroup>
     <Description>The Cake core library.</Description>
   </PropertyGroup>
+  
   <!-- Import shared functionality -->
   <Import Project="..\Shared.msbuild" />
+
   <!-- .NET Core packages -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />
@@ -20,6 +24,7 @@
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.1" />
   </ItemGroup>
+
   <!-- .NET Framework packages -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
@@ -28,7 +33,9 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
+
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+
 </Project>

--- a/src/Cake.Testing.Xunit/Cake.Testing.Xunit.csproj
+++ b/src/Cake.Testing.Xunit/Cake.Testing.Xunit.csproj
@@ -1,25 +1,31 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <AssemblyName>Cake.Testing.Xunit</AssemblyName>
     <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
     <OutputType>Library</OutputType>
     <PlatformTarget>AnyCpu</PlatformTarget>
   </PropertyGroup>
+
   <!-- Import shared functionality -->
   <Import Project="..\Shared.msbuild" />
+
   <!-- Global packages -->
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
   </ItemGroup>
+
   <!-- Project references -->
   <ItemGroup>
     <ProjectReference Include="..\Cake.Core\Cake.Core.csproj" />
   </ItemGroup>
+
   <!-- .NET Framework packages -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="System.Runtime" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
+
 </Project>

--- a/src/Shared.msbuild
+++ b/src/Shared.msbuild
@@ -58,7 +58,7 @@
   </PropertyGroup>
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta001">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
StyleCop should now run when running MSBuild from the commandline. Not sure why it didn't work but updating the StyleCop.Analyzers package solved it.

Also had to fix the `SA1623` and `SA1624` errors to make the CI build pass, so proving that this works is kind of difficult...

Fixes #1841