### PR TITLE
GH74: Adds MSpec support

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/MSpecRunnerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/MSpecRunnerFixture.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Cake.Common.Tools.MSpec;
+using Cake.Core.IO;
+using Cake.Testing.Fixtures;
+
+namespace Cake.Common.Tests.Fixtures.Tools
+{
+    internal sealed class MSpecRunnerFixture : ToolFixture<MSpecSettings>
+    {
+        public List<FilePath> Assemblies { get; set; }
+
+        public MSpecRunnerFixture()
+            : base("mspec-clr4.exe")
+        {
+            Assemblies = new List<FilePath>();
+            Assemblies.Add(new FilePath("./Test1.dll"));
+        }
+
+        public MSpecRunnerFixture(string toolFileName) : base(toolFileName)
+        {
+            Assemblies = new List<FilePath>();
+            Assemblies.Add(new FilePath("./Test1.dll"));
+        }
+
+        protected override void RunTool()
+        {
+            var tool = new MSpecRunner(FileSystem, Environment, ProcessRunner, Tools);
+            tool.Run(Assemblies, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/MSpec/MSpecRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSpec/MSpecRunnerTests.cs
@@ -1,0 +1,404 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tests.Fixtures.Tools;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Testing;
+using Cake.Testing.Xunit;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.MSpec
+{
+    public sealed class MSpecRunnerTests
+    {
+        public sealed class TheRunMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Assembly_Path_Is_Null()
+            {
+                // Given
+                var fixture = new MSpecRunnerFixture();
+                fixture.Assemblies = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "assemblyPaths");
+            }
+
+            [Fact]
+            public void Should_Throw_If_MSpec_Runner_Was_Not_Found()
+            {
+                // Given
+                var fixture = new MSpecRunnerFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("MSpec: Could not locate executable.", result?.Message);
+            }
+
+            [Theory]
+            [InlineData("/bin/MSpec/mspec.exe", "/bin/MSpec/mspec.exe")]
+            [InlineData("./tools/MSpec/mspec.exe", "/Working/tools/MSpec/mspec.exe")]
+            public void Should_Use_MSpec_Runner_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new MSpecRunnerFixture();
+                fixture.Settings.ToolPath = toolPath;
+                fixture.GivenSettingsToolPathExist();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Path.FullPath);
+            }
+
+            [WindowsTheory]
+            [InlineData("C:/MSpec/mspec.exe", "C:/MSpec/mspec.exe")]
+            public void Should_Use_MSpec_Runner_From_Tool_Path_If_Provided_On_Windows(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new MSpecRunnerFixture();
+                fixture.Settings.ToolPath = toolPath;
+                fixture.GivenSettingsToolPathExist();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Path.FullPath);
+            }
+
+            [Fact]
+            public void Should_Find_MSpec_Runner_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new MSpecRunnerFixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/Working/tools/mspec-clr4.exe", result.Path.FullPath);
+            }
+
+            [Fact]
+            public void Should_Use_Provided_Assembly_Path_In_Process_Arguments()
+            {
+                // Given
+                var fixture = new MSpecRunnerFixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("\"/Working/Test1.dll\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Use_Provided_Assembly_Paths_In_Process_Arguments()
+            {
+                // Given
+                var fixture = new MSpecRunnerFixture();
+                fixture.Assemblies.Clear();
+                fixture.Assemblies.Add(new FilePath("./Test1.dll"));
+                fixture.Assemblies.Add(new FilePath("./Test2.dll"));
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("\"/Working/Test1.dll\" \"/Working/Test2.dll\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Set_Working_Directory()
+            {
+                // Given
+                var fixture = new MSpecRunnerFixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/Working", result.Process.WorkingDirectory.FullPath);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new MSpecRunnerFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("MSpec: Process was not started.", result?.Message);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new MSpecRunnerFixture();
+                fixture.GivenProcessExitsWithCode(1);
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("MSpec: Process returned an error (exit code 1).", result?.Message);
+            }
+
+            [Fact]
+            public void Should_Throw_If_HtmlReport_Is_Set_But_OutputDirectory_Is_Null()
+            {
+                // Given
+                var fixture = new MSpecRunnerFixture();
+                fixture.Settings.HtmlReport = true;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("Cannot generate HTML report when no output directory has been set.", result?.Message);
+            }
+
+            [Fact]
+            public void Should_Generate_Html_Report_With_Correct_Name_For_Single_Assembly()
+            {
+                // Given
+                var fixture = new MSpecRunnerFixture();
+                fixture.Settings.OutputDirectory = "/Output";
+                fixture.Settings.HtmlReport = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("--html \"/Output/Test1.dll.html\" \"/Working/Test1.dll\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Generate_Html_Report_With_Correct_Name_For_Single_Assembly_ReportName()
+            {
+                // Given
+                var fixture = new MSpecRunnerFixture();
+                fixture.Settings.OutputDirectory = "/Output";
+                fixture.Settings.HtmlReport = true;
+                fixture.Settings.ReportName = "MSpecUnitReport";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("--html \"/Output/MSpecUnitReport.html\" \"/Working/Test1.dll\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Generate_Html_Report_With_Correct_Name_For_Multiple_Assemblies()
+            {
+                // Given
+                var fixture = new MSpecRunnerFixture();
+                fixture.Assemblies.Clear();
+                fixture.Assemblies.AddRange(new FilePath[] { "./Test1.dll", "./Test2.dll" });
+                fixture.Settings.OutputDirectory = "/Output";
+                fixture.Settings.HtmlReport = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("--html \"/Output/TestResults.html\" " +
+                    "\"/Working/Test1.dll\" \"/Working/Test2.dll\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Generate_Html_Report_With_Correct_Name_For_Multiple_Assemblies_ReportName()
+            {
+                // Given
+                var fixture = new MSpecRunnerFixture();
+                fixture.Assemblies.Clear();
+                fixture.Assemblies.AddRange(new FilePath[] { "./Test1.dll", "./Test2.dll" });
+                fixture.Settings.OutputDirectory = "/Output";
+                fixture.Settings.HtmlReport = true;
+                fixture.Settings.ReportName = "MSpecUnitReport";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("--html \"/Output/MSpecUnitReport.html\" " +
+                             "\"/Working/Test1.dll\" \"/Working/Test2.dll\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Throw_If_XmlReport_Is_Set_But_OutputDirectory_Is_Null()
+            {
+                // Given
+                var fixture = new MSpecRunnerFixture();
+                fixture.Settings.XmlReport = true;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("Cannot generate XML report when no output directory has been set.", result?.Message);
+            }
+
+            [Fact]
+            public void Should_Generate_Xml_Report_With_Correct_Name_For_Single_Assembly()
+            {
+                // Given
+                var fixture = new MSpecRunnerFixture();
+                fixture.Settings.OutputDirectory = "/Output";
+                fixture.Settings.XmlReport = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("--xml \"/Output/Test1.dll.xml\" \"/Working/Test1.dll\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Generate_Xml_Report_With_Correct_Name_For_Single_Assembly_ReportName()
+            {
+                // Given
+                var fixture = new MSpecRunnerFixture();
+                fixture.Settings.OutputDirectory = "/Output";
+                fixture.Settings.XmlReport = true;
+                fixture.Settings.ReportName = "MSpecUnitReport";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("--xml \"/Output/MSpecUnitReport.xml\" \"/Working/Test1.dll\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Generate_Xml_Report_With_Correct_Name_For_Multiple_Assemblies()
+            {
+                // Given
+                var fixture = new MSpecRunnerFixture();
+                fixture.Assemblies.Clear();
+                fixture.Assemblies.AddRange(new FilePath[] { "./Test1.dll", "./Test2.dll" });
+                fixture.Settings.OutputDirectory = "/Output";
+                fixture.Settings.XmlReport = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("--xml \"/Output/TestResults.xml\" " +
+                    "\"/Working/Test1.dll\" \"/Working/Test2.dll\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Generate_Xml_Report_With_Correct_Name_For_Multiple_Assemblies_ReportName()
+            {
+                // Given
+                var fixture = new MSpecRunnerFixture();
+                fixture.Assemblies.Clear();
+                fixture.Assemblies.AddRange(new FilePath[] { "./Test1.dll", "./Test2.dll" });
+                fixture.Settings.OutputDirectory = "/Output";
+                fixture.Settings.XmlReport = true;
+                fixture.Settings.ReportName = "MSpecUnitReport";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("--xml \"/Output/MSpecUnitReport.xml\" " +
+                             "\"/Working/Test1.dll\" \"/Working/Test2.dll\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Set_Commandline_Switches()
+            {
+                // Given
+                var fixture = new MSpecRunnerFixture();
+                fixture.Settings.Filters = "Filters.txt";
+                fixture.Settings.Include = "foo,bar,foo_bar";
+                fixture.Settings.Exclude = "foo,bar,foo_bar";
+                fixture.Settings.TimeInfo = true;
+                fixture.Settings.Silent = true;
+                fixture.Settings.Progress = true;
+                fixture.Settings.NoColor = true;
+                fixture.Settings.Wait = true;
+                fixture.Settings.TeamCity = true;
+                fixture.Settings.NoTeamCity = true;
+                fixture.Settings.Appveyor = true;
+                fixture.Settings.NoAppveyor = true;
+                fixture.Settings.HtmlReport = true;
+                fixture.Settings.XmlReport = true;
+                fixture.Settings.ReportName = "UnitTests";
+                fixture.Settings.OutputDirectory = "Reports";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-f \"/Working/Filters.txt\" " +
+                    "-i \"foo,bar,foo_bar\" " +
+                    "-x \"foo,bar,foo_bar\" " +
+                    "-t " +
+                    "-s " +
+                    "-p " +
+                    "-c " +
+                    "-w " +
+                    "--teamcity " +
+                    "--no-teamcity-autodetect " +
+                    "--appveyor " +
+                    "--no-appveyor-autodetect " +
+                    "--html \"/Working/Reports/UnitTests.html\" " +
+                    "--xml \"/Working/Reports/UnitTests.xml\" " +
+                    "\"/Working/Test1.dll\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Mspec_X86_Flag_Is_Not_Set_To_True()
+            {
+                // Given
+                var fixture = new MSpecRunnerFixture("mspec-x86-clr4.exe");
+                fixture.Settings.UseX86 = false;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("MSpec: Could not locate executable.", result?.Message);
+            }
+
+            [Fact]
+            public void Should_Find_MSpec_X86_Runner_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new MSpecRunnerFixture("mspec-x86-clr4.exe");
+                fixture.Settings.UseX86 = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/Working/tools/mspec-x86-clr4.exe", result.Path.FullPath);
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Tools/MSpec/MSpecAliases.cs
+++ b/src/Cake.Common/Tools/MSpec/MSpecAliases.cs
@@ -1,0 +1,201 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.MSpec
+{
+    /// <summary>
+    /// <para>Contains functionality related to running <see href="https://github.com/machine/machine.specifications">Machine.Specifications</see> tests.</para>
+    /// <para>
+    /// In order to use the commands for this alias, include the following in your build.cake file to download and
+    /// install from NuGet.org, or specify the ToolPath within the <see cref="MSpecSettings" /> class:
+    /// <code>
+    /// #tool "nuget:?package=mspec.runner.console"
+    /// </code>
+    /// </para>
+    /// </summary>
+    [CakeAliasCategory("MSpec")]
+    public static class MSpecAliases
+    {
+        /// <summary>
+        /// Runs all MSpec tests in the assemblies matching the specified pattern.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="pattern">The pattern.</param>
+        /// <example>
+        /// <code>
+        /// MSpec("./src/**/bin/Release/*.Tests.dll");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static void MSpec(this ICakeContext context, string pattern)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var assemblies = context.Globber.GetFiles(pattern).ToArray();
+            if (assemblies.Length == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any files.");
+                return;
+            }
+
+            MSpec(context, assemblies, new MSpecSettings());
+        }
+
+        /// <summary>
+        /// Runs all MSpec tests in the assemblies matching the specified pattern.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="pattern">The pattern.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// MSpec("./src/**/bin/Release/*.Tests.dll",
+        ///      new MSpecSettings {
+        ///         Parallelism = ParallelismOption.All,
+        ///         HtmlReport = true,
+        ///         NoAppDomain = true,
+        ///         OutputDirectory = "./build"
+        ///     });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static void MSpec(this ICakeContext context, string pattern, MSpecSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var assemblies = context.Globber.GetFiles(pattern).ToArray();
+            if (assemblies.Length == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any files.");
+                return;
+            }
+
+            MSpec(context, assemblies, settings);
+        }
+
+        /// <summary>
+        /// Runs all MSpec tests in the specified assemblies.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="assemblies">The assemblies.</param>
+        /// <example>
+        /// <code>
+        /// MSpec(new []{
+        ///     "./src/Cake.Common.Tests/bin/Release/Cake.Common.Tests.dll",
+        ///     "./src/Cake.Core.Tests/bin/Release/Cake.Core.Tests.dll",
+        ///     "./src/Cake.NuGet.Tests/bin/Release/Cake.NuGet.Tests.dll",
+        ///     "./src/Cake.Tests/bin/Release/Cake.Tests.dll"
+        ///     });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static void MSpec(this ICakeContext context, IEnumerable<string> assemblies)
+        {
+            if (assemblies == null)
+            {
+                throw new ArgumentNullException(nameof(assemblies));
+            }
+            var paths = assemblies.Select(p => new FilePath(p));
+            MSpec(context, paths, new MSpecSettings());
+        }
+
+        /// <summary>
+        /// Runs all MSpec tests in the specified assemblies.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="assemblies">The assemblies.</param>
+        /// <example>
+        /// <code>
+        /// var testAssemblies = GetFiles("./src/**/bin/Release/*.Tests.dll");
+        /// MSpec(testAssemblies);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static void MSpec(this ICakeContext context, IEnumerable<FilePath> assemblies)
+        {
+            MSpec(context, assemblies, new MSpecSettings());
+        }
+
+        /// <summary>
+        /// Runs all MSpec tests in the specified assemblies.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="assemblies">The assemblies.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// MSpec(new []{
+        ///     "./src/Cake.Common.Tests/bin/Release/Cake.Common.Tests.dll",
+        ///     "./src/Cake.Core.Tests/bin/Release/Cake.Core.Tests.dll",
+        ///     "./src/Cake.NuGet.Tests/bin/Release/Cake.NuGet.Tests.dll",
+        ///     "./src/Cake.Tests/bin/Release/Cake.Tests.dll"
+        ///      },
+        ///      new MSpecSettings {
+        ///         Parallelism = ParallelismOption.All,
+        ///         HtmlReport = true,
+        ///         NoAppDomain = true,
+        ///         OutputDirectory = "./build"
+        ///     });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static void MSpec(this ICakeContext context, IEnumerable<string> assemblies, MSpecSettings settings)
+        {
+            if (assemblies == null)
+            {
+                throw new ArgumentNullException(nameof(assemblies));
+            }
+            var paths = assemblies.Select(p => new FilePath(p));
+            MSpec(context, paths, settings);
+        }
+
+        /// <summary>
+        /// Runs all MSpec tests in the specified assemblies.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="assemblies">The assemblies.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// var testAssemblies = GetFiles("./src/**/bin/Release/*.Tests.dll");
+        /// MSpec(testAssemblies,
+        ///      new MSpecSettings {
+        ///         Parallelism = ParallelismOption.All,
+        ///         HtmlReport = true,
+        ///         NoAppDomain = true,
+        ///         OutputDirectory = "./build"
+        ///     });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static void MSpec(this ICakeContext context, IEnumerable<FilePath> assemblies, MSpecSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(assemblies));
+            }
+            if (assemblies == null)
+            {
+                throw new ArgumentNullException(nameof(assemblies));
+            }
+
+            var runner = new MSpecRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            runner.Run(assemblies, settings);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/MSpec/MSpecRunner.cs
+++ b/src/Cake.Common/Tools/MSpec/MSpecRunner.cs
@@ -1,0 +1,212 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.MSpec
+{
+    /// <summary>
+    /// The MSpec unit test runner.
+    /// </summary>
+    public sealed class MSpecRunner : Tool<MSpecSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+        private bool _useX86;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MSpec.MSpecRunner"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="tools">The tool locator.</param>
+        public MSpecRunner(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IToolLocator tools) : base(fileSystem, environment, processRunner, tools)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Runs the tests in the specified assemblies, using the specified settings.
+        /// </summary>
+        /// <param name="assemblyPaths">The assembly paths.</param>
+        /// <param name="settings">The settings.</param>
+        public void Run(IEnumerable<FilePath> assemblyPaths, MSpecSettings settings)
+        {
+            if (assemblyPaths == null)
+            {
+                throw new ArgumentNullException(nameof(assemblyPaths));
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            if (string.IsNullOrWhiteSpace(settings.OutputDirectory?.FullPath))
+            {
+                if (settings.HtmlReport)
+                {
+                    throw new CakeException("Cannot generate HTML report when no output directory has been set.");
+                }
+
+                if (settings.XmlReport)
+                {
+                    throw new CakeException("Cannot generate XML report when no output directory has been set.");
+                }
+            }
+
+            _useX86 = settings.UseX86;
+
+            var paths = assemblyPaths as FilePath[] ?? assemblyPaths.ToArray();
+
+            Run(settings, GetArguments(paths, settings));
+        }
+
+        private ProcessArgumentBuilder GetArguments(IReadOnlyList<FilePath> assemblyPaths, MSpecSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            FilterTests(settings, builder);
+
+            GeneralSettings(settings, builder);
+
+            BuildServerSettings(settings, builder);
+
+            ReportSettings(assemblyPaths, settings, builder);
+
+            AssembliesToTest(assemblyPaths, builder);
+
+            return builder;
+        }
+
+        private static void GeneralSettings(MSpecSettings settings, ProcessArgumentBuilder builder)
+        {
+            if (settings.TimeInfo)
+            {
+                builder.Append("-t");
+            }
+
+            if (settings.Silent)
+            {
+                builder.Append("-s");
+            }
+
+            if (settings.Progress)
+            {
+                builder.Append("-p");
+            }
+
+            if (settings.NoColor)
+            {
+                builder.Append("-c");
+            }
+
+            if (settings.Wait)
+            {
+                builder.Append("-w");
+            }
+        }
+
+        private static void BuildServerSettings(MSpecSettings settings, ProcessArgumentBuilder builder)
+        {
+            if (settings.TeamCity)
+            {
+                builder.Append("--teamcity");
+            }
+
+            if (settings.NoTeamCity)
+            {
+                builder.Append("--no-teamcity-autodetect");
+            }
+
+            if (settings.Appveyor)
+            {
+                builder.Append("--appveyor");
+            }
+
+            if (settings.NoAppveyor)
+            {
+                builder.Append("--no-appveyor-autodetect");
+            }
+        }
+
+        private void FilterTests(MSpecSettings settings, ProcessArgumentBuilder builder)
+        {
+            if (settings.Filters != null)
+            {
+                builder.Append("-f");
+                builder.AppendQuoted(settings.Filters.MakeAbsolute(_environment).FullPath);
+            }
+
+            if (!string.IsNullOrWhiteSpace(settings.Include))
+            {
+                builder.Append("-i");
+                builder.AppendQuoted(settings.Include);
+            }
+
+            if (!string.IsNullOrWhiteSpace(settings.Exclude))
+            {
+                builder.Append("-x");
+                builder.AppendQuoted(settings.Exclude);
+            }
+        }
+
+        private void AssembliesToTest(IReadOnlyList<FilePath> assemblyPaths, ProcessArgumentBuilder builder)
+        {
+            foreach (var assemblyPath in assemblyPaths)
+            {
+                builder.AppendQuoted(assemblyPath.MakeAbsolute(_environment).FullPath);
+            }
+        }
+
+        private void ReportSettings(IReadOnlyList<FilePath> assemblyPaths, MSpecSettings settings, ProcessArgumentBuilder builder)
+        {
+            if (settings.HtmlReport)
+            {
+                var reportFileName = MSpecRunnerUtilities.GetReportFileName(assemblyPaths, settings);
+                var assemblyFilename = reportFileName.AppendExtension(".html");
+                var outputPath = settings.OutputDirectory.MakeAbsolute(_environment).GetFilePath(assemblyFilename);
+
+                builder.Append("--html");
+                builder.AppendQuoted(outputPath.FullPath);
+            }
+
+            if (settings.XmlReport)
+            {
+                var reportFileName = MSpecRunnerUtilities.GetReportFileName(assemblyPaths, settings);
+                var assemblyFilename = reportFileName.AppendExtension(".xml");
+                var outputPath = settings.OutputDirectory.MakeAbsolute(_environment).GetFilePath(assemblyFilename);
+
+                builder.Append("--xml");
+                builder.AppendQuoted(outputPath.FullPath);
+            }
+        }
+
+        /// <summary>
+        /// Gets the name of the tool.
+        /// </summary>
+        /// <returns>The name of the tool.</returns>
+        protected override string GetToolName()
+        {
+            return "MSpec";
+        }
+
+        /// <summary>
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return _useX86 ? new[] { "mspec-x86-clr4.exe" } : new[] { "mspec-clr4.exe" };
+        }
+    }
+}

--- a/src/Cake.Common/Tools/MSpec/MSpecRunnerUtilities.cs
+++ b/src/Cake.Common/Tools/MSpec/MSpecRunnerUtilities.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.MSpec
+{
+    internal static class MSpecRunnerUtilities
+    {
+        internal static FilePath GetReportFileName(IReadOnlyList<FilePath> assemblyPaths, MSpecSettings settings)
+        {
+            if (string.IsNullOrEmpty(settings.ReportName))
+            {
+                return assemblyPaths.Count == 1
+                    ? assemblyPaths[0].GetFilename()
+                    : new FilePath("TestResults");
+            }
+            else
+            {
+                return settings.ReportName;
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Tools/MSpec/MspecSettings.cs
+++ b/src/Cake.Common/Tools/MSpec/MspecSettings.cs
@@ -1,0 +1,114 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.MSpec
+{
+    /// <summary>
+    ///     Contains settings used by <see cref="MSpecRunner" />.
+    /// </summary>
+    public sealed class MSpecSettings : ToolSettings
+    {
+        /// <summary>
+        ///     Gets or sets the path to the filter file specifying contexts to execute(full type name, one per line). Takes precedence over
+        ///     tags
+        /// </summary>
+        public FilePath Filters { get; set; }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether reporting for TeamCity CI integration(also auto - detected)
+        /// </summary>
+        /// <value>
+        ///     <c>true</c> to turn on TeamCity service messages; otherwise, <c>false</c>.
+        /// </value>
+        public bool TeamCity { get; set; }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether to suppress colored console output
+        /// </summary>
+        /// <value>
+        ///     <c>true</c> disable color output; otherwise, <c>false</c>.
+        /// </value>
+        public bool NoColor { get; set; }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether an XML report should be generated.
+        /// </summary>
+        /// <value>
+        ///     <c>true</c> if an XML report should be generated; otherwise, <c>false</c>.
+        /// </value>
+        public bool XmlReport { get; set; }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether an HTML report should be generated.
+        /// </summary>
+        /// <value>
+        ///     <c>true</c> if an HTML report should be generated; otherwise, <c>false</c>.
+        /// </value>
+        public bool HtmlReport { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the name that should be used for the HTML and XML reports.
+        /// </summary>
+        /// <value>The custom report name.</value>
+        public string ReportName { get; set; }
+
+        /// <summary>
+        ///      Gets or sets Executes all specifications in contexts with these comma delimited tags. Ex. - i "foo,bar,foo_bar"
+        /// </summary>
+        public string Include { get; set; }
+
+        /// <summary>
+        ///     Gets or sets Exclude specifications in contexts with these comma delimited tags. Ex. - x "foo,bar,foo_bar"
+        /// </summary>
+        public string Exclude { get; set; }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether to show time-related information in HTML output
+        /// </summary>
+        public bool TimeInfo { get; set; }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether to suppress progress output(print fatal errors, failures and summary)
+        /// </summary>
+        public bool Silent { get; set; }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether to print dotted progress output
+        /// </summary>
+        public bool Progress { get; set; }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether to wait 15 seconds for debugger to be attached
+        /// </summary>
+        public bool Wait { get; set; }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether to disable TeamCity autodetection
+        /// </summary>
+        public bool NoTeamCity { get; set; }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether to enable reporting for AppVeyor CI integration(also auto - detected)
+        /// </summary>
+        public bool Appveyor { get; set; }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether disable AppVeyor autodetection
+        /// </summary>
+        public bool NoAppveyor { get; set; }
+
+        /// <summary>
+        ///     Gets or sets output directory for reports
+        /// </summary>
+        public DirectoryPath OutputDirectory { get; set; }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether to use X86
+        /// </summary>
+        public bool UseX86 { get; set; }
+    }
+}


### PR DESCRIPTION
This adds support for MSpec unit tests
  - Support NET4 and X86.
  - Doesn't support NET2 (assuming no one uses it anymore).
  - The mspec console currently doesn't support dotnet core.

