### PR TITLE
Prevent old versions of tool to be used

### DIFF
--- a/src/Cake.Core.Tests/Unit/Tooling/ToolResolutionStrategyTests.cs
+++ b/src/Cake.Core.Tests/Unit/Tooling/ToolResolutionStrategyTests.cs
@@ -149,7 +149,7 @@ namespace Cake.Core.Tests.Unit.Tooling
                 var result = Record.Exception(() => fixture.Resolve("tool.exe"));
 
                 // Then
-                AssertEx.IsCakeException(result, "Multiple tools of the same name is detected");
+                AssertEx.IsCakeException(result, "Found multiple versions of tool.exe");
             }
 
             [Fact]

--- a/src/Cake.Core.Tests/Unit/Tooling/ToolResolutionStrategyTests.cs
+++ b/src/Cake.Core.Tests/Unit/Tooling/ToolResolutionStrategyTests.cs
@@ -138,6 +138,21 @@ namespace Cake.Core.Tests.Unit.Tooling
             }
 
             [Fact]
+            public void Should_Throw_If_Multiple_Tools_With_Same_Name_Is_Detected()
+            {
+                // Given
+                var fixture = new ToolResolutionStrategyFixture();
+                fixture.FileSystem.CreateFile("/Working/tools/Tool.1.0.0/tool.exe");
+                fixture.FileSystem.CreateFile("/Working/tools/Tool.2.0.0/tool.exe");
+
+                // When
+                var result = Record.Exception(() => fixture.Resolve("tool.exe"));
+
+                // Then
+                AssertEx.IsCakeException(result, "Multiple tools of the same name is detected");
+            }
+
+            [Fact]
             public void Should_Resolve_Tool_From_Tools_Directory_Specified_In_Configuration_If_Not_Present_In_Repository()
             {
                 // Given

--- a/src/Cake.Core/Tooling/ToolResolutionStrategy.cs
+++ b/src/Cake.Core/Tooling/ToolResolutionStrategy.cs
@@ -104,10 +104,11 @@ namespace Cake.Core.Tooling
             var pattern = string.Concat(GetToolsDirectory().FullPath, "/**/", tool);
             var toolPaths = _globber.GetFiles(pattern).ToList();
 
-            if (toolPaths.Count() > 1) {
+            if (toolPaths.Count() > 1)
+            {
                 throw new CakeException($"Found multiple versions of {tool}");
             }
-            
+
             return toolPaths.SingleOrDefault()?.MakeAbsolute(_environment);
         }
 

--- a/src/Cake.Core/Tooling/ToolResolutionStrategy.cs
+++ b/src/Cake.Core/Tooling/ToolResolutionStrategy.cs
@@ -105,7 +105,7 @@ namespace Cake.Core.Tooling
             var toolPaths = _globber.GetFiles(pattern).ToList();
 
             if (toolPaths.Count() > 1) {
-                throw new CakeException("Multiple tools of the same name is detected");
+                throw new CakeException($"Found multiple versions of {tool}");
             }
             
             return toolPaths.SingleOrDefault()?.MakeAbsolute(_environment);

--- a/src/Cake.Core/Tooling/ToolResolutionStrategy.cs
+++ b/src/Cake.Core/Tooling/ToolResolutionStrategy.cs
@@ -102,8 +102,13 @@ namespace Cake.Core.Tooling
         private FilePath LookInToolsDirectory(string tool)
         {
             var pattern = string.Concat(GetToolsDirectory().FullPath, "/**/", tool);
-            var toolPath = _globber.GetFiles(pattern).FirstOrDefault();
-            return toolPath?.MakeAbsolute(_environment);
+            var toolPaths = _globber.GetFiles(pattern).ToList();
+
+            if (toolPaths.Count() > 1) {
+                throw new CakeException("Multiple tools of the same name is detected");
+            }
+            
+            return toolPaths.SingleOrDefault()?.MakeAbsolute(_environment);
         }
 
         private FilePath LookInPath(string tool)


### PR DESCRIPTION
Throw exception in In ToolResolutionStrategy.Resolve when multiple tools are found, to
prevent that we use an outdated version of a tool

This is the simplest fix I could find for #2280 - I'm a little unsure if CakeException is the correct thing to throw, so any advice is appreciated.