### PR TITLE
GH1955: Add support for results directory to test settings

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Test/DotNetCoreTesterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Test/DotNetCoreTesterTests.cs
@@ -116,12 +116,13 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Test
                 fixture.Settings.TestAdapterPath = @"/Working/custom-test-adapter";
                 fixture.Settings.Logger = @"trx;LogFileName=/Working/logfile.trx";
                 fixture.Settings.DiagnosticFile = "./artifacts/logging/diagnostics.txt";
+                fixture.Settings.ResultsDirectory = "./tests/";
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("test --settings \"/Working/demo.runsettings\" --filter \"Priority = 1\" --test-adapter-path \"/Working/custom-test-adapter\" --logger \"trx;LogFileName=/Working/logfile.trx\" --output \"/Working/artifacts\" --framework dnxcore50 --configuration Release --diag \"/Working/artifacts/logging/diagnostics.txt\" --no-build", result.Args);
+                Assert.Equal("test --settings \"/Working/demo.runsettings\" --filter \"Priority = 1\" --test-adapter-path \"/Working/custom-test-adapter\" --logger \"trx;LogFileName=/Working/logfile.trx\" --output \"/Working/artifacts\" --framework dnxcore50 --configuration Release --diag \"/Working/artifacts/logging/diagnostics.txt\" --no-build --results-directory \"/Working/tests\"", result.Args);
             }
 
             [Fact]

--- a/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTestSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTestSettings.cs
@@ -58,5 +58,10 @@ namespace Cake.Common.Tools.DotNetCore.Test
         /// Gets or sets a file to write diagnostic messages to.
         /// </summary>
         public FilePath DiagnosticFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the results directory. This setting is only available from 2.0.0 upward.
+        /// </summary>
+        public DirectoryPath ResultsDirectory { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTester.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTester.cs
@@ -120,6 +120,12 @@ namespace Cake.Common.Tools.DotNetCore.Test
                 builder.Append("--no-build");
             }
 
+            if (settings.ResultsDirectory != null)
+            {
+                builder.Append("--results-directory");
+                builder.AppendQuoted(settings.ResultsDirectory.MakeAbsolute(_environment).FullPath);
+            }
+
             return builder;
         }
     }


### PR DESCRIPTION
**Note**: as this option is only available for `2.0.0` upward I reflected this in the `XML` comment. Should I handle this in another way?

Fix #1955 


