### PR TITLE
GH2140: PR DotNetCorePublish does not respect SelfContained DotNetCorePublishSettings property #2140

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Publish/DotNetCorePublisherTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Publish/DotNetCorePublisherTests.cs
@@ -125,6 +125,30 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Publish
             }
 
             [Fact]
+            public void Should_Add_SelfContained_False_Settings()
+            {
+                // Given
+                var fixture = new DotNetCorePublisherFixture();
+                fixture.Settings.NoDependencies = true;
+                fixture.Settings.NoRestore = true;
+                fixture.Settings.Framework = "dnxcore50";
+                fixture.Settings.Configuration = "Release";
+                fixture.Settings.Runtime = "runtime1";
+                fixture.Settings.OutputDirectory = "./artifacts/";
+                fixture.Settings.VersionSuffix = "rc1";
+                fixture.Settings.Verbosity = DotNetCoreVerbosity.Minimal;
+                fixture.Settings.Force = true;
+                fixture.Settings.SelfContained = false;
+                fixture.Settings.Sources = new[] { "https://api.nuget.org/v3/index.json" };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("publish --output \"/Working/artifacts\" --runtime runtime1 --framework dnxcore50 --configuration Release --version-suffix rc1 --no-dependencies --no-restore --force --self-contained false --source \"https://api.nuget.org/v3/index.json\" --verbosity Minimal", result.Args);
+            }
+
+            [Fact]
             public void Should_Add_Host_Arguments()
             {
                 // Given

--- a/src/Cake.Common/Tools/DotNetCore/Publish/DotNetCorePublishSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Publish/DotNetCorePublishSettings.cs
@@ -69,7 +69,7 @@ namespace Cake.Common.Tools.DotNetCore.Publish
         /// <remarks>
         /// Requires .NET Core 2.x or newer.
         /// </remarks>
-        public bool SelfContained { get; set; }
+        public bool? SelfContained { get; set; }
 
         /// <summary>
         /// Gets or sets the specified NuGet package sources to use during the restore.

--- a/src/Cake.Common/Tools/DotNetCore/Publish/DotNetCorePublisher.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Publish/DotNetCorePublisher.cs
@@ -114,9 +114,17 @@ namespace Cake.Common.Tools.DotNetCore.Publish
             }
 
             // Self contained
-            if (settings.SelfContained)
+            if (settings.SelfContained.HasValue)
             {
-                builder.Append("--self-contained");
+                if (settings.SelfContained.Value)
+                {
+                    builder.Append("--self-contained");
+                }
+                else
+                {
+                    builder.Append("--self-contained");
+                    builder.Append("false");
+                }
             }
 
             // Sources


### PR DESCRIPTION
Made SelfContainedproperty of DotNetPublishSettings a nullable boolean since no setting means it takes…the .Net default of true when runtime is included.  Added the logic to include false for self contain and test when running DotNetPublish.

https://github.com/cake-build/cake/issues/2140


