### PR TITLE
GH1931: Add ability to set NuGet.config through env var or cake.config

### DIFF
--- a/src/Cake.NuGet.Tests/Unit/NuGetPackageInstallerTests.cs
+++ b/src/Cake.NuGet.Tests/Unit/NuGetPackageInstallerTests.cs
@@ -395,6 +395,29 @@ namespace Cake.NuGet.Tests.Unit
                 // Then
                 Assert.False(fixture.FileSystem.GetDirectory("/Working/nuget/cake.foo.1.2.3").Exists);
             }
+
+            // the case where Config is not set is covered by Should_Install_Resource and many of the other tests
+            [Fact]
+            public void Should_Use_Explicit_NuGet_Config_If_Set()
+            {
+                var fixture = new NuGetPackageInstallerFixture();
+                fixture.Config.GetValue(Arg.Is(Constants.NuGet.ConfigFile)).Returns("/Working/nuget.config");
+
+                fixture.Install();
+
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Is<FilePath>(path => path.FullPath == "/Working/tools/nuget.exe"),
+                    Arg.Is<ProcessSettings>(settings =>
+                        settings.Arguments.Render() ==
+                            "install \"Cake.Foo\" " +
+                            "-OutputDirectory \"/Working/nuget/cake.foo.1.2.3\" " +
+                            "-Source \"https://myget.org/temp/\" " +
+                            "-ConfigFile \"/Working/nuget.config\" " +
+                            "-Version \"1.2.3\" " +
+                            "-Prerelease " +
+                            "-ExcludeVersion " +
+                            "-NonInteractive"));
+            }
         }
     }
 }

--- a/src/Cake.NuGet/Constants.cs
+++ b/src/Cake.NuGet/Constants.cs
@@ -22,6 +22,11 @@ namespace Cake.NuGet
             /// The config key name for enabling loading of nuget package dependencies
             /// </summary>
             public const string LoadDependencies = "NuGet_LoadDependencies";
+
+            /// <summary>
+            /// The config key name for overriding the default nuget config file
+            /// </summary>
+            public const string ConfigFile = "NuGet_ConfigFile";
         }
 
         public static class Paths

--- a/src/Cake.NuGet/Install/NuGetPackageInstaller.cs
+++ b/src/Cake.NuGet/Install/NuGetPackageInstaller.cs
@@ -65,9 +65,17 @@ namespace Cake.NuGet.Install
             _config = config ?? throw new ArgumentNullException(nameof(config));
             _currentFramework = NuGetFramework.Parse(_environment.Runtime.TargetFramework.FullName, DefaultFrameworkNameProvider.Instance);
             _nugetLogger = new NuGetLogger(_log);
+
+            var nugetConfig = GetNuGetConfigPath(_environment, _config);
+
+            var nugetConfigDirectoryPath = nugetConfig.Item1;
+            var nugetConfigFilePath = nugetConfig.Item2;
+
+            _log.Debug($"Found NuGet.config at: {nugetConfigFilePath}");
+
             _nugetSettings = Settings.LoadDefaultSettings(
-                GetToolPath(),
-                null,
+                nugetConfigDirectoryPath.FullPath,
+                nugetConfigFilePath.GetFilename().ToString(),
                 new XPlatMachineWideSetting());
             _gatherCache = new GatherCache();
         }
@@ -132,12 +140,12 @@ namespace Cake.NuGet.Install
             return DependencyBehavior.Ignore;
         }
 
-        private string GetToolPath()
+        private static string GetToolPath(ICakeEnvironment environment, ICakeConfiguration config)
         {
-            var toolPath = _config.GetValue(Constants.Paths.Tools);
+            var toolPath = config.GetValue(Constants.Paths.Tools);
             return !string.IsNullOrWhiteSpace(toolPath) ?
-                new DirectoryPath(toolPath).MakeAbsolute(_environment).FullPath :
-                _environment.WorkingDirectory.Combine("tools").MakeAbsolute(_environment).FullPath;
+                new DirectoryPath(toolPath).MakeAbsolute(environment).FullPath :
+                environment.WorkingDirectory.Combine("tools").MakeAbsolute(environment).FullPath;
         }
 
         private static PackageIdentity GetPackageId(PackageReference package, NuGetSourceRepositoryProvider sourceRepositoryProvider, NuGetFramework targetFramework, ILogger logger)
@@ -170,6 +178,28 @@ namespace Cake.NuGet.Install
                 }
             }
             return null;
+        }
+
+        private static Tuple<DirectoryPath, FilePath> GetNuGetConfigPath(ICakeEnvironment environment, ICakeConfiguration config)
+        {
+            DirectoryPath rootPath;
+            FilePath filePath;
+
+            var nugetConfigFile = config.GetValue(Constants.NuGet.ConfigFile);
+            if (!string.IsNullOrEmpty(nugetConfigFile))
+            {
+                var configFilePath = new FilePath(nugetConfigFile);
+
+                rootPath = configFilePath.GetDirectory();
+                filePath = configFilePath.GetFilename();
+            }
+            else
+            {
+                rootPath = GetToolPath(environment, config);
+                filePath = null;
+            }
+
+            return Tuple.Create(rootPath, filePath);
         }
     }
 }

--- a/src/Cake.NuGet/NuGetPackageInstaller.cs
+++ b/src/Cake.NuGet/NuGetPackageInstaller.cs
@@ -240,6 +240,14 @@ namespace Cake.NuGet
                 }
             }
 
+            // Config
+            var nugetConfig = config.GetValue(Constants.NuGet.ConfigFile);
+            if (!string.IsNullOrWhiteSpace(nugetConfig))
+            {
+                arguments.Append("-ConfigFile");
+                arguments.AppendQuoted(nugetConfig);
+            }
+
             // Version
             if (definition.Parameters.ContainsKey("version"))
             {


### PR DESCRIPTION
Implements #1931 

With these changes you can now explicitly set the path for the NuGet.config file either through an env var or cake.config.

This should work for both the In Process client and the one invoking NuGet.exe.