### PR TITLE
GH2232: Document exclusive argument

### DIFF
--- a/src/Cake/Commands/HelpCommand.cs
+++ b/src/Cake/Commands/HelpCommand.cs
@@ -46,6 +46,7 @@ namespace Cake.Commands
                 _console.WriteLine("    --debug              Performs a debug.");
                 _console.WriteLine("    --showdescription    Shows description about tasks.");
                 _console.WriteLine("    --dryrun             Performs a dry run.");
+                _console.WriteLine("    --exclusive          Execute a single task without any dependencies.");
                 _console.WriteLine("    --version            Displays version information.");
                 _console.WriteLine("    --help               Displays usage information.");
                 _console.WriteLine();


### PR DESCRIPTION
Fixes #2232 

Adds documentation for exclusive command line argument which can be passed to Cake.