### PR TITLE
GH2111: Removes retired cli-deps NuGet feed

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -122,8 +122,6 @@ Task("Restore-NuGet-Packages")
         Verbosity = DotNetCoreVerbosity.Minimal,
         Sources = new [] {
             "https://www.myget.org/F/xunit/api/v3/index.json",
-            "https://dotnet.myget.org/F/dotnet-core/api/v3/index.json",
-            "https://dotnet.myget.org/F/cli-deps/api/v3/index.json",
             "https://api.nuget.org/v3/index.json"
         },
         MSBuildSettings = msBuildSettings


### PR DESCRIPTION
* also removes unused dotnet-core feed
* fixes #2111