### PR TITLE
GH1401: Support for DotCover configuration file added

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotCover/Analyse/DotCoverAnalyserTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotCover/Analyse/DotCoverAnalyserTests.cs
@@ -295,6 +295,22 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Analyse
                              "/TargetArguments=\"\\\"/Working/Test.dll\\\" -noshadow\" " +
                              "/Output=\"/Working/result.xml\"", result.Args);
             }
+
+            [Fact]
+            public void Should_Append_ConfigurationFile()
+            {
+                // Given
+                var fixture = new DotCoverAnalyserFixture();
+                fixture.Settings.WithConfigFile(new FilePath("./config.xml"));
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("Analyse \"/Working/config.xml\" /TargetExecutable=\"/Working/tools/Test.exe\" " +
+                             "/TargetArguments=\"-argument\" " +
+                             "/Output=\"/Working/result.xml\"", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/DotCover/Cover/DotCoverCovererTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotCover/Cover/DotCoverCovererTests.cs
@@ -275,6 +275,22 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                              "/TargetArguments=\"\\\"/Working/Test.dll\\\" -noshadow\" " +
                              "/Output=\"/Working/result.dcvr\"", result.Args);
             }
+
+            [Fact]
+            public void Should_Append_ConfigurationFile()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.WithConfigFile(new FilePath("./config.xml"));
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("Cover \"/Working/config.xml\" /TargetExecutable=\"/Working/tools/Test.exe\" " +
+                             "/TargetArguments=\"-argument\" " +
+                             "/Output=\"/Working/result.dcvr\"", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/DotCover/Merge/DotCoverMergerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotCover/Merge/DotCoverMergerTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using Cake.Common.Tests.Fixtures.Tools.DotCover.Merge;
+using Cake.Common.Tools.DotCover;
 using Cake.Core.IO;
 using Xunit;
 
@@ -84,6 +85,22 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Merge
                              "/Source=\"/Working/result1.dcvr;/Working/result2.dcvr\" " +
                              "/Output=\"/Working/result.dcvr\" " +
                              "/LogFile=\"/Working/logfile.log\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_ConfigurationFile()
+            {
+                // Given
+                var fixture = new DotCoverMergerFixture();
+                fixture.Settings.WithConfigFile(new FilePath("./config.xml"));
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("Merge \"/Working/config.xml\" " +
+                             "/Source=\"/Working/result1.dcvr;/Working/result2.dcvr\" " +
+                             "/Output=\"/Working/result.dcvr\"", result.Args);
             }
         }
     }

--- a/src/Cake.Common.Tests/Unit/Tools/DotCover/Report/DotCoverReporterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotCover/Report/DotCoverReporterTests.cs
@@ -4,10 +4,7 @@
 
 using Cake.Common.Tests.Fixtures.Tools.DotCover.Report;
 using Cake.Common.Tools.DotCover;
-using Cake.Common.Tools.NUnit;
-using Cake.Common.Tools.XUnit;
 using Cake.Core.IO;
-using Cake.Testing;
 using Xunit;
 
 namespace Cake.Common.Tests.Unit.Tools.DotCover.Report
@@ -94,6 +91,22 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Report
                              "/Source=\"/Working/result.dcvr\" " +
                              "/Output=\"/Working/result.xml\" " +
                              "/LogFile=\"/Working/logfile.log\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_ConfigurationFile()
+            {
+                // Given
+                var fixture = new DotCoverReporterFixture();
+                fixture.Settings.WithConfigFile(new FilePath("./config.xml"));
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("Report \"/Working/config.xml\" " +
+                             "/Source=\"/Working/result.dcvr\" " +
+                             "/Output=\"/Working/result.xml\"", result.Args);
             }
         }
     }

--- a/src/Cake.Common/Tools/DotCover/Analyse/DotCoverAnalyser.cs
+++ b/src/Cake.Common/Tools/DotCover/Analyse/DotCoverAnalyser.cs
@@ -75,6 +75,9 @@ namespace Cake.Common.Tools.DotCover.Analyse
 
             builder.Append("Analyse");
 
+            // Set configuration file if exists.
+            GetConfigurationFileArgument(settings).CopyTo(builder);
+
             // Get Target executable arguments
             GetTargetArguments(context, action).CopyTo(builder);
 

--- a/src/Cake.Common/Tools/DotCover/Cover/DotCoverCoverer.cs
+++ b/src/Cake.Common/Tools/DotCover/Cover/DotCoverCoverer.cs
@@ -75,6 +75,9 @@ namespace Cake.Common.Tools.DotCover.Cover
 
             builder.Append("Cover");
 
+            // Set configuration file if exists.
+            GetConfigurationFileArgument(settings).CopyTo(builder);
+
             // Get Target executable arguments
             GetTargetArguments(context, action).CopyTo(builder);
 

--- a/src/Cake.Common/Tools/DotCover/DotCoverSettings.cs
+++ b/src/Cake.Common/Tools/DotCover/DotCoverSettings.cs
@@ -17,5 +17,12 @@ namespace Cake.Common.Tools.DotCover
         /// This represents the <c>/LogFile</c> option.
         /// </summary>
         public FilePath LogFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that enables DotCover configuration file.
+        /// A configuration file is a reasonable alternative
+        /// to specifying all parameters in-line or having them in a batch file.
+        /// </summary>
+        public FilePath ConfigFile { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotCover/DotCoverSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/DotCover/DotCoverSettingsExtensions.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotCover
+{
+    /// <summary>
+    /// Contains extensions for <see cref="DotCoverSettings"/>.
+    /// </summary>
+    public static class DotCoverSettingsExtensions
+    {
+        /// <summary>
+        /// Adds the scope.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="configFile">The DotCover configuration file.</param>
+        /// <typeparam name="T">The settings type, derived from <see cref="DotCoverSettings"/></typeparam>
+        /// <returns>The same <see cref="DotCoverSettings"/> instance so that multiple calls can be chained.</returns>
+        public static T WithConfigFile<T>(this T settings, FilePath configFile)
+            where T : DotCoverSettings
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            settings.ConfigFile = configFile;
+            return settings;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotCover/DotCoverTool.cs
+++ b/src/Cake.Common/Tools/DotCover/DotCoverTool.cs
@@ -70,5 +70,22 @@ namespace Cake.Common.Tools.DotCover
 
             return builder;
         }
+
+        /// <summary>
+        /// Get configuration full path from coverage settings
+        /// </summary>
+        /// <param name="settings">The settings</param>
+        /// <returns>The process arguments</returns>
+        protected ProcessArgumentBuilder GetConfigurationFileArgument(DotCoverSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            if (settings.ConfigFile != null)
+            {
+                builder.AppendQuoted(settings.ConfigFile.MakeAbsolute(_environment).FullPath);
+            }
+
+            return builder;
+        }
     }
 }

--- a/src/Cake.Common/Tools/DotCover/Merge/DotCoverMerger.cs
+++ b/src/Cake.Common/Tools/DotCover/Merge/DotCoverMerger.cs
@@ -71,6 +71,9 @@ namespace Cake.Common.Tools.DotCover.Merge
 
             builder.Append("Merge");
 
+            // Set configuration file if exists.
+            GetConfigurationFileArgument(settings).CopyTo(builder);
+
             // Set the Source files.
             var source = string.Join(";", sourceFiles.Select(s => s.MakeAbsolute(_environment).FullPath));
             builder.AppendSwitch("/Source", "=", source.Quote());

--- a/src/Cake.Common/Tools/DotCover/Report/DotCoverReporter.cs
+++ b/src/Cake.Common/Tools/DotCover/Report/DotCoverReporter.cs
@@ -69,6 +69,9 @@ namespace Cake.Common.Tools.DotCover.Report
 
             builder.Append("Report");
 
+            // Set configuration file if exists.
+            GetConfigurationFileArgument(settings).CopyTo(builder);
+
             // Set the Source file.
             sourceFile = sourceFile.MakeAbsolute(_environment);
             builder.AppendSwitch("/Source", "=", sourceFile.FullPath.Quote());


### PR DESCRIPTION
Support for DotCover configuration file added (now properly rebased).
Based on documentation for "cover" command
https://www.jetbrains.com/help/dotcover/dotCover__Console_Runner_Commands.html
"
It is possible to specify part of the parameters or all of them in the configuration file.
usage: dotCover cover <configuration file name> [parameters]
"
configuration file name should be right after command

fixes #1401.