### PR TITLE
GH2084: Resolve assemblies in NuGet packages located in lib

### DIFF
--- a/src/Cake.NuGet.Tests/Unit/NuGetContentResolverTests.cs
+++ b/src/Cake.NuGet.Tests/Unit/NuGetContentResolverTests.cs
@@ -237,7 +237,7 @@ namespace Cake.NuGet.Tests.Unit
 
                 fixture.CreateCLRAssembly("/Working/file1.dll");
                 fixture.CreateCLRAssembly("/Working/file2.dll");
-                fixture.CreateCLRAssembly("/Working/file3.dll");
+                fixture.CreateCLRAssembly("/Working/lib/file3.dll");
 
                 // When
                 var result = fixture.GetFiles();
@@ -246,7 +246,7 @@ namespace Cake.NuGet.Tests.Unit
                 Assert.Equal(3, result.Count);
                 Assert.Equal("/Working/file1.dll", result.ElementAt(0).Path.FullPath);
                 Assert.Equal("/Working/file2.dll", result.ElementAt(1).Path.FullPath);
-                Assert.Equal("/Working/file3.dll", result.ElementAt(2).Path.FullPath);
+                Assert.Equal("/Working/lib/file3.dll", result.ElementAt(2).Path.FullPath);
             }
 
             [Theory]
@@ -259,6 +259,7 @@ namespace Cake.NuGet.Tests.Unit
 
                 fixture.CreateCLRAssembly("/Working/lib/net461/file.dll");
                 fixture.CreateCLRAssembly("/Working/lib/netstandard1.6/file.dll");
+                fixture.CreateCLRAssembly("/Working/lib/file.dll");
                 fixture.CreateCLRAssembly("/Working/file.dll");
 
                 // When

--- a/src/Cake.NuGet/NuGetContentResolver.cs
+++ b/src/Cake.NuGet/NuGetContentResolver.cs
@@ -110,7 +110,16 @@ namespace Cake.NuGet
 
         private NuGetFramework ParseFromDirectoryPath(NuGetFramework current, DirectoryPath path)
         {
-            var queue = new Queue<string>(path.Segments);
+            var segments = path.Segments;
+
+            if (segments.Length == 1 &&
+                segments[0].Equals("lib", StringComparison.OrdinalIgnoreCase))
+            {
+                // Treat as AnyFramework if lib folder
+                return NuGetFramework.AnyFramework;
+            }
+
+            var queue = new Queue<string>(segments);
             while (queue.Count > 0)
             {
                 var other = NuGetFramework.Parse(queue.Dequeue(), DefaultFrameworkNameProvider.Instance);


### PR DESCRIPTION
- Improve dependency loading, load in correct order as installed by NuGet.
- Resolve assemblies also from lib
- Fixes #2084