### PR TITLE
Updated the WiX tool documentation

### DIFF
--- a/src/Cake.Common/Tools/WiX/WiXAliases.cs
+++ b/src/Cake.Common/Tools/WiX/WiXAliases.cs
@@ -19,7 +19,7 @@ namespace Cake.Common.Tools.WiX
     /// In order to use the commands for this alias, include the following in your build.cake file to download and
     /// install from NuGet.org, or specify the ToolPath within the appropriate settings class:
     /// <code>
-    /// #tool "nuget:?package=WiX.Toolset"
+    /// #tool "nuget:?package=WiX"
     /// </code>
     /// </para>
     /// </summary>


### PR DESCRIPTION
This is a small change to the documentation for the WiX tool.

Previously the recommended tool in the docs was the WiX.Toolset owned by akoeplinger but I've changed this to the WiX package owned by kzu.

The other day I ran into a problem while I was writing a cake script. I was struggling to understand why my WiX installer was building from the command line but failing to build with cake. The problem turned out to be that I was using an old version of WiX package.

The problem is that the WiX.Toolset package was last updated in early 2015 and only goes up to version 3.9. The kzu WiX package on the other hand has the most recent versions of the package and was updated just 5 months ago (only a couple of weeks after the last official release of WiX).

akoeplinger only has one package upload on NuGet.
kzu maintains 237 packages and seems to keep them up to date.

So it seems to me that it would be better to recommend people use the more maintained package all else being equal.

I have tested the WiX package in my own cake script and compared the package contents side by side. There are some differences in the folder structure of the packages but as far as I can tell it will work with cake scripts just fine.