### PR TITLE
(GH-1689) Add documentation that Chocolatey licensed is required

### DIFF
--- a/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
@@ -1146,6 +1146,7 @@ namespace Cake.Common.Tools.Chocolatey
 
         /// <summary>
         /// Downloads a Chocolatey package to the current working directory.
+        /// Requires Chocolatey licensed edition.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="packageId">The id of the package to download.</param>
@@ -1165,6 +1166,9 @@ namespace Cake.Common.Tools.Chocolatey
 
         /// <summary>
         /// Downloads a Chocolatey package using the specified settings.
+        /// Requires Chocolatey licensed edition.
+        /// Features requiring Chocolatey for Business or a minimum version are documented
+        /// in <see cref="ChocolateyDownloadSettings"/>.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="packageId">The id of the package to install.</param>

--- a/src/Cake.Common/Tools/Chocolatey/Download/ChocolateyDownloader.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Download/ChocolateyDownloader.cs
@@ -36,6 +36,9 @@ namespace Cake.Common.Tools.Chocolatey.Download
 
         /// <summary>
         /// Downloads Chocolatey packages using the specified package id and settings.
+        /// Requires Chocolatey licensed edition.
+        /// Features requiring Chocolatey for Business or a minimum version are documented
+        /// in <see cref="ChocolateyDownloadSettings"/>.
         /// </summary>
         /// <param name="packageId">The source package id.</param>
         /// <param name="settings">The settings.</param>


### PR DESCRIPTION
Add XML comment mentioning that Chocolatey licensed edition is required for `choco download`.

Fixes #1689 