### PR TITLE
GH2141: Added Verbosity property to GitVersionSettings

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/GitVersionRunnerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/GitVersionRunnerFixture.cs
@@ -46,6 +46,12 @@ namespace Cake.Common.Tests.Fixtures.Tools
 
             ProcessRunner.Process.SetStandardOutput(standardOutput);
             Log = Substitute.For<ICakeLog>();
+            Log.Verbosity = Verbosity.Normal;
+        }
+
+        public void SetLogVerbosity(Verbosity verbosity)
+        {
+            Log.Verbosity = verbosity;
         }
 
         protected override void RunTool()

--- a/src/Cake.Common.Tests/Unit/Tools/GitVersion/GitVersionRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/GitVersion/GitVersionRunnerTests.cs
@@ -5,6 +5,7 @@
 using Cake.Common.Tests.Fixtures.Tools;
 using Cake.Common.Tools.GitVersion;
 using Cake.Core;
+using Cake.Core.Diagnostics;
 using Cake.Testing;
 using Xunit;
 
@@ -311,6 +312,43 @@ namespace Cake.Common.Tests.Unit.Tools.GitVersion
                 Assert.Equal(expect.CommitsSinceVersionSource, result.CommitsSinceVersionSource);
                 Assert.Equal(expect.CommitsSinceVersionSourcePadded, result.CommitsSinceVersionSourcePadded);
                 Assert.Equal(expect.CommitDate, result.CommitDate);
+            }
+
+            [Theory]
+            [InlineData(GitVersionVerbosity.None, "None")]
+            [InlineData(GitVersionVerbosity.Debug, "Debug")]
+            [InlineData(GitVersionVerbosity.Info, "Info")]
+            [InlineData(GitVersionVerbosity.Warn, "Warn")]
+            [InlineData(GitVersionVerbosity.Error, "Error")]
+            public void Should_Add_Verbosity_To_Arguments_If_Set(GitVersionVerbosity verbosity, string arg)
+            {
+                // Given
+                var fixture = new GitVersionRunnerFixture();
+                fixture.Settings.Verbosity = verbosity;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal($"-verbosity {arg}", result.Args);
+            }
+
+            [Theory]
+            [InlineData(Verbosity.Quiet, "None")]
+            [InlineData(Verbosity.Diagnostic, "Debug")]
+            [InlineData(Verbosity.Verbose, "Debug")]
+            [InlineData(Verbosity.Minimal, "Error")]
+            public void Should_Add_Default_Verbosity_To_Arguments_If_Not_Set(Verbosity verbosity, string arg)
+            {
+                // Given
+                var fixture = new GitVersionRunnerFixture();
+                fixture.SetLogVerbosity(verbosity);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal($"-verbosity {arg}", result.Args);
             }
         }
     }

--- a/src/Cake.Common/Tools/GitVersion/GitVersionRunner.cs
+++ b/src/Cake.Common/Tools/GitVersion/GitVersionRunner.cs
@@ -159,6 +159,52 @@ namespace Cake.Common.Tools.GitVersion
                 builder.Append("-nofetch");
             }
 
+            if (settings.Verbosity.HasValue)
+            {
+                switch (settings.Verbosity.Value)
+                {
+                    case GitVersionVerbosity.None:
+                        builder.Append("-verbosity");
+                        builder.Append(nameof(GitVersionVerbosity.None));
+                        break;
+                    case GitVersionVerbosity.Debug:
+                        builder.Append("-verbosity");
+                        builder.Append(nameof(GitVersionVerbosity.Debug));
+                        break;
+                    case GitVersionVerbosity.Info:
+                        builder.Append("-verbosity");
+                        builder.Append(nameof(GitVersionVerbosity.Info));
+                        break;
+                    case GitVersionVerbosity.Warn:
+                        builder.Append("-verbosity");
+                        builder.Append(nameof(GitVersionVerbosity.Warn));
+                        break;
+                    case GitVersionVerbosity.Error:
+                        builder.Append("-verbosity");
+                        builder.Append(nameof(GitVersionVerbosity.Error));
+                        break;
+                }
+            }
+            else
+            {
+                switch (_log.Verbosity)
+                {
+                    case Verbosity.Quiet:
+                        builder.Append("-verbosity");
+                        builder.Append(nameof(GitVersionVerbosity.None));
+                        break;
+                    case Verbosity.Diagnostic:
+                    case Verbosity.Verbose:
+                        builder.Append("-verbosity");
+                        builder.Append(nameof(GitVersionVerbosity.Debug));
+                        break;
+                    case Verbosity.Minimal:
+                        builder.Append("-verbosity");
+                        builder.Append(nameof(GitVersionVerbosity.Error));
+                        break;
+                }
+            }
+
             return builder;
         }
 

--- a/src/Cake.Common/Tools/GitVersion/GitVersionSettings.cs
+++ b/src/Cake.Common/Tools/GitVersion/GitVersionSettings.cs
@@ -77,5 +77,10 @@ namespace Cake.Common.Tools.GitVersion
         /// Gets or sets the path to the log file.
         /// </summary>
         public FilePath LogFilePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the logging verbosity.
+        /// </summary>
+        public GitVersionVerbosity? Verbosity { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/GitVersion/GitVersionVerbosity.cs
+++ b/src/Cake.Common/Tools/GitVersion/GitVersionVerbosity.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Tools.GitVersion
+{
+    /// <summary>
+    /// The GitVersion verbosity.
+    /// </summary>
+    public enum GitVersionVerbosity
+    {
+        /// <summary>
+        /// No messages will be logged.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Only log error messages.
+        /// </summary>
+        Error,
+
+        /// <summary>
+        /// Only log wanring messages.
+        /// </summary>
+        Warn,
+
+        /// <summary>
+        /// Only log info messages.
+        /// </summary>
+        Info,
+
+        /// <summary>
+        /// Only log debug messages.
+        /// </summary>
+        Debug
+    }
+}


### PR DESCRIPTION
Pull request to address [2141](https://github.com/cake-build/cake/issues/2141)

A Verbosity property has been added to GitVersionSettings which can be explicitly set otherwise it defaults depending on the verbosity of Cake itself. The rationale behind defaulting is in CI environments (TeamCity in my case) where it is handy to increase verbosity of logging without having to modify the script.