### PR TITLE
GH2081: Improve source repository handling

### DIFF
--- a/src/Cake.NuGet.Tests/Unit/NuGetSourceRepositoryProviderTests.cs
+++ b/src/Cake.NuGet.Tests/Unit/NuGetSourceRepositoryProviderTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Cake.Core.Configuration;
 using Cake.Core.Packaging;
 using Cake.NuGet.Install;
+using NSubstitute;
 using NuGet.Configuration;
 using Xunit;
 
@@ -26,7 +27,7 @@ namespace Cake.NuGet.Tests.Unit
             public void Should_Throw_If_CakeConfiguration_Is_Null()
             {
                 var package = new PackageReference("nuget:?package=First.Package");
-                var settings = NSubstitute.Substitute.For<ISettings>();
+                var settings = Substitute.For<ISettings>();
                 var result = Record.Exception(() => new NuGetSourceRepositoryProvider(settings, null, package));
 
                 AssertEx.IsArgumentNullException(result, "config");
@@ -36,7 +37,7 @@ namespace Cake.NuGet.Tests.Unit
             public void Should_Throw_If_PackageReference_Is_Null()
             {
                 var configuration = new CakeConfiguration(new Dictionary<string, string>());
-                var settings = NSubstitute.Substitute.For<ISettings>();
+                var settings = Substitute.For<ISettings>();
                 var result = Record.Exception(() => new NuGetSourceRepositoryProvider(settings, configuration, null));
 
                 AssertEx.IsArgumentNullException(result, "package");
@@ -48,7 +49,7 @@ namespace Cake.NuGet.Tests.Unit
                 var nugetV3Api = "https://api.nuget.org/v3/index.json";
                 var nugetV2Api = "https://packages.nuget.org/api/v2";
                 var package = new PackageReference("nuget:?package=First.Package");
-                var settings = NSubstitute.Substitute.For<ISettings>();
+                var settings = Substitute.For<ISettings>();
                 var configuration = new CakeConfiguration(new Dictionary<string, string>()
                 {
                     [Constants.NuGet.Source] = nugetV2Api + ";" + nugetV3Api,
@@ -66,7 +67,7 @@ namespace Cake.NuGet.Tests.Unit
             {
                 var nugetV2Api = "https://packages.nuget.org/api/v2";
                 var package = new PackageReference("nuget:?package=First.Package");
-                var settings = NSubstitute.Substitute.For<ISettings>();
+                var settings = Substitute.For<ISettings>();
                 var configuration = new CakeConfiguration(new Dictionary<string, string>()
                 {
                     [Constants.NuGet.Source] = nugetV2Api + ";",
@@ -82,7 +83,7 @@ namespace Cake.NuGet.Tests.Unit
             public void Should_Not_Throw_For_Null_NugetSource_Value_In_CakeConfiguration()
             {
                 var package = new PackageReference("nuget:?package=First.Package");
-                var settings = NSubstitute.Substitute.For<ISettings>();
+                var settings = Substitute.For<ISettings>();
                 var configuration = new CakeConfiguration(new Dictionary<string, string>()
                 {
                     [Constants.NuGet.Source] = null,
@@ -91,6 +92,149 @@ namespace Cake.NuGet.Tests.Unit
                 var provider = new NuGetSourceRepositoryProvider(settings, configuration, package);
 
                 Assert.Empty(provider.GetRepositories());
+            }
+
+            [Fact]
+            public void Should_Set_Source_Specified_In_Directive_As_Primary_But_Not_For_Config()
+            {
+                var nugetV3Api = "https://api.nuget.org/v3/index.json";
+                var nugetV2Api = "https://packages.nuget.org/api/v2";
+                var primaryApi = "https://foo.bar/api.json";
+                var package = new PackageReference($"nuget:{primaryApi}?package=First.Package");
+                var settings = Substitute.For<ISettings>();
+                var configuration = new CakeConfiguration(new Dictionary<string, string>()
+                {
+                    [Constants.NuGet.Source] = $"{nugetV3Api};{nugetV2Api}",
+                });
+
+                var provider = new NuGetSourceRepositoryProvider(settings, configuration, package);
+
+                Assert.Single(provider.GetPrimaryRepositories());
+                Assert.Contains(provider.GetPrimaryRepositories(), p => p.PackageSource.Source == primaryApi);
+                Assert.Equal(3, provider.GetRepositories().Count());
+                Assert.Contains(provider.GetRepositories(), p => p.PackageSource.Source == primaryApi);
+                Assert.Contains(provider.GetRepositories(), p => p.PackageSource.Source == nugetV2Api);
+                Assert.Contains(provider.GetRepositories(), p => p.PackageSource.Source == nugetV3Api);
+            }
+
+            [Fact]
+            public void Should_Set_Source_Specified_In_Directive_As_Primary_But_Not_For_Settings()
+            {
+                var nugetV3Api = "https://api.nuget.org/v3/index.json";
+                var nugetV2Api = "https://packages.nuget.org/api/v2";
+                var primaryApi = "https://foo.bar/api.json";
+                var package = new PackageReference($"nuget:{primaryApi}?package=First.Package");
+                var settings = Substitute.For<ISettings>();
+                settings.GetSettingValues(ConfigurationConstants.PackageSources, Arg.Any<bool>())
+                    .Returns(new List<SettingValue>
+                    {
+                        new SettingValue("V3", nugetV3Api, true),
+                        new SettingValue("V2", nugetV2Api, true),
+                    });
+                var configuration = new CakeConfiguration(new Dictionary<string, string>()
+                {
+                    [Constants.NuGet.Source] = string.Empty,
+                });
+
+                var provider = new NuGetSourceRepositoryProvider(settings, configuration, package);
+
+                Assert.Single(provider.GetPrimaryRepositories());
+                Assert.Contains(provider.GetPrimaryRepositories(), p => p.PackageSource.Source == primaryApi);
+                Assert.Equal(3, provider.GetRepositories().Count());
+                Assert.Contains(provider.GetRepositories(), p => p.PackageSource.Source == primaryApi);
+                Assert.Contains(provider.GetRepositories(), p => p.PackageSource.Source == nugetV2Api);
+                Assert.Contains(provider.GetRepositories(), p => p.PackageSource.Source == nugetV3Api);
+            }
+
+            [Fact]
+            public void Should_Set_Configuration_Source_As_Primary_If_Not_Specified_In_Directive()
+            {
+                var nugetV3Api = "https://api.nuget.org/v3/index.json";
+                var nugetV2Api = "https://packages.nuget.org/api/v2";
+                var package = new PackageReference($"nuget:?package=First.Package");
+                var settings = Substitute.For<ISettings>();
+                var configuration = new CakeConfiguration(new Dictionary<string, string>()
+                {
+                    [Constants.NuGet.Source] = $"{nugetV3Api};{nugetV2Api}",
+                });
+
+                var provider = new NuGetSourceRepositoryProvider(settings, configuration, package);
+
+                Assert.Equal(2, provider.GetPrimaryRepositories().Count());
+                Assert.Contains(provider.GetPrimaryRepositories(), p => p.PackageSource.Source == nugetV2Api);
+                Assert.Contains(provider.GetPrimaryRepositories(), p => p.PackageSource.Source == nugetV3Api);
+            }
+
+            [Fact]
+            public void Should_Set_Settings_Source_As_Primary_If_Not_Specified_In_Directive()
+            {
+                var nugetV3Api = "https://api.nuget.org/v3/index.json";
+                var nugetV2Api = "https://packages.nuget.org/api/v2";
+                var package = new PackageReference($"nuget:?package=First.Package");
+                var settings = Substitute.For<ISettings>();
+                settings.GetSettingValues(ConfigurationConstants.PackageSources, Arg.Any<bool>())
+                    .Returns(new List<SettingValue>
+                    {
+                        new SettingValue("V3", nugetV3Api, true),
+                        new SettingValue("V2", nugetV2Api, true),
+                    });
+                var configuration = new CakeConfiguration(new Dictionary<string, string>()
+                {
+                    [Constants.NuGet.Source] = string.Empty,
+                });
+
+                var provider = new NuGetSourceRepositoryProvider(settings, configuration, package);
+
+                Assert.Equal(2, provider.GetPrimaryRepositories().Count());
+                Assert.Contains(provider.GetPrimaryRepositories(), p => p.PackageSource.Source == nugetV2Api);
+                Assert.Contains(provider.GetPrimaryRepositories(), p => p.PackageSource.Source == nugetV3Api);
+            }
+
+            [Fact]
+            public void Should_Not_Set_Source_From_Settings_If_Cake_Config_Source_Is_Provided()
+            {
+                var nugetV3Api = "https://api.nuget.org/v3/index.json";
+                var nugetV2Api = "https://packages.nuget.org/api/v2";
+                var settingsApi = "https://foo.bar/api.json";
+                var package = new PackageReference($"nuget:?package=First.Package");
+                var settings = Substitute.For<ISettings>();
+                settings.GetSettingValues(ConfigurationConstants.PackageSources, Arg.Any<bool>())
+                    .Returns(new List<SettingValue>
+                    {
+                        new SettingValue("foobar", settingsApi, true)
+                    });
+                var configuration = new CakeConfiguration(new Dictionary<string, string>()
+                {
+                    [Constants.NuGet.Source] = $"{nugetV3Api};{nugetV2Api}",
+                });
+
+                var provider = new NuGetSourceRepositoryProvider(settings, configuration, package);
+
+                Assert.Equal(2, provider.GetRepositories().Count());
+                Assert.Contains(provider.GetRepositories(), p => p.PackageSource.Source == nugetV2Api);
+                Assert.Contains(provider.GetRepositories(), p => p.PackageSource.Source == nugetV3Api);
+            }
+
+            [Fact]
+            public void Should_Set_Source_From_Settings_If_Cake_Config_Source_Is_Not_Provided()
+            {
+                var settingsApi = "https://foo.bar/api.json";
+                var package = new PackageReference($"nuget:?package=First.Package");
+                var settings = Substitute.For<ISettings>();
+                settings.GetSettingValues(ConfigurationConstants.PackageSources, Arg.Any<bool>())
+                    .Returns(new List<SettingValue>
+                    {
+                        new SettingValue("foobar", settingsApi, true)
+                    });
+                var configuration = new CakeConfiguration(new Dictionary<string, string>()
+                {
+                    [Constants.NuGet.Source] = string.Empty,
+                });
+
+                var provider = new NuGetSourceRepositoryProvider(settings, configuration, package);
+
+                Assert.Single(provider.GetRepositories());
+                Assert.Contains(provider.GetRepositories(), p => p.PackageSource.Source == settingsApi);
             }
         }
     }

--- a/src/Cake.NuGet/Install/NuGetPackageInstaller.cs
+++ b/src/Cake.NuGet/Install/NuGetPackageInstaller.cs
@@ -139,6 +139,7 @@ namespace Cake.NuGet.Install
                 packageIdentity,
                 resolutionContext,
                 projectContext,
+                sourceRepositoryProvider.GetPrimaryRepositories(),
                 sourceRepositoryProvider.GetRepositories(),
                 CancellationToken.None).Result;
 


### PR DESCRIPTION
- Don't use default sources from NuGet.Config's if nuget_source config value is provided.
- Make difference on primary and secondary sources. Target package must
be found int primary source and dependencies may be fetched from
secondary sources.
- Fixes #2081

Needs #2085 to be merged first.