### PR TITLE
GH2286: Adds .NET Core Build Server Shutdown Alias

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/DotNetCore/BuildServer/DotNetCoreBuildServerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/DotNetCore/BuildServer/DotNetCoreBuildServerFixture.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNetCore.BuildServer;
+
+namespace Cake.Common.Tests.Fixtures.Tools.DotNetCore.Build
+{
+    internal sealed class DotNetCoreBuildServerFixture : DotNetCoreFixture<DotNetCoreBuildServerSettings>
+    {
+        protected override void RunTool()
+        {
+            var tool = new DotNetCoreBuildServer(FileSystem, Environment, ProcessRunner, Tools);
+            tool.Shutdown(Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/BuildServer/DotNetCoreBuildServerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/BuildServer/DotNetCoreBuildServerTests.cs
@@ -1,0 +1,108 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tests.Fixtures.Tools.DotNetCore.Build;
+using Cake.Common.Tools.DotNetCore;
+using Cake.Common.Tools.DotNetCore.BuildServer;
+using Cake.Testing;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.DotNetCore.BuildServer
+{
+    public sealed class DotNetCoreBuildServerTests
+    {
+        public sealed class TheShutdownMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new DotNetCoreBuildServerFixture();
+                fixture.Settings = null;
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new DotNetCoreBuildServerFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new DotNetCoreBuildServerFixture();
+                fixture.GivenProcessExitsWithCode(1);
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new DotNetCoreBuildServerFixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("build-server shutdown", result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, null, null, "build-server shutdown --msbuild")]
+            [InlineData(null, true, null, "build-server shutdown --razor")]
+            [InlineData(null, null, true, "build-server shutdown --vbcscompiler")]
+            [InlineData(true, true, true, "build-server shutdown --msbuild --razor --vbcscompiler")]
+            public void Should_Add_Settings_Arguments(bool? msBuild, bool? razor, bool? vbcscompiler, string expected)
+            {
+                // Given
+                var fixture = new DotNetCoreBuildServerFixture();
+                fixture.Settings.MSBuild = msBuild;
+                fixture.Settings.Razor = razor;
+                fixture.Settings.VBCSCompiler = vbcscompiler;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Host_Arguments()
+            {
+                // Given
+                var fixture = new DotNetCoreBuildServerFixture();
+                fixture.Settings.DiagnosticOutput = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("--diagnostics build-server shutdown", result.Args);
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/BuildServer/DotNetCoreBuildServer.cs
+++ b/src/Cake.Common/Tools/DotNetCore/BuildServer/DotNetCoreBuildServer.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.DotNetCore.BuildServer
+{
+    /// <summary>
+    /// .NET Core project builder.
+    /// </summary>
+    public sealed class DotNetCoreBuildServer : DotNetCoreTool<DotNetCoreBuildServerSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotNetCoreBuildServer" /> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="tools">The tool locator.</param>
+        public DotNetCoreBuildServer(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IToolLocator tools) : base(fileSystem, environment, processRunner, tools)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Build the project using the specified path and settings.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        public void Shutdown(DotNetCoreBuildServerSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            RunCommand(settings, GetArguments(settings));
+        }
+
+        private ProcessArgumentBuilder GetArguments(DotNetCoreBuildServerSettings settings)
+        {
+            var builder = CreateArgumentBuilder(settings);
+
+            builder.Append("build-server");
+            builder.Append("shutdown");
+
+            if (settings.MSBuild ?? false)
+            {
+                builder.Append("--msbuild");
+            }
+
+            if (settings.Razor ?? false)
+            {
+                builder.Append("--razor");
+            }
+
+            if (settings.VBCSCompiler ?? false)
+            {
+                builder.Append("--vbcscompiler");
+            }
+
+            return builder;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/BuildServer/DotNetCoreBuildServerSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/BuildServer/DotNetCoreBuildServerSettings.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Tools.DotNetCore.BuildServer
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetCoreBuildServer" />.
+    /// </summary>
+    public sealed class DotNetCoreBuildServerSettings : DotNetCoreSettings
+    {
+        /// <summary>
+        /// Gets or sets if to shuts down the MSBuild build server.
+        /// </summary>
+        public bool? MSBuild { get; set; }
+
+        /// <summary>
+        /// Gets or sets if to shuts down the the Razor build server.
+        /// </summary>
+        public bool? Razor { get; set; }
+
+        /// <summary>
+        /// Gets or sets if to shuts down the VB/C# compiler build server.
+        /// </summary>
+        public bool? VBCSCompiler { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using Cake.Common.IO;
 using Cake.Common.Tools.DotNetCore.Build;
+using Cake.Common.Tools.DotNetCore.BuildServer;
 using Cake.Common.Tools.DotNetCore.Clean;
 using Cake.Common.Tools.DotNetCore.Execute;
 using Cake.Common.Tools.DotNetCore.MSBuild;
@@ -1135,6 +1136,51 @@ namespace Cake.Common.Tools.DotNetCore
             var runner = new DotNetCoreToolRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
 
             runner.Execute(projectPath, command, arguments, settings);
+        }
+
+        /// <summary>
+        /// Shuts down build servers that are started from dotnet.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <example>
+        /// <code>
+        ///     DotNetCoreBuildServerShutdown();
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Build Server")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.BuildServer")]
+        public static void DotNetCoreBuildServerShutdown(this ICakeContext context)
+        {
+            context.DotNetCoreBuildServerShutdown(null);
+        }
+
+        /// <summary>
+        /// Shuts down build servers that are started from dotnet.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        ///     DotNetCoreBuildServerShutdown(
+        ///         new DotNetCoreBuildServerSettings {
+        ///             MSBuild = true
+        ///         });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Build Server")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.BuildServer")]
+        public static void DotNetCoreBuildServerShutdown(this ICakeContext context, DotNetCoreBuildServerSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var buildServer = new DotNetCoreBuildServer(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+
+            buildServer.Shutdown(settings ?? new DotNetCoreBuildServerSettings());
         }
     }
 }

--- a/tests/integration/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cake
+++ b/tests/integration/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cake
@@ -147,7 +147,8 @@ Task("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreTest.Fail")
     Assert.Equal(exception.Message, ".NET Core CLI: Process returned an error (exit code 1).");
 });
 
-Task("Cake.Common.Tools.DotNetCore.DotNetCoreAliases")
+
+Task("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreBuildServerShutdown")
     .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreRestore")
     .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreBuild")
     .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreTest")
@@ -155,4 +156,12 @@ Task("Cake.Common.Tools.DotNetCore.DotNetCoreAliases")
     .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCorePack")
     .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCorePublish")
     .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreExecute")
-    .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreTest.Fail");
+    .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreTest.Fail")
+    .Does(() =>
+{
+    // When
+    DotNetCoreBuildServerShutdown();
+});;
+
+Task("Cake.Common.Tools.DotNetCore.DotNetCoreAliases")
+    .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreBuildServerShutdown");


### PR DESCRIPTION
Example shutdown all
```cake
DotNetCoreBuildServerShutdown();
```

Example shutdown just MSBuild
```cake
DotNetCoreBuildServerShutdown(
    new DotNetCoreBuildServerSettings {
        MSBuild = true
    });
```

* fixes #2286