### PR TITLE
GH1609: Add additional VSTS actions

### DIFF
--- a/src/Cake.Common/Build/TFBuild/Data/TFBuildPublishCodeCoverageData.cs
+++ b/src/Cake.Common/Build/TFBuild/Data/TFBuildPublishCodeCoverageData.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Build.TFBuild.Data
+{
+    /// <summary>
+    /// Providers TF Build agent for publishing code coverage results
+    /// </summary>
+    public class TFBuildPublishCodeCoverageData
+    {
+        /// <summary>
+        /// Gets or Sets the tool from which code coverage results are generated.
+        /// </summary>
+        public TFCodeCoverageToolType? CodeCoverageTool { get; set; }
+
+        /// <summary>
+        /// Gets or Sets the path ath of the summary file containing code coverage statistics, such as line, method, and class coverage.
+        /// </summary>
+        public string SummaryFileLocation { get; set; }
+
+        /// <summary>
+        /// Gets or Sets the Path of the code coverage HTML report directory. The report directory is published for later viewing as an artifact of the build.
+        /// </summary>
+        public string ReportDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or Sets the file paths for any additional code coverage files to be published as artifacts of the build.
+        /// </summary>
+        public string[] AdditionalCodeCoverageFiles { get; set; }
+
+        internal Dictionary<string, string> GetProperties(ICakeEnvironment environment)
+        {
+            if (environment == null)
+            {
+                throw new ArgumentNullException(nameof(environment));
+            }
+
+            var properties = new Dictionary<string, string>();
+
+            if (CodeCoverageTool.HasValue)
+            {
+                properties.Add("codecoveragetool", CodeCoverageTool.Value.ToString());
+            }
+            if (!string.IsNullOrWhiteSpace(SummaryFileLocation))
+            {
+                properties.Add("summaryfile", new FilePath(SummaryFileLocation).MakeAbsolute(environment).FullPath.Replace("/", "\\"));
+            }
+            if (!string.IsNullOrWhiteSpace(ReportDirectory))
+            {
+                properties.Add("reportdirectory", new DirectoryPath(ReportDirectory).MakeAbsolute(environment).FullPath.Replace("/", "\\"));
+            }
+            if (AdditionalCodeCoverageFiles != null && AdditionalCodeCoverageFiles.Any())
+            {
+                properties.Add("additionalcodecoveragefiles", string.Join(",", AdditionalCodeCoverageFiles.Select(filePath => new FilePath(filePath).MakeAbsolute(environment).FullPath.Replace("/", "\\"))));
+            }
+            return properties;
+        }
+    }
+}

--- a/src/Cake.Common/Build/TFBuild/Data/TFBuildPublishTestResultsData.cs
+++ b/src/Cake.Common/Build/TFBuild/Data/TFBuildPublishTestResultsData.cs
@@ -1,0 +1,93 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Build.TFBuild.Data
+{
+    /// <summary>
+    ///  Provides TF Build agent info for publishing test results
+    /// </summary>
+    public class TFBuildPublishTestResultsData
+    {
+        /// <summary>
+        /// Gets or Sets the type test runner the results are formated in
+        /// </summary>
+        public TFTestRunnerType? TestRunner { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of Test Result files to publish.
+        /// </summary>
+        public string[] TestResultsFiles { get; set; }
+
+        /// <summary>
+        /// Gets or Sets whether to merge all Test Result Files into one run
+        /// </summary>
+        public bool? MergeTestResults { get; set; }
+
+        /// <summary>
+        /// Gets or Sets the Platform for which the tests were run on
+        /// </summary>
+        public string Platform { get; set; }
+
+        /// <summary>
+        /// Gets or Sets the configuration for which the tests were run on
+        /// </summary>
+        public string Configuration { get; set; }
+
+        /// <summary>
+        /// Gets or Sets a name for the Test Run.
+        /// </summary>
+        public string TestRunTitle { get; set; }
+
+        /// <summary>
+        /// Gets or Sets whether to opt in/out of publishing test run level attachments
+        /// </summary>
+        public bool? PublishRunAttachments { get; set; }
+
+        internal Dictionary<string, string> GetProperties(ICakeEnvironment environment)
+        {
+            if (environment == null)
+            {
+                throw new ArgumentNullException(nameof(environment));
+            }
+
+            var properties = new Dictionary<string, string>();
+
+            if (TestRunner.HasValue)
+            {
+                properties.Add("type", TestRunner.Value.ToString());
+            }
+            if (MergeTestResults.HasValue)
+            {
+                properties.Add("mergeResults", MergeTestResults.ToString().ToLowerInvariant());
+            }
+            if (!string.IsNullOrWhiteSpace(Platform))
+            {
+                properties.Add("platform", Platform);
+            }
+            if (!string.IsNullOrWhiteSpace(Configuration))
+            {
+                properties.Add("config", Configuration);
+            }
+            if (!string.IsNullOrWhiteSpace(TestRunTitle))
+            {
+                properties.Add("runTitle", $"'{TestRunTitle}'");
+            }
+            if (PublishRunAttachments.HasValue)
+            {
+                properties.Add("publishRunAttachments", PublishRunAttachments.ToString().ToLowerInvariant());
+            }
+            if (TestResultsFiles != null && TestResultsFiles.Any())
+            {
+                properties.Add("resultFiles", string.Join(",", TestResultsFiles.Select(filePath => new FilePath(filePath).MakeAbsolute(environment).FullPath.Replace("/", "\\"))));
+            }
+            return properties;
+        }
+    }
+}

--- a/src/Cake.Common/Build/TFBuild/Data/TFCodeCoverageToolType.cs
+++ b/src/Cake.Common/Build/TFBuild/Data/TFCodeCoverageToolType.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Build.TFBuild.Data
+{
+    /// <summary>
+    ///  Provides the known values for the Code Coverage tool formats
+    /// </summary>
+    public enum TFCodeCoverageToolType
+    {
+        /// <summary>
+        /// JaCoCo code coverage format
+        /// </summary>
+        JaCoCo,
+
+        /// <summary>
+        /// Cobertura code coverage format
+        /// </summary>
+        Cobertura
+    }
+}

--- a/src/Cake.Common/Build/TFBuild/Data/TFTestRunnerType.cs
+++ b/src/Cake.Common/Build/TFBuild/Data/TFTestRunnerType.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Build.TFBuild.Data
+{
+    /// <summary>
+    /// Providers known values for the TF Test Runner types
+    /// </summary>
+    public enum TFTestRunnerType
+    {
+        /// <summary>
+        /// JUnit Test Result Format
+        /// </summary>
+        JUnit,
+
+        /// <summary>
+        /// NUnit (v2) Test Result Format
+        /// </summary>
+        NUnit,
+
+        /// <summary>
+        /// Visual Studio (MSTest) Test Result Format
+        /// </summary>
+        VSTest,
+
+        /// <summary>
+        /// XUnit Test Result Format
+        /// </summary>
+        XUnit
+    }
+}

--- a/src/Cake.Common/Build/TFBuild/ITFBuildCommands.cs
+++ b/src/Cake.Common/Build/TFBuild/ITFBuildCommands.cs
@@ -172,5 +172,17 @@ namespace Cake.Common.Build.TFBuild
         /// </remarks>
         /// <param name="tag">The tag.</param>
         void AddBuildTag(string tag);
+
+        /// <summary>
+        /// Publishes and uploads tests results
+        /// </summary>
+        /// <param name="data">The publish test results data</param>
+        void PublishTestResults(TFBuildPublishTestResultsData data);
+
+        /// <summary>
+        /// Publishes and uploads code coverage results
+        /// </summary>
+        /// <param name="data">The code coverage data</param>
+        void PublishCodeCoverage(TFBuildPublishCodeCoverageData data);
     }
 }

--- a/src/Cake.Common/Build/TFBuild/TFBuildCommands.cs
+++ b/src/Cake.Common/Build/TFBuild/TFBuildCommands.cs
@@ -313,6 +313,26 @@ namespace Cake.Common.Build.TFBuild
             WriteLoggingCommand("build.addbuildtag", tag);
         }
 
+        /// <summary>
+        /// Publishes and uploads tests results
+        /// </summary>
+        /// <param name="data">The publish test results data</param>
+        public void PublishTestResults(TFBuildPublishTestResultsData data)
+        {
+            var properties = data.GetProperties(_environment);
+            WriteLoggingCommand("results.publish", properties, string.Empty);
+        }
+
+        /// <summary>
+        /// Publishes and uploads code coverage results
+        /// </summary>
+        /// <param name="data">The code coverage data</param>
+        public void PublishCodeCoverage(TFBuildPublishCodeCoverageData data)
+        {
+            var properties = data.GetProperties(_environment);
+            WriteLoggingCommand("codecoverage.publish", properties, string.Empty);
+        }
+
         private void WriteLoggingCommand(string actionName, string value)
         {
             WriteLoggingCommand(actionName, new Dictionary<string, string>(), value);


### PR DESCRIPTION
This pull request added  PublishTestResults and PublishCodeCoverage commands to the TFSBuilder. This is related to open issue #1609