### PR TITLE
GH2106: Obsolete removed NUnit3 --err option

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/NUnit/NUnit3RunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NUnit/NUnit3RunnerTests.cs
@@ -217,8 +217,8 @@ namespace Cake.Common.Tests.Unit.Tools.NUnit
                 fixture.Settings.StopOnError = true;
                 fixture.Settings.Work = "out";
                 fixture.Settings.OutputFile = "stdout.txt";
-                fixture.Settings.ErrorOutputFile = "stderr.txt";
                 #pragma warning disable 0618
+                fixture.Settings.ErrorOutputFile = "stderr.txt";
                 fixture.Settings.Full = true;
                 #pragma warning restore 0618
                 fixture.Settings.Results = new[]

--- a/src/Cake.Common/Tools/NUnit/NUnit3Runner.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnit3Runner.cs
@@ -109,12 +109,12 @@ namespace Cake.Common.Tools.NUnit
                 builder.AppendQuoted(string.Format(CultureInfo.InvariantCulture, "--out={0}", settings.OutputFile.MakeAbsolute(_environment).FullPath));
             }
 
+            #pragma warning disable 0618
             if (settings.ErrorOutputFile != null)
             {
                 builder.AppendQuoted(string.Format(CultureInfo.InvariantCulture, "--err={0}", settings.ErrorOutputFile.MakeAbsolute(_environment).FullPath));
             }
 
-            #pragma warning disable 0618
             if (settings.Full)
             {
                 builder.Append("--full");

--- a/src/Cake.Common/Tools/NUnit/NUnit3Settings.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnit3Settings.cs
@@ -99,6 +99,7 @@ namespace Cake.Common.Tools.NUnit
         /// Gets or sets the location that NUnit should write test error output.
         /// </summary>
         /// <value>The location that NUnit should write test error output.</value>
+        [Obsolete("This argument was removed from NUnit3", false)]
         public FilePath ErrorOutputFile { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Fixes #2106.

When I got to the code, I saw that the `Full` and `Verbose` options, which were in the same position, have both just been Obsoleted rather than fully removed. For consistency, I did the same for `ErrorOutputFile`.