### PR TITLE
GH1943: Allow ChocolateyPackSettings to specify dependent packages

### DIFF
--- a/src/Cake.Common.Tests/Properties/Resources.resx
+++ b/src/Cake.Common.Tests/Properties/Resources.resx
@@ -143,6 +143,10 @@
     &lt;releaseNotes&gt;&lt;![CDATA[Line #1
 Line #2
 Line #3]]&gt;&lt;/releaseNotes&gt;
+    &lt;dependencies&gt;
+      &lt;dependency id="Dependency1" version="1.0.0" /&gt;
+      &lt;dependency id="Dependency2" version="[2.0.0]" /&gt;
+    &lt;/dependencies&gt;
   &lt;/metadata&gt;
   &lt;files&gt;
     &lt;file src="tools\**" target="tools" /&gt;
@@ -175,6 +179,10 @@ Line #3]]&gt;&lt;/releaseNotes&gt;
     &lt;releaseNotes&gt;&lt;![CDATA[Line #1
 Line #2
 Line #3]]&gt;&lt;/releaseNotes&gt;
+    &lt;dependencies&gt;
+      &lt;dependency id="Dependency1" version="1.0.0" /&gt;
+      &lt;dependency id="Dependency2" version="[2.0.0]" /&gt;
+    &lt;/dependencies&gt;
   &lt;/metadata&gt;
   &lt;files&gt;
     &lt;file src="tools\**" target="tools" /&gt;

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Pack/ChocolateyPackerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Pack/ChocolateyPackerTests.cs
@@ -344,6 +344,11 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pack
                 fixture.Settings.RequireLicenseAcceptance = true;
                 fixture.Settings.IconUrl = new Uri("https://icon.com");
                 fixture.Settings.ReleaseNotes = new[] { "Line #1", "Line #2", "Line #3" };
+                fixture.Settings.Dependencies = new[]
+                {
+                    new ChocolateyNuSpecDependency { Id = "Dependency1", Version = "1.0.0" },
+                    new ChocolateyNuSpecDependency { Id = "Dependency2", Version = "[2.0.0]" }
+                };
 
                 // When
                 var result = fixture.Run();
@@ -379,6 +384,11 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pack
                 fixture.Settings.RequireLicenseAcceptance = true;
                 fixture.Settings.IconUrl = new Uri("https://icon.com");
                 fixture.Settings.ReleaseNotes = new[] { "Line #1", "Line #2", "Line #3" };
+                fixture.Settings.Dependencies = new[]
+                {
+                    new ChocolateyNuSpecDependency { Id = "Dependency1", Version = "1.0.0" },
+                    new ChocolateyNuSpecDependency { Id = "Dependency2", Version = "[2.0.0]" }
+                };
 
                 // When
                 var result = fixture.Run();
@@ -415,6 +425,11 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pack
                 fixture.Settings.RequireLicenseAcceptance = true;
                 fixture.Settings.IconUrl = new Uri("https://icon.com");
                 fixture.Settings.ReleaseNotes = new[] { "Line #1", "Line #2", "Line #3" };
+                fixture.Settings.Dependencies = new[]
+                {
+                    new ChocolateyNuSpecDependency { Id = "Dependency1", Version = "1.0.0" },
+                    new ChocolateyNuSpecDependency { Id = "Dependency2", Version = "[2.0.0]" }
+                };
 
                 // When
                 var result = fixture.Run();
@@ -455,6 +470,11 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pack
             {
                 new ChocolateyNuSpecContent { Source = @"tools\**", Target = "tools" },
             };
+            fixture.Settings.Dependencies = new[]
+            {
+                new ChocolateyNuSpecDependency { Id = "Dependency1", Version = "1.0.0" },
+                new ChocolateyNuSpecDependency { Id = "Dependency2", Version = "[2.0.0]" }
+            };
 
             // When
             var result = fixture.Run();
@@ -494,6 +514,11 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pack
             fixture.Settings.Files = new[]
             {
                 new ChocolateyNuSpecContent { Source = @"tools\**", Target = "tools" },
+            };
+            fixture.Settings.Dependencies = new[]
+            {
+                new ChocolateyNuSpecDependency { Id = "Dependency1", Version = "1.0.0" },
+                new ChocolateyNuSpecDependency { Id = "Dependency2", Version = "[2.0.0]" }
             };
 
             // When

--- a/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyNuSpecDependency.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyNuSpecDependency.cs
@@ -1,0 +1,20 @@
+﻿namespace Cake.Common.Tools.Chocolatey.Pack
+{
+    /// <summary>
+    /// Represents a Chocolatey NuGet nuspec dependency
+    /// </summary>
+    public class ChocolateyNuSpecDependency
+    {
+        /// <summary>
+        /// Gets or sets the dependency's package ID.
+        /// </summary>
+        /// <value>The dependency's package ID.</value>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dependency's version.
+        /// </summary>
+        /// <value>The dependency's version.</value>
+        public string Version { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyNuSpecTransformer.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyNuSpecTransformer.cs
@@ -95,6 +95,20 @@ namespace Cake.Common.Tools.Chocolatey.Pack
                     fileElement.AddAttributeIfSpecified(file.Target, "target");
                 }
             }
+
+            if (settings.Dependencies != null && settings.Dependencies.Count > 0)
+            {
+                var dependenciesElement = FindOrCreateElement(document, namespaceManager, "dependencies");
+
+                // Add or update the dependency references
+                dependenciesElement.RemoveAll();
+                foreach (var dependency in settings.Dependencies)
+                {
+                    var dependencyElement = document.CreateAndAppendElement(dependenciesElement, "dependency");
+                    dependencyElement.AddAttributeIfSpecified(dependency.Id, "id");
+                    dependencyElement.AddAttributeIfSpecified(dependency.Version, "version");
+                }
+            }
         }
 
         private static XmlNode GetPackageElement(XmlDocument document)

--- a/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyPackSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyPackSettings.cs
@@ -144,6 +144,12 @@ namespace Cake.Common.Tools.Chocolatey.Pack
         public ICollection<ChocolateyNuSpecContent> Files { get; set; }
 
         /// <summary>
+        /// Gets or sets the package dependencies.
+        /// </summary>
+        /// <value>The package files.</value>
+        public ICollection<ChocolateyNuSpecDependency> Dependencies { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to run in debug mode.
         /// </summary>
         /// <value>The debug flag</value>

--- a/src/Cake.Common/Tools/NuGet/Pack/NuSpecDependency.cs
+++ b/src/Cake.Common/Tools/NuGet/Pack/NuSpecDependency.cs
@@ -22,9 +22,9 @@ namespace Cake.Common.Tools.NuGet.Pack
         public string Version { get; set; }
 
         /// <summary>
-        /// Gets or sets the dependency's version.
+        /// Gets or sets the target framework for the dependency.
         /// </summary>
-        /// <value>The dependency's version.</value>
+        /// <value>The target framework for the dependency.</value>
         public string TargetFramework { get; set; }
     }
 }


### PR DESCRIPTION
This PR adds a Dependencies property, of type ICollection<ChocolateyNuSpecDependency>, to the ChocolateyPackSettings class (mirroring the existing behavior in the NuGet pack processing). If package dependencies are specified using this mechanism, the ChocolateyNuSpecTransformer has been modified to place those dependency records into the transformed NuSpec. The ChocolateyPackerTests have also been modified to verify that the transformed output matches expectations.