### PR TITLE
Add AseemblySemFileVer to GitVersion

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/GitVersion/GitVersionRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/GitVersion/GitVersionRunnerTests.cs
@@ -237,6 +237,7 @@ namespace Cake.Common.Tests.Unit.Tools.GitVersion
                         LegacySemVer = "0.1.1",
                         LegacySemVerPadded = "0.1.1",
                         AssemblySemVer = "0.1.1.0",
+                        AssemblySemFileVer = "0.1.1.0",
                         FullSemVer = "0.1.1",
                         InformationalVersion = "0.1.1+Branch.master.Sha.f2467748c78b3c8b37972ad0b30df2e15dfbf2cb",
                         BranchName = "master",
@@ -267,6 +268,7 @@ namespace Cake.Common.Tests.Unit.Tools.GitVersion
                         "  \"LegacySemVer\":\"0.1.1\",",
                         "  \"LegacySemVerPadded\":\"0.1.1\",",
                         "  \"AssemblySemVer\":\"0.1.1.0\",",
+                        "  \"AssemblySemFileVer\":\"0.1.1.0\",",
                         "  \"FullSemVer\":\"0.1.1\",",
                         "  \"InformationalVersion\":\"0.1.1+Branch.master.Sha.f2467748c78b3c8b37972ad0b30df2e15dfbf2cb\",",
                         "  \"BranchName\":\"master\",",
@@ -299,6 +301,7 @@ namespace Cake.Common.Tests.Unit.Tools.GitVersion
                 Assert.Equal(expect.LegacySemVer, result.LegacySemVer);
                 Assert.Equal(expect.LegacySemVerPadded, result.LegacySemVerPadded);
                 Assert.Equal(expect.AssemblySemVer, result.AssemblySemVer);
+                Assert.Equal(expect.AssemblySemFileVer, result.AssemblySemFileVer);
                 Assert.Equal(expect.FullSemVer, result.FullSemVer);
                 Assert.Equal(expect.InformationalVersion, result.InformationalVersion);
                 Assert.Equal(expect.BranchName, result.BranchName);

--- a/src/Cake.Common/Tools/GitVersion/GitVersion.cs
+++ b/src/Cake.Common/Tools/GitVersion/GitVersion.cs
@@ -85,6 +85,11 @@ namespace Cake.Common.Tools.GitVersion
         public string AssemblySemVer { get; set; }
 
         /// <summary>
+        /// Gets or sets the assembly semantic file version.
+        /// </summary>
+        public string AssemblySemFileVer { get; set; }
+
+        /// <summary>
         /// Gets or sets the full Semantic Version.
         /// </summary>
         public string FullSemVer { get; set; }

--- a/src/Cake.Common/Tools/GitVersion/GitVersionInternal.cs
+++ b/src/Cake.Common/Tools/GitVersion/GitVersionInternal.cs
@@ -120,6 +120,13 @@ namespace Cake.Common.Tools.GitVersion
         }
 
         [DataMember]
+        public string AssemblySemFileVer
+        {
+            get => GitVersion.AssemblySemFileVer;
+            set => GitVersion.AssemblySemFileVer = value;
+        }
+
+        [DataMember]
         public string FullSemVer
         {
             get => GitVersion.FullSemVer;


### PR DESCRIPTION
Fixes #1922 

Added missing AssemblySemFileVer, which is output as part of the Json format when running GitVersion.