### PR TITLE
GH1731: Adding variables for version 9+ runner.

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Build/GitLabCIInfoFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/GitLabCIInfoFixture.cs
@@ -12,22 +12,38 @@ namespace Cake.Common.Tests.Fixtures.Build
     {
         public ICakeEnvironment Environment { get; set; }
 
-        public GitLabCIInfoFixture()
+        public GitLabCIInfoFixture(bool versionNineOrNewer = false)
         {
             Environment = Substitute.For<ICakeEnvironment>();
 
             // Example values taken from https://docs.gitlab.com/ce/ci/variables/README.html
             Environment.GetEnvironmentVariable("CI_SERVER").Returns("yes");
-            Environment.GetEnvironmentVariable("CI_BUILD_ID").Returns("50");
-            Environment.GetEnvironmentVariable("CI_BUILD_REF").Returns("1ecfd275763eff1d6b4844ea3168962458c9f27a");
-            Environment.GetEnvironmentVariable("CI_BUILD_REF_NAME").Returns("master");
-            Environment.GetEnvironmentVariable("CI_BUILD_REPO").Returns("https://gitab-ci-token:abcde-1234ABCD5678ef@gitlab.com/gitlab-org/gitlab-ce.git");
-            Environment.GetEnvironmentVariable("CI_BUILD_TAG").Returns("1.0.0");
-            Environment.GetEnvironmentVariable("CI_BUILD_NAME").Returns("spec:other");
-            Environment.GetEnvironmentVariable("CI_BUILD_STAGE").Returns("test");
-            Environment.GetEnvironmentVariable("CI_BUILD_MANUAL").Returns("true");
-            Environment.GetEnvironmentVariable("CI_BUILD_TRIGGERED").Returns("true");
-            Environment.GetEnvironmentVariable("CI_BUILD_TOKEN").Returns("abcde-1234ABCD5678ef");
+            if (versionNineOrNewer)
+            {
+                Environment.GetEnvironmentVariable("CI_JOB_ID").Returns("50");
+                Environment.GetEnvironmentVariable("CI_COMMIT_SHA").Returns("1ecfd275763eff1d6b4844ea3168962458c9f27a");
+                Environment.GetEnvironmentVariable("CI_COMMIT_REF_NAME").Returns("master");
+                Environment.GetEnvironmentVariable("CI_REPOSITORY_URL").Returns("https://gitab-ci-token:abcde-1234ABCD5678ef@gitlab.com/gitlab-org/gitlab-ce.git");
+                Environment.GetEnvironmentVariable("CI_COMMIT_TAG").Returns("1.0.0");
+                Environment.GetEnvironmentVariable("CI_JOB_NAME").Returns("spec:other");
+                Environment.GetEnvironmentVariable("CI_JOB_STAGE").Returns("test");
+                Environment.GetEnvironmentVariable("CI_JOB_MANUAL").Returns("true");
+                Environment.GetEnvironmentVariable("CI_PIPELINE_TRIGGERED").Returns("true");
+                Environment.GetEnvironmentVariable("CI_JOB_TOKEN").Returns("abcde-1234ABCD5678ef");
+            }
+            else
+            {
+                Environment.GetEnvironmentVariable("CI_BUILD_ID").Returns("50");
+                Environment.GetEnvironmentVariable("CI_BUILD_REF").Returns("1ecfd275763eff1d6b4844ea3168962458c9f27a");
+                Environment.GetEnvironmentVariable("CI_BUILD_REF_NAME").Returns("master");
+                Environment.GetEnvironmentVariable("CI_BUILD_REPO").Returns("https://gitab-ci-token:abcde-1234ABCD5678ef@gitlab.com/gitlab-org/gitlab-ce.git");
+                Environment.GetEnvironmentVariable("CI_BUILD_TAG").Returns("1.0.0");
+                Environment.GetEnvironmentVariable("CI_BUILD_NAME").Returns("spec:other");
+                Environment.GetEnvironmentVariable("CI_BUILD_STAGE").Returns("test");
+                Environment.GetEnvironmentVariable("CI_BUILD_MANUAL").Returns("true");
+                Environment.GetEnvironmentVariable("CI_BUILD_TRIGGERED").Returns("true");
+                Environment.GetEnvironmentVariable("CI_BUILD_TOKEN").Returns("abcde-1234ABCD5678ef");
+            }
             Environment.GetEnvironmentVariable("CI_PIPELINE_ID").Returns("1000");
             Environment.GetEnvironmentVariable("CI_PROJECT_ID").Returns("34");
             Environment.GetEnvironmentVariable("CI_PROJECT_DIR").Returns("/builds/gitlab-org/gitlab-ce");

--- a/src/Cake.Common.Tests/Unit/Build/GitLabCI/Data/GitLabCIBuildInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/GitLabCI/Data/GitLabCIBuildInfoTests.cs
@@ -24,6 +24,19 @@ namespace Cake.Common.Tests.Unit.Build.GitLabCI.Data
                 // Then
                 Assert.Equal(50, result);
             }
+
+            [Fact]
+            public void Should_Return_Correct_Value_Version_Nine_Or_Newer()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture(true).CreateBuildInfo();
+
+                // When
+                var result = info.Id;
+
+                // Then
+                Assert.Equal(50, result);
+            }
         }
 
         public sealed class TheManualProperty
@@ -40,6 +53,19 @@ namespace Cake.Common.Tests.Unit.Build.GitLabCI.Data
                 // Then
                 Assert.Equal(true, result);
             }
+
+            [Fact]
+            public void Should_Return_Correct_Value_Version_Nine_Or_Newer()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture(true).CreateBuildInfo();
+
+                // When
+                var result = info.Manual;
+
+                // Then
+                Assert.Equal(true, result);
+            }
         }
 
         public sealed class TheNameProperty
@@ -49,6 +75,19 @@ namespace Cake.Common.Tests.Unit.Build.GitLabCI.Data
             {
                 // Given
                 var info = new GitLabCIInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.Name;
+
+                // Then
+                Assert.Equal("spec:other", result);
+            }
+
+            [Fact]
+            public void Should_Return_Correct_Value_Version_Nine_Or_Newer()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture(true).CreateBuildInfo();
 
                 // When
                 var result = info.Name;
@@ -88,6 +127,19 @@ namespace Cake.Common.Tests.Unit.Build.GitLabCI.Data
                 // Then
                 Assert.Equal("1ecfd275763eff1d6b4844ea3168962458c9f27a", result);
             }
+
+            [Fact]
+            public void Should_Return_Correct_Value_Version_Nine_Or_Newer()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.Reference;
+
+                // Then
+                Assert.Equal("1ecfd275763eff1d6b4844ea3168962458c9f27a", result);
+            }
         }
 
         public sealed class TheRefNameProperty
@@ -97,6 +149,19 @@ namespace Cake.Common.Tests.Unit.Build.GitLabCI.Data
             {
                 // Given
                 var info = new GitLabCIInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.RefName;
+
+                // Then
+                Assert.Equal("master", result);
+            }
+
+            [Fact]
+            public void Should_Return_Correct_Value_Version_Nine_Or_Newer()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture(true).CreateBuildInfo();
 
                 // When
                 var result = info.RefName;
@@ -120,6 +185,19 @@ namespace Cake.Common.Tests.Unit.Build.GitLabCI.Data
                 // Then
                 Assert.Equal("https://gitab-ci-token:abcde-1234ABCD5678ef@gitlab.com/gitlab-org/gitlab-ce.git", result);
             }
+
+            [Fact]
+            public void Should_Return_Correct_Value_Version_Nine_Or_Newer()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture(true).CreateBuildInfo();
+
+                // When
+                var result = info.RepoUrl;
+
+                // Then
+                Assert.Equal("https://gitab-ci-token:abcde-1234ABCD5678ef@gitlab.com/gitlab-org/gitlab-ce.git", result);
+            }
         }
 
         public sealed class TheStageProperty
@@ -129,6 +207,19 @@ namespace Cake.Common.Tests.Unit.Build.GitLabCI.Data
             {
                 // Given
                 var info = new GitLabCIInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.Stage;
+
+                // Then
+                Assert.Equal("test", result);
+            }
+
+            [Fact]
+            public void Should_Return_Correct_Value_Version_Nine_Or_Newer()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture(true).CreateBuildInfo();
 
                 // When
                 var result = info.Stage;
@@ -152,6 +243,19 @@ namespace Cake.Common.Tests.Unit.Build.GitLabCI.Data
                 // Then
                 Assert.Equal("1.0.0", result);
             }
+
+            [Fact]
+            public void Should_Return_Correct_Value_Version_Nine_Or_Newer()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture(true).CreateBuildInfo();
+
+                // When
+                var result = info.Tag;
+
+                // Then
+                Assert.Equal("1.0.0", result);
+            }
         }
 
         public sealed class TheTokenProperty
@@ -168,6 +272,19 @@ namespace Cake.Common.Tests.Unit.Build.GitLabCI.Data
                 // Then
                 Assert.Equal("abcde-1234ABCD5678ef", result);
             }
+
+            [Fact]
+            public void Should_Return_Correct_Value_Version_Nine_Or_Newer()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture(true).CreateBuildInfo();
+
+                // When
+                var result = info.Token;
+
+                // Then
+                Assert.Equal("abcde-1234ABCD5678ef", result);
+            }
         }
 
         public sealed class TheTriggeredProperty
@@ -177,6 +294,19 @@ namespace Cake.Common.Tests.Unit.Build.GitLabCI.Data
             {
                 // Given
                 var info = new GitLabCIInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.Triggered;
+
+                // Then
+                Assert.Equal(true, result);
+            }
+
+            [Fact]
+            public void Should_Return_Correct_Value_Version_Nine_Or_Newer()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture(true).CreateBuildInfo();
 
                 // When
                 var result = info.Triggered;

--- a/src/Cake.Common/Build/GitLabCI/Data/GitLabCIBuildInfo.cs
+++ b/src/Cake.Common/Build/GitLabCI/Data/GitLabCIBuildInfo.cs
@@ -26,7 +26,7 @@ namespace Cake.Common.Build.GitLabCI.Data
         /// <value>
         /// The build ID.
         /// </value>
-        public int Id => GetEnvironmentInteger("CI_BUILD_ID");
+        public int Id => GetEnvironmentInteger("CI_JOB_ID", "CI_BUILD_ID");
 
         /// <summary>
         /// Gets the commit revision for which project is built.
@@ -34,7 +34,7 @@ namespace Cake.Common.Build.GitLabCI.Data
         /// <value>
         /// The commit revision hash.
         /// </value>
-        public string Reference => GetEnvironmentString("CI_BUILD_REF");
+        public string Reference => GetEnvironmentString("CI_COMMIT_SHA", "CI_BUILD_REF");
 
         /// <summary>
         /// Gets the commit tag name. Present only when building tags.
@@ -42,7 +42,7 @@ namespace Cake.Common.Build.GitLabCI.Data
         /// <value>
         /// The build tag name.
         /// </value>
-        public string Tag => GetEnvironmentString("CI_BUILD_TAG");
+        public string Tag => GetEnvironmentString("CI_COMMIT_TAG", "CI_BUILD_TAG");
 
         /// <summary>
         /// Gets the name of the build as defined in .gitlab-ci.yml.
@@ -50,7 +50,7 @@ namespace Cake.Common.Build.GitLabCI.Data
         /// <value>
         /// The name of the build.
         /// </value>
-        public string Name => GetEnvironmentString("CI_BUILD_NAME");
+        public string Name => GetEnvironmentString("CI_JOB_NAME", "CI_BUILD_NAME");
 
         /// <summary>
         /// Gets the name of the stage as defined in .gitlab-ci.yml.
@@ -58,7 +58,7 @@ namespace Cake.Common.Build.GitLabCI.Data
         /// <value>
         /// The name of the current stage.
         /// </value>
-        public string Stage => GetEnvironmentString("CI_BUILD_STAGE");
+        public string Stage => GetEnvironmentString("CI_JOB_STAGE", "CI_BUILD_STAGE");
 
         /// <summary>
         /// Gets the branch or tag name for which project is built.
@@ -66,7 +66,7 @@ namespace Cake.Common.Build.GitLabCI.Data
         /// <value>
         /// The branch or tag for this build.
         /// </value>
-        public string RefName => GetEnvironmentString("CI_BUILD_REF_NAME");
+        public string RefName => GetEnvironmentString("CI_COMMIT_REF_NAME", "CI_BUILD_REF_NAME");
 
         /// <summary>
         /// Gets the URL to clone the Git repository.
@@ -74,7 +74,7 @@ namespace Cake.Common.Build.GitLabCI.Data
         /// <value>
         /// The repository URL.
         /// </value>
-        public string RepoUrl => GetEnvironmentString("CI_BUILD_REPO");
+        public string RepoUrl => GetEnvironmentString("CI_REPOSITORY_URL", "CI_BUILD_REPO");
 
         /// <summary>
         /// Gets a value indicating whether the build was triggered.
@@ -82,7 +82,7 @@ namespace Cake.Common.Build.GitLabCI.Data
         /// <value>
         /// <c>True</c> if the build was triggered, otherwise <c>false</c>.
         /// </value>
-        public bool Triggered => GetEnvironmentBoolean("CI_BUILD_TRIGGERED");
+        public bool Triggered => GetEnvironmentBoolean("CI_PIPELINE_TRIGGERED", "CI_BUILD_TRIGGERED");
 
         /// <summary>
         /// Gets a value indicating whether the build was manually started.
@@ -90,7 +90,7 @@ namespace Cake.Common.Build.GitLabCI.Data
         /// <value>
         /// <c>True</c> if the build was started manually, otherwise <c>false</c>.
         /// </value>
-        public bool Manual => GetEnvironmentBoolean("CI_BUILD_MANUAL");
+        public bool Manual => GetEnvironmentBoolean("CI_JOB_MANUAL", "CI_BUILD_MANUAL");
 
         /// <summary>
         /// Gets the token used for authenticating with the GitLab Container Registry.
@@ -98,7 +98,7 @@ namespace Cake.Common.Build.GitLabCI.Data
         /// <value>
         /// The build authorisation token.
         /// </value>
-        public string Token => GetEnvironmentString("CI_BUILD_TOKEN");
+        public string Token => GetEnvironmentString("CI_JOB_TOKEN", "CI_BUILD_TOKEN");
 
         /// <summary>
         /// Gets the unique id of the current pipeline that GitLab CI uses internally.

--- a/src/Cake.Common/Build/GitLabCI/GitLabCIInfo.cs
+++ b/src/Cake.Common/Build/GitLabCI/GitLabCIInfo.cs
@@ -34,6 +34,17 @@ namespace Cake.Common.Build.GitLabCI
         }
 
         /// <summary>
+        /// Gets an environment variable as a <see cref="System.String"/>.
+        /// </summary>
+        /// <param name="primaryVariable">The primary environment variable name.</param>
+        /// <param name="secondaryVariable">The secondary environment variable name.</param>
+        /// <returns>The environment variable.</returns>
+        protected string GetEnvironmentString(string primaryVariable, string secondaryVariable)
+        {
+            return !string.IsNullOrEmpty(GetEnvironmentString(primaryVariable)) ? GetEnvironmentString(primaryVariable) : GetEnvironmentString(secondaryVariable);
+        }
+
+        /// <summary>
         /// Gets an environment variable as a <see cref="System.Int32"/>.
         /// </summary>
         /// <param name="variable">The environment variable name.</param>
@@ -53,6 +64,17 @@ namespace Cake.Common.Build.GitLabCI
         }
 
         /// <summary>
+        /// Gets an environment variable as a <see cref="System.Int32"/>.
+        /// </summary>
+        /// <param name="primaryVariable">The primary environment variable name.</param>
+        /// <param name="secondaryVariable">The secondary environment variable name.</param>
+        /// <returns>The environment variable.</returns>
+        protected int GetEnvironmentInteger(string primaryVariable, string secondaryVariable)
+        {
+            return GetEnvironmentInteger(primaryVariable) != 0 ? GetEnvironmentInteger(primaryVariable) : GetEnvironmentInteger(secondaryVariable);
+        }
+
+        /// <summary>
         /// Gets an environment variable as a <see cref="System.Boolean"/>.
         /// </summary>
         /// <param name="variable">The environment variable name.</param>
@@ -65,6 +87,17 @@ namespace Cake.Common.Build.GitLabCI
                 return value.Equals("true", StringComparison.OrdinalIgnoreCase);
             }
             return false;
+        }
+
+        /// <summary>
+        /// Gets an environment variable as a <see cref="System.Boolean"/>.
+        /// </summary>
+        /// <param name="primaryVariable">The primary environment variable name.</param>
+        /// <param name="secondaryVariable">The secondary environment variable name.</param>
+        /// <returns>The environment variable.</returns>
+        protected bool GetEnvironmentBoolean(string primaryVariable, string secondaryVariable)
+        {
+            return GetEnvironmentBoolean(primaryVariable) ? GetEnvironmentBoolean(primaryVariable) : GetEnvironmentBoolean(secondaryVariable);
         }
     }
 }


### PR DESCRIPTION
Environment variables for version 9+ of the gitlab runner have been
added with tests.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over CONTRIBUTING - https://github.com/cake-build/cake/blob/develop/CONTRIBUTING.md. We provide VERY defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - You are not submitting a pull request from your MASTER branch.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
