### PR TITLE
GH2031: Add set FileVersion and InformationalVersion

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/MSBuild/DotNetCoreMSBuildSettingsExtensionsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/MSBuild/DotNetCoreMSBuildSettingsExtensionsTests.cs
@@ -714,6 +714,103 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.MSBuild
             }
         }
 
+        public sealed class TheSetFileVersionMethod
+        {
+            private const string FileVersion = "1.0.0-test";
+
+            [Fact]
+            public void Should_Set_FileVersion()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+                const string key = "FileVersion";
+
+                // When
+                settings.SetFileVersion(FileVersion);
+
+                // Then
+                Assert.True(settings.Properties.ContainsKey(key));
+                Assert.Equal(FileVersion, settings.Properties[key].FirstOrDefault());
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.SetFileVersion(FileVersion);
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheSetInformationalVersionMethod
+        {
+            private const string InformationalVersion = "1.0.0-test";
+
+            [Fact]
+            public void Should_Set_InformationalVersion()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+                const string key = "InformationalVersion";
+
+                // When
+                settings.SetInformationalVersion(InformationalVersion);
+
+                // Then
+                Assert.True(settings.Properties.ContainsKey(key));
+                Assert.Equal(InformationalVersion, settings.Properties[key].FirstOrDefault());
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.SetInformationalVersion(InformationalVersion);
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
+        public sealed class TheSuppressVersionRecommendedFormatWarningMethod
+        {
+            [Fact]
+            public void Should_Set_NoWarn7035()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+                const string key = "nowarn";
+
+                // When
+                settings.SuppressVersionRecommendedFormatWarning();
+
+                // Then
+                Assert.True(settings.Properties.ContainsKey(key));
+                Assert.Equal("7035", settings.Properties[key].FirstOrDefault());
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new DotNetCoreMSBuildSettings();
+
+                // When
+                var result = settings.SuppressVersionRecommendedFormatWarning();
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
         public sealed class TheSetVersionPrefixMethod
         {
             private const string VersionPrefix = "1.0.0";

--- a/src/Cake.Common/Tools/DotNetCore/MSBuild/DotNetCoreMSBuildSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/DotNetCore/MSBuild/DotNetCoreMSBuildSettingsExtensions.cs
@@ -382,6 +382,36 @@ namespace Cake.Common.Tools.DotNetCore.MSBuild
             => settings.WithProperty("Version", version);
 
         /// <summary>
+        /// Sets the file version.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="fileVersion">The file version.</param>
+        /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetCoreMSBuildSettings SetFileVersion(this DotNetCoreMSBuildSettings settings, string fileVersion)
+            => settings.WithProperty("FileVersion", fileVersion);
+
+        /// <summary>
+        /// Sets the informational version.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="informationalVersion">The informational version.</param>
+        /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetCoreMSBuildSettings SetInformationalVersion(this DotNetCoreMSBuildSettings settings, string informationalVersion)
+            => settings.WithProperty("InformationalVersion", informationalVersion);
+
+        /// <summary>
+        /// Suppress warning CS7035.
+        /// This is useful when using semantic versioning and either the file or informational version
+        /// doesn't match the recommended format.
+        /// The recommended format is: major.minor.build.revision where
+        /// each is an integer between 0 and 65534 (inclusive).
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetCoreMSBuildSettings SuppressVersionRecommendedFormatWarning(this DotNetCoreMSBuildSettings settings)
+            => settings.WithProperty("nowarn", "7035");
+
+        /// <summary>
         /// Sets the version prefix.
         /// </summary>
         /// <param name="settings">The settings.</param>


### PR DESCRIPTION
- Add set `MSBuild` `FileVersion` and `InformationalVersion` properties
- Add suppress `CS7035` (version recommended format)

Fix #2031 
