### PR TITLE
GH1522: MSTest.exe tool path support for VS2017

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSTest/MSTestRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSTest/MSTestRunnerTests.cs
@@ -94,6 +94,9 @@ namespace Cake.Common.Tests.Unit.Tools.MSTest
         [InlineData("/ProgramFilesX86/Microsoft Visual Studio 12.0/Common7/IDE/mstest.exe")]
         [InlineData("/ProgramFilesX86/Microsoft Visual Studio 11.0/Common7/IDE/mstest.exe")]
         [InlineData("/ProgramFilesX86/Microsoft Visual Studio 10.0/Common7/IDE/mstest.exe")]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2017/Enterprise/Common7/IDE/mstest.exe")]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2017/Professional/Common7/IDE/mstest.exe")]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2017/Community/Common7/IDE/mstest.exe")]
         public void Should_Use_Available_Tool_Path(string existingToolPath)
         {
             // Given

--- a/src/Cake.Common/Tools/MSTest/MSTestRunner.cs
+++ b/src/Cake.Common/Tools/MSTest/MSTestRunner.cs
@@ -114,9 +114,18 @@ namespace Cake.Common.Tools.MSTest
         /// <returns>The default tool path.</returns>
         protected override IEnumerable<FilePath> GetAlternativeToolPaths(MSTestSettings settings)
         {
+            foreach (var yearAndEdition in new[] { "2017/Enterprise", "2017/Professional", "2017/Community" })
+            {
+                var path = GetYearAndEditionToolPath(yearAndEdition);
+                if (_fileSystem.Exist(path))
+                {
+                    yield return path;
+                }
+            }
+
             foreach (var version in new[] { "14.0", "12.0", "11.0", "10.0" })
             {
-                var path = GetToolPath(version);
+                var path = GetVersionNumberToolPath(version);
                 if (_fileSystem.Exist(path))
                 {
                     yield return path;
@@ -133,10 +142,17 @@ namespace Cake.Common.Tools.MSTest
             }
         }
 
-        private FilePath GetToolPath(string version)
+        private FilePath GetVersionNumberToolPath(string version)
         {
             var programFiles = _environment.GetSpecialPath(SpecialPath.ProgramFilesX86);
             var root = programFiles.Combine(string.Concat("Microsoft Visual Studio ", version, "/Common7/IDE"));
+            return root.CombineWithFilePath("mstest.exe");
+        }
+
+        private FilePath GetYearAndEditionToolPath(string yearAndEdition)
+        {
+            var programFiles = _environment.GetSpecialPath(SpecialPath.ProgramFilesX86);
+            var root = programFiles.Combine(string.Concat("Microsoft Visual Studio/", yearAndEdition, "/Common7/IDE"));
             return root.CombineWithFilePath("mstest.exe");
         }
 


### PR DESCRIPTION
The mstest path in VS2017 is more complex than previous VS versions, it contains the year and edition.

I didn't want to create a data type for this simple use case, neither did I want to create nested loop since we don't know what edition names Microsoft comes up with next.