### PR TITLE
GH2095: add   skipnontestassemblies funcionality to nunit3 runner

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/NUnit/NUnit3RunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NUnit/NUnit3RunnerTests.cs
@@ -155,6 +155,7 @@ namespace Cake.Common.Tests.Unit.Tools.NUnit
             [InlineData(-1, "NUnit3: Invalid argument (exit code -1).")]
             [InlineData(-2, "NUnit3: Invalid assembly (exit code -2).")]
             [InlineData(-4, "NUnit3: Invalid test fixture (exit code -4).")]
+            [InlineData(-5, "NUnit3: Unload error (exit code -5).")]
             [InlineData(-100, "NUnit3: Unexpected error (exit code -100).")]
             [InlineData(-10, "NUnit3: Unrecognised error (exit code -10).")]
             public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code(int exitCode, string expectedMessage)
@@ -215,6 +216,7 @@ namespace Cake.Common.Tests.Unit.Tools.NUnit
                 fixture.Settings.Seed = 6;
                 fixture.Settings.Workers = 7;
                 fixture.Settings.StopOnError = true;
+                fixture.Settings.SkipNonTestAssemblies = true;
                 fixture.Settings.Work = "out";
                 fixture.Settings.OutputFile = "stdout.txt";
                 #pragma warning disable 0618
@@ -255,7 +257,7 @@ namespace Cake.Common.Tests.Unit.Tools.NUnit
                 // Then
                 Assert.Equal("\"/Working/Test1.dll\" --test=Test1,Test2 \"--testlist=/Working/Testlist.txt\" " +
                         "--where \"cat==Data\" --timeout=5 --seed=6 --workers=7 " +
-                        "--stoponerror \"--work=/Working/out\" \"--out=/Working/stdout.txt\" " +
+                        "--stoponerror --skipnontestassemblies \"--work=/Working/out\" \"--out=/Working/stdout.txt\" " +
                         "\"--err=/Working/stderr.txt\" --full " +
                         "\"--result=/Working/NewTestResult.xml;format=nunit2;transform=/Working/nunit2.xslt\" " +
                         "\"--result=/Working/NewTestResult2.xml;format=nunit3\" " +

--- a/src/Cake.Common/Tools/NUnit/NUnit3Runner.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnit3Runner.cs
@@ -13,7 +13,7 @@ using Cake.Core.Tooling;
 namespace Cake.Common.Tools.NUnit
 {
     /// <summary>
-    /// The NUnit unit test runner.
+    /// The NUnit3 unit test runner.
     /// </summary>
     public sealed class NUnit3Runner : Tool<NUnit3Settings>
     {
@@ -97,6 +97,11 @@ namespace Cake.Common.Tools.NUnit
             if (settings.StopOnError)
             {
                 builder.Append("--stoponerror");
+            }
+
+            if (settings.SkipNonTestAssemblies)
+            {
+                builder.Append("--skipnontestassemblies");
             }
 
             if (settings.Work != null)
@@ -256,7 +261,7 @@ namespace Cake.Common.Tools.NUnit
         }
 
         /// <summary>
-        /// Customized exit code handling.
+        /// Customized Nunit3 exit code handling.
         /// Throws <see cref="CakeException"/> on non-zero exit code
         /// </summary>
         /// <param name="exitCode">The process exit code</param>
@@ -278,6 +283,9 @@ namespace Cake.Common.Tools.NUnit
                         break;
                     case -4:
                         error = "Invalid test fixture";
+                        break;
+                    case -5:
+                        error = "Unload error";
                         break;
                     case -100:
                         error = "Unexpected error";

--- a/src/Cake.Common/Tools/NUnit/NUnit3Settings.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnit3Settings.cs
@@ -81,6 +81,16 @@ namespace Cake.Common.Tools.NUnit
         public bool StopOnError { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether execution of the test run should
+        /// skip any non-test assemblies specified, without error.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if execution of the test run should skip any non-test assemblies specified, without error;
+        /// otherwise, <c>false</c>.
+        /// </value>
+        public bool SkipNonTestAssemblies { get; set; }
+
+        /// <summary>
         /// Gets or sets the directory to use for output files. If
         /// not specified, defaults to the current directory.
         /// </summary>

--- a/src/Cake.Common/Tools/NUnit/NUnitRunner.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnitRunner.cs
@@ -188,7 +188,7 @@ namespace Cake.Common.Tools.NUnit
         }
 
         /// <summary>
-        /// Customized exit code handling.
+        /// Customized Nunit exit code handling.
         /// Throws <see cref="CakeException"/> on non-zero exit code
         /// </summary>
         /// <param name="exitCode">The process exit code</param>


### PR DESCRIPTION
### What You Are Seeing?
NUnit3Settings class does not have property SkipNonTestAssemblies
### What is Expected?
NUnit3Settings class does have property SkipNonTestAssemblies and features behind it as described here: https://github.com/nunit/docs/wiki/Console-Command-Line
### What version of Cake are you using?
v0.26.1
### Are you running on a 32 or 64 bit system?
64
### What environment are you running on?  Windows? Linux? Mac?
Windows
### Are you running on a CI Server?  If so, which one?
NO
