### PR TITLE
GH1998: Adds missing .NET CLI dependencies/restore switches

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Build/DotNetCoreBuilderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Build/DotNetCoreBuilderTests.cs
@@ -147,13 +147,14 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Build
                 var fixture = new DotNetCoreBuilderFixture();
                 fixture.Settings.NoIncremental = true;
                 fixture.Settings.NoDependencies = true;
+                fixture.Settings.NoRestore = true;
                 fixture.Project = "./src/*";
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("build \"./src/*\" --no-incremental --no-dependencies", result.Args);
+                Assert.Equal("build \"./src/*\" --no-incremental --no-dependencies --no-restore", result.Args);
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Pack/DotNetCorePackerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Pack/DotNetCorePackerTests.cs
@@ -106,6 +106,8 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Pack
                 // Given
                 var fixture = new DotNetCorePackFixture();
                 fixture.Settings.NoBuild = true;
+                fixture.Settings.NoDependencies = true;
+                fixture.Settings.NoRestore = true;
                 fixture.Settings.Configuration = "Release";
                 fixture.Settings.OutputDirectory = "./artifacts/";
                 fixture.Settings.VersionSuffix = "rc1";
@@ -118,7 +120,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Pack
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("pack --output \"/Working/artifacts\" --no-build --include-symbols --include-source --configuration Release --version-suffix rc1 --serviceable --verbosity Minimal", result.Args);
+                Assert.Equal("pack --output \"/Working/artifacts\" --no-build --no-dependencies --no-restore --include-symbols --include-source --configuration Release --version-suffix rc1 --serviceable --verbosity Minimal", result.Args);
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Publish/DotNetCorePublisherTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Publish/DotNetCorePublisherTests.cs
@@ -105,6 +105,8 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Publish
             {
                 // Given
                 var fixture = new DotNetCorePublisherFixture();
+                fixture.Settings.NoDependencies = true;
+                fixture.Settings.NoRestore = true;
                 fixture.Settings.Framework = "dnxcore50";
                 fixture.Settings.Configuration = "Release";
                 fixture.Settings.Runtime = "runtime1";
@@ -116,7 +118,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Publish
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("publish --output \"/Working/artifacts\" --runtime runtime1 --framework dnxcore50 --configuration Release --version-suffix rc1 --verbosity Minimal", result.Args);
+                Assert.Equal("publish --output \"/Working/artifacts\" --runtime runtime1 --framework dnxcore50 --configuration Release --version-suffix rc1 --no-dependencies --no-restore --verbosity Minimal", result.Args);
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Test/DotNetCoreTesterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Test/DotNetCoreTesterTests.cs
@@ -108,6 +108,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Test
                 // Given
                 var fixture = new DotNetCoreTesterFixture();
                 fixture.Settings.NoBuild = true;
+                fixture.Settings.NoRestore = true;
                 fixture.Settings.Framework = "dnxcore50";
                 fixture.Settings.Configuration = "Release";
                 fixture.Settings.OutputDirectory = "./artifacts/";
@@ -122,7 +123,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Test
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("test --settings \"/Working/demo.runsettings\" --filter \"Priority = 1\" --test-adapter-path \"/Working/custom-test-adapter\" --logger \"trx;LogFileName=/Working/logfile.trx\" --output \"/Working/artifacts\" --framework dnxcore50 --configuration Release --diag \"/Working/artifacts/logging/diagnostics.txt\" --no-build --results-directory \"/Working/tests\"", result.Args);
+                Assert.Equal("test --settings \"/Working/demo.runsettings\" --filter \"Priority = 1\" --test-adapter-path \"/Working/custom-test-adapter\" --logger \"trx;LogFileName=/Working/logfile.trx\" --output \"/Working/artifacts\" --framework dnxcore50 --configuration Release --diag \"/Working/artifacts/logging/diagnostics.txt\" --no-build --no-restore --results-directory \"/Working/tests\"", result.Args);
             }
 
             [Fact]

--- a/src/Cake.Common/Tools/DotNetCore/Build/DotNetCoreBuildSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Build/DotNetCoreBuildSettings.cs
@@ -49,6 +49,15 @@ namespace Cake.Common.Tools.DotNetCore.Build
         public bool NoDependencies { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to not do implicit NuGet package restore.
+        /// This makes build faster, but requires restore to be done before build is executed.
+        /// </summary>
+        /// <remarks>
+        /// Requires .NET Core 2.x or newer.
+        /// </remarks>
+        public bool NoRestore { get; set; }
+
+        /// <summary>
         /// Gets or sets additional arguments to be passed to MSBuild.
         /// </summary>
         public DotNetCoreMSBuildSettings MSBuildSettings { get; set; }

--- a/src/Cake.Common/Tools/DotNetCore/Build/DotNetCoreBuilder.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Build/DotNetCoreBuilder.cs
@@ -105,10 +105,16 @@ namespace Cake.Common.Tools.DotNetCore.Build
                 builder.Append("--no-incremental");
             }
 
-            // No Incremental
+            // No Dependencies
             if (settings.NoDependencies)
             {
                 builder.Append("--no-dependencies");
+            }
+
+            // No Restore
+            if (settings.NoRestore)
+            {
+                builder.Append("--no-restore");
             }
 
             if (settings.MSBuildSettings != null)

--- a/src/Cake.Common/Tools/DotNetCore/Pack/DotNetCorePackSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Pack/DotNetCorePackSettings.cs
@@ -33,6 +33,23 @@ namespace Cake.Common.Tools.DotNetCore.Pack
         public bool NoBuild { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to ignore project to project references and only build the root project.
+        /// </summary>
+        /// <remarks>
+        /// Requires .NET Core 2.x or newer.
+        /// </remarks>
+        public bool NoDependencies { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to not do implicit NuGet package restore.
+        /// This makes build faster, but requires restore to be done before build is executed.
+        /// </summary>
+        /// <remarks>
+        /// Requires .NET Core 2.x or newer.
+        /// </remarks>
+        public bool NoRestore { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to generate the symbols nupkg.
         /// </summary>
         public bool IncludeSymbols { get; set; }

--- a/src/Cake.Common/Tools/DotNetCore/Pack/DotNetCorePacker.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Pack/DotNetCorePacker.cs
@@ -73,6 +73,18 @@ namespace Cake.Common.Tools.DotNetCore.Pack
                 builder.Append("--no-build");
             }
 
+            // No Dependencies
+            if (settings.NoDependencies)
+            {
+                builder.Append("--no-dependencies");
+            }
+
+            // No Restore
+            if (settings.NoRestore)
+            {
+                builder.Append("--no-restore");
+            }
+
             // Include symbols
             if (settings.IncludeSymbols)
             {

--- a/src/Cake.Common/Tools/DotNetCore/Publish/DotNetCorePublishSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Publish/DotNetCorePublishSettings.cs
@@ -38,6 +38,23 @@ namespace Cake.Common.Tools.DotNetCore.Publish
         public string VersionSuffix { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to ignore project to project references and only build the root project.
+        /// </summary>
+        /// <remarks>
+        /// Requires .NET Core 2.x or newer.
+        /// </remarks>
+        public bool NoDependencies { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to not do implicit NuGet package restore.
+        /// This makes build faster, but requires restore to be done before build is executed.
+        /// </summary>
+        /// <remarks>
+        /// Requires .NET Core 2.x or newer.
+        /// </remarks>
+        public bool NoRestore { get; set; }
+
+        /// <summary>
         /// Gets or sets additional arguments to be passed to MSBuild.
         /// </summary>
         public DotNetCoreMSBuildSettings MSBuildSettings { get; set; }

--- a/src/Cake.Common/Tools/DotNetCore/Publish/DotNetCorePublisher.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Publish/DotNetCorePublisher.cs
@@ -95,6 +95,18 @@ namespace Cake.Common.Tools.DotNetCore.Publish
                 builder.Append(settings.VersionSuffix);
             }
 
+            // No Dependencies
+            if (settings.NoDependencies)
+            {
+                builder.Append("--no-dependencies");
+            }
+
+            // No Restore
+            if (settings.NoRestore)
+            {
+                builder.Append("--no-restore");
+            }
+
             if (settings.MSBuildSettings != null)
             {
                 builder.AppendMSBuildSettings(settings.MSBuildSettings, _environment);

--- a/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTestSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTestSettings.cs
@@ -55,6 +55,15 @@ namespace Cake.Common.Tools.DotNetCore.Test
         public bool NoBuild { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to not do implicit NuGet package restore.
+        /// This makes build faster, but requires restore to be done before build is executed.
+        /// </summary>
+        /// <remarks>
+        /// Requires .NET Core 2.x or newer.
+        /// </remarks>
+        public bool NoRestore { get; set; }
+
+        /// <summary>
         /// Gets or sets a file to write diagnostic messages to.
         /// </summary>
         public FilePath DiagnosticFile { get; set; }

--- a/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTester.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTester.cs
@@ -115,9 +115,16 @@ namespace Cake.Common.Tools.DotNetCore.Test
                 builder.AppendQuoted(settings.DiagnosticFile.MakeAbsolute(_environment).FullPath);
             }
 
+            // No Build
             if (settings.NoBuild)
             {
                 builder.Append("--no-build");
+            }
+
+            // No Restore
+            if (settings.NoRestore)
+            {
+                builder.Append("--no-restore");
             }
 
             if (settings.ResultsDirectory != null)


### PR DESCRIPTION
* Build
  * No Restore
* Pack
  * No Dependencies
  * No Restore
* Publish
  * No Dependencoes
  * No Restore
* Test
  * No Restore
* fixes #1998
