### PR TITLE
GH-1930: Fix ParameterEmitter to correctly handle out params

### DIFF
--- a/src/Cake.Core.Tests/Data/MethodAliasGeneratorData.cs
+++ b/src/Cake.Core.Tests/Data/MethodAliasGeneratorData.cs
@@ -40,6 +40,12 @@ namespace Cake.Core.Tests.Data
         }
 
         [CakeMethodAlias]
+        public static void NonGeneric_ExtensionMethodWithOutputParameter(this ICakeContext context, out IDisposable arg)
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
         public static void NonGeneric_ExtensionMethodWithGenericParameter(this ICakeContext context, Action<int> value)
         {
             throw new NotImplementedException();

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOutputParameter
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithOutputParameter
@@ -1,0 +1,4 @@
+﻿public void NonGeneric_ExtensionMethodWithOutputParameter(out System.IDisposable arg)
+{
+    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOutputParameter(Context, out arg);
+}

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/MethodAliasGeneratorTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/MethodAliasGeneratorTests.cs
@@ -52,6 +52,7 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
             [InlineData("NonGeneric_ExtensionMethodWithOptionalNullableLongParameter")]
             [InlineData("NonGeneric_ExtensionMethodWithOptionalNullableDoubleParameter")]
             [InlineData("NonGeneric_ExtensionMethodWithReservedKeywordParameter")]
+            [InlineData("NonGeneric_ExtensionMethodWithOutputParameter")]
             public void Should_Return_Correct_Generated_Code_For_Non_Generic_Methods(string name)
             {
                 // Given

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/ParameterEmitterTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/ParameterEmitterTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using System.Resources;
 using Cake.Core.Scripting.CodeGen;
 using Xunit;
 // ReSharper disable UnusedMember.Local
@@ -357,6 +358,16 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
             public static void OptionalNullableIntKeywordWithNullDefault(int? @new = null)
             {
             }
+
+            public static void OutputParameterInterface(out IDisposable arg)
+            {
+                arg = null;
+            }
+
+            public static void OutputParameterInt32(out int arg)
+            {
+                arg = 0;
+            }
         }
 
         [Theory]
@@ -444,6 +455,8 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
         [InlineData("RequiredNullableIntKeyword", "System.Nullable<System.Int32> @new")]
         [InlineData("OptionalIntKeywordWithNonNullDefault", "System.Int32 @new = (System.Int32)1")]
         [InlineData("OptionalNullableIntKeywordWithNullDefault", "System.Nullable<System.Int32> @new = null")]
+        [InlineData("OutputParameterInterface", "out System.IDisposable arg")]
+        [InlineData("OutputParameterInt32", "out System.Int32 arg")]
         public void Should_Return_Correct_Generated_Code_For_Method_Parameters(string methodName, string expected)
         {
             // Given

--- a/src/Cake.Core/Scripting/CodeGen/ParameterEmitter.cs
+++ b/src/Cake.Core/Scripting/CodeGen/ParameterEmitter.cs
@@ -38,7 +38,16 @@ namespace Cake.Core.Scripting.CodeGen
                 {
                     yield return "params ";
                 }
-                yield return parameter.ParameterType.GetFullName();
+                // if the parameter is 'out' (or implicitly, by ref),
+                // use GetElementType to get the correct value for codegen (instead of IDisposable& or similar)
+                if (parameter.ParameterType.IsByRef)
+                {
+                    yield return parameter.ParameterType.GetElementType().GetFullName();
+                }
+                else
+                {
+                    yield return parameter.ParameterType.GetFullName();
+                }
                 yield return " ";
             }
 


### PR DESCRIPTION
This adjusts the logic in the `ParameterEmitter` to correctly handle the case described in GH-1930 and adds test coverage for the same.

If there's additional test coverage desired, please let me know.