### PR TITLE
GH1855: Resolve Signtool in newer Windows 10 SDKs

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/SignToolResolverFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/SignToolResolverFixture.cs
@@ -54,27 +54,15 @@ namespace Cake.Common.Tests.Fixtures.Tools
             }
         }
 
-        public void GivenThatToolExistInKnownPathWindows10SpecificSDK()
-        {
-            if (_is64Bit)
-            {
-                FileSystem.Exist(Arg.Is<FilePath>(p => p.FullPath == "/ProgramFilesX86/Windows Kits/10/bin/10.0.15063.0/x64/signtool.exe")).Returns(true);
-            }
-            else
-            {
-                FileSystem.Exist(Arg.Is<FilePath>(p => p.FullPath == "/ProgramFiles/Windows Kits/10/bin/10.0.15063.0/x86/signtool.exe")).Returns(true);
-            }
-        }
-
         public void GivenThatToolExistInKnownPathAppCertificationKit()
         {
             if (_is64Bit)
             {
-                FileSystem.Exist(Arg.Is<FilePath>(p => p.FullPath == "/ProgramFilesX86/Windows Kits10/App Certification Kit/signtool.exe")).Returns(true);
+                FileSystem.Exist(Arg.Is<FilePath>(p => p.FullPath == "/ProgramFilesX86/Windows Kits/10/App Certification Kit/signtool.exe")).Returns(true);
             }
             else
             {
-                FileSystem.Exist(Arg.Is<FilePath>(p => p.FullPath == "/ProgramFiles/Windows Kits10/App Certification Kit/signtool.exe")).Returns(true);
+                FileSystem.Exist(Arg.Is<FilePath>(p => p.FullPath == "/ProgramFiles/Windows Kits/10/App Certification Kit/signtool.exe")).Returns(true);
             }
         }
 
@@ -97,7 +85,7 @@ namespace Cake.Common.Tests.Fixtures.Tools
         public void GivenThatToolHasRegistryKeyWindowsKits()
         {
             var signToolKey = Substitute.For<IRegistryKey>();
-            signToolKey.GetValue("KitsRoot10").Returns("/SignTool");
+            signToolKey.GetValue("KitsRoot").Returns("/SignTool");
 
             var localMachine = Substitute.For<IRegistryKey>();
             localMachine.OpenKey("Software\\Microsoft\\Windows Kits\\Installed Roots").Returns(signToolKey);
@@ -109,6 +97,34 @@ namespace Cake.Common.Tests.Fixtures.Tools
             else
             {
                 FileSystem.Exist(Arg.Is<FilePath>(p => p.FullPath == "/SignTool/bin/x86/signtool.exe")).Returns(true);
+            }
+
+            Registry.LocalMachine.Returns(localMachine);
+        }
+
+        public void GivenThatToolHasRegistryKeyWindows10Kits()
+        {
+            var versions = new[] { "10.0.15063.0", "10.0.16299.0" };
+
+            var signToolKey = Substitute.For<IRegistryKey>();
+            signToolKey.GetValue("KitsRoot10").Returns("/SignTool");
+            signToolKey.GetSubKeyNames().Returns(versions);
+
+            var localMachine = Substitute.For<IRegistryKey>();
+            localMachine.OpenKey("Software\\Microsoft\\Windows Kits\\Installed Roots").Returns(signToolKey);
+
+            foreach (string version in versions)
+            {
+                if (_is64Bit)
+                {
+                    FileSystem.Exist(Arg.Is<FilePath>(p => p.FullPath == $"/SignTool/bin/{version}/x64/signtool.exe"))
+                        .Returns(true);
+                }
+                else
+                {
+                    FileSystem.Exist(Arg.Is<FilePath>(p => p.FullPath == $"/SignTool/bin/{version}/x86/signtool.exe"))
+                        .Returns(true);
+                }
             }
 
             Registry.LocalMachine.Returns(localMachine);

--- a/src/Cake.Common.Tests/Unit/Tools/SignTool/SignToolResolverTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/SignTool/SignToolResolverTests.cs
@@ -91,22 +91,6 @@ namespace Cake.Common.Tests.Unit.Tools.SignTool
             [Theory]
             [InlineData(true)]
             [InlineData(false)]
-            public void Should_Return_From_Disc_If_Found_Windows_10_Specific_SDK(bool is64Bit)
-            {
-                // Given
-                var fixture = new SignToolResolverFixture(is64Bit);
-                fixture.GivenThatToolExistInKnownPathWindows10SpecificSDK();
-
-                // When
-                var result = fixture.Resolve();
-
-                // Then
-                Assert.NotNull(result);
-            }
-
-            [Theory]
-            [InlineData(true)]
-            [InlineData(false)]
             public void Should_Return_From_Disc_If_Found_App_Certification_Kit(bool is64Bit)
             {
                 // Given
@@ -142,6 +126,22 @@ namespace Cake.Common.Tests.Unit.Tools.SignTool
                 // Given
                 var fixture = new SignToolResolverFixture(is64Bit);
                 fixture.GivenThatToolHasRegistryKeyWindowsKits();
+
+                // When
+                var result = fixture.Resolve();
+
+                // Then
+                Assert.NotNull(result);
+            }
+
+            [Theory]
+            [InlineData(true)]
+            [InlineData(false)]
+            public void Should_Return_From_Registry_If_Windows_10_Kits_Found(bool is64Bit)
+            {
+                // Given
+                var fixture = new SignToolResolverFixture(is64Bit);
+                fixture.GivenThatToolHasRegistryKeyWindows10Kits();
 
                 // When
                 var result = fixture.Resolve();


### PR DESCRIPTION
Addresses #1855 

Uses registry keys to find installed Windows 10 SDK versions.