### PR TITLE
GH2134: References latest Newtonsoft.Json from Cake.NuGet

### DIFF
--- a/src/Cake.NuGet/Cake.NuGet.csproj
+++ b/src/Cake.NuGet/Cake.NuGet.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="NuGet.Frameworks" Version="4.6.0" />
     <PackageReference Include="NuGet.Versioning" Version="4.6.0" />
     <PackageReference Include="NuGet.ProjectModel" Version="4.6.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
   <!-- .NET Core packages -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">


### PR DESCRIPTION
Confirmed this results in `Newtonsoft.Json` 11.0.2 ending up in Cake bin for net46 target framework. This should resolve 90% of cases, but does not introduce a long-term fix of building a reference dependency graph and loading the newest (that'll take some time).

#2134 