### PR TITLE
GH2055: Build Cake.exe for net461

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -161,9 +161,15 @@ Task("Run-Unit-Tests")
         });
 
         // .NET Framework/Mono
+        // Total hack, but gets the work done.
+        var framework = "net46";
+        if(project.ToString().EndsWith("Cake.Tests.csproj")) {
+            framework = "net461";
+        }
+
         DotNetCoreTest(project.ToString(), new DotNetCoreTestSettings
         {
-            Framework = "net46",
+            Framework = framework,
             NoBuild = true,
             NoRestore = true,
             Configuration = parameters.Configuration
@@ -178,7 +184,7 @@ Task("Copy-Files")
     // .NET 4.6
     DotNetCorePublish("./src/Cake", new DotNetCorePublishSettings
     {
-        Framework = "net46",
+        Framework = "net461",
         NoRestore = true,
         VersionSuffix = parameters.Version.DotNetAsterix,
         Configuration = parameters.Configuration,
@@ -201,7 +207,7 @@ Task("Copy-Files")
     CopyFileToDirectory("./LICENSE", parameters.Paths.Directories.ArtifactsBinNetCore); 
 
     // Copy Cake.XML (since publish does not do this anymore)
-    CopyFileToDirectory("./src/Cake/bin/" + parameters.Configuration + "/net46/Cake.xml", parameters.Paths.Directories.ArtifactsBinFullFx);
+    CopyFileToDirectory("./src/Cake/bin/" + parameters.Configuration + "/net461/Cake.xml", parameters.Paths.Directories.ArtifactsBinFullFx);
     CopyFileToDirectory("./src/Cake/bin/" + parameters.Configuration + "/netcoreapp2.0/Cake.xml", parameters.Paths.Directories.ArtifactsBinNetCore);
 });
 

--- a/build/paths.cake
+++ b/build/paths.cake
@@ -24,13 +24,13 @@ public class BuildPaths
 
         var artifactsDir = (DirectoryPath)(context.Directory("./artifacts") + context.Directory("v" + semVersion));
         var artifactsBinDir = artifactsDir.Combine("bin");
-        var artifactsBinFullFx = artifactsBinDir.Combine("net46");
+        var artifactsBinFullFx = artifactsBinDir.Combine("net461");
         var artifactsBinNetCore = artifactsBinDir.Combine("netcoreapp2.0");
         var testResultsDir = artifactsDir.Combine("test-results");
         var nugetRoot = artifactsDir.Combine("nuget");
 
         var zipArtifactPathCoreClr = artifactsDir.CombineWithFilePath("Cake-bin-coreclr-v" + semVersion + ".zip");
-        var zipArtifactPathDesktop = artifactsDir.CombineWithFilePath("Cake-bin-net46-v" + semVersion + ".zip");
+        var zipArtifactPathDesktop = artifactsDir.CombineWithFilePath("Cake-bin-net461-v" + semVersion + ".zip");
 
         var testCoverageOutputFilePath = testResultsDir.CombineWithFilePath("OpenCover.xml");
 

--- a/src/Cake.Core.Tests/Unit/CakeRuntimeTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeRuntimeTests.cs
@@ -42,7 +42,7 @@ namespace Cake.Core.Tests.Unit
                 var framework = runtime.BuiltFramework;
 
                 // Then
-                Assert.Equal(".NETFramework,Version=v4.6", framework.FullName);
+                Assert.Equal(".NETFramework,Version=v4.6.1", framework.FullName);
             }
         }
     }

--- a/src/Cake.Core/Polyfill/EnvironmentHelper.cs
+++ b/src/Cake.Core/Polyfill/EnvironmentHelper.cs
@@ -121,7 +121,7 @@ namespace Cake.Core.Polyfill
 #if NETCORE
             return new FrameworkName(".NETStandard,Version=v2.0");
 #else
-            return new FrameworkName(".NETFramework,Version=v4.6");
+            return new FrameworkName(".NETFramework,Version=v4.6.1");
 #endif
         }
     }

--- a/src/Cake.Tests/Cake.Tests.csproj
+++ b/src/Cake.Tests/Cake.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Cake.Tests</AssemblyName>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsCakeTestProject>true</IsCakeTestProject>
   </PropertyGroup>

--- a/src/Cake/Cake.csproj
+++ b/src/Cake/Cake.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Cake</AssemblyName>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <PlatformTarget>AnyCpu</PlatformTarget>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
This PR builds `Cake.exe` for `net461` instead of `net46`, which would make it possible for addins to target `netstandard20` and avoid an unneccesary breaking change.