### PR TITLE
GH1548: Add logic to escape colorization for single {0} token

### DIFF
--- a/src/Cake.Core.Tests/Unit/Diagnostics/CakeBuildLogTests.cs
+++ b/src/Cake.Core.Tests/Unit/Diagnostics/CakeBuildLogTests.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Cake.Core.Diagnostics;
 using Cake.Testing;
+using NSubstitute;
 using Xunit;
 
 namespace Cake.Core.Tests.Unit.Diagnostics
@@ -80,6 +82,40 @@ namespace Cake.Core.Tests.Unit.Diagnostics
 
                 // Then
                 Assert.Single(console.ErrorMessages);
+            }
+
+            [Fact]
+            public void Should_Not_Colorize_A_Log_Message_Containg_A_Single_Token()
+            {
+                // Given
+                var console = Substitute.For<IConsole>();
+                var log = new CakeBuildLog(console, Verbosity.Diagnostic);
+
+                // When
+                log.Write(Verbosity.Diagnostic, LogLevel.Information, "{0}", "Hello World");
+
+                // Then
+                console.Received().Write("{0}", "Hello World");
+                console.DidNotReceive().BackgroundColor = ConsoleColor.DarkBlue;
+            }
+
+            [Fact]
+            public void Should_Colorize_Tokens_Correctly()
+            {
+                // Given
+                var console = Substitute.For<IConsole>();
+                var log = new CakeBuildLog(console, Verbosity.Diagnostic);
+
+                // When
+                log.Write(Verbosity.Diagnostic, LogLevel.Information, "Hello, {0}", "World");
+
+                // Then
+                console.Received().Write("{0}", "Hello, ");
+                console.Received().Write("{0}", "World");
+
+                // console would have been set to fore/back color for the "World" argument.
+                console.Received().BackgroundColor = ConsoleColor.DarkBlue;
+                console.Received().ForegroundColor = ConsoleColor.White;
             }
         }
     }

--- a/src/Cake.Core/Diagnostics/CakeBuildLog.cs
+++ b/src/Cake.Core/Diagnostics/CakeBuildLog.cs
@@ -56,9 +56,14 @@ namespace Cake.Core.Diagnostics
                 {
                     var palette = _palettes[level];
                     var tokens = FormatParser.Parse(format);
+
+                    // if the entirety of the formatting string is a single token, as is coming from
+                    // the LogExtensions implementation of (string) and (object), don't attempt to colorize the output.
+                    var colorize = !"{0}".Equals(format, StringComparison.OrdinalIgnoreCase);
+
                     foreach (var token in tokens)
                     {
-                        SetPalette(token, palette);
+                        SetPalette(token, palette, colorize);
                         if (level > LogLevel.Error)
                         {
                             _console.Write("{0}", token.Render(args));
@@ -84,10 +89,9 @@ namespace Cake.Core.Diagnostics
             }
         }
 
-        private void SetPalette(FormatToken token, ConsolePalette palette)
+        private void SetPalette(FormatToken token, ConsolePalette palette, bool colorize)
         {
-            var property = token as PropertyToken;
-            if (property != null)
+            if (colorize && token is PropertyToken)
             {
                 _console.BackgroundColor = palette.ArgumentBackground;
                 _console.ForegroundColor = palette.ArgumentForeground;


### PR DESCRIPTION
This addresses the regression identified in GH-1548.

Because of the changes that were made as part of 0.18.0, the `CakeBuildLog` will ultimately be consuming _some_ strings that consist solely of `{0}`.  In those cases, it doesn't make sense to change the `BackgroundColor` and `ForegroundColor` for the entire string (treating the entire string as a token argument)

These cases come into play in the `LogExtensions` methods like 
```
public static void Warning(this ICakeLog log, object value)
{
    log.Warning("{0}", value);
}
public static void Warning(this ICakeLog log, string value)
{
    log.Warning("{0}", value);
}
```

By introducing an extra check for the entire raw string being `{0}`, we can allow the output to be colorized in the same way it was prior to 0.18.0