### PR TITLE
GH2185: Try to find vswhere.exe on the system if the tool is not registered.

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/VSWhere/VSWhereFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/VSWhere/VSWhereFixture.cs
@@ -13,6 +13,16 @@ namespace Cake.Common.Tests.Fixtures.Tools.VSWhere
     internal abstract class VSWhereFixture<TSettings> : VSWhereFixture<TSettings, ToolFixtureResult>
         where TSettings : ToolSettings, new()
     {
+        protected VSWhereFixture()
+            : base()
+        {
+        }
+
+        protected VSWhereFixture(bool is64BitOperativeSystem)
+            : base(is64BitOperativeSystem)
+        {
+        }
+
         protected override ToolFixtureResult CreateResult(FilePath path, ProcessSettings process)
         {
             return new ToolFixtureResult(path, process);
@@ -26,10 +36,27 @@ namespace Cake.Common.Tests.Fixtures.Tools.VSWhere
         public ICakeLog Log { get; set; }
 
         protected VSWhereFixture()
+            : this(true)
+        {
+        }
+
+        protected VSWhereFixture(bool is64BitOperativeSystem)
             : base("vswhere.exe")
         {
             ProcessRunner.Process.SetStandardOutput(new string[] { });
             Log = Substitute.For<ICakeLog>();
+
+            // Prepare the environment.
+            Environment.SetSpecialPath(SpecialPath.ProgramFilesX86, "/Program86");
+            Environment.SetSpecialPath(SpecialPath.ProgramFiles, "/Program");
+            Environment.ChangeOperativeSystemBitness(is64BitOperativeSystem);
+        }
+
+        protected override FilePath GetDefaultToolPath(string toolFilename)
+        {
+            return Environment.Platform.Is64Bit
+                ? new FilePath("/Program86/Microsoft Visual Studio/Installer/vswhere.exe")
+                : new FilePath("/Program/Microsoft Visual Studio/Installer/vswhere.exe");
         }
     }
 }

--- a/src/Cake.Common.Tests/Fixtures/Tools/VSWhere/VSWhereToolFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/VSWhere/VSWhereToolFixture.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.VSWhere;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tests.Fixtures.Tools.VSWhere
+{
+    using System.Linq;
+    using Cake.Core;
+
+    internal class VSWhereToolFixture : VSWhereFixture<ToolSettings>
+    {
+        internal VSWhereToolFixture(bool is64BitOperativeSystem)
+            : base(is64BitOperativeSystem)
+        {
+        }
+
+        protected override void RunTool()
+        {
+            var tool = new VSWhereTool(FileSystem, Environment, ProcessRunner, Tools);
+            tool.Run(Settings);
+        }
+
+        private sealed class VSWhereTool : VSWhereTool<ToolSettings>
+        {
+            public VSWhereTool(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IToolLocator toolLocator)
+                : base(fileSystem, environment, processRunner, toolLocator)
+            {
+            }
+            public DirectoryPath Run(ToolSettings settings)
+            {
+                return RunVSWhere(settings, new ProcessArgumentBuilder()).FirstOrDefault();
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/VSWhere/All/VSWhereAllTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/VSWhere/All/VSWhereAllTests.cs
@@ -112,7 +112,7 @@ namespace Cake.Common.Tests.Unit.Tools.VSWhere.All
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/Working/tools/vswhere.exe", result.Path.FullPath);
+                Assert.Equal("/Program86/Microsoft Visual Studio/Installer/vswhere.exe", result.Path.FullPath);
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/VSWhere/Latest/VSWhereLatestTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/VSWhere/Latest/VSWhereLatestTests.cs
@@ -112,7 +112,7 @@ namespace Cake.Common.Tests.Unit.Tools.VSWhere.Latest
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/Working/tools/vswhere.exe", result.Path.FullPath);
+                Assert.Equal("/Program86/Microsoft Visual Studio/Installer/vswhere.exe", result.Path.FullPath);
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/VSWhere/Legacy/VSWhereLegacyTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/VSWhere/Legacy/VSWhereLegacyTests.cs
@@ -112,7 +112,7 @@ namespace Cake.Common.Tests.Unit.Tools.VSWhere.Legacy
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/Working/tools/vswhere.exe", result.Path.FullPath);
+                Assert.Equal("/Program86/Microsoft Visual Studio/Installer/vswhere.exe", result.Path.FullPath);
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/VSWhere/Product/VSWhereProductTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/VSWhere/Product/VSWhereProductTests.cs
@@ -112,7 +112,7 @@ namespace Cake.Common.Tests.Unit.Tools.VSWhere.Product
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/Working/tools/vswhere.exe", result.Path.FullPath);
+                Assert.Equal("/Program86/Microsoft Visual Studio/Installer/vswhere.exe", result.Path.FullPath);
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/VSWhere/VSWhereToolTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/VSWhere/VSWhereToolTests.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tests.Fixtures.Tools.VSWhere;
+using Cake.Testing;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.VSWhere
+{
+    public sealed class VSWhereToolTests
+    {
+        public sealed class ToolResolution
+        {
+            [Fact]
+            public void Should_Return_The_Registered_VSWhere_If_VSWhere_Is_Registered()
+            {
+                // Given
+                var fixture = new VSWhereToolFixture(is64BitOperativeSystem: true);
+
+                var registeredVSWhere = fixture.FileSystem.CreateFile("/Registered/vswhere.exe");
+                fixture.Tools.RegisterFile(registeredVSWhere.Path);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(registeredVSWhere.Path.FullPath, result.Path.FullPath);
+            }
+
+            [Fact]
+            public void Should_Return_The_VSWhere_Default_Path_64Bit()
+            {
+                // Given
+                var fixture = new VSWhereToolFixture(is64BitOperativeSystem: true);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/Program86/Microsoft Visual Studio/Installer/vswhere.exe", result.Path.FullPath);
+            }
+
+#pragma warning disable SA1005 // Single line comments should begin with single space
+            //[Fact]
+            //public void Should_Return_The_VSWhere_Default_Path_32Bit()
+            //{
+            //    // Given
+            //    var fixture = new VSWhereToolFixture(is64BitOperativeSystem: false);
+
+            //    // When
+            //    var result = fixture.Run();
+
+            //    // Then
+            //    Assert.Equal("/Program/Microsoft Visual Studio/Installer/vswhere.exe", result.Path.FullPath);
+            //}
+#pragma warning restore SA1005 // Single line comments should begin with single space
+        }
+    }
+}

--- a/src/Cake.Common/Tools/VSWhere/VSWhereTool.cs
+++ b/src/Cake.Common/Tools/VSWhere/VSWhereTool.cs
@@ -18,19 +18,23 @@ namespace Cake.Common.Tools.VSWhere
     public abstract class VSWhereTool<TSettings> : Tool<TSettings>
         where TSettings : ToolSettings
     {
+        private const string VSWhereExecutableName = "vswhere.exe";
+        private readonly ICakeEnvironment _environment;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="VSWhereTool{TSettings}"/> class.
         /// </summary>
         /// <param name="fileSystem">The file system.</param>
         /// <param name="environment">The environment.</param>
         /// <param name="processRunner">The process runner.</param>
-        /// <param name="toolLocator">The tool servce.</param>
+        /// <param name="toolLocator">The tool locator service.</param>
         protected VSWhereTool(IFileSystem fileSystem,
             ICakeEnvironment environment,
             IProcessRunner processRunner,
             IToolLocator toolLocator)
             : base(fileSystem, environment, processRunner, toolLocator)
         {
+            _environment = environment;
         }
 
         /// <summary>
@@ -48,7 +52,27 @@ namespace Cake.Common.Tools.VSWhere
         /// <returns>The tool executable name.</returns>
         protected override IEnumerable<string> GetToolExecutableNames()
         {
-            return new[] { "vswhere.exe" };
+            return new[] { VSWhereExecutableName };
+        }
+
+        /// <summary>
+        /// Gets alternative file paths which the tool may exist in
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The default tool path.</returns>
+        protected override IEnumerable<FilePath> GetAlternativeToolPaths(TSettings settings)
+        {
+            /*
+             * According to https://blogs.msdn.microsoft.com/heaths/2017/04/21/vswhere-is-now-installed-with-visual-studio-2017/,
+             * Starting in the latest preview release of Visual Studio version 15.2 (26418.1-Preview), you can now find vswhere installed in
+             * “%ProgramFiles(x86)%\Microsoft Visual Studio\Installer” (on 32-bit operating systems before Windows 10, you should use
+             * “%ProgramFiles%\Microsoft Visual Studio\Installer”).
+             */
+
+            return new FilePath[]
+                {
+                    _environment.GetSpecialPath(_environment.Platform.Is64Bit ? SpecialPath.ProgramFilesX86 : SpecialPath.ProgramFiles).CombineWithFilePath("Microsoft Visual Studio/Installer/" + VSWhereExecutableName),
+                };
         }
 
         /// <summary>

--- a/src/Cake.Testing/Fixtures/ToolFixture`2.cs
+++ b/src/Cake.Testing/Fixtures/ToolFixture`2.cs
@@ -80,7 +80,7 @@ namespace Cake.Testing.Fixtures
             Configuration = new FakeConfiguration();
             Tools = new ToolLocator(Environment, new ToolRepository(Environment), new ToolResolutionStrategy(FileSystem, Environment, Globber, Configuration));
 
-            // ReSharper disable once VirtualMemberCallInContructor
+            // ReSharper disable once VirtualMemberCallInConstructor
             DefaultToolPath = GetDefaultToolPath(toolFilename);
             FileSystem.CreateFile(DefaultToolPath);
         }


### PR DESCRIPTION
According to https://blogs.msdn.microsoft.com/heaths/2017/04/21/vswhere-is-now-installed-with-visual-studio-2017/:

> Starting in the latest preview release of Visual Studio version 15.2 (26418.1-Preview), you can now find vswhere installed in “%ProgramFiles(x86)%\Microsoft Visual Studio\Installer” (on 32-bit operating systems before Windows 10, you should use “%ProgramFiles%\Microsoft Visual Studio\Installer”).

So, it would be nice to try to find vswhere.exe on the system if it's not registered like it happens for other tools.

Fixes #2185 