### PR TITLE
Clean up some parser tests

### DIFF
--- a/src/Cake.Tests/Unit/Arguments/ArgumentParserTests.cs
+++ b/src/Cake.Tests/Unit/Arguments/ArgumentParserTests.cs
@@ -69,10 +69,9 @@ namespace Cake.Tests.Unit.Arguments
                 // Given
                 var fixture = new ArgumentParserFixture();
                 var parser = new ArgumentParser(fixture.Log, fixture.VerbosityParser);
-                var arguments = input.Split(new[] { ' ' }, StringSplitOptions.None);
 
                 // When
-                var result = parser.Parse(arguments);
+                var result = parser.Parse(new[] { input });
 
                 // Then
                 Assert.NotNull(result);

--- a/src/Cake.Tests/Unit/Arguments/ArgumentParserTests.cs
+++ b/src/Cake.Tests/Unit/Arguments/ArgumentParserTests.cs
@@ -79,19 +79,12 @@ namespace Cake.Tests.Unit.Arguments
                 Assert.Equal("/home/test/build.cake", result.Script.FullPath);
             }
 
-            [Theory]
-            [InlineData(".cakefile")]
-            [InlineData("build.cake")]
-            public void Can_Find_Default_Scripts(string scriptName)
+            [Fact]
+            public void Can_Find_Default_BuildCake_Script()
             {
                 // Given
                 var fixture = new ArgumentParserFixture();
                 var parser = new ArgumentParser(fixture.Log, fixture.VerbosityParser);
-                var file = Substitute.For<IFile>();
-                file.Exists.Returns(true);
-
-                fixture.FileSystem.GetFile(Arg.Is<FilePath>(fp => fp.FullPath == scriptName))
-                    .Returns(file);
 
                 // When
                 var result = parser.Parse(new string[] { });


### PR DESCRIPTION
Mainly, raising this as a PR to provide a context for the conversation about some ArgumentParser tests

As it seems there used to be a dependency on file system and specific file existence when figuring out what default script file to use.

Another thing, there seem to have been two potential default scripts, 'build.cake' and '.cakefile' (and this is where file existence check might have had sense). Anyways, doesn't seem like '.cakefile' default is around any more

Tests are just cleaned to reflect the current state of the matters


