### PR TITLE
GH1937: Check if package is already installed

### DIFF
--- a/src/Cake.NuGet.Tests/Fixtures/NuGetPackageInstallerFixture.cs
+++ b/src/Cake.NuGet.Tests/Fixtures/NuGetPackageInstallerFixture.cs
@@ -61,9 +61,20 @@ namespace Cake.NuGet.Tests.Fixtures
             return new NuGetPackageInstaller(FileSystem, Environment, ProcessRunner, ToolResolver, ContentResolver, Log, Config);
         }
 
+        public Install.NuGetPackageInstaller CreateInProcessInstaller()
+        {
+            return new Install.NuGetPackageInstaller(FileSystem, Environment, ContentResolver, Log, Config);
+        }
+
         public IReadOnlyCollection<IFile> Install()
         {
             var installer = CreateInstaller();
+            return installer.Install(Package, PackageType, InstallPath);
+        }
+
+        public IReadOnlyCollection<IFile> InProcessInstall()
+        {
+            var installer = CreateInProcessInstaller();
             return installer.Install(Package, PackageType, InstallPath);
         }
 

--- a/src/Cake.NuGet.Tests/Unit/NuGetPackageInstallerTests.cs
+++ b/src/Cake.NuGet.Tests/Unit/NuGetPackageInstallerTests.cs
@@ -359,6 +359,27 @@ namespace Cake.NuGet.Tests.Unit
             }
 
             [Fact]
+            public void Should_Not_Install_InProcess_If_Resource_Already_Is_Installed()
+            {
+                // Given
+                var fixture = new NuGetPackageInstallerFixture();
+                fixture.Config.GetValue(Constants.NuGet.UseInProcessClient).Returns(bool.TrueString);
+                fixture.FileSystem.CreateDirectory("/Working/nuget/cake.foo.1.2.3/Cake.Foo");
+                fixture.ContentResolver.GetFiles(
+                    Arg.Any<DirectoryPath>(), Arg.Any<PackageReference>(), Arg.Any<PackageType>())
+                    .Returns(new List<IFile> { Substitute.For<IFile>() });
+
+                // When
+                fixture.InProcessInstall();
+
+                // Then
+                fixture.Log.Received(1).Write(
+                    Verbosity.Diagnostic, LogLevel.Debug,
+                    "Package {0} has already been installed.",
+                    "Cake.Foo");
+            }
+
+            [Fact]
             public void Should_Return_Correct_Files_When_Resource_Has_Dependencies()
             {
                 // Given

--- a/src/Cake.NuGet/Install/NuGetPackageInstaller.cs
+++ b/src/Cake.NuGet/Install/NuGetPackageInstaller.cs
@@ -87,6 +87,10 @@ namespace Cake.NuGet.Install
             }
 
             var packageRoot = path.MakeAbsolute(_environment).FullPath;
+
+            path = GetPackagePath(path.MakeAbsolute(_environment), package);
+            var root = _fileSystem.GetDirectory(path);
+
             var targetFramework = type == PackageType.Addin ? _currentFramework : NuGetFramework.AnyFramework;
             var sourceRepositoryProvider = new NuGetSourceRepositoryProvider(_nugetSettings, _config, package);
             sourceRepositoryProvider.CreateRepository(packageRoot);
@@ -94,6 +98,18 @@ namespace Cake.NuGet.Install
             if (packageIdentity == null)
             {
                 return Array.Empty<IFile>();
+            }
+
+            var packagePath = GetPackagePath(root, package.Package);
+            if (packagePath != null)
+            {
+                // Fetch available content from disc.
+                var content = _contentResolver.GetFiles(packagePath, package, type);
+                if (content.Any())
+                {
+                    _log.Debug("Package {0} has already been installed.", package.Package);
+                    return content;
+                }
             }
 
             var pathResolver = new PackagePathResolver(packageRoot);
@@ -113,6 +129,22 @@ namespace Cake.NuGet.Install
                 CancellationToken.None).Wait();
 
             return project.GetFiles(path, package, type);
+        }
+
+        private static DirectoryPath GetPackagePath(IDirectory root, string package)
+        {
+            var directories = root.GetDirectories("*", SearchScope.Current).ToArray();
+            return directories.FirstOrDefault(p => p.Path.GetDirectoryName().Equals(package, StringComparison.OrdinalIgnoreCase))?.Path;
+        }
+
+        private static DirectoryPath GetPackagePath(DirectoryPath root, PackageReference package)
+        {
+            if (package.Parameters.ContainsKey("version"))
+            {
+                var version = package.Parameters["version"].First();
+                return root.Combine($"{package.Package}.{version}".ToLowerInvariant());
+            }
+            return root.Combine(package.Package.ToLowerInvariant());
         }
 
         private DependencyBehavior GetDependencyBehavior(PackageType type, PackageReference package)


### PR DESCRIPTION
- Port over logic from NuGetPackageInstaller to (InProcess) Install/NuGetPackageInstaller.cs
- Add test for this scenario
- Fixes #1937