### PR TITLE
GH2047: Added option to provide version in nuget updation

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/NuGet/Update/NuGetUpdaterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NuGet/Update/NuGetUpdaterTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using Cake.Common.Tests.Fixtures.Tools.NuGet.Update;
 using Cake.Common.Tools.NuGet;
@@ -240,6 +241,20 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Update
 
                 // Then
                 Assert.Equal(expected, result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Version_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new NuGetUpdateFixture();
+                fixture.Settings.Version = "1.0.0.0";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("update \"/Working/packages.config\" -Version 1.0.0.0 -NonInteractive", result.Args);
             }
         }
     }

--- a/src/Cake.Common/Tools/NuGet/Update/NuGetUpdateSettings.cs
+++ b/src/Cake.Common/Tools/NuGet/Update/NuGetUpdateSettings.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using Cake.Core.Tooling;
 
@@ -53,5 +54,11 @@ namespace Cake.Common.Tools.NuGet.Update
         /// </summary>
         /// <value>The version of MSBuild to be used with this command.</value>
         public NuGetMSBuildVersion? MSBuildVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets package version to be used with this command.
+        /// </summary>
+        /// <value>The package version to be used with this command.</value>
+        public string Version { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/NuGet/Update/NuGetUpdater.cs
+++ b/src/Cake.Common/Tools/NuGet/Update/NuGetUpdater.cs
@@ -99,6 +99,13 @@ namespace Cake.Common.Tools.NuGet.Update
                 builder.Append(settings.MSBuildVersion.Value.ToString("D"));
             }
 
+            // Version
+            if (!string.IsNullOrWhiteSpace(settings.Version))
+            {
+                builder.Append("-Version");
+                builder.Append(settings.Version);
+            }
+
             builder.Append("-NonInteractive");
 
             return builder;


### PR DESCRIPTION
This PR provides option to specify package version while updating and is same as doing

    nuget.exe Update "FooBar.sln" -Version 1.0.0.0