### PR TITLE
GH1547: Fix issue with parsing escaped curly braces in FormatParser

### DIFF
--- a/src/Cake.Core.Tests/Unit/Diagnostics/FormatParserTests.cs
+++ b/src/Cake.Core.Tests/Unit/Diagnostics/FormatParserTests.cs
@@ -48,6 +48,90 @@ namespace Cake.Core.Tests.Unit.Diagnostics
             }
 
             [Fact]
+            public void Should_Return_Literal_Tokens_For_Message_With_Nothing_But_Escaped_Braces()
+            {
+                // Given, When
+                var result = FormatParser.Parse("{{}}").ToArray();
+
+                // Then
+                Assert.Equal(2, result.Length);
+                Assert.IsType<LiteralToken>(result[0]);
+                Assert.Equal("{", ((LiteralToken)result[0]).Text);
+                Assert.Equal("}", ((LiteralToken)result[1]).Text);
+            }
+
+            [Fact]
+            public void Should_Return_Literal_Tokens_For_Message_With_Escaped_Braces_And_Properties()
+            {
+                // Given, When
+                var result = FormatParser.Parse("{{}} {0}").ToArray();
+
+                // Then
+                Assert.Equal(3, result.Length);
+                Assert.IsType<LiteralToken>(result[0]);
+                Assert.Equal("{", ((LiteralToken)result[0]).Text);
+                Assert.Equal("} ", ((LiteralToken)result[1]).Text);
+
+                Assert.IsType<PropertyToken>(result[2]);
+                Assert.Equal(0, ((PropertyToken)result[2]).Position);
+                Assert.Equal(null, ((PropertyToken)result[2]).Format);
+            }
+
+            [Fact]
+            public void Should_Return_Literal_Token_For_Unbalanced_Escaped_Opening_Curly_Braces()
+            {
+                // Given, When
+                var result = FormatParser.Parse("{{ test {0}").ToArray();
+
+                // Then
+                Assert.Equal(3, result.Length);
+                Assert.IsType<LiteralToken>(result[0]);
+                Assert.Equal("{", ((LiteralToken)result[0]).Text);
+                Assert.Equal(" test ", ((LiteralToken)result[1]).Text);
+
+                Assert.IsType<PropertyToken>(result[2]);
+                Assert.Equal(0, ((PropertyToken)result[2]).Position);
+                Assert.Equal(null, ((PropertyToken)result[2]).Format);
+            }
+
+            [Fact]
+            public void Should_Return_Literal_Tokens_For_Multiple_Unbalanced_Escaped_Opening_Curly_Braces()
+            {
+                // Given, When
+                var result = FormatParser.Parse("{{{{ test {0}").ToArray();
+
+                // Then
+                Assert.Equal(4, result.Length);
+                Assert.IsType<LiteralToken>(result[0]);
+                Assert.Equal("{", ((LiteralToken)result[0]).Text);
+                Assert.Equal("{", ((LiteralToken)result[1]).Text);
+                Assert.Equal(" test ", ((LiteralToken)result[2]).Text);
+
+                Assert.IsType<PropertyToken>(result[3]);
+                Assert.Equal(0, ((PropertyToken)result[3]).Position);
+                Assert.Equal(null, ((PropertyToken)result[3]).Format);
+            }
+
+            [Fact]
+            public void Should_Return_Literal_Token_For_Unbalanced_Escaped_Closing_Curly_Braces()
+            {
+                // Given, When
+                var result = FormatParser.Parse("test {0:d} }}").ToArray();
+
+                // Then
+                Assert.Equal(3, result.Length);
+                Assert.IsType<LiteralToken>(result[0]);
+                Assert.Equal("test ", ((LiteralToken)result[0]).Text);
+
+                Assert.IsType<PropertyToken>(result[1]);
+                Assert.Equal(0, ((PropertyToken)result[1]).Position);
+                Assert.Equal("d", ((PropertyToken)result[1]).Format);
+
+                Assert.IsType<LiteralToken>(result[2]);
+                Assert.Equal(" }", ((LiteralToken)result[2]).Text);
+            }
+
+            [Fact]
             public void Should_Return_Literal_Tokens_For_Message_With_Escaped_Braces()
             {
                 // Given, When
@@ -56,8 +140,8 @@ namespace Cake.Core.Tests.Unit.Diagnostics
                 // Then
                 Assert.Equal(2, result.Length);
                 Assert.IsType<LiteralToken>(result[0]);
-                Assert.Equal("{{", ((LiteralToken)result[0]).Text);
-                Assert.Equal("0}}", ((LiteralToken)result[1]).Text);
+                Assert.Equal("{", ((LiteralToken)result[0]).Text);
+                Assert.Equal("0}", ((LiteralToken)result[1]).Text);
             }
 
             [Fact]
@@ -85,6 +169,17 @@ namespace Cake.Core.Tests.Unit.Diagnostics
             }
 
             [Fact]
+            public void Should_Throw_If_A_Format_Item_Is_Not_Positional_Even_If_Other_Valid_Tokens_Are_Present()
+            {
+                // Given, When
+                var result = Record.Exception(() => FormatParser.Parse("{} {0}").ToArray());
+
+                // Then
+                Assert.IsType<FormatException>(result);
+                Assert.Equal("Input string was not in a correct format.", result?.Message);
+            }
+
+            [Fact]
             public void Should_Throw_If_A_Format_Item_With_Format_Is_Not_Positional()
             {
                 // Given, When
@@ -103,10 +198,17 @@ namespace Cake.Core.Tests.Unit.Diagnostics
 
                 // Then
                 Assert.Equal(5, result.Length);
+
                 Assert.IsType<LiteralToken>(result[0]);
+
                 Assert.IsType<PropertyToken>(result[1]);
+                Assert.Equal(0, ((PropertyToken)result[1]).Position);
+
                 Assert.IsType<LiteralToken>(result[2]);
+
                 Assert.IsType<PropertyToken>(result[3]);
+                Assert.Equal(1, ((PropertyToken)result[3]).Position);
+
                 Assert.IsType<LiteralToken>(result[4]);
             }
         }

--- a/src/Cake.Core/Diagnostics/Formatting/FormatParser.cs
+++ b/src/Cake.Core/Diagnostics/Formatting/FormatParser.cs
@@ -45,7 +45,7 @@ namespace Cake.Core.Diagnostics.Formatting
             if ((char)reader.Peek() == '{')
             {
                 reader.Read();
-                return new LiteralToken("{{");
+                return new LiteralToken("{");
             }
             var builder = new StringBuilder();
             while (true)
@@ -105,6 +105,12 @@ namespace Cake.Core.Diagnostics.Formatting
                 if (character == '{')
                 {
                     break;
+                }
+                if (character == '}' && reader.Peek() == '}')
+                {
+                    // escaped curly sequence, consume the first character,
+                    // let the iteration/append continue below.
+                    reader.Read();
                 }
                 builder.Append((char)reader.Read());
             }


### PR DESCRIPTION
This addresses the issues described in GH-1547 regarding escaping curlies.

As detailed in the original issue, testing this fix uncovered an additional bug (inconsistency with `string.Format` implementation)

> The one thing that I think this exposes is a bug in the LiteralToken that is being returned for escaped curlies 
>`Information("{{}} {0}", 123); outputs "{{}} 123"`
>@DixonDs is right in that this should probably output {} 123 to be consistent with expectations, namely the implementation of string.Format. I have adjusted the parser to return a single '{' or '}' in those cases and updated the tests to match.

