### PR TITLE
GH2234: Removed Mono from CakeOption

### DIFF
--- a/src/Cake.Tests/Unit/Arguments/ArgumentParserTests.cs
+++ b/src/Cake.Tests/Unit/Arguments/ArgumentParserTests.cs
@@ -321,23 +321,6 @@ namespace Cake.Tests.Unit.Arguments
                     // Then
                     Assert.Equal(expected, result.PerformDebug);
                 }
-
-                [Theory]
-                [InlineData("-mono", true)]
-                [InlineData("-mono=true", true)]
-                [InlineData("-mono=false", false)]
-                public void Can_Parse_Mono(string input, bool expected)
-                {
-                    // Given
-                    var fixture = new ArgumentParserFixture();
-                    var parser = new ArgumentParser(fixture.Log, fixture.VerbosityParser);
-
-                    // When
-                    var result = parser.Parse(new[] { "build.cake", input });
-
-                    // Then
-                    Assert.Equal(expected, result.Mono);
-                }
             }
 
             public sealed class WithTwoDashLongArguments
@@ -545,23 +528,6 @@ namespace Cake.Tests.Unit.Arguments
 
                     // Then
                     Assert.Equal(expected, result.PerformDebug);
-                }
-
-                [Theory]
-                [InlineData("--mono", true)]
-                [InlineData("--mono=true", true)]
-                [InlineData("--mono=false", false)]
-                public void Can_Parse_Mono(string input, bool expected)
-                {
-                    // Given
-                    var fixture = new ArgumentParserFixture();
-                    var parser = new ArgumentParser(fixture.Log, fixture.VerbosityParser);
-
-                    // When
-                    var result = parser.Parse(new[] { "build.cake", input });
-
-                    // Then
-                    Assert.Equal(expected, result.Mono);
                 }
 
                 [Theory]

--- a/src/Cake/Arguments/ArgumentParser.cs
+++ b/src/Cake/Arguments/ArgumentParser.cs
@@ -166,11 +166,6 @@ namespace Cake.Arguments
                 options.PerformDebug = ParseBooleanValue(value);
             }
 
-            if (name.Equals("mono", StringComparison.OrdinalIgnoreCase))
-            {
-                options.Mono = ParseBooleanValue(value);
-            }
-
             if (name.Equals("bootstrap", StringComparison.OrdinalIgnoreCase))
             {
                 options.Bootstrap = ParseBooleanValue(value);

--- a/src/Cake/CakeOptions.cs
+++ b/src/Cake/CakeOptions.cs
@@ -83,14 +83,6 @@ namespace Cake
         public bool HasError { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to use the Mono compiler or not.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if the mono compiler should be used; otherwise, <c>false</c>.
-        /// </value>
-        public bool Mono { get; set; }
-
-        /// <summary>
         /// Gets or sets a value indicating whether to bootstrap Cake modules.
         /// </summary>
         public bool Bootstrap { get; set; }

--- a/src/Cake/Modules/ScriptingModule.cs
+++ b/src/Cake/Modules/ScriptingModule.cs
@@ -28,12 +28,6 @@ namespace Cake.Modules
                 throw new ArgumentNullException(nameof(registrar));
             }
 
-            if (_options.Mono)
-            {
-                _log.Warning("The Mono script engine has been removed so the expected behavior might differ. " +
-                    "See Release Notes for Cake 0.22.0 for more information.");
-            }
-
             registrar.RegisterType<RoslynScriptEngine>().As<IScriptEngine>().Singleton();
         }
     }


### PR DESCRIPTION
Fixes #2234 

Removed the Mono property from CakeOptions, and then removed all usages of it.