### PR TITLE
GH1908: Octo improvements - list-deployments implementation for octo.exe

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/OctopusDeploymentQueryierFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/OctopusDeploymentQueryierFixture.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -9,30 +9,25 @@ using Cake.Testing.Fixtures;
 
 namespace Cake.Common.Tests.Fixtures.Tools
 {
-    internal sealed class OctopusDeployPusherFixture : ToolFixture<OctopusPushSettings>
+    internal sealed class OctopusDeploymentQueryierFixture : ToolFixture<OctopusDeploymentQuerySettings>
     {
         internal string Server { get; set; }
 
         internal string ApiKey { get; set; }
 
-        public List<FilePath> Packages { get; set; }
-
-        public OctopusDeployPusherFixture()
+        public OctopusDeploymentQueryierFixture()
             : base("Octo.exe")
         {
-            Packages = new List<FilePath>
-            {
-                "MyPackage.1.0.0.zip",
-                "MyOtherPackage.1.0.1.nupkg"
-            };
             Server = "http://octopus";
             ApiKey = "API-12345";
         }
 
+        public DeploymentQueryResultParser Parser { get; set; } = new DeploymentQueryResultParser();
+
         protected override void RunTool()
         {
-            var tool = new OctopusDeployPusher(FileSystem, Environment, ProcessRunner, Tools);
-            tool.PushPackage(Server, ApiKey, Packages?.ToArray(), Settings);
+            var tool = new OctopusDeployDeploymentQuerier(FileSystem, Environment, ProcessRunner, Tools);
+            var results = tool.QueryOctopusDeployments(Server, ApiKey, Settings);
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctopusDeploymentQueryTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctopusDeploymentQueryTests.cs
@@ -1,0 +1,300 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cake.Common.Tests.Fixtures.Tools;
+using Cake.Common.Tools.OctopusDeploy;
+using Cake.Core.IO;
+using Cake.Testing;
+using Cake.Testing.Xunit;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.OctopusDeploy
+{
+    public sealed class OctopusDeploymentQueryTests
+    {
+        public sealed class TheQueryDeploymentsMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Count_Is_Less_Than_1()
+            {
+                // Given
+                var fixture = new OctopusDeploymentQueryierFixture();
+                fixture.Settings.Count = 0;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentOutOfRangeException(result, "Query must return at least one result");
+            }
+
+            [Fact]
+            public void Should_Map_Count_To_Query_Filter()
+            {
+                // Given
+                var fixture = new OctopusDeploymentQueryierFixture();
+                fixture.Settings.Count = 10;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("list-deployments --number 10 " +
+                             "--server http://octopus --apiKey API-12345", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_ProjectName_To_Query_Filter()
+            {
+                // Given
+                var fixture = new OctopusDeploymentQueryierFixture();
+                fixture.Settings.ProjectName = "Project A";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("list-deployments --project \"Project A\" --number 1 " +
+                             "--server http://octopus --apiKey API-12345", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_EnvironmentName_To_Query_Filter()
+            {
+                // Given
+                var fixture = new OctopusDeploymentQueryierFixture();
+                fixture.Settings.EnvironmentName = "Env A";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("list-deployments --environment \"Env A\" --number 1 " +
+                             "--server http://octopus --apiKey API-12345", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_TenantName_To_Query_Filter()
+            {
+                // Given
+                var fixture = new OctopusDeploymentQueryierFixture();
+                fixture.Settings.TenantName = "Tenant A";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("list-deployments --tenant \"Tenant A\" --number 1 " +
+                             "--server http://octopus --apiKey API-12345", result.Args);
+            }
+
+            [Fact]
+            public void Should_Map_All_Query_Filter_Options()
+            {
+                // Given
+                var fixture = new OctopusDeploymentQueryierFixture();
+                fixture.Settings.ProjectName = "Project A";
+                fixture.Settings.EnvironmentName = "Env A";
+                fixture.Settings.TenantName = "Tenant A";
+                fixture.Settings.Count = 5;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("list-deployments --environment \"Env A\" " +
+                             "--project \"Project A\" " +
+                             "--tenant \"Tenant A\" --number 5 " +
+                             "--server http://octopus --apiKey API-12345", result.Args);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Octo_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new OctopusDeploymentQueryierFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, "Octo: Could not locate executable.");
+            }
+
+            [Theory]
+            [InlineData("/bin/tools/octopus/octo.exe", "/bin/tools/octopus/octo.exe")]
+            [InlineData("./tools/octopus/octo.exe", "/Working/tools/octopus/octo.exe")]
+            public void Should_Use_Octo_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new OctopusDeploymentQueryierFixture();
+                fixture.Settings.ToolPath = toolPath;
+                fixture.GivenSettingsToolPathExist();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Path.FullPath);
+            }
+
+            [WindowsTheory]
+            [InlineData("C:/octopusDeploy/octo.exe", "C:/octopusDeploy/octo.exe")]
+            public void Should_Use_Octo_Executable_From_Tool_Path_If_Provided_On_Windows(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new OctopusDeploymentQueryierFixture();
+                fixture.Settings.ToolPath = toolPath;
+                fixture.GivenSettingsToolPathExist();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Path.FullPath);
+            }
+
+            [Fact]
+            public void Should_Find_Octo_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new OctopusDeploymentQueryierFixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/Working/tools/Octo.exe", result.Path.FullPath);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new OctopusDeploymentQueryierFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, "Octo: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new OctopusDeploymentQueryierFixture();
+                fixture.GivenProcessExitsWithCode(1);
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, "Octo: Process returned an error (exit code 1).");
+            }
+        }
+
+        public sealed class TheResultParser
+        {
+            [Fact]
+            public void Should_Return_Empty_List_If_No_Valid_Results_Exist()
+            {
+                var parser = new DeploymentQueryResultParser();
+                var t = Results.Split(new[] { System.Environment.NewLine }, StringSplitOptions.None);
+
+                var results = parser.ParseResults(t.ToList().Take(4));
+
+                Assert.Empty(results);
+            }
+
+            [Fact]
+            public void Should_Handle_Empty_Response_Gracefully()
+            {
+                var parser = new DeploymentQueryResultParser();
+
+                var results = parser.ParseResults(null);
+                Assert.Empty(results);
+            }
+
+            [Fact]
+            public void Should_Parse_Correct_Response_From_Octo_EXE()
+            {
+                var parser = new DeploymentQueryResultParser();
+                var t = Results.Split(new[] { System.Environment.NewLine }, StringSplitOptions.None);
+
+                var results = parser.ParseResults(t);
+                Assert.Equal(3, results.Count());
+
+                var expected = new OctopusDeployment
+                                {
+                                    Assembled = DateTimeOffset.Parse("11/2/2017 12:53:34 -04:00"),
+                                    Channel = "Default",
+                                    Created = DateTimeOffset.Parse("11/2/2017 12:53:35 -04:00"),
+                                    Environment = "Staging",
+                                    PackageVersions = "Package A 0.9.104; Package B 0.9.104",
+                                    ProjectName = "Project A",
+                                    ReleaseNotesHtml = "<h1> Project A </h1>",
+                                    Version = "0.9.104"
+                                };
+                var actual = results.First();
+                Assert.Equal(expected.Environment, actual.Environment);
+                Assert.Equal(expected.Assembled, actual.Assembled);
+                Assert.Equal(expected.Channel, actual.Channel);
+                Assert.Equal(expected.Created, actual.Created);
+                Assert.Equal(expected.PackageVersions, actual.PackageVersions);
+                Assert.Equal(expected.ProjectName, actual.ProjectName);
+                Assert.Equal(expected.ReleaseNotesHtml, actual.ReleaseNotesHtml);
+                Assert.Equal(expected.Version, actual.Version);
+
+                Assert.Equal("Package A 0.5.114; Package B 0.5.114", results.Last().PackageVersions);
+            }
+
+            private string Results =
+@"Octopus Deploy Command Line Tool, version 4.24.4
+
+Handshaking with Octopus server: http://octo
+Handshake successful. Octopus version: 3.17.2; API version: 3.0.0
+Authenticated as: user (a service account)
+Loading projects...
+Loading environments...
+Loading tenants...
+Loading deployments...
+Showing 3 results...
+ - Project: Project A
+ - Environment: Staging
+ - Channel: Default
+   Created: 11/2/2017 12:53:35 -04:00
+   Version: 0.9.104
+   Assembled: 11/2/2017 12:53:34 -04:00
+   Package Versions: Package A 0.9.104; Package B 0.9.104
+   Release Notes: <h1> Project A </h1>
+
+ - Project: Project B
+ - Environment: Production
+ - Channel: Default
+   Created: 11/1/2017 16:43:36 -04:00
+   Version: 0.5.115
+   Assembled: 11/1/2017 16:43:35 -04:00
+   Package Versions: Package C 0.5.115; Package D 0.5.115
+   Release Notes: <h1> Project B</h1>
+
+ - Project: Project A
+ - Environment: Production
+ - Channel: Default
+   Created: 11/1/2017 16:31:09 -04:00
+   Version: 0.5.114
+   Assembled: 11/1/2017 16:31:09 -04:00
+   Package Versions: Package A 0.5.114; Package B 0.5.114
+   Release Notes: <h1> Public Website</h1><p>lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor </p>
+
+";
+        }
+    }
+}

--- a/src/Cake.Common/Tools/OctopusDeploy/DeploymentQueryResultParser.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/DeploymentQueryResultParser.cs
@@ -1,0 +1,94 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Cake.Common.Tools.OctopusDeploy
+{
+    /// <summary>
+    /// Parses the Console Output of the octo.exe call when called with list-deployments
+    /// </summary>
+    public class DeploymentQueryResultParser
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeploymentQueryResultParser"/> class.
+        /// </summary>
+        public DeploymentQueryResultParser()
+        {
+        }
+
+        /// <summary>
+        /// Parse the results from The Deployment Query
+        /// </summary>
+        /// <param name="output">Console Output from the Run Process</param>
+        /// <returns>A collection of Octopus deployments.</returns>
+        public IEnumerable<OctopusDeployment> ParseResults(IEnumerable<string> output)
+        {
+            var results = new List<OctopusDeployment>();
+            if (output == null)
+            {
+                return results;
+            }
+            var l = new List<string>(output);
+            if (l.Count < 10)
+            {
+                return results;
+            }
+            /* yes, this is fragile and I'm open to better ideas,
+             * however, i can't ask the tool to format as something serialized
+             * dump the status lines */
+            l.RemoveRange(0, 10);
+            while (l.Count > 0)
+            {
+                var nibSize = l.Count >= 9 ? 9 : l.Count;
+                var interesting = l.GetRange(0, nibSize);
+                var deployment = ParseSet(interesting);
+                if (deployment != null)
+                {
+                    results.Add(deployment);
+                }
+                l.RemoveRange(0, nibSize);
+            }
+            return results;
+        }
+
+        /// <summary>
+        /// Parses a set of lines from the output
+        /// </summary>
+        /// <param name="lineSet">A set of lines to parse</param>
+        /// <returns>an OctopusDeployment or null</returns>
+        protected virtual OctopusDeployment ParseSet(List<string> lineSet)
+        {
+            // the ninth line is blank, so 8 is technically ok, but w/e
+            if (lineSet.Count < 8)
+            {
+                return null;
+            }
+            var d = new OctopusDeployment()
+            {
+                ProjectName = getValueFromLine("Project", lineSet[0]),
+                Environment = getValueFromLine("Environment", lineSet[1]),
+                Channel = getValueFromLine("Channel", lineSet[2]),
+                Created = DateTimeOffset.Parse(getValueFromLine("Created", lineSet[3])),
+                Version = getValueFromLine("Version", lineSet[4]),
+                Assembled = DateTimeOffset.Parse(getValueFromLine("Assembled", lineSet[5])),
+                PackageVersions = getValueFromLine("Package Version", lineSet[6]),
+                ReleaseNotesHtml = getValueFromLine("Release Notes", lineSet[7])
+            };
+            return d;
+        }
+
+        private string getValueFromLine(string propName, string line)
+        {
+            /* this could probably accept a string[] lines instead, and hunt
+             * but direct index is faster and can still validate. */
+            if (!line.Contains(propName))
+            {
+                throw new Exception(string.Format("Could not parse Deployment - Expected: '{0}', was '{1}'", propName, line));
+            }
+            return line.Split(new[] { ':' }, 2)[1].Trim();
+        }
+    }
+}

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployDeploymentLister.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployDeploymentLister.cs
@@ -1,0 +1,103 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.OctopusDeploy
+{
+    /// <summary>
+    /// Allows you to query your Octopus Deploy server deployment history
+    /// </summary>
+    public class OctopusDeployDeploymentQuerier : Tool<OctopusDeploymentQuerySettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OctopusDeployDeploymentQuerier"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="tools">The tool locator.</param>
+        public OctopusDeployDeploymentQuerier(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IToolLocator tools)
+            : base(fileSystem, environment, processRunner, tools)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Gets the name of the tool.
+        /// </summary>
+        /// <returns>The name of the tool.</returns>
+        protected override string GetToolName()
+        {
+            return "Octo";
+        }
+
+        /// <summary>
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return new[] { "Octo.exe" };
+        }
+
+        /// <summary>
+        /// Pushes the specified packages to Octopus Deploy internal repository
+        /// </summary>
+        /// <param name="server">The Octopus server URL</param>
+        /// <param name="apiKey">The user's API key</param>
+        /// <param name="querySettings">The query</param>
+        /// <returns>A list of Octopus Deployments</returns>
+        public IEnumerable<OctopusDeployment> QueryOctopusDeployments(string server, string apiKey, OctopusDeploymentQuerySettings querySettings)
+        {
+            if (querySettings == null)
+            {
+                throw new ArgumentNullException(nameof(querySettings));
+            }
+            if (string.IsNullOrEmpty(server))
+            {
+                throw new ArgumentException("No server specified.", nameof(server));
+            }
+            if (string.IsNullOrEmpty(apiKey))
+            {
+                throw new ArgumentException("No API key specified.", nameof(apiKey));
+            }
+            if (querySettings.Count < 1)
+            {
+                throw new ArgumentOutOfRangeException("Query must return at least one result", nameof(querySettings.Count));
+            }
+
+            var builder = new OctopusDeploymentQueryArgumentBuilder(server, apiKey, _environment, querySettings);
+            var process = RunProcess(querySettings, builder.Get());
+
+            if (querySettings.ToolTimeout.HasValue)
+            {
+                if (!process.WaitForExit((int)querySettings.ToolTimeout.Value.TotalMilliseconds))
+                {
+                    const string message = "Tool timeout ({0}): {1}";
+                    throw new TimeoutException(string.Format(CultureInfo.InvariantCulture, message, querySettings.ToolTimeout.Value, GetToolName()));
+                }
+            }
+            else
+            {
+                process.WaitForExit();
+            }
+
+            ProcessExitCode(process.GetExitCode());
+            var parser = new DeploymentQueryResultParser();
+            return parser.ParseResults(process.GetStandardOutput());
+        }
+    }
+}

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployment.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployment.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Cake.Common.Tools.OctopusDeploy
+{
+    /// <summary>
+    /// An object representing a deployment in Octopus Deploy
+    /// </summary>
+    public class OctopusDeployment
+    {
+        /// <summary>
+        /// gets or sets the Name of the Deployment's Project
+        /// </summary>
+        public string ProjectName { get; set; }
+
+        /// <summary>
+        /// gets or sets the Environment the project was deployed to
+        /// </summary>
+        public string Environment { get; set; }
+
+        /// <summary>
+        /// gets or sets the Deployment's channel
+        /// </summary>
+        public string Channel { get; set; }
+
+        /// <summary>
+        /// gets or sets When the deployment was created
+        /// </summary>
+        public DateTimeOffset Created { get; set; }
+
+        /// <summary>
+        /// gets or sets when the deployment was assembled
+        /// </summary>
+        public DateTimeOffset Assembled { get; set; }
+
+        /// <summary>
+        /// gets or sets the deployed project version
+        /// </summary>
+        public string Version { get; set; }
+
+        /// <summary>
+        /// gets or sets the list of packages in the deployment
+        /// </summary>
+        public string PackageVersions { get; set; }
+
+        /// <summary>
+        /// gets or sets the release notes for the deployment (HTML Markup)
+        /// </summary>
+        public string ReleaseNotesHtml { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusDeploymentQueryArgumentBuilder.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusDeploymentQueryArgumentBuilder.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.OctopusDeploy
+{
+    internal class OctopusDeploymentQueryArgumentBuilder : OctopusDeployArgumentBuilder<OctopusDeploymentQuerySettings>
+    {
+        public OctopusDeploymentQueryArgumentBuilder(string server, string apiKey, ICakeEnvironment environment, OctopusDeploymentQuerySettings settings) : base(server, apiKey, environment, settings)
+        {
+        }
+
+        public ProcessArgumentBuilder Get()
+        {
+            AppendPackageArguments();
+            AppendCommonArguments();
+            return Builder;
+        }
+
+        private void AppendPackageArguments()
+        {
+            Builder.Append("list-deployments");
+
+            if (!string.IsNullOrEmpty(Settings.EnvironmentName))
+            {
+                Builder.Append("--environment \"{0}\"", Settings.EnvironmentName);
+            }
+
+            if (!string.IsNullOrEmpty(Settings.ProjectName))
+            {
+                Builder.Append("--project \"{0}\"", Settings.ProjectName);
+            }
+
+            if (!string.IsNullOrEmpty(Settings.TenantName))
+            {
+                Builder.Append("--tenant \"{0}\"", Settings.TenantName);
+            }
+
+            Builder.Append("--number {0}", Settings.Count);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusDeploymentQuerySettings.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusDeploymentQuerySettings.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Tools.OctopusDeploy
+{
+    /// <summary>
+    /// Contains settings used by <see cref="OctopusDeployDeploymentQuerier.QueryOctopusDeployments"/>.
+    /// </summary>
+    public sealed class OctopusDeploymentQuerySettings : OctopusDeploySettings
+    {
+        /// <summary>
+        /// Gets or Sets a value that is an Octopus Environment Name to filter for.
+        /// </summary>
+        public string EnvironmentName { get; set; }
+
+        /// <summary>
+        /// Gets or Sets a value that is an Octopus Project Name to filter for.
+        /// </summary>
+        public string ProjectName { get; set; }
+
+        /// <summary>
+        /// Gets or Sets a value that is an Octopus Tenamt Name to filter for.
+        /// </summary>
+        public string TenantName { get; set; }
+
+        /// <summary>
+        /// Gets or Sets a value that indicates how many deployments to retrieve
+        /// in Date Descending order (most recent first)
+        /// Default: 1
+        /// </summary>
+        public int Count { get; set; } = 1;
+    }
+}

--- a/src/Cake.Testing.Xunit/ExceptionAsserts.cs
+++ b/src/Cake.Testing.Xunit/ExceptionAsserts.cs
@@ -16,6 +16,12 @@ namespace Xunit
             Assert.Equal(parameterName, ((ArgumentNullException)exception).ParamName);
         }
 
+        public static void IsArgumentOutOfRangeException(Exception exception, string parameterName)
+        {
+            Assert.IsType<ArgumentOutOfRangeException>(exception);
+            Assert.Equal(parameterName, ((ArgumentOutOfRangeException)exception).ParamName);
+        }
+
         public static void IsArgumentException(Exception exception, string parameterName, string message)
         {
             Assert.IsType<ArgumentException>(exception);


### PR DESCRIPTION
reference feature request #1908 

I am guessing you might want something cleaner for the stuff for the string in src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctopusDeploymentQueryTests.cs line 260+.

I'm open to ideas as to how you approach that, since most of the source I read was write-heavy and doesn't do too much parsing, relying mostly on return codes when you have to shell out. I figured that I'd leave it until you said otherwise, since it's pretty darn specific and going the whole embedded resource route or similar seemed a bit overkill.