### PR TITLE
GH1874: NuGet script load: Do not add include for all cake scripts when include already specified

### DIFF
--- a/src/Cake.Core/Extensions/UriExtensions.cs
+++ b/src/Cake.Core/Extensions/UriExtensions.cs
@@ -9,8 +9,16 @@ using System.Linq;
 // ReSharper disable once CheckNamespace
 namespace Cake.Core
 {
-    internal static class UriExtensions
+    /// <summary>
+    /// Extensions for <see cref="System.Uri"/>
+    /// </summary>
+    public static class UriExtensions
     {
+        /// <summary>
+        /// Extracts query string of <see cref="System.Uri"/>
+        /// </summary>
+        /// <param name="uri">The URI</param>
+        /// <returns>Collection of parameters and it's values</returns>
         public static IReadOnlyDictionary<string, IReadOnlyList<string>> GetQueryString(this Uri uri)
         {
             var result = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);

--- a/src/Cake.Core/Packaging/PackageReference.cs
+++ b/src/Cake.Core/Packaging/PackageReference.cs
@@ -58,7 +58,7 @@ namespace Cake.Core.Packaging
         /// </summary>
         /// <param name="uri">The URI.</param>
         /// <exception cref="System.ArgumentException">Package query string parameter is missing.;uri</exception>
-        internal PackageReference(Uri uri)
+        public PackageReference(Uri uri)
         {
             OriginalString = uri.OriginalString;
             Scheme = uri.Scheme;

--- a/src/Cake.NuGet.Tests/Fixtures/NuGetLoadDirectiveProviderFixture.cs
+++ b/src/Cake.NuGet.Tests/Fixtures/NuGetLoadDirectiveProviderFixture.cs
@@ -25,12 +25,17 @@ namespace Cake.NuGet.Tests.Fixtures
         public List<FilePath> InstallResult { get; set; }
 
         public NuGetLoadDirectiveProviderFixture()
+            : this("nuget:?package=Cake.Recipe")
+        {
+        }
+
+        public NuGetLoadDirectiveProviderFixture(string uri)
         {
             Environment = FakeEnvironment.CreateUnixEnvironment();
             Installer = Substitute.For<INuGetPackageInstaller>();
             Configuration = new FakeConfiguration();
             Log = new FakeLog();
-            Reference = new LoadReference(new Uri("nuget:?package=Cake.Recipe"));
+            Reference = new LoadReference(new Uri(uri));
             InstallResult = new List<FilePath>();
 
             Context = Substitute.For<IScriptAnalyzerContext>();

--- a/src/Cake.NuGet.Tests/Unit/NuGetLoadDirectiveProviderTests.cs
+++ b/src/Cake.NuGet.Tests/Unit/NuGetLoadDirectiveProviderTests.cs
@@ -32,7 +32,7 @@ namespace Cake.NuGet.Tests.Unit
         public sealed class TheLoadMethod
         {
             [Fact]
-            public void Should_Install_Package()
+            public void Should_Install_Package_Without_Include_Query()
             {
                 // Given
                 var fixture = new NuGetLoadDirectiveProviderFixture();
@@ -42,6 +42,45 @@ namespace Cake.NuGet.Tests.Unit
 
                 // Then
                 Assert.Equal("nuget:?package=Cake.Recipe&include=./**/*.cake", result.Package.OriginalString);
+            }
+
+            [Fact]
+            public void Should_Install_Package_With_Include_Query()
+            {
+                // Given
+                var fixture = new NuGetLoadDirectiveProviderFixture("nuget:?package=Cake.Recipe&include=test/main.cake");
+
+                // When
+                var result = fixture.Load();
+
+                // Then
+                Assert.Equal("nuget:?package=Cake.Recipe&include=test/main.cake", result.Package.OriginalString);
+            }
+
+            [Fact]
+            public void Should_Install_Package_With_Other_Query()
+            {
+                // Given
+                var fixture = new NuGetLoadDirectiveProviderFixture("nuget:?package=Cake.Recipe&exclude=test/main.cake");
+
+                // When
+                var result = fixture.Load();
+
+                // Then
+                Assert.Equal("nuget:?package=Cake.Recipe&exclude=test/main.cake&include=./**/*.cake", result.Package.OriginalString);
+            }
+
+            [Fact]
+            public void Should_Install_Package_With_Other_And_Include_Query()
+            {
+                // Given
+                var fixture = new NuGetLoadDirectiveProviderFixture("nuget:?package=Cake.Recipe&exclude=test/no.cake&include=test/main.cake");
+
+                // When
+                var result = fixture.Load();
+
+                // Then
+                Assert.Equal("nuget:?package=Cake.Recipe&exclude=test/no.cake&include=test/main.cake", result.Package.OriginalString);
             }
 
             [Fact]

--- a/src/Cake.NuGet/NuGetLoadDirectiveProvider.cs
+++ b/src/Cake.NuGet/NuGetLoadDirectiveProvider.cs
@@ -40,10 +40,16 @@ namespace Cake.NuGet
         public void Load(IScriptAnalyzerContext context, LoadReference reference)
         {
             // Create a package reference from our load reference.
-            // The package should contain the necessary include parameters to make sure
-            // that .cake files are included as part of the result.
-            var separator = reference.OriginalString.Contains("?") ? "&" : "?";
-            var uri = string.Concat(reference.OriginalString, $"{separator}include=./**/*.cake");
+            // If not specified in script, the package should contain the necessary include
+            // parameters to make sure that .cake files are included as part of the result.
+            var uri = new Uri(reference.OriginalString);
+            var parameters = uri.GetQueryString();
+            const string includeParameterName = "include";
+            if (!parameters.ContainsKey(includeParameterName))
+            {
+                var separator = parameters.Count > 0 ? "&" : "?";
+                uri = new Uri(string.Concat(reference.OriginalString, $"{separator}include=./**/*.cake"));
+            }
             var package = new PackageReference(uri);
 
             // Find the tool folder.


### PR DESCRIPTION
Fixes #1874
