### PR TITLE
GH1899: Concatenate paths using the divide operator

### DIFF
--- a/src/Cake.Common.Tests/Unit/IO/Paths/ConvertableDirectoryPathTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/Paths/ConvertableDirectoryPathTests.cs
@@ -247,6 +247,265 @@ namespace Cake.Common.Tests.Unit.IO.Paths
             }
         }
 
+        public sealed class TheDivideOperator
+        {
+            public sealed class AddingConvertableDirectoryPath
+            {
+                [Fact]
+                public void Should_Combine_The_Two_Paths()
+                {
+                    // Given
+                    var path = new ConvertableDirectoryPath("./root");
+
+                    // When
+                    var result = path / new ConvertableDirectoryPath("other");
+
+                    // Then
+                    Assert.Equal("root/other", result.Path.FullPath);
+                }
+
+                [Fact]
+                public void Should_Return_A_Convertable_Directory_Path()
+                {
+                    // Given
+                    var path = new ConvertableDirectoryPath("./root");
+
+                    // When
+                    var result = path / new ConvertableDirectoryPath("other");
+
+                    // Then
+                    Assert.IsType<ConvertableDirectoryPath>(result);
+                }
+
+                [Fact]
+                public void Should_Return_A_New_Convertable_Directory_Path()
+                {
+                    // Given
+                    var path = new ConvertableDirectoryPath("./root");
+
+                    // When
+                    var result = path / new ConvertableDirectoryPath("other");
+
+                    // Then
+                    Assert.NotSame(path, result);
+                }
+
+                [Fact]
+                public void Should_Throw_If_Left_Operand_Is_Null()
+                {
+                    // Given, When
+                    var result = Record.Exception(() =>
+                        (ConvertableDirectoryPath)null / new ConvertableDirectoryPath("other"));
+
+                    // Then
+                    AssertEx.IsArgumentNullException(result, "left");
+                }
+
+                [Fact]
+                public void Should_Throw_If_Right_Operand_Is_Null()
+                {
+                    // Given, When
+                    var result = Record.Exception(() =>
+                        new ConvertableDirectoryPath("./root") / (ConvertableDirectoryPath)null);
+
+                    // Then
+                    AssertEx.IsArgumentNullException(result, "right");
+                }
+            }
+
+            public sealed class AddingDirectoryPath
+            {
+                [Fact]
+                public void Should_Combine_The_Two_Paths()
+                {
+                    // Given
+                    var path = new ConvertableDirectoryPath("./root");
+
+                    // When
+                    var result = path / new DirectoryPath("other");
+
+                    // Then
+                    Assert.Equal("root/other", result.Path.FullPath);
+                }
+
+                [Fact]
+                public void Should_Return_A_Convertable_Directory_Path()
+                {
+                    // Given
+                    var path = new ConvertableDirectoryPath("./root");
+
+                    // When
+                    var result = path / new DirectoryPath("other");
+
+                    // Then
+                    Assert.IsType<ConvertableDirectoryPath>(result);
+                }
+
+                [Fact]
+                public void Should_Return_A_New_Convertable_Directory_Path()
+                {
+                    // Given
+                    var path = new ConvertableDirectoryPath("./root");
+
+                    // When
+                    var result = path / new ConvertableDirectoryPath("other");
+
+                    // Then
+                    Assert.NotSame(path, result);
+                }
+
+                [Fact]
+                public void Should_Throw_If_Left_Operand_Is_Null()
+                {
+                    // Given, When
+                    var result = Record.Exception(() =>
+                        (ConvertableDirectoryPath)null / new DirectoryPath("other"));
+
+                    // Then
+                    AssertEx.IsArgumentNullException(result, "left");
+                }
+
+                [Fact]
+                public void Should_Throw_If_Right_Operand_Is_Null()
+                {
+                    // Given, When
+                    var result = Record.Exception(() =>
+                        new ConvertableDirectoryPath("./root") / (DirectoryPath)null);
+
+                    // Then
+                    AssertEx.IsArgumentNullException(result, "right");
+                }
+            }
+
+            public sealed class AddingConvertableFilePath
+            {
+                [Fact]
+                public void Should_Combine_The_Two_Paths()
+                {
+                    // Given
+                    var path = new ConvertableDirectoryPath("./root");
+
+                    // When
+                    var result = path / new ConvertableFilePath("other.txt");
+
+                    // Then
+                    Assert.Equal("root/other.txt", result.Path.FullPath);
+                }
+
+                [Fact]
+                public void Should_Return_A_Convertable_File_Path()
+                {
+                    // Given
+                    var path = new ConvertableDirectoryPath("./root");
+
+                    // When
+                    var result = path / new ConvertableFilePath("other.txt");
+
+                    // Then
+                    Assert.IsType<ConvertableFilePath>(result);
+                }
+
+                [Fact]
+                public void Should_Return_A_New_Convertable_File_Path()
+                {
+                    // Given
+                    var path = new ConvertableDirectoryPath("./root");
+
+                    // When
+                    var result = path / new ConvertableFilePath("other.txt");
+
+                    // Then
+                    Assert.NotSame(path, result);
+                }
+
+                [Fact]
+                public void Should_Throw_If_Left_Operand_Is_Null()
+                {
+                    // Given, When
+                    var result = Record.Exception(() =>
+                        (ConvertableDirectoryPath)null / new ConvertableFilePath("other.txt"));
+
+                    // Then
+                    AssertEx.IsArgumentNullException(result, "directory");
+                }
+
+                [Fact]
+                public void Should_Throw_If_Right_Operand_Is_Null()
+                {
+                    // Given, When
+                    var result = Record.Exception(() =>
+                        new ConvertableDirectoryPath("./root") / (ConvertableFilePath)null);
+
+                    // Then
+                    AssertEx.IsArgumentNullException(result, "file");
+                }
+            }
+
+            public sealed class AddingFilePath
+            {
+                [Fact]
+                public void Should_Combine_The_Two_Paths()
+                {
+                    // Given
+                    var path = new ConvertableDirectoryPath("./root");
+
+                    // When
+                    var result = path / new FilePath("other.txt");
+
+                    // Then
+                    Assert.Equal("root/other.txt", result.Path.FullPath);
+                }
+
+                [Fact]
+                public void Should_Return_A_Convertable_File_Path()
+                {
+                    // Given
+                    var path = new ConvertableDirectoryPath("./root");
+
+                    // When
+                    var result = path / new FilePath("other.txt");
+
+                    // Then
+                    Assert.IsType<ConvertableFilePath>(result);
+                }
+
+                [Fact]
+                public void Should_Return_A_New_Convertable_File_Path()
+                {
+                    // Given
+                    var path = new ConvertableDirectoryPath("./root");
+
+                    // When
+                    var result = path / new ConvertableFilePath("other.txt");
+
+                    // Then
+                    Assert.NotSame(path, result);
+                }
+
+                [Fact]
+                public void Should_Throw_If_Left_Operand_Is_Null()
+                {
+                    // Given, When
+                    var result = Record.Exception(() =>
+                        (ConvertableDirectoryPath)null / new FilePath("other.txt"));
+
+                    // Then
+                    AssertEx.IsArgumentNullException(result, "directory");
+                }
+
+                [Fact]
+                public void Should_Throw_If_Right_Operand_Is_Null()
+                {
+                    // Given, When
+                    var result = Record.Exception(() =>
+                        new ConvertableDirectoryPath("./root") / (FilePath)null);
+
+                    // Then
+                    AssertEx.IsArgumentNullException(result, "file");
+                }
+            }
+        }
+
         public sealed class TheImplicitConversionOperator
         {
             public sealed class ConvertToDirectoryPath

--- a/src/Cake.Common/IO/Paths/ConvertableDirectoryPath.cs
+++ b/src/Cake.Common/IO/Paths/ConvertableDirectoryPath.cs
@@ -47,7 +47,7 @@ namespace Cake.Common.IO.Paths
         }
 
         /// <summary>
-        /// Operator that combines A <see cref="ConvertableDirectoryPath"/> instance
+        /// Operator that combines a <see cref="ConvertableDirectoryPath"/> instance
         /// with another <see cref="ConvertableDirectoryPath"/> instance.
         /// </summary>
         /// <param name="left">The left directory path operand.</param>
@@ -67,7 +67,7 @@ namespace Cake.Common.IO.Paths
         }
 
         /// <summary>
-        /// Operator that combines A <see cref="ConvertableDirectoryPath"/> instance
+        /// Operator that combines a <see cref="ConvertableDirectoryPath"/> instance
         /// with a <see cref="DirectoryPath"/> instance.
         /// </summary>
         /// <param name="left">The left directory path operand.</param>
@@ -87,7 +87,7 @@ namespace Cake.Common.IO.Paths
         }
 
         /// <summary>
-        /// Operator that combines A <see cref="ConvertableDirectoryPath"/> instance
+        /// Operator that combines a <see cref="ConvertableDirectoryPath"/> instance
         /// with a <see cref="ConvertableFilePath"/> instance.
         /// </summary>
         /// <param name="directory">The left directory path operand.</param>
@@ -107,13 +107,93 @@ namespace Cake.Common.IO.Paths
         }
 
         /// <summary>
-        /// Operator that combines A <see cref="ConvertableDirectoryPath"/> instance
+        /// Operator that combines a <see cref="ConvertableDirectoryPath"/> instance
         /// with a <see cref="FilePath"/> instance.
         /// </summary>
         /// <param name="directory">The left directory path operand.</param>
         /// <param name="file">The right file path operand.</param>
         /// <returns>A new file path representing a combination of the two provided paths.</returns>
         public static ConvertableFilePath operator +(ConvertableDirectoryPath directory, FilePath file)
+        {
+            if (directory == null)
+            {
+                throw new ArgumentNullException(nameof(directory));
+            }
+            if (file == null)
+            {
+                throw new ArgumentNullException(nameof(file));
+            }
+            return new ConvertableFilePath(directory.Path.CombineWithFilePath(file));
+        }
+
+        /// <summary>
+        /// Operator that combines a <see cref="ConvertableDirectoryPath"/> instance
+        /// with another <see cref="ConvertableDirectoryPath"/> instance.
+        /// </summary>
+        /// <param name="left">The left directory path operand.</param>
+        /// <param name="right">The right directory path operand.</param>
+        /// <returns>A new directory path representing a combination of the two provided paths.</returns>
+        public static ConvertableDirectoryPath operator /(ConvertableDirectoryPath left, ConvertableDirectoryPath right)
+        {
+            if (left == null)
+            {
+                throw new ArgumentNullException(nameof(left));
+            }
+            if (right == null)
+            {
+                throw new ArgumentNullException(nameof(right));
+            }
+            return new ConvertableDirectoryPath(left.Path.Combine(right.Path));
+        }
+
+        /// <summary>
+        /// Operator that combines a <see cref="ConvertableDirectoryPath"/> instance
+        /// with a <see cref="DirectoryPath"/> instance.
+        /// </summary>
+        /// <param name="left">The left directory path operand.</param>
+        /// <param name="right">The right directory path operand.</param>
+        /// <returns>A new directory path representing a combination of the two provided paths.</returns>
+        public static ConvertableDirectoryPath operator /(ConvertableDirectoryPath left, DirectoryPath right)
+        {
+            if (left == null)
+            {
+                throw new ArgumentNullException(nameof(left));
+            }
+            if (right == null)
+            {
+                throw new ArgumentNullException(nameof(right));
+            }
+            return new ConvertableDirectoryPath(left.Path.Combine(right));
+        }
+
+        /// <summary>
+        /// Operator that combines a <see cref="ConvertableDirectoryPath"/> instance
+        /// with a <see cref="ConvertableFilePath"/> instance.
+        /// </summary>
+        /// <param name="directory">The left directory path operand.</param>
+        /// <param name="file">The right file path operand.</param>
+        /// <returns>A new file path representing a combination of the two provided paths.</returns>
+        public static ConvertableFilePath operator /(ConvertableDirectoryPath directory, ConvertableFilePath file)
+        {
+            if (directory == null)
+            {
+                throw new ArgumentNullException(nameof(directory));
+            }
+            if (file == null)
+            {
+                throw new ArgumentNullException(nameof(file));
+            }
+            return new ConvertableFilePath(directory.Path.CombineWithFilePath(file.Path));
+        }
+
+        /// <summary>
+        /// Operator that combines a <see cref="ConvertableDirectoryPath"/> instance
+        /// with a <see cref="FilePath"/> instance.
+        /// </summary>
+        /// <param name="directory">The left directory path operand.</param>
+        /// <param name="file">The right file path operand.</param>
+        /// <returns>A new file path representing a combination of the two provided paths.</returns>
+        public static ConvertableFilePath operator /(ConvertableDirectoryPath directory, FilePath file)
         {
             if (directory == null)
             {

--- a/src/Cake.Core.Tests/Unit/IO/DirectoryPathCollectionTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/DirectoryPathCollectionTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Linq;
 using Cake.Core.IO;
 using Xunit;
@@ -207,6 +208,120 @@ namespace Cake.Core.Tests.Unit.IO
 
                     // Then
                     Assert.False(ReferenceEquals(result, collection));
+                }
+            }
+        }
+
+        public sealed class TheDivisionOperator
+        {
+            public sealed class WithSinglePath
+            {
+                [Fact]
+                public void Should_Throw_If_Collection_Is_Null()
+                {
+                    // Given
+                    DirectoryPathCollection collection = null;
+
+                    // When
+                    // ReSharper disable once ExpressionIsAlwaysNull
+                    var result = Record.Exception(() => collection / new DirectoryPath("A"));
+
+                    // Then
+                    AssertEx.IsArgumentNullException(result, "collection");
+                }
+
+                [Fact]
+                public void Should_Add_Null_If_Path_Is_Null()
+                {
+                    // Given
+                    var collection = new DirectoryPathCollection(new PathComparer(false));
+
+                    // When
+                    var result = collection / (DirectoryPath)null;
+
+                    // Then
+                    Assert.Contains(null, result);
+                }
+
+                [Fact]
+                public void Should_Respect_File_System_Case_Sensitivity_When_Adding_Path()
+                {
+                    // Given
+                    var collection = new DirectoryPathCollection(new PathComparer(false));
+                    collection.Add("B");
+
+                    // When
+                    var result = collection / new DirectoryPath("A");
+
+                    // Then
+                    Assert.Equal(2, result.Count);
+                }
+
+                [Fact]
+                public void Should_Return_New_Collection()
+                {
+                    // Given
+                    var collection = new DirectoryPathCollection(new PathComparer(false));
+
+                    // When
+                    var result = collection / new DirectoryPath("A");
+
+                    // Then
+                    Assert.NotSame(collection, result);
+                }
+            }
+
+            public sealed class WithMultiplePaths
+            {
+                [Fact]
+                public void Should_Throw_If_Collection_Is_Null()
+                {
+                    // Given
+                    DirectoryPathCollection collection = null;
+                    var paths = new DirectoryPathCollection(new PathComparer(false));
+                    paths.Add("A");
+                    paths.Add("B");
+
+                    // When
+                    // ReSharper disable once ExpressionIsAlwaysNull
+                    var result = Record.Exception(() => collection / paths);
+
+                    // Then
+                    AssertEx.IsArgumentNullException(result, "collection");
+                }
+
+                [Fact]
+                public void Should_Respect_File_System_Case_Sensitivity_When_Adding_Paths()
+                {
+                    // Given
+                    var comparer = new PathComparer(false);
+                    var collection = new DirectoryPathCollection(comparer);
+                    var paths = new DirectoryPathCollection(comparer);
+                    paths.Add("A");
+                    paths.Add("B");
+
+                    // When
+                    var result = collection / paths;
+
+                    // Then
+                    Assert.Equal(2, result.Count);
+                }
+
+                [Fact]
+                public void Should_Return_New_Collection()
+                {
+                    // Given
+                    var comparer = new PathComparer(false);
+                    var collection = new DirectoryPathCollection(comparer);
+                    var paths = new DirectoryPathCollection(comparer);
+                    paths.Add("A");
+                    paths.Add("B");
+
+                    // When
+                    var result = collection / paths;
+
+                    // Then
+                    Assert.NotSame(collection, result);
                 }
             }
         }

--- a/src/Cake.Core.Tests/Unit/IO/FilePathCollectionTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/FilePathCollectionTests.cs
@@ -211,6 +211,119 @@ namespace Cake.Core.Tests.Unit.IO
             }
         }
 
+        public sealed class TheDivideOperator
+        {
+            public sealed class WithSinglePath
+            {
+                [Fact]
+                public void Should_Throw_If_Collection_Is_Null()
+                {
+                    // Given
+                    FilePathCollection collection = null;
+
+                    // When
+                    // ReSharper disable once ExpressionIsAlwaysNull
+                    var result = Record.Exception(() => collection / new FilePath("A.txt"));
+
+                    // Then
+                    AssertEx.IsArgumentNullException(result, "collection");
+                }
+
+                [Fact]
+                public void Should_Add_Null_If_Path_Is_Null()
+                {
+                    // Given
+                    var collection = new FilePathCollection(new PathComparer(false));
+
+                    // When
+                    var result = collection / (FilePath)null;
+
+                    // Then
+                    Assert.Contains(null, result);
+                }
+
+                [Fact]
+                public void Should_Respect_File_System_Case_Sensitivity_When_Adding_Path()
+                {
+                    // Given
+                    var collection = new FilePathCollection(new PathComparer(false));
+                    collection.Add("B.txt");
+
+                    // When
+                    var result = collection / new FilePath("A.txt");
+
+                    // Then
+                    Assert.Equal(2, result.Count);
+                }
+
+                [Fact]
+                public void Should_Return_New_Collection()
+                {
+                    // Given
+                    var collection = new FilePathCollection(new PathComparer(false));
+
+                    // When
+                    var result = collection / new FilePath("A.txt");
+
+                    // Then
+                    Assert.NotSame(collection, result);
+                }
+            }
+
+            public sealed class WithMultiplePaths
+            {
+                [Fact]
+                public void Should_Throw_If_Collection_Is_Null()
+                {
+                    // Given
+                    FilePathCollection collection = null;
+                    var paths = new FilePathCollection(new PathComparer(false));
+                    paths.Add("A.txt");
+                    paths.Add("B.txt");
+
+                    // When
+                    var result = Record.Exception(() => collection / paths);
+
+                    // Then
+                    AssertEx.IsArgumentNullException(result, "collection");
+                }
+
+                [Fact]
+                public void Should_Respect_File_System_Case_Sensitivity_When_Adding_Paths()
+                {
+                    // Given
+                    var comparer = new PathComparer(false);
+                    var collection = new FilePathCollection(comparer);
+                    var paths = new FilePathCollection(comparer);
+                    paths.Add("A.txt");
+                    paths.Add("B.txt");
+
+                    // When
+                    var result = collection / paths;
+
+                    // Then
+                    Assert.Equal(2, result.Count);
+                }
+
+                [Fact]
+                public void Should_Return_New_Collection()
+                {
+                    // Given
+                    var comparer = new PathComparer(false);
+                    var collection = new FilePathCollection(comparer);
+                    var paths = new FilePathCollection(comparer);
+                    paths.Add("A.txt");
+                    paths.Add("B.txt");
+
+                    // When
+                    var result = collection / paths;
+
+                    // Then
+                    Assert.NotSame(collection, result);
+                }
+            }
+        }
+
         public sealed class TheMinusOperator
         {
             public sealed class WithSinglePath

--- a/src/Cake.Core/IO/DirectoryPathCollection.cs
+++ b/src/Cake.Core/IO/DirectoryPathCollection.cs
@@ -132,6 +132,33 @@ namespace Cake.Core.IO
             return new DirectoryPathCollection(collection, collection.Comparer) { paths };
         }
 
+        /// <summary>Adds a path to the collection.</summary>
+        /// <param name="collection">The collection.</param>
+        /// <param name="path">The path to add.</param>
+        /// <returns>A new <see cref="DirectoryPathCollection"/> that contains the provided path as
+        /// well as the paths in the original collection.</returns>
+        public static DirectoryPathCollection operator /(DirectoryPathCollection collection, DirectoryPath path)
+        {
+            if (collection == null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+            return new DirectoryPathCollection(collection, collection.Comparer) { path };
+        }
+
+        /// <summary>Adds multiple paths to the collection.</summary>
+        /// <param name="collection">The collection.</param>
+        /// <param name="paths">The paths to add.</param>
+        /// <returns>A new <see cref="DirectoryPathCollection"/> with the content of both collections.</returns>
+        public static DirectoryPathCollection operator /(DirectoryPathCollection collection, IEnumerable<DirectoryPath> paths)
+        {
+            if (collection == null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+            return new DirectoryPathCollection(collection, collection.Comparer) { paths };
+        }
+
         /// <summary>
         /// Removes a path from the collection.
         /// </summary>

--- a/src/Cake.Core/IO/FilePathCollection.cs
+++ b/src/Cake.Core/IO/FilePathCollection.cs
@@ -131,6 +131,33 @@ namespace Cake.Core.IO
             return new FilePathCollection(collection, collection.Comparer) { paths };
         }
 
+        /// <summary>Adds a path to the collection.</summary>
+        /// <param name="collection">The collection.</param>
+        /// <param name="path">The path to add.</param>
+        /// <returns>A new <see cref="FilePathCollection"/> that contains the provided path as
+        /// well as the paths in the original collection.</returns>
+        public static FilePathCollection operator /(FilePathCollection collection, FilePath path)
+        {
+            if (collection == null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+            return new FilePathCollection(collection, collection.Comparer) { path };
+        }
+
+        /// <summary>Adds multiple paths to the collection.</summary>
+        /// <param name="collection">The collection.</param>
+        /// <param name="paths">The paths to add.</param>
+        /// <returns>A new <see cref="FilePathCollection"/> with the content of both collections.</returns>
+        public static FilePathCollection operator /(FilePathCollection collection, IEnumerable<FilePath> paths)
+        {
+            if (collection == null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+            return new FilePathCollection(collection, collection.Comparer) { paths };
+        }
+
         /// <summary>
         /// Removes a path from the collection.
         /// </summary>

--- a/tests/integration/Cake.Common/IO/Paths.cake
+++ b/tests/integration/Cake.Common/IO/Paths.cake
@@ -1,0 +1,42 @@
+#load "./../../utilities/xunit.cake"
+
+//////////////////////////////////////////////////////////////////////////////
+
+//////////////////////////////////////////////////////////////////////////////
+
+Task("Cake.Common.IO.Paths.DivideOperator.CombineDirectoryPathWithFilePath")
+    .Does(() =>
+{
+    // When
+    var path = Directory("./") / File("test.file");
+
+    // Then
+    Assert.Equal($"./test.file", path);
+});
+
+Task("Cake.Common.IO.Paths.DivideOperator.CombineDirectoryPathWithDirectoryPath")
+    .Does(() =>
+{
+    // When
+    var path = Directory("./") / Directory("temp");
+
+    // Then
+    Assert.Equal($"./temp", path);
+});
+
+Task("Cake.Common.IO.Paths.DivideOperator.CombineDirectoryPathWithDirectoryPathAndFilePath")
+    .Does(() =>
+{
+    // When
+    var path = Directory("./") / Directory("temp") / File("test.file");
+
+    // Then
+    Assert.Equal($"./temp/test.file", path);
+});
+
+//////////////////////////////////////////////////////////////////////////////
+
+Task("Cake.Common.IO.Paths")
+    .IsDependentOn("Cake.Common.IO.Paths.DivideOperator.CombineDirectoryPathWithFilePath")
+    .IsDependentOn("Cake.Common.IO.Paths.DivideOperator.CombineDirectoryPathWithDirectoryPath")
+    .IsDependentOn("Cake.Common.IO.Paths.DivideOperator.CombineDirectoryPathWithDirectoryPathAndFilePath");

--- a/tests/integration/build.cake
+++ b/tests/integration/build.cake
@@ -9,6 +9,7 @@
 #load "./Cake.Common/IO/DirectoryAliases.cake"
 #load "./Cake.Common/IO/FileAliases.cake"
 #load "./Cake.Common/IO/FileAsync.cake"
+#load "./Cake.Common/IO/Paths.cake"
 #load "./Cake.Common/IO/ZipAliases.cake"
 #load "./Cake.Common/ReleaseNotesAliases.cake"
 #load "./Cake.Common/Security/SecurityAliases.cake"


### PR DESCRIPTION
This allows to concatenate directory and file paths using the `/` operator, in addition to the regular `+` operator.

For example, while it was previously possible to do this:

```csharp
var directory = Directory("dir");
var subdirectory = Directory("subdir");
var file = File("file.txt");

var path = directory + subdirectory + file;
```

You now also have to choice to concatenate the paths using the `/` operator:

```csharp
var directory = Directory("dir");
var subdirectory = Directory("subdir");
var file = File("file.txt");

var path = directory / subdirectory / file;
```

Which arguably looks better, especially for longer paths.

This feature was inspired by the blog post by @maartenba titled ["Using operator overloads for concatenating file system paths in CSharp"](https://blog.maartenballiauw.be/post/2017/10/26/operator-overloads-concatenate-file-system-path.html).