### PR TITLE
GH-1987: Normalize exception handling in PropertyToken for invalid parameter index

### DIFF
--- a/src/Cake.Core.Tests/Unit/Diagnostics/Formatting/PropertyTokenTests.cs
+++ b/src/Cake.Core.Tests/Unit/Diagnostics/Formatting/PropertyTokenTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Cake.Core.Diagnostics.Formatting;
+using Xunit;
+
+namespace Cake.Core.Tests.Unit.Diagnostics.Formatting
+{
+    public sealed class PropertyTokenTests
+    {
+        public sealed class TheRenderMethod
+        {
+            [Fact]
+            public void Should_Throw_FormatException_When_Index_And_Args_Are_Mismatched()
+            {
+                // Given
+                var token = new PropertyToken(1, null);
+
+                // When
+                var ex = Record.Exception(() => token.Render(new object[] { "test" }));
+
+                // Then
+                Assert.IsType<FormatException>(ex);
+                Assert.Equal("Index (zero based) must be greater than or equal to zero and less than the size of the argument list.", ex.Message);
+            }
+
+            [Fact]
+            public void Should_Format_Argument_According_To_Formatting_Rules()
+            {
+                // Given
+                var token = new PropertyToken(0, "B");
+
+                // When
+                var result = token.Render(new object[] { new Guid("d6ed7358ef9645bf9245864025de28fa") });
+
+                // Then
+                Assert.Equal("{d6ed7358-ef96-45bf-9245-864025de28fa}", result);
+            }
+
+            [Fact]
+            public void Should_Format_Argument_As_String_When_No_Formatting_Rules_Specified()
+            {
+                // Given
+                var token = new PropertyToken(0, null);
+
+                // When
+                var result = token.Render(new object[] { new Guid("{d6ed7358-ef96-45bf-9245-864025de28fa}") });
+
+                // Then
+                Assert.Equal("d6ed7358-ef96-45bf-9245-864025de28fa", result);
+            }
+        }
+    }
+}

--- a/src/Cake.Core/Diagnostics/Formatting/PropertyToken.cs
+++ b/src/Cake.Core/Diagnostics/Formatting/PropertyToken.cs
@@ -21,6 +21,11 @@ namespace Cake.Core.Diagnostics.Formatting
 
         public override string Render(object[] args)
         {
+            if (Position < 0 || Position >= args.Length)
+            {
+                throw new FormatException("Index (zero based) must be greater than or equal to zero and less than the size of the argument list.");
+            }
+
             var value = args[Position];
             if (!string.IsNullOrWhiteSpace(Format))
             {


### PR DESCRIPTION
This addresses the concern outlined in GH-1987 and uses the same exception type + message as `string.Format` for consistency.

Consider the following:
`var s = string.Format("Testing message {1}", "parameter formatting");`
 
and 

```
Task("Default")
    .Does(() => {
	Information("Testing message {1}", "parameter formatting");
    });

RunTarget("Default");
```

In both cases, the exception is `FormatException` with message _"Index (zero based) must be greater than or equal to zero and less than the size of the argument list."_

It is worth noting that while this is cleaner than _"Index was outside the bounds of the array."_, it will still (partially) render the content by nature of the implementation of the token parsing/rendering.

```
======================================== 
Default                                  
======================================== 
Executing task: Default                  
Testing message                          
```

If we want to short-circuit the partial-rendering, the only way I can see in the way of an "all or nothing" approach would be to effectively perform a pre-flight check of the formatting string, something like this in [CakeBuildLog](https://github.com/cake-build/cake/blob/3b9aeced6d4d73f1fe8dde4485a31bec85b01036/src/Cake.Core/Diagnostics/CakeBuildLog.cs#L47), which I don't think is necessary or desirable, but can amend the PR accordingly if that's something we want to move forward with.
```
public void Write(Verbosity verbosity, LogLevel level, string format, params object[] args)
{
    if (verbosity > Verbosity)
    {
        return;
    }

    // make sure the format string + args align
    try
    {
       var output = string.Format(format, args);
    }
    catch(FormatException) 
    { 
        throw; 
    }

    // continue normal implementation
```