### PR TITLE
GH2078: Expand environment variables in Uri

### DIFF
--- a/src/Cake.Core.Tests/Unit/Scripting/Processors/LoadDirectiveProcessorTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/Processors/LoadDirectiveProcessorTests.cs
@@ -69,6 +69,45 @@ namespace Cake.Core.Tests.Unit.Scripting.Processors
             Assert.Equal("/Working/other.cake", result.Script.Includes[1].Path.FullPath);
         }
 
+        [Theory]
+        [InlineData("#l \"%CAKE_TEST_SCRIPT_PATH%/utils.cake\"")]
+        public void Should_Process_Environment_Variable_Found_In_Source(string source)
+        {
+            // Given
+            var fixture = new ScriptAnalyzerFixture();
+            fixture.Environment.SetEnvironmentVariable("CAKE_TEST_SCRIPT_PATH", "test");
+            fixture.Providers.Add(new FileLoadDirectiveProvider());
+            fixture.GivenScriptExist("/Working/script.cake", source);
+            fixture.GivenScriptExist("/Working/test/utils.cake", "Console.WriteLine();");
+
+            // When
+            var result = fixture.Analyze("/Working/script.cake");
+
+            // Then
+            Assert.Equal(1, result.Script.Includes.Count);
+            Assert.Equal("/Working/test/utils.cake", result.Script.Includes[0].Path.FullPath);
+        }
+
+        [Theory]
+        [InlineData("#l \"%CAKE_TEST_SCRIPT_BASE_PATH%/%CAKE_TEST_SCRIPT_PATH%/utils.cake\"")]
+        public void Should_Process_Multiple_Environment_Variable_Found_In_Source(string source)
+        {
+            // Given
+            var fixture = new ScriptAnalyzerFixture();
+            fixture.Environment.SetEnvironmentVariable("CAKE_TEST_SCRIPT_BASE_PATH", "test");
+            fixture.Environment.SetEnvironmentVariable("CAKE_TEST_SCRIPT_PATH", "scripts");
+            fixture.Providers.Add(new FileLoadDirectiveProvider());
+            fixture.GivenScriptExist("/Working/script.cake", source);
+            fixture.GivenScriptExist("/Working/test/scripts/utils.cake", "Console.WriteLine();");
+
+            // When
+            var result = fixture.Analyze("/Working/script.cake");
+
+            // Then
+            Assert.Equal(1, result.Script.Includes.Count);
+            Assert.Equal("/Working/test/scripts/utils.cake", result.Script.Includes[0].Path.FullPath);
+        }
+
         [Fact]
         public void Should_Insert_Line_Directives_When_Processing_Load_Directives()
         {

--- a/src/Cake.Core/ICakeEnvironmentExtensions.cs
+++ b/src/Cake.Core/ICakeEnvironmentExtensions.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Cake.Core
+{
+    /// <summary>
+    /// Extension methods for ICakeEnvironment
+    /// </summary>
+    public static class ICakeEnvironmentExtensions
+    {
+        /// <summary>
+        /// Expands the environment variables in the text. Variables shoud be quoted with %.
+        /// </summary>
+        /// <param name="environment">The cake environment interface</param>
+        /// <param name="text">A string containing the names of zero or more environment variables.</param>
+        /// <returns>A string with each environment variable replaced by its value.</returns>
+        public static string ExpandEnvironmentVariables(this ICakeEnvironment environment, string text)
+        {
+            var environmentVariables = environment.GetEnvironmentVariables();
+            Regex r = new Regex("%(.*?)%");
+            var matches = r.Matches(text);
+            foreach (Match m in matches)
+            {
+                string varName = m.Groups[1].Value;
+                if (environmentVariables.ContainsKey(varName))
+                {
+                    text = text.Replace(m.Value, environmentVariables[varName]);
+                }
+            }
+            return text;
+        }
+    }
+}

--- a/src/Cake.Core/Scripting/Analysis/ScriptAnalyzer.cs
+++ b/src/Cake.Core/Scripting/Analysis/ScriptAnalyzer.cs
@@ -117,7 +117,7 @@ namespace Cake.Core.Scripting.Analysis
             {
                 string replacement = null;
 
-                if (!_lineProcessors.Any(p => p.Process(context, line, out replacement)))
+                if (!_lineProcessors.Any(p => p.Process(context, _environment.ExpandEnvironmentVariables(line), out replacement)))
                 {
                     context.AddScriptLine(line);
                 }

--- a/tests/integration/Cake.Core/Scripting/LoadDirective.cake
+++ b/tests/integration/Cake.Core/Scripting/LoadDirective.cake
@@ -1,4 +1,5 @@
 #load "../../resources/Cake.Core/Scripting/file with spaces.cake"
+#load "%CAKE_INTEGRATION_TEST_ROOT%/resources/Cake.Core/Scripting/file with spaces.cake"
 
 Task("Cake.Core.Scripting.LoadDirective.WithSpaces")
     .Does(() =>

--- a/tests/integration/build.ps1
+++ b/tests/integration/build.ps1
@@ -170,6 +170,7 @@ if (!(Test-Path $NuGetPath)) {
 #####################################################################
 
 $Env:MyEnvironmentVariable = "Hello World"
+$Env:CAKE_INTEGRATION_TEST_ROOT = "../.."
 
 #####################################################################
 # RUN TESTS

--- a/tests/integration/build.sh
+++ b/tests/integration/build.sh
@@ -133,6 +133,7 @@ fi
 #####################################################################
 
 export MyEnvironmentVariable="Hello World"
+export CAKE_INTEGRATION_TEST_ROOT="../.."
 
 #####################################################################
 # RUN TESTS


### PR DESCRIPTION
This is the second PR after the first was accidentally merged. Here are my thoughts from the previous conversation:

I was thinking about to do this in `ScriptAnalyzer` but it looked quite risky to me. Maybe it is not a good idea to expand the env variables in all lines because we don't know the context. I mean it would replace variables in string, comments, etc. Furthermore this environment variable expansion is only important in the preprocessor directives. In the cake script you can easily access env vars with `EnvironmentVariable` function. But in the preprocess step it is not possible to use these functions or variables of course so my only idea was the environment variable to access various values during the preprocess step. 
That's why i implemented in `UriDirectiveProcessor` so the expansion happens only in URI-s. 

Or is it possible somehow to use variables in this directives? Like `$"#load {repoRoute}/utils.cake"` or `#addin $"nuget:?package=Cake.Some.Nuget&version={someNugetVersion}"`. Would this be a better way?