### PR TITLE
GH2284: Version command display SemVer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ Thumbs.db
 
 # Mac
 .DS_Store
+
+# Generated Assembly info
+AssemblyInfo.Generated.cs

--- a/src/Cake.Common.Tests/Properties/AssemblyInfo.cs
+++ b/src/Cake.Common.Tests/Properties/AssemblyInfo.cs
@@ -9,7 +9,6 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cake.Common.Tests")]
-[assembly: AssemblyDescription("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/Cake.Common/Properties/AssemblyInfo.cs
+++ b/src/Cake.Common/Properties/AssemblyInfo.cs
@@ -11,7 +11,6 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cake.Common")]
-[assembly: AssemblyDescription("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/Cake.Core.Tests/Properties/AssemblyInfo.cs
+++ b/src/Cake.Core.Tests/Properties/AssemblyInfo.cs
@@ -9,7 +9,6 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cake.Tests")]
-[assembly: AssemblyDescription("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/Cake.Core/Properties/AssemblyInfo.cs
+++ b/src/Cake.Core/Properties/AssemblyInfo.cs
@@ -11,7 +11,6 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cake.Core")]
-[assembly: AssemblyDescription("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/Cake.NuGet.Tests/Properties/AssemblyInfo.cs
+++ b/src/Cake.NuGet.Tests/Properties/AssemblyInfo.cs
@@ -9,7 +9,6 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cake.NuGet.Tests")]
-[assembly: AssemblyDescription("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/Cake.NuGet/Properties/AssemblyInfo.cs
+++ b/src/Cake.NuGet/Properties/AssemblyInfo.cs
@@ -11,7 +11,6 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cake.NuGet")]
-[assembly: AssemblyDescription("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/Cake.Testing.Xunit/Properties/AssemblyInfo.cs
+++ b/src/Cake.Testing.Xunit/Properties/AssemblyInfo.cs
@@ -9,7 +9,6 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cake.Testing.Xunit")]
-[assembly: AssemblyDescription("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/Cake.Testing/Properties/AssemblyInfo.cs
+++ b/src/Cake.Testing/Properties/AssemblyInfo.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cake.Testing")]
-[assembly: AssemblyDescription("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/Cake.Tests/Properties/AssemblyInfo.cs
+++ b/src/Cake.Tests/Properties/AssemblyInfo.cs
@@ -9,7 +9,6 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cake.Tests")]
-[assembly: AssemblyDescription("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/Cake/Commands/VersionCommand.cs
+++ b/src/Cake/Commands/VersionCommand.cs
@@ -32,7 +32,7 @@ namespace Cake.Commands
         private static string GetVersion()
         {
             var assembly = typeof(CakeApplication).GetTypeInfo().Assembly;
-            return FileVersionInfo.GetVersionInfo(assembly.Location).ProductVersion;
+            return FileVersionInfo.GetVersionInfo(assembly.Location).Comments;
         }
     }
 }

--- a/src/Cake/Properties/AssemblyInfo.cs
+++ b/src/Cake/Properties/AssemblyInfo.cs
@@ -11,8 +11,6 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cake")]
-[assembly: AssemblyDescription("")]
-
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.


### PR DESCRIPTION
This will place SemVer in previous empty AssemblyDescription so it can be used to display version
```
Cake.exe --version
```
Example output
```
0.31.0-GH2284-0001
```

* fixes #2284
