### PR TITLE
Failed NugetPack when using NuGetPackSettings.Properties fix #1933

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/NuGet/Pack/NuGetPackerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NuGet/Pack/NuGetPackerTests.cs
@@ -841,7 +841,7 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Pack
                     var result = fixture.Run();
 
                     // Then
-                    Assert.Equal("pack \"/Working/existing.csproj\" -Properties Configuration=Release", result.Args);
+                    Assert.Equal("pack \"/Working/existing.csproj\" -Properties \"Configuration=Release\"", result.Args);
                 }
 
                 [Fact]
@@ -859,7 +859,7 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Pack
                     var result = fixture.Run();
 
                     // Then
-                    Assert.Equal("pack \"/Working/existing.csproj\" -Properties Configuration=Release;Foo=Bar", result.Args);
+                    Assert.Equal("pack \"/Working/existing.csproj\" -Properties \"Configuration=Release;Foo=Bar\"", result.Args);
                 }
 
                 [Theory]

--- a/src/Cake.Common/Tools/NuGet/Pack/NuGetPacker.cs
+++ b/src/Cake.Common/Tools/NuGet/Pack/NuGetPacker.cs
@@ -210,7 +210,7 @@ namespace Cake.Common.Tools.NuGet.Pack
                     throw new CakeException("Properties keys can not be null or empty.");
                 }
                 builder.Append("-Properties");
-                builder.Append(string.Join(";",
+                builder.AppendQuoted(string.Join(";",
                     settings.Properties.Select(property => string.Concat(property.Key, "=", property.Value))));
             }
 


### PR DESCRIPTION
Fixes issue #1933 where the properties of `NuGetPackSettings` get resolved without being quoted. Fix just uses `AppendQuoted` instead of `Append` in `NuGetPacker`.
