### PR TITLE
GH2243: Improve DotNetCoreVSTest with ResultsDirectory

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/VSTest/DotNetCoreVSTesterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/VSTest/DotNetCoreVSTesterTests.cs
@@ -329,6 +329,26 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.VSTest
             }
 
             [Fact]
+            public void Should_Add_ResultsDirectory_Argument()
+            {
+                // Given
+                var fixture = new DotNetCoreVSTesterFixture
+                {
+                    TestFiles = new[] { (FilePath)"./test/unit.tests.csproj" },
+                    Settings = new DotNetCoreVSTestSettings
+                    {
+                        ResultsDirectory = "./artifacts/TestResults"
+                    }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("vstest \"/Working/test/unit.tests.csproj\" --ResultsDirectory:\"/Working/artifacts/TestResults\"", result.Args);
+            }
+
+            [Fact]
             public void Should_Add_Extra_Argument()
             {
                 // Given
@@ -349,7 +369,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.VSTest
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("vstest \"/Working/test/unit.tests.csproj\" Arg1=\"Value1\" Arg2=\"Value2\"", result.Args);
+                Assert.Equal("vstest \"/Working/test/unit.tests.csproj\" Arg1:\"Value1\" Arg2:\"Value2\"", result.Args);
             }
 
             [Fact]

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -951,11 +951,11 @@ namespace Cake.Common.Tools.DotNetCore
         /// <example>
         /// <para>Specify the path to the .csproj file in the test project</para>
         /// <code>
-        ///     DotNetCoreTest("./test/Project.Tests/Project.Tests.csproj");
+        ///     DotNetCoreVSTest("./test/Project.Tests/bin/Release/netcoreapp2.1/Project.Tests.dll");
         /// </code>
         /// <para>You could also specify a glob pattern to run multiple test projects.</para>
         /// <code>
-        ///     DotNetCoreTest("./**/*.Tests.csproj");
+        ///     DotNetCoreVSTest("./**/bin/Release/netcoreapp2.1/*.Tests.dll");
         /// </code>
         /// </example>
         [CakeMethodAlias]
@@ -972,24 +972,24 @@ namespace Cake.Common.Tools.DotNetCore
         /// <example>
         /// <para>Specify the path to the .csproj file in the test project</para>
         /// <code>
-        ///     var settings = new DotNetCoreTestSettings
+        ///     var settings = new DotNetCoreVSTestSettings
         ///     {
         ///         Framework = "FrameworkCore10",
         ///         Platform = "x64"
         ///     };
         ///
-        ///     DotNetCoreTest("./test/Project.Tests/Project.Tests.csproj", settings);
+        ///     DotNetCoreTest("./test/Project.Tests/bin/Release/netcoreapp2.1/Project.Tests.dll", settings);
         /// </code>
         /// <para>You could also specify a glob pattern to run multiple test projects.</para>
         /// <code>
-        ///     var settings = new DotNetCoreTestSettings
+        ///     var settings = new DotNetCoreVSTestSettings
         ///     {
         ///         Framework = "FrameworkCore10",
         ///         Platform = "x64",
         ///         Parallel = true
         ///     };
         ///
-        ///     DotNetCoreTest("./**/*.Tests.csproj", settings);
+        ///     DotNetCoreVSTest("./**/bin/Release/netcoreapp2.1/*.Tests.dll", settings);
         /// </code>
         /// </example>
         [CakeMethodAlias]
@@ -1010,13 +1010,13 @@ namespace Cake.Common.Tools.DotNetCore
         /// <param name="settings">The settings.</param>
         /// <example>
         /// <code>
-        ///     var settings = new DotNetCoreTestSettings
+        ///     var settings = new DotNetCoreVSTestSettings
         ///     {
         ///         Framework = "FrameworkCore10",
         ///         Platform = "x64"
         ///     };
         ///
-        ///     DotNetCoreTest(new[] { (FilePath)"./Test/Cake.Common.Tests.csproj" }, settings);
+        ///     DotNetCoreVSTest(new[] { (FilePath)"./test/Project.Tests/bin/Release/netcoreapp2.1/Project.Tests.dll" }, settings);
         /// </code>
         /// <para>You could also specify a task that runs multiple test projects.</para>
         /// <para>Cake task:</para>
@@ -1024,16 +1024,16 @@ namespace Cake.Common.Tools.DotNetCore
         /// Task("Test")
         ///     .Does(() =>
         /// {
-        ///     var settings = new DotNetCoreTestSettings
+        ///     var settings = new DotNetCoreVSTestSettings
         ///     {
         ///         Framework = "FrameworkCore10",
         ///         Platform = "x64",
         ///         Parallel = true
         ///     };
         ///
-        ///     var projectFiles = GetFiles("./test/**/*.csproj");
+        ///     var testFiles = GetFiles("./test/**/bin/Release/netcoreapp2.1/*.Test.dll");
         ///
-        ///     DotNetCoreTest(projectFiles, settings);
+        ///     DotNetCoreVSTest(testFiles, settings);
         /// });
         /// </code>
         /// </example>

--- a/src/Cake.Common/Tools/DotNetCore/VSTest/DotNetCoreVSTestSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/VSTest/DotNetCoreVSTestSettings.cs
@@ -79,6 +79,11 @@ namespace Cake.Common.Tools.DotNetCore.VSTest
         public FilePath DiagnosticFile { get; set; }
 
         /// <summary>
+        /// Gets or sets the path to put the test results in.
+        /// </summary>
+        public DirectoryPath ResultsDirectory { get; set; }
+
+        /// <summary>
         /// Gets or sets a list of extra arguments that should be passed to adapter.
         /// </summary>
         public IDictionary<string, string> Arguments { get; set; }

--- a/src/Cake.Common/Tools/DotNetCore/VSTest/DotNetCoreVSTester.cs
+++ b/src/Cake.Common/Tools/DotNetCore/VSTest/DotNetCoreVSTester.cs
@@ -133,10 +133,16 @@ namespace Cake.Common.Tools.DotNetCore.VSTest
                 builder.AppendSwitchQuoted("--Diag", ":", settings.DiagnosticFile.MakeAbsolute(_environment).FullPath);
             }
 
+            // Path to output test results
+            if (settings.ResultsDirectory != null)
+            {
+                builder.AppendSwitchQuoted("--ResultsDirectory", ":", settings.ResultsDirectory.MakeAbsolute(_environment).FullPath);
+            }
+
             // Extra arguments
             foreach (var argument in settings.Arguments)
             {
-                builder.AppendSwitchQuoted(argument.Key, "=", argument.Value);
+                builder.AppendSwitchQuoted(argument.Key, ":", argument.Value);
             }
 
             return builder;


### PR DESCRIPTION
This PR contains some improvements to DotNetCoreVSTest and issue #2243

- Improved documentation which reflex the capability of `dotnet vstest` as it should be assembly based and not project based.
- Add support to specify the ResultsDirectory to specify where to store the test results.
