### PR TITLE
(GH2008/GH1594/GH1772) Typed context improvements

### DIFF
--- a/src/Cake.Core/CakeEngineActions.cs
+++ b/src/Cake.Core/CakeEngineActions.cs
@@ -12,7 +12,7 @@ namespace Cake.Core
         private readonly ICakeDataService _data;
         private readonly List<Action> _validations;
 
-        public Action<ICakeContext> Setup { get; private set; }
+        public Action<ISetupContext> Setup { get; private set; }
         public Action<ITeardownContext> Teardown { get; private set; }
         public Action<ITaskSetupContext> TaskSetup { get; private set; }
         public Action<ITaskTeardownContext> TaskTeardown { get; private set; }
@@ -24,14 +24,14 @@ namespace Cake.Core
             _validations = new List<Action>();
         }
 
-        public void RegisterSetup(Action<ICakeContext> action)
+        public void RegisterSetup(Action<ISetupContext> action)
         {
             EnsureNotRegistered(Setup, "Setup");
             Setup = action;
             DataType = null;
         }
 
-        public void RegisterSetup<TData>(Func<ICakeContext, TData> action)
+        public void RegisterSetup<TData>(Func<ISetupContext, TData> action)
             where TData : class
         {
             EnsureNotRegistered(Setup, "Setup");

--- a/src/Cake.Core/CakeTaskBuilder.Criterias.cs
+++ b/src/Cake.Core/CakeTaskBuilder.Criterias.cs
@@ -116,5 +116,49 @@ namespace Cake.Core
             builder.Target.AddCriteria(criteria, message);
             return builder;
         }
+
+        /// <summary>
+        /// Adds a criteria that has to be fulfilled for the task to run.
+        /// The criteria is evaluated when traversal of the graph occurs.
+        /// </summary>
+        /// <typeparam name="TData">The type of the data context.</typeparam>
+        /// <param name="builder">The task builder.</param>
+        /// <param name="criteria">The criteria.</param>
+        /// <returns>The same <see cref="CakeTaskBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static CakeTaskBuilder WithCriteria<TData>(this CakeTaskBuilder builder, Func<TData, ICakeContext, bool> criteria) where TData : class
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.Target.AddCriteria(
+                context => criteria(context.Data.Get<TData>(), context));
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds a criteria that has to be fulfilled for the task to run.
+        /// The criteria is evaluated when traversal of the graph occurs.
+        /// </summary>
+        /// <typeparam name="TData">The type of the data context.</typeparam>
+        /// <param name="builder">The task builder.</param>
+        /// <param name="criteria">The criteria.</param>
+        /// <param name="message">The message to display if the task was skipped due to the provided criteria.</param>
+        /// <returns>The same <see cref="CakeTaskBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static CakeTaskBuilder WithCriteria<TData>(this CakeTaskBuilder builder, Func<TData, ICakeContext, bool> criteria, string message) where TData : class
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.Target.AddCriteria(
+                context => criteria(context.Data.Get<TData>(), context),
+                message);
+
+            return builder;
+        }
     }
 }

--- a/src/Cake.Core/DefaultExecutionStrategy.cs
+++ b/src/Cake.Core/DefaultExecutionStrategy.cs
@@ -29,7 +29,7 @@ namespace Cake.Core
         /// </summary>
         /// <param name="action">The action.</param>
         /// <param name="context">The context.</param>
-        public void PerformSetup(Action<ICakeContext> action, ISetupContext context)
+        public void PerformSetup(Action<ISetupContext> action, ISetupContext context)
         {
             if (action != null)
             {

--- a/src/Cake.Core/ICakeEngine.cs
+++ b/src/Cake.Core/ICakeEngine.cs
@@ -51,7 +51,7 @@ namespace Cake.Core
         /// If setup fails, no tasks will be executed but teardown will be performed.
         /// </summary>
         /// <param name="action">The action to be executed.</param>
-        void RegisterSetupAction(Action<ICakeContext> action);
+        void RegisterSetupAction(Action<ISetupContext> action);
 
         /// <summary>
         /// Allows registration of an action that's executed before any tasks are run.
@@ -59,7 +59,7 @@ namespace Cake.Core
         /// </summary>
         /// <typeparam name="TData">The data type.</typeparam>
         /// <param name="action">The action to be executed.</param>
-        void RegisterSetupAction<TData>(Func<ICakeContext, TData> action) where TData : class;
+        void RegisterSetupAction<TData>(Func<ISetupContext, TData> action) where TData : class;
 
         /// <summary>
         /// Allows registration of an action that's executed after all other tasks have been run.

--- a/src/Cake.Core/IExecutionStrategy.cs
+++ b/src/Cake.Core/IExecutionStrategy.cs
@@ -17,7 +17,7 @@ namespace Cake.Core
         /// </summary>
         /// <param name="action">The action.</param>
         /// <param name="context">The context.</param>
-        void PerformSetup(Action<ICakeContext> action, ISetupContext context);
+        void PerformSetup(Action<ISetupContext> action, ISetupContext context);
 
         /// <summary>
         /// Performs the teardown.

--- a/src/Cake.Core/ISetupContext.cs
+++ b/src/Cake.Core/ISetupContext.cs
@@ -8,6 +8,11 @@ namespace Cake.Core
     public interface ISetupContext : ICakeContext
     {
         /// <summary>
+        /// Gets target / initating task.
+        /// </summary>
+        ICakeTaskInfo TargetTask { get; }
+
+        /// <summary>
         /// Gets all registered tasks that are going to be executed.
         /// </summary>
         IReadOnlyCollection<ICakeTaskInfo> TasksToExecute { get; }

--- a/src/Cake.Core/Scripting/IScriptHost.cs
+++ b/src/Cake.Core/Scripting/IScriptHost.cs
@@ -37,7 +37,7 @@ namespace Cake.Core.Scripting
         /// If setup fails, no tasks will be executed but teardown will be performed.
         /// </summary>
         /// <param name="action">The action to be executed.</param>
-        void Setup(Action<ICakeContext> action);
+        void Setup(Action<ISetupContext> action);
 
         /// <summary>
         /// Allows registration of an action that's executed before any tasks are run.
@@ -45,7 +45,7 @@ namespace Cake.Core.Scripting
         /// </summary>
         /// <param name="action">The action to be executed.</param>
         /// <typeparam name="TData">The data type.</typeparam>
-        void Setup<TData>(Func<ICakeContext, TData> action) where TData : class;
+        void Setup<TData>(Func<ISetupContext, TData> action) where TData : class;
 
         /// <summary>
         /// Allows registration of an action that's executed after all other tasks have been run.

--- a/src/Cake.Core/Scripting/ScriptHost.cs
+++ b/src/Cake.Core/Scripting/ScriptHost.cs
@@ -73,7 +73,7 @@ namespace Cake.Core.Scripting
         /// });
         /// </code>
         /// </example>
-        public void Setup(Action<ICakeContext> action)
+        public void Setup(Action<ISetupContext> action)
         {
             Engine.RegisterSetupAction(action);
         }
@@ -91,7 +91,7 @@ namespace Cake.Core.Scripting
         /// });
         /// </code>
         /// </example>
-        public void Setup<TData>(Func<ICakeContext, TData> action)
+        public void Setup<TData>(Func<ISetupContext, TData> action)
             where TData : class
         {
             Engine.RegisterSetupAction(action);

--- a/src/Cake.Core/SetupContext.cs
+++ b/src/Cake.Core/SetupContext.cs
@@ -9,6 +9,11 @@ namespace Cake.Core
     public sealed class SetupContext : CakeContextAdapter, ISetupContext
     {
         /// <summary>
+        /// Gets target / initating task.
+        /// </summary>
+        public ICakeTaskInfo TargetTask { get;  }
+
+        /// <summary>
         /// Gets all registered tasks that are going to be executed.
         /// </summary>
         public IReadOnlyCollection<ICakeTaskInfo> TasksToExecute { get; }
@@ -17,10 +22,14 @@ namespace Cake.Core
         /// Initializes a new instance of the <see cref="SetupContext"/> class.
         /// </summary>
         /// <param name="context">The Cake context.</param>
+        /// <param name="targetTask">The target / initating task.</param>
         /// <param name="tasksToExecute">The tasks to execute.</param>
-        public SetupContext(ICakeContext context, IEnumerable<ICakeTaskInfo> tasksToExecute)
+        public SetupContext(ICakeContext context,
+            ICakeTaskInfo targetTask,
+            IEnumerable<ICakeTaskInfo> tasksToExecute)
             : base(context)
         {
+            TargetTask = targetTask;
             TasksToExecute = new List<ICakeTaskInfo>(tasksToExecute ?? Array.Empty<ICakeTaskInfo>());
         }
     }

--- a/src/Cake/Scripting/DryRunExecutionStrategy.cs
+++ b/src/Cake/Scripting/DryRunExecutionStrategy.cs
@@ -20,7 +20,7 @@ namespace Cake.Scripting
             _counter = 1;
         }
 
-        public void PerformSetup(Action<ICakeContext> action, ISetupContext context)
+        public void PerformSetup(Action<ISetupContext> action, ISetupContext context)
         {
         }
 

--- a/tests/integration/setup.cake
+++ b/tests/integration/setup.cake
@@ -7,8 +7,18 @@
 // SETUP
 //////////////////////////////////////////////////
 
-Setup<ScriptContext>(ctx =>
+Setup<ScriptContext>(setupContext =>
 {
+    // Output information from setup task
+    setupContext.Log.Information(
+        Verbosity.Quiet,
+        "Performing setup initated by {0} ({1} tasks to be executed beginning with {2})",
+        setupContext.TargetTask?.Name,
+        setupContext.TasksToExecute?.Count,
+        setupContext.TasksToExecute?.Select(task => task.Name).FirstOrDefault()
+        );
+
+    // Perform artifact cleanup
     CleanDirectory(Paths.Temp);
 
     // Create a new script context.
@@ -43,6 +53,20 @@ Task("Can-Access-Typed-Data-With-Context-Async")
     await System.Threading.Tasks.Task.Delay(0);
 });
 
+Task("Can-Access-Typed-Data-WithCriteria-True")
+    .WithCriteria<ScriptContext>((data, context) => data.Initialized)
+    .Does<ScriptContext>(data => 
+{
+    Assert.True(data.Initialized);
+});
+
+Task("Can-Access-Typed-Data-WithCriteria-False-Message")
+    .WithCriteria<ScriptContext>((data, context) => !data.Initialized, "Should only run if not initialized.")
+    .Does<ScriptContext>(data => 
+{
+    Assert.False(data.Initialized);
+});
+
 //////////////////////////////////////////////////
 // TARGETS
 //////////////////////////////////////////////////
@@ -51,4 +75,6 @@ Task("Setup-Tests")
     .IsDependentOn("Can-Access-Typed-Data")
     .IsDependentOn("Can-Access-Typed-Data-Async")
     .IsDependentOn("Can-Access-Typed-Data-With-Context")
-    .IsDependentOn("Can-Access-Typed-Data-With-Context-Async");
+    .IsDependentOn("Can-Access-Typed-Data-With-Context-Async")
+    .IsDependentOn("Can-Access-Typed-Data-WithCriteria-True")
+    .IsDependentOn("Can-Access-Typed-Data-WithCriteria-False-Message");


### PR DESCRIPTION
* Relates to #2008, #1594 and #1772
* Changes Setup from `ICakeContext` to `ISetupContext`
* Adds target/initating task as `TargetTask` on `ISetupContext`
* Adds typed context `WithCriteria` `CakeTaskBuilder` extension methods
* Adds integration tests for `ISetupContext`/`TData` Setup and typed `WithCriteria`
