### PR TITLE
GH2039: Fix XUnit2Settings + XUnit2Runner to honor ParallelismOption.None

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/XUnit/XUnit2RunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/XUnit/XUnit2RunnerTests.cs
@@ -542,11 +542,12 @@ namespace Cake.Common.Tests.Unit.Tools.XUnit
             }
 
             [Theory]
+            [InlineData(null, "\"/Working/Test1.dll\"")]
             [InlineData(ParallelismOption.All, "\"/Working/Test1.dll\" -parallel all")]
             [InlineData(ParallelismOption.Assemblies, "\"/Working/Test1.dll\" -parallel assemblies")]
             [InlineData(ParallelismOption.Collections, "\"/Working/Test1.dll\" -parallel collections")]
-            [InlineData(ParallelismOption.None, "\"/Working/Test1.dll\"")]
-            public void Should_Use_Parallel_Switch_If_Settings_Value_Is_Not_None(ParallelismOption option, string expected)
+            [InlineData(ParallelismOption.None, "\"/Working/Test1.dll\" -parallel none")]
+            public void Should_Use_Parallel_Switch_If_Settings_Value_Is_Specified(ParallelismOption? option, string expected)
             {
                 // Given
                 var fixture = new XUnit2RunnerFixture();

--- a/src/Cake.Common.Tests/Unit/Tools/XUnit/XUnit2SettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/XUnit/XUnit2SettingsTests.cs
@@ -83,13 +83,13 @@ namespace Cake.Common.Tests.Unit.Tools.XUnit
             }
 
             [Fact]
-            public void Should_Set_Parallelism_Option_To_None_By_Default()
+            public void Should_Set_Parallelism_Option_To_Null_By_Default()
             {
                 // Given, When
                 var settings = new XUnit2Settings();
 
                 // Then
-                Assert.Equal(settings.Parallelism, ParallelismOption.None);
+                Assert.Null(settings.Parallelism);
             }
 
             [Fact]

--- a/src/Cake.Common/Tools/XUnit/XUnit2Runner.cs
+++ b/src/Cake.Common/Tools/XUnit/XUnit2Runner.cs
@@ -128,7 +128,7 @@ namespace Cake.Common.Tools.XUnit
             }
 
             // parallelize test execution?
-            if (settings.Parallelism != ParallelismOption.None)
+            if (settings.Parallelism.HasValue)
             {
                 builder.Append("-parallel " + settings.Parallelism.ToString().ToLowerInvariant());
             }

--- a/src/Cake.Common/Tools/XUnit/XUnit2Settings.cs
+++ b/src/Cake.Common/Tools/XUnit/XUnit2Settings.cs
@@ -81,7 +81,7 @@ namespace Cake.Common.Tools.XUnit
         /// <value>
         /// The parallelism option.
         /// </value>
-        public ParallelismOption Parallelism { get; set; }
+        public ParallelismOption? Parallelism { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to run tests in using x86 test runner.


### PR DESCRIPTION
Here is the first pass over what I believe to be the most appropriate fix for GH-2039.
I've made the property on the `XUnit2Settings` class nullable.
By default, assuming a user hasn't set the value, it will not be emitted as an argument.
This maintains parity with the previous implementation where `ParallelismOptions.None`, the CLR default, would suppress the emission.  In either case, no explicit argument will allow the runner to use the default.

The _other_ option that I entertained that we could explore further would be setting the default on the `XUnit2Settings` class to `Collections` to match the runner, but I think this has the potential to create regressions for people.

Please feel free to suggest other implementations if they're more desirable.
