### PR TITLE
GH-1997: Add support for --trace command line option for NUnit3 settings and runner

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/NUnit/NUnit3RunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NUnit/NUnit3RunnerTests.cs
@@ -241,6 +241,7 @@ namespace Cake.Common.Tests.Unit.Tools.NUnit
                 fixture.Settings.DisposeRunners = true;
                 fixture.Settings.ShadowCopy = true;
                 fixture.Settings.Agents = 3;
+                fixture.Settings.TraceLevel = NUnitInternalTraceLevel.Debug;
                 fixture.Settings.Params = new Dictionary<string, string>
                 {
                     ["one"] = "1",
@@ -262,6 +263,7 @@ namespace Cake.Common.Tests.Unit.Tools.NUnit
                         "\"--config=Debug\" \"--framework=net3.5\" --x86 " +
                         "--dispose-runners --shadowcopy --agents=3 " +
                         "--process=InProcess --domain=Single " +
+                        "--trace=verbose " +
                         "\"--params=one=1\" " +
                         "\"--params=two=2\" " +
                         "\"--params=three=3\"", result.Args);
@@ -329,6 +331,20 @@ namespace Cake.Common.Tests.Unit.Tools.NUnit
                 // Given
                 var fixture = new NUnit3RunnerFixture();
                 fixture.Settings.AppDomainUsage = NUnit3AppDomainUsage.Default;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("\"/Working/Test1.dll\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Set_Switch_For_Default_TraceLevel()
+            {
+                // Given
+                var fixture = new NUnit3RunnerFixture();
+                fixture.Settings.TraceLevel = null;
 
                 // When
                 var result = fixture.Run();

--- a/src/Cake.Common.Tests/Unit/Tools/NUnit/NUnit3SettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NUnit/NUnit3SettingsTests.cs
@@ -50,6 +50,16 @@ namespace Cake.Common.Tests.Unit.Tools.NUnit
                 // Then
                 Assert.Equal(settings.AppDomainUsage, NUnit3AppDomainUsage.Default);
             }
+
+            [Fact]
+            public void Should_Use_No_Internal_Trace_By_Default()
+            {
+                // Given, When
+                var settings = new NUnit3Settings();
+
+                // Then
+                Assert.Equal(settings.TraceLevel, null);
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/NUnit/NUnitInternalTraceLevelExtensionsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NUnit/NUnitInternalTraceLevelExtensionsTests.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Common.Tools.NUnit;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.NUnit
+{
+    public sealed class NUnitInternalTraceLevelExtensionsTests
+    {
+        public sealed class TheGetArgumentValueMethod
+        {
+            [Theory]
+            [InlineData(NUnitInternalTraceLevel.Off, "off")]
+            [InlineData(NUnitInternalTraceLevel.Error, "error")]
+            [InlineData(NUnitInternalTraceLevel.Warning, "warning")]
+            [InlineData(NUnitInternalTraceLevel.Info, "info")]
+            [InlineData(NUnitInternalTraceLevel.Debug, "verbose")]
+#pragma warning disable xUnit1025 // InlineData should be unique within the Theory it belongs to
+            [InlineData(NUnitInternalTraceLevel.Verbose, "verbose")]
+#pragma warning restore xUnit1025 // InlineData should be unique within the Theory it belongs to
+            public void Should_Return_Correct_Value(NUnitInternalTraceLevel level, string expected)
+            {
+                // Given, When
+                var result = level.GetArgumentValue();
+
+                // Then
+                Assert.Equal(expected, result);
+            }
+
+            [Fact]
+            public void Should_Throw_On_Unexpected_Value()
+            {
+                // Given
+                var level = (NUnitInternalTraceLevel)128;
+
+                // When
+                var ex = Record.Exception(() => level.GetArgumentValue());
+
+                // Then
+                Assert.IsType<ArgumentOutOfRangeException>(ex);
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Tools/NUnit/NUnit3Runner.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnit3Runner.cs
@@ -216,6 +216,11 @@ namespace Cake.Common.Tools.NUnit
                 builder.Append("--domain=" + settings.AppDomainUsage);
             }
 
+            if (settings.TraceLevel.HasValue)
+            {
+                builder.Append("--trace=" + settings.TraceLevel.Value.GetArgumentValue());
+            }
+
             if (settings.Params != null && settings.Params.Count > 0)
             {
                 foreach (var param in settings.Params)

--- a/src/Cake.Common/Tools/NUnit/NUnit3Settings.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnit3Settings.cs
@@ -242,5 +242,15 @@ namespace Cake.Common.Tools.NUnit
         /// List of parametes (key/value) which are passed to the runner.
         /// </value>
         public IDictionary<string, string> Params { get; set; }
+
+        /// <summary>
+        /// Gets or sets the level of detail at which the runner should write to its internal trace log.
+        /// Corresponds to the -trace=LEVEL command line argument.
+        /// If <c>null</c>, no argument will be specified
+        /// </summary>
+        /// <value>
+        /// The trace level.
+        /// </value>
+        public NUnitInternalTraceLevel? TraceLevel { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/NUnit/NUnitInternalTraceLevel.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnitInternalTraceLevel.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Tools.NUnit
+{
+    /// <summary>
+    /// Represents the level of detail at which NUnit should set internal tracing
+    /// </summary>
+    public enum NUnitInternalTraceLevel
+    {
+        /// <summary>
+        /// Do not display any trace messages
+        /// </summary>
+        Off = 0,
+
+        /// <summary>
+        /// Display Error messages only
+        /// </summary>
+        Error = 1,
+
+        /// <summary>
+        /// Display Warning level and higher messages
+        /// </summary>
+        Warning = 2,
+
+        /// <summary>
+        /// Display informational and higher messages
+        /// </summary>
+        Info = 3,
+
+        /// <summary>
+        /// Display debug messages and higher - i.e. all messages
+        /// </summary>
+        Debug = 4,
+
+        /// <summary>
+        /// Display debug messages and higher - i.e. all messages
+        /// </summary>
+        Verbose = Debug
+    }
+}

--- a/src/Cake.Common/Tools/NUnit/NUnitInternalTraceLevelExtensions.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnitInternalTraceLevelExtensions.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Common.Tools.NUnit;
+
+namespace Cake.Common.Tools.NUnit
+{
+    /// <summary>
+    /// Contains extension methods for <see cref="NUnitInternalTraceLevel"/>.
+    /// </summary>
+    public static class NUnitInternalTraceLevelExtensions
+    {
+        /// <summary>
+        /// Gets the LEVEL value for the --trace command line argument for the given <see cref="NUnitInternalTraceLevel"/>
+        /// </summary>
+        /// <param name="level">The <see cref="NUnitInternalTraceLevel"/> value for which to get the <see cref="string"/> representation</param>
+        /// <returns>Returns the appropriate <see cref="string"/> representation for the given <see cref="NUnitInternalTraceLevel"/> value</returns>
+        public static string GetArgumentValue(this NUnitInternalTraceLevel level)
+        {
+            string result;
+            switch (level)
+            {
+                case NUnitInternalTraceLevel.Debug:
+                    result = "verbose";
+                    break;
+                default:
+                    result = Enum.GetName(typeof(NUnitInternalTraceLevel), level)?.ToLowerInvariant();
+                    break;
+            }
+
+            return result ?? throw new ArgumentOutOfRangeException(nameof(level), level, "Unexpected value was encountered.");
+        }
+    }
+}


### PR DESCRIPTION
This addresses the improvement identified in GH-1997.

A couple of things to note -
- Please feel free to comment on the name of type `NUnitInternalTraceLevel`.  I think it could conceivably be shortened (`NUnitTraceLevel`, maybe?); I don't feel strongly that we necessarily _need_ to disambiguate the type as "Internal", as there's really only one notion of "trace".
- I took this implementation in the direction of an `enum` over the `string Trace { get; set; }` implementation in the v2 implementation of `NUnitSettings`.  I believe that the usage of enums here creates a stronger API that forces users into a successful end-state by constraining their choices.  However, I acknowledge that it creates a divide between the v2 and v3 Cake API that we may not wish to introduce.  That said, the changes between NUnit v2 and v3 were already significant enough that I don't know that we need to be too particularly concerned with this.

If there are changes to be made, please let me know.