### PR TITLE
GH1952: Add support for targeting namespace/class/method via xunit.console runner

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/XUnit/XUnit2RunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/XUnit/XUnit2RunnerTests.cs
@@ -605,6 +605,48 @@ namespace Cake.Common.Tests.Unit.Tools.XUnit
                 // Then
                 Assert.Equal("\"/Working/Test1.dll\" -notrait \"Trait1=value1A\" -notrait \"Trait1=value1B\" -notrait \"Trait2=value2\"", result.Args);
             }
+
+            [Fact]
+            public void Should_Set_Switches_For_NamespacesToInclude_Defined_In_Settings()
+            {
+                // Given
+                var fixture = new XUnit2RunnerFixture();
+                fixture.Settings.IncludeNamespace("Company.Product.Feature");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("\"/Working/Test1.dll\" -namespace \"Company.Product.Feature\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Set_Switches_For_ClassNameToInclude_Defined_In_Settings()
+            {
+                // Given
+                var fixture = new XUnit2RunnerFixture();
+                fixture.Settings.IncludeClass("Company.Product.Feature.ClassName");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("\"/Working/Test1.dll\" -class \"Company.Product.Feature.ClassName\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Set_Switches_For_MethodNameToInclude_Defined_In_Settings()
+            {
+                // Given
+                var fixture = new XUnit2RunnerFixture();
+                fixture.Settings.IncludeMethod("Company.Product.Feature.ClassName.MethodName");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("\"/Working/Test1.dll\" -method \"Company.Product.Feature.ClassName.MethodName\"", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/XUnit/XUnit2SettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/XUnit/XUnit2SettingsTests.cs
@@ -133,6 +133,36 @@ namespace Cake.Common.Tests.Unit.Tools.XUnit
             }
 
             [Fact]
+            public void Should_Set_NamespacesToInclude_To_Empty_By_Default()
+            {
+                // Given, When
+                var settings = new XUnit2Settings();
+
+                // Then
+                Assert.Empty(settings.NamespacesToInclude);
+            }
+
+            [Fact]
+            public void Should_Set_ClassesToInclude_To_Empty_By_Default()
+            {
+                // Given, When
+                var settings = new XUnit2Settings();
+
+                // Then
+                Assert.Empty(settings.ClassesToInclude);
+            }
+
+            [Fact]
+            public void Should_Set_MethodsToInclude_To_Empty_By_Default()
+            {
+                // Given, When
+                var settings = new XUnit2Settings();
+
+                // Then
+                Assert.Empty(settings.MethodsToInclude);
+            }
+
+            [Fact]
             public void Should_Set_UseX86_To_False_By_Default()
             {
                 // Given, When

--- a/src/Cake.Common/Tools/XUnit/XUnit2Runner.cs
+++ b/src/Cake.Common/Tools/XUnit/XUnit2Runner.cs
@@ -158,6 +158,21 @@ namespace Cake.Common.Tools.XUnit
                 builder.Append("-notrait \"{0}={1}\"", trait.Name, trait.Value);
             }
 
+            foreach (var ns in settings.NamespacesToInclude)
+            {
+                builder.Append("-namespace \"{0}\"", ns);
+            }
+
+            foreach (var cn in settings.ClassesToInclude)
+            {
+                builder.Append("-class \"{0}\"", cn);
+            }
+
+            foreach (var mn in settings.MethodsToInclude)
+            {
+                builder.Append("-method \"{0}\"", mn);
+            }
+
             return builder;
         }
 

--- a/src/Cake.Common/Tools/XUnit/XUnit2Settings.cs
+++ b/src/Cake.Common/Tools/XUnit/XUnit2Settings.cs
@@ -142,6 +142,42 @@ namespace Cake.Common.Tools.XUnit
         public IDictionary<string, IList<string>> TraitsToExclude { get; private set; }
 
         /// <summary>
+        /// Gets the namespaces to include.
+        /// </summary>
+        /// <remarks>
+        /// Runs all methods in a given namespace (i.e., 'MyNamespace.MySubNamespace')
+        /// If more than one is specified, it acts as an OR operation.
+        /// </remarks>
+        /// <value>
+        /// The namespaces to include
+        /// </value>
+        public ICollection<string> NamespacesToInclude { get; }
+
+        /// <summary>
+        /// Gets the class names to include.
+        /// </summary>
+        /// <remarks>
+        /// Runs all methods in a given test class (should be fully specified; i.e., 'MyNamespace.MyClass')
+        /// If more than one is specified, it acts as an OR operation.
+        /// </remarks>
+        /// <value>
+        /// The class names to include
+        /// </value>
+        public ICollection<string> ClassesToInclude { get; }
+
+        /// <summary>
+        /// Gets the test methods to include.
+        /// </summary>
+        /// <remarks>
+        /// Runs the given test methods (should be fully specified; i.e., 'MyNamespace.MyClass.MyTestMethod')
+        /// If more than one is specified, it acts as an OR operation.
+        /// </remarks>
+        /// <value>
+        /// The namespaces to include
+        /// </value>
+        public ICollection<string> MethodsToInclude { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="XUnit2Settings"/> class.
         /// </summary>
         public XUnit2Settings()
@@ -149,6 +185,9 @@ namespace Cake.Common.Tools.XUnit
             TraitsToInclude = new Dictionary<string, IList<string>>(StringComparer.OrdinalIgnoreCase);
             TraitsToExclude = new Dictionary<string, IList<string>>(StringComparer.OrdinalIgnoreCase);
             ShadowCopy = true;
+            NamespacesToInclude = new List<string>();
+            ClassesToInclude = new List<string>();
+            MethodsToInclude = new List<string>();
         }
     }
 }

--- a/src/Cake.Common/Tools/XUnit/XUnit2SettingsExtensions.cs
+++ b/src/Cake.Common/Tools/XUnit/XUnit2SettingsExtensions.cs
@@ -92,5 +92,74 @@ namespace Cake.Common.Tools.XUnit
 
             return settings;
         }
+
+        /// <summary>
+        /// Adds a namespace to the settings, to include in test execution.  Namespace should be fully qualified; i.e., MyNameSpace.MySubNamespace
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="namespaceToInclude">The namespace to include.</param>
+        /// <returns>The same <see cref="XUnit2Settings"/> instance so that multiple calls can be chained.</returns>
+        public static XUnit2Settings IncludeNamespace(this XUnit2Settings settings, string namespaceToInclude)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            if (string.IsNullOrEmpty(namespaceToInclude))
+            {
+                throw new ArgumentException("Value cannot be null or empty.", nameof(namespaceToInclude));
+            }
+
+            settings.NamespacesToInclude.Add(namespaceToInclude);
+
+            return settings;
+        }
+
+        /// <summary>
+        /// Adds a class name to the settings, to include in test execution. Class name should be fully qualified; i.e., MyNameSpace.MyClassName
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="classNameToInclude">The class name to include.</param>
+        /// <returns>The same <see cref="XUnit2Settings"/> instance so that multiple calls can be chained.</returns>
+        public static XUnit2Settings IncludeClass(this XUnit2Settings settings, string classNameToInclude)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            if (string.IsNullOrEmpty(classNameToInclude))
+            {
+                throw new ArgumentException("Value cannot be null or empty.", nameof(classNameToInclude));
+            }
+
+            settings.ClassesToInclude.Add(classNameToInclude);
+
+            return settings;
+        }
+
+        /// <summary>
+        /// Adds a method name to the settings, to include in test execution. Method name should be fully qualified; i.e., MyNameSpace.MyClassName.MyMethod
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="methodNameToInclude">The method name to include.</param>
+        /// <returns>The same <see cref="XUnit2Settings"/> instance so that multiple calls can be chained.</returns>
+        public static XUnit2Settings IncludeMethod(this XUnit2Settings settings, string methodNameToInclude)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            if (string.IsNullOrEmpty(methodNameToInclude))
+            {
+                throw new ArgumentException("Value cannot be null or empty.", nameof(methodNameToInclude));
+            }
+
+            settings.MethodsToInclude.Add(methodNameToInclude);
+
+            return settings;
+        }
     }
 }


### PR DESCRIPTION
This addresses GH-1952.

This adds the properties to `XUnit2Settings` + correct extension methods to `XUnit2SettingsExtensions`, and the implementation to `XUnit2Runner` to pass these switches into the runner.