### PR TITLE
GH2201: Extend supported globber patterns

### DIFF
--- a/src/Cake.Core.Tests/Fixtures/GlobberFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/GlobberFixture.cs
@@ -49,6 +49,10 @@ namespace Cake.Core.Tests.Fixtures
             FileSystem.CreateFile("C:/Some %2F Directory/MyTool.dll");
             FileSystem.CreateFile("C:/Some ! Directory/MyTool.dll");
             FileSystem.CreateFile("C:/Some@Directory/MyTool.dll");
+
+            FileSystem.CreateFile("C:/Working/foobar.rs");
+            FileSystem.CreateFile("C:/Working/foobaz.rs");
+            FileSystem.CreateFile("C:/Working/foobax.rs");
         }
 
         private void PrepareUnixFixture()
@@ -82,6 +86,9 @@ namespace Cake.Core.Tests.Fixtures
             FileSystem.CreateFile("/Foo (Bar)/Baz.c");
             FileSystem.CreateFile("/Foo@Bar/Baz.c");
             FileSystem.CreateFile("/嵌套/目录/文件.延期");
+            FileSystem.CreateFile("/Working/foobar.rs");
+            FileSystem.CreateFile("/Working/foobaz.rs");
+            FileSystem.CreateFile("/Working/foobax.rs");
         }
 
         public void SetWorkingDirectory(DirectoryPath path)

--- a/src/Cake.Core.Tests/Unit/IO/GlobberTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/GlobberTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics;
 using Cake.Core.IO;
+using Cake.Core.IO.Globbing;
 using Cake.Core.Tests.Fixtures;
 using Cake.Testing.Xunit;
 using NSubstitute;
@@ -392,7 +393,7 @@ namespace Cake.Core.Tests.Unit.IO
                 var result = fixture.Match("/Working/**/*");
 
                 // Then
-                Assert.Equal(15, result.Length);
+                Assert.Equal(18, result.Length);
                 AssertEx.ContainsDirectoryPath(result, "/Working/Foo");
                 AssertEx.ContainsDirectoryPath(result, "/Working/Foo/Bar");
                 AssertEx.ContainsDirectoryPath(result, "/Working/Foo/Baz");
@@ -408,6 +409,9 @@ namespace Cake.Core.Tests.Unit.IO
                 AssertEx.ContainsFilePath(result, "/Working/Quz.FooTest.dll");
                 AssertEx.ContainsFilePath(result, "/Working/Bar/Qux.c");
                 AssertEx.ContainsFilePath(result, "/Working/Bar/Qux.h");
+                AssertEx.ContainsFilePath(result, "/Working/foobar.rs");
+                AssertEx.ContainsFilePath(result, "/Working/foobaz.rs");
+                AssertEx.ContainsFilePath(result, "/Working/foobax.rs");
             }
 
             [Fact]
@@ -619,6 +623,96 @@ namespace Cake.Core.Tests.Unit.IO
                 // Then
                 Assert.Single(result);
                 AssertEx.ContainsFilePath(result, "/嵌套/目录/文件.延期");
+            }
+
+            [Fact]
+            public void Should_Return_Files_And_Folders_For_Pattern_Containing_Bracket_Wildcard()
+            {
+                // Given
+                var fixture = new GlobberFixture();
+
+                // When
+                var result = fixture.Match("/Working/fooba[rz].rs");
+
+                // Then
+                Assert.Equal(2, result.Length);
+                AssertEx.ContainsFilePath(result, "/Working/foobar.rs");
+                AssertEx.ContainsFilePath(result, "/Working/foobaz.rs");
+            }
+
+            [WindowsFact]
+            public void Should_Return_Files_And_Folders_For_Pattern_Containing_Bracket_Wildcard_On_Windows()
+            {
+                // Given
+                var fixture = new GlobberFixture(windows: true);
+
+                // When
+                var result = fixture.Match("C:/Working/fooba[rz].rs");
+
+                // Then
+                Assert.Equal(2, result.Length);
+                AssertEx.ContainsFilePath(result, "C:/Working/foobar.rs");
+                AssertEx.ContainsFilePath(result, "C:/Working/foobaz.rs");
+            }
+
+            [Fact]
+            public void Should_Return_Files_And_Folders_For_Pattern_Containing_Brace_Expansion()
+            {
+                // Given
+                var fixture = new GlobberFixture();
+
+                // When
+                var result = fixture.Match("/Working/foo{bar,bax}.rs");
+
+                // Then
+                Assert.Equal(2, result.Length);
+                AssertEx.ContainsFilePath(result, "/Working/foobar.rs");
+                AssertEx.ContainsFilePath(result, "/Working/foobax.rs");
+            }
+
+            [WindowsFact]
+            public void Should_Return_Files_And_Folders_For_Pattern_Containing_Brace_Expansion_On_Windows()
+            {
+                // Given
+                var fixture = new GlobberFixture(windows: true);
+
+                // When
+                var result = fixture.Match("C:/Working/foo{bar,bax}.rs");
+
+                // Then
+                Assert.Equal(2, result.Length);
+                AssertEx.ContainsFilePath(result, "C:/Working/foobar.rs");
+                AssertEx.ContainsFilePath(result, "C:/Working/foobax.rs");
+            }
+
+            [Fact]
+            public void Should_Return_Files_And_Folders_For_Pattern_Containing_Negated_Bracket_Wildcard()
+            {
+                // Given
+                var fixture = new GlobberFixture();
+
+                // When
+                var result = fixture.Match("/Working/fooba[!x].rs");
+
+                // Then
+                Assert.Equal(2, result.Length);
+                AssertEx.ContainsFilePath(result, "/Working/foobar.rs");
+                AssertEx.ContainsFilePath(result, "/Working/foobaz.rs");
+            }
+
+            [WindowsFact]
+            public void Should_Return_Files_And_Folders_For_Pattern_Containing_Negated_Bracket_Wildcard_On_Windows()
+            {
+                // Given
+                var fixture = new GlobberFixture(windows: true);
+
+                // When
+                var result = fixture.Match("C:/Working/fooba[!x].rs");
+
+                // Then
+                Assert.Equal(2, result.Length);
+                AssertEx.ContainsFilePath(result, "C:/Working/foobar.rs");
+                AssertEx.ContainsFilePath(result, "C:/Working/foobaz.rs");
             }
         }
     }

--- a/src/Cake.Core/IO/Globbing/GlobNodeRewriter.cs
+++ b/src/Cake.Core/IO/Globbing/GlobNodeRewriter.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using Cake.Core.IO.Globbing.Nodes;
+using Cake.Core.IO.Globbing.Nodes.Segments;
 
 namespace Cake.Core.IO.Globbing
 {
@@ -34,12 +35,12 @@ namespace Cake.Core.IO.Globbing
         {
             foreach (var node in nodes)
             {
-                var segmentNode = node as PathSegment;
+                var segmentNode = node as PathNode;
                 if (segmentNode?.Tokens.Count == 1)
                 {
-                    if (segmentNode.Tokens[0].Kind == GlobTokenKind.Wildcard)
+                    if (segmentNode.Tokens[0] is WildcardSegment)
                     {
-                        yield return new WildcardSegment();
+                        yield return new WildcardNode();
                         continue;
                     }
                 }

--- a/src/Cake.Core/IO/Globbing/GlobNodeValidator.cs
+++ b/src/Cake.Core/IO/Globbing/GlobNodeValidator.cs
@@ -15,9 +15,9 @@ namespace Cake.Core.IO.Globbing
             var current = node;
             while (current != null)
             {
-                if (previous is RecursiveWildcardSegment)
+                if (previous is RecursiveWildcardNode)
                 {
-                    if (current is ParentSegment)
+                    if (current is ParentDirectoryNode)
                     {
                         throw new NotSupportedException("Visiting a parent that is a recursive wildcard is not supported.");
                     }

--- a/src/Cake.Core/IO/Globbing/GlobParserContext.cs
+++ b/src/Cake.Core/IO/Globbing/GlobParserContext.cs
@@ -10,15 +10,14 @@ namespace Cake.Core.IO.Globbing
 {
     internal sealed class GlobParserContext
     {
-        private readonly GlobTokenizer _tokenizer;
+        private readonly GlobTokenBuffer _buffer;
 
         public GlobToken CurrentToken { get; private set; }
-
         public RegexOptions Options { get; }
 
-        public GlobParserContext(string pattern, bool caseSensitive)
+        public GlobParserContext(GlobTokenBuffer buffer, bool caseSensitive)
         {
-            _tokenizer = new GlobTokenizer(pattern);
+            _buffer = buffer;
             CurrentToken = null;
             Options = RegexOptions.Compiled | RegexOptions.Singleline;
 
@@ -28,33 +27,25 @@ namespace Cake.Core.IO.Globbing
             }
         }
 
-        /// <summary>
-        /// Gets the next GlobToken from the context
-        /// </summary>
-        /// <returns>The Peek'd token</returns>
         public GlobToken Peek()
         {
-            return _tokenizer.Peek();
+            return _buffer.Peek();
         }
 
-        /// <summary>
-        /// Accepts the current GlobToken and loads the next into CurrentToken
-        /// </summary>
-        public void Accept()
+        public GlobToken Accept()
         {
-            CurrentToken = _tokenizer.Scan();
+            var result = CurrentToken;
+            CurrentToken = _buffer.Read();
+            return result;
         }
 
-        /// <summary>
-        /// Accepts the CurrentToken if it is of the specified TokenKind(s), and fetches the next token.
-        /// </summary>
-        /// <param name="kind">The types of acceptable <see cref="GlobTokenKind"/></param>
-        public void Accept(params GlobTokenKind[] kind)
+        public GlobToken Accept(params GlobTokenKind[] kind)
         {
             if (kind.Any(k => k == CurrentToken.Kind))
             {
+                var result = CurrentToken;
                 Accept();
-                return;
+                return result;
             }
 
             throw new InvalidOperationException("Unexpected token kind.");

--- a/src/Cake.Core/IO/Globbing/GlobToken.cs
+++ b/src/Cake.Core/IO/Globbing/GlobToken.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+
 namespace Cake.Core.IO.Globbing
 {
+    [DebuggerDisplay("{Value,nq} ({Kind,nq})")]
     internal sealed class GlobToken
     {
         public GlobTokenKind Kind { get; }

--- a/src/Cake.Core/IO/Globbing/GlobTokenBuffer.cs
+++ b/src/Cake.Core/IO/Globbing/GlobTokenBuffer.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+
+namespace Cake.Core.IO.Globbing
+{
+    internal sealed class GlobTokenBuffer
+    {
+        private readonly Queue<GlobToken> _tokens;
+
+        public GlobTokenBuffer(IEnumerable<GlobToken> tokens)
+        {
+            _tokens = new Queue<GlobToken>(tokens);
+        }
+
+        public GlobToken Peek()
+        {
+            if (_tokens.Count == 0)
+            {
+                return null;
+            }
+            return _tokens.Peek();
+        }
+
+        public GlobToken Read()
+        {
+            if (_tokens.Count == 0)
+            {
+                return null;
+            }
+            return _tokens.Dequeue();
+        }
+    }
+}

--- a/src/Cake.Core/IO/Globbing/GlobTokenKind.cs
+++ b/src/Cake.Core/IO/Globbing/GlobTokenKind.cs
@@ -8,12 +8,12 @@ namespace Cake.Core.IO.Globbing
     {
         Wildcard,
         CharacterWildcard,
-        DirectoryWildcard,
         PathSeparator,
-        Identifier,
+        Text,
         WindowsRoot,
         Parent,
         Current,
-        EndOfText
+        BracketWildcard,
+        BraceExpansion
     }
 }

--- a/src/Cake.Core/IO/Globbing/GlobTokenizer.cs
+++ b/src/Cake.Core/IO/Globbing/GlobTokenizer.cs
@@ -1,152 +1,141 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace Cake.Core.IO.Globbing
 {
-    internal sealed class GlobTokenizer
+    internal static class GlobTokenizer
     {
-        private readonly Dictionary<string, Func<GlobTokenKind>> _tokenKindChars = new Dictionary<string, Func<GlobTokenKind>>();
-        private readonly Lazy<Queue<GlobToken>> _tokens;
-        private string _remainingPattern;
-        private string _currentContent;
-
-        public GlobTokenizer(string pattern)
+        public static GlobTokenBuffer Tokenize(string input)
         {
-            _remainingPattern = pattern;
-            _tokens = new Lazy<Queue<GlobToken>>(QueueTokens);
-
-            _tokenKindChars.Add("?",  () => GlobTokenKind.CharacterWildcard);
-            _tokenKindChars.Add("*",  () => GlobTokenKind.Wildcard);
-            _tokenKindChars.Add("**", () => GlobTokenKind.DirectoryWildcard);
-            _tokenKindChars.Add("/",  () => GlobTokenKind.PathSeparator);
-            _tokenKindChars.Add(@"\", () => GlobTokenKind.PathSeparator);
-            _tokenKindChars.Add(":",  () => GlobTokenKind.WindowsRoot);
-            _tokenKindChars.Add(".", HandlePeriod);
-            _tokenKindChars.Add("..", () => GlobTokenKind.Parent);
-            _tokenKindChars.Add("\0", () => GlobTokenKind.EndOfText);
+            return Tokenize(new StringReader(input));
         }
 
-        /// <summary>
-        /// Gets the next token from the pattern.
-        /// </summary>
-        /// <returns>The next GlobToken.</returns>
-        public GlobToken Scan()
+        private static GlobTokenBuffer Tokenize(StringReader reader)
         {
-            if (_tokens.Value.Count == 0)
+            var tokens = new List<GlobToken>();
+            while (reader.Peek() != -1)
             {
-                return null;
+                var token = ReadToken(reader);
+                if (token != null)
+                {
+                    tokens.Add(token);
+                }
             }
 
-            return _tokens.Value.Dequeue();
-        }
-
-        /// <summary>
-        /// Peeks the next token from the pattern.
-        /// </summary>
-        /// <returns>The peek'd GlobToken.</returns>
-        public GlobToken Peek()
-        {
-            return _tokens.Value.Peek();
-        }
-
-        /// <summary>
-        /// Loads the tokens into the token queue.
-        /// </summary>
-        /// <returns>A queue of tokens representing the pattern.</returns>
-        private Queue<GlobToken> QueueTokens()
-        {
-            var tokenQueue = new Queue<GlobToken>();
-
-            while (_remainingPattern.Length > 0)
+            var queue = new Queue<GlobToken>(tokens);
+            var result = new List<GlobToken>();
+            while (queue.Count > 0)
             {
-                GlobTokenKind tokenKind = GetGlobTokenKindAndTrimRemainingPattern();
-
-                if (tokenKind != GlobTokenKind.Identifier)
+                var current = queue.Peek();
+                if (current.Kind == GlobTokenKind.Text)
                 {
-                    tokenQueue.Enqueue(new GlobToken(tokenKind, string.Empty));
-                    continue;
-                }
-
-                while (tokenKind == GlobTokenKind.Identifier)
-                {
-                    if (!string.IsNullOrEmpty(_remainingPattern))
+                    var accumulator = new List<GlobToken>();
+                    while (queue.Count > 0)
                     {
-                        tokenKind = GetGlobTokenKindAndTrimRemainingPattern();
+                        var item = queue.Peek();
+                        if (item.Kind != GlobTokenKind.Text)
+                        {
+                            break;
+                        }
+                        accumulator.Add(queue.Dequeue());
                     }
-                    else
+                    result.Add(new GlobToken(GlobTokenKind.Text, string.Join(string.Empty, accumulator.Select(i => i.Value))));
+                }
+                else
+                {
+                    result.Add(queue.Dequeue());
+                }
+            }
+
+            // Turn the tokens into a token buffer.
+            return new GlobTokenBuffer(result);
+        }
+
+        private static GlobToken ReadToken(StringReader reader)
+        {
+            char current = (char)reader.Peek();
+
+            if (current == '?')
+            {
+                reader.Read();
+                return new GlobToken(GlobTokenKind.CharacterWildcard, "?");
+            }
+            else if (current == '*')
+            {
+                reader.Read();
+                return new GlobToken(GlobTokenKind.Wildcard, "*");
+            }
+            else if (current == '.')
+            {
+                reader.Read();
+                if (reader.Peek() != -1)
+                {
+                    var next = (char)reader.Peek();
+                    if (next == '/' || next == '\\')
                     {
-                        break;
+                        return new GlobToken(GlobTokenKind.Current, ".");
+                    }
+                    if (next == '.')
+                    {
+                        reader.Read();
+                        return new GlobToken(GlobTokenKind.Parent, "..");
                     }
                 }
-
-                // We know we've got at least one Identifer, so queue it with the contents read
-                tokenQueue.Enqueue(new GlobToken(GlobTokenKind.Identifier, _currentContent));
-                _currentContent = string.Empty;
-
-                // If we quit the while loop due to hitting a new token (rather than end of string), queue it.
-                if (tokenKind != GlobTokenKind.Identifier)
-                {
-                    tokenQueue.Enqueue(new GlobToken(tokenKind, string.Empty));
-                }
+                return new GlobToken(GlobTokenKind.Text, current.ToString());
+            }
+            else if (current == ':')
+            {
+                reader.Read();
+                return new GlobToken(GlobTokenKind.WindowsRoot, ":");
+            }
+            else if (current == '[')
+            {
+                return ReadScope(reader, GlobTokenKind.BracketWildcard, '[', ']');
+            }
+            else if (current == '{')
+            {
+                return ReadScope(reader, GlobTokenKind.BraceExpansion, '{', '}');
+            }
+            else if (current == '\\' || current == '/')
+            {
+                reader.Read();
+                return new GlobToken(GlobTokenKind.PathSeparator, "/");
             }
 
-            return tokenQueue;
+            reader.Read();
+            return new GlobToken(GlobTokenKind.Text, current.ToString());
         }
 
-        /// <summary>
-        /// Searches the private dictionary for a set of tokens matching the current (and future) character position(s).
-        /// Performs a greedy match of the keys in the dictionary against the remaining pattern.
-        /// </summary>
-        /// <returns>The GlobTokenKind associated with the mathing entry, or GlobTokenKind.Identifier if none were found. </returns>
-        private GlobTokenKind GetGlobTokenKindAndTrimRemainingPattern()
+        private static GlobToken ReadScope(StringReader reader, GlobTokenKind kind, char first, char last)
         {
-            int numberOfCharsToRemove;
-            GlobTokenKind tokenKind;
+            char current = (char)reader.Read();
+            Debug.Assert(current == first, "Unexpected token.");
 
-            var matches = _tokenKindChars.Where(pair => _remainingPattern.IndexOf(pair.Key, StringComparison.Ordinal) == 0);
-            var greediestMatch = matches.OrderByDescending(pair => pair.Key.Length).FirstOrDefault();
-
-            if (greediestMatch.Key == null)
+            var accumulator = new StringBuilder();
+            while (reader.Peek() != -1)
             {
-                tokenKind = GlobTokenKind.Identifier;
-                numberOfCharsToRemove = 1;
-            }
-            else
-            {
-                tokenKind = greediestMatch.Value();
-                numberOfCharsToRemove = greediestMatch.Key.Length;
-            }
-
-            if (tokenKind == GlobTokenKind.Identifier)
-            {
-                _currentContent += _remainingPattern.Substring(0, numberOfCharsToRemove);
-            }
-
-            _remainingPattern = _remainingPattern.Substring(numberOfCharsToRemove);
-            return tokenKind;
-        }
-
-        /// <summary>
-        /// Determine what GlobTokenKind a period represents given the context
-        /// </summary>
-        /// <returns>The appropriate GlobTokenKind depending on the next character</returns>
-        private GlobTokenKind HandlePeriod()
-        {
-            if (_remainingPattern.Length > 1)
-            {
-                var nextCharacter = _remainingPattern[1];
-                if (nextCharacter == '\\' || nextCharacter == '/')
+                current = (char)reader.Peek();
+                if (current == last)
                 {
-                    return GlobTokenKind.Current;
+                    break;
                 }
+                accumulator.Append((char)reader.Read());
             }
 
-            return GlobTokenKind.Identifier;
+            if (reader.Peek() == -1)
+            {
+                throw new InvalidOperationException($"Expected '{last}' but reached end of pattern.");
+            }
+
+            // Consume the last characer.
+            current = (char)reader.Read();
+            Debug.Assert(current == last, "Unexpected token.");
+
+            return new GlobToken(kind, accumulator.ToString());
         }
     }
 }

--- a/src/Cake.Core/IO/Globbing/GlobVisitor.cs
+++ b/src/Cake.Core/IO/Globbing/GlobVisitor.cs
@@ -27,7 +27,7 @@ namespace Cake.Core.IO.Globbing
             return context.Results;
         }
 
-        public void VisitRecursiveWildcardSegment(RecursiveWildcardSegment node, GlobVisitorContext context)
+        public void VisitRecursiveWildcardSegment(RecursiveWildcardNode node, GlobVisitorContext context)
         {
             var path = context.FileSystem.GetDirectory(context.Path);
             if (context.FileSystem.Exist(path.Path))
@@ -63,7 +63,7 @@ namespace Cake.Core.IO.Globbing
             }
         }
 
-        public void VisitRelativeRoot(RelativeRoot node, GlobVisitorContext context)
+        public void VisitRelativeRoot(RelativeRootNode node, GlobVisitorContext context)
         {
             // Push each path to the context.
             var pushedSegmentCount = 0;
@@ -83,7 +83,7 @@ namespace Cake.Core.IO.Globbing
             }
         }
 
-        public void VisitSegment(PathSegment node, GlobVisitorContext context)
+        public void VisitSegment(PathNode node, GlobVisitorContext context)
         {
             if (node.IsIdentifier)
             {
@@ -153,14 +153,14 @@ namespace Cake.Core.IO.Globbing
             }
         }
 
-        public void VisitUnixRoot(UnixRoot node, GlobVisitorContext context)
+        public void VisitUnixRoot(UnixRootNode node, GlobVisitorContext context)
         {
             context.Push(string.Empty);
             node.Next.Accept(this, context);
             context.Pop();
         }
 
-        public void VisitWildcardSegmentNode(WildcardSegment node, GlobVisitorContext context)
+        public void VisitWildcardSegmentNode(WildcardNode node, GlobVisitorContext context)
         {
             var path = context.FileSystem.GetDirectory(context.Path);
             if (context.FileSystem.Exist(path.Path))
@@ -181,14 +181,14 @@ namespace Cake.Core.IO.Globbing
             }
         }
 
-        public void VisitWindowsRoot(WindowsRoot node, GlobVisitorContext context)
+        public void VisitWindowsRoot(WindowsRootNode node, GlobVisitorContext context)
         {
             context.Push(node.Drive + ":");
             node.Next.Accept(this, context);
             context.Pop();
         }
 
-        public void VisitParent(ParentSegment node, GlobVisitorContext context)
+        public void VisitParent(ParentDirectoryNode node, GlobVisitorContext context)
         {
             // Back up one level.
             var last = context.Pop();
@@ -199,7 +199,7 @@ namespace Cake.Core.IO.Globbing
             context.Push(last);
         }
 
-        public void VisitCurrent(CurrentSegment node, GlobVisitorContext context)
+        public void VisitCurrent(CurrentDirectoryNode node, GlobVisitorContext context)
         {
             node.Next.Accept(this, context);
         }

--- a/src/Cake.Core/IO/Globbing/Nodes/CurrentDirectoryNode.cs
+++ b/src/Cake.Core/IO/Globbing/Nodes/CurrentDirectoryNode.cs
@@ -6,13 +6,13 @@ using System.Diagnostics;
 
 namespace Cake.Core.IO.Globbing.Nodes
 {
-    [DebuggerDisplay("..")]
-    internal sealed class ParentSegment : GlobNode
+    [DebuggerDisplay(".")]
+    internal sealed class CurrentDirectoryNode : GlobNode
     {
         [DebuggerStepThrough]
         public override void Accept(GlobVisitor visitor, GlobVisitorContext context)
         {
-            visitor.VisitParent(this, context);
+            visitor.VisitCurrent(this, context);
         }
     }
 }

--- a/src/Cake.Core/IO/Globbing/Nodes/ParentDirectoryNode.cs
+++ b/src/Cake.Core/IO/Globbing/Nodes/ParentDirectoryNode.cs
@@ -6,13 +6,13 @@ using System.Diagnostics;
 
 namespace Cake.Core.IO.Globbing.Nodes
 {
-    [DebuggerDisplay("./")]
-    internal sealed class RelativeRoot : GlobNode
+    [DebuggerDisplay("..")]
+    internal sealed class ParentDirectoryNode : GlobNode
     {
         [DebuggerStepThrough]
-        public override void Accept(GlobVisitor globber, GlobVisitorContext context)
+        public override void Accept(GlobVisitor visitor, GlobVisitorContext context)
         {
-            globber.VisitRelativeRoot(this, context);
+            visitor.VisitParent(this, context);
         }
     }
 }

--- a/src/Cake.Core/IO/Globbing/Nodes/RecursiveWildcardNode.cs
+++ b/src/Cake.Core/IO/Globbing/Nodes/RecursiveWildcardNode.cs
@@ -6,13 +6,13 @@ using System.Diagnostics;
 
 namespace Cake.Core.IO.Globbing.Nodes
 {
-    [DebuggerDisplay("*")]
-    internal sealed class WildcardSegment : MatchableNode
+    [DebuggerDisplay("**")]
+    internal sealed class RecursiveWildcardNode : MatchableNode
     {
         [DebuggerStepThrough]
-        public override void Accept(GlobVisitor visitor, GlobVisitorContext context)
+        public override void Accept(GlobVisitor globber, GlobVisitorContext context)
         {
-            visitor.VisitWildcardSegmentNode(this, context);
+            globber.VisitRecursiveWildcardSegment(this, context);
         }
 
         public override bool IsMatch(string value)

--- a/src/Cake.Core/IO/Globbing/Nodes/RelativeRootNode.cs
+++ b/src/Cake.Core/IO/Globbing/Nodes/RelativeRootNode.cs
@@ -6,18 +6,13 @@ using System.Diagnostics;
 
 namespace Cake.Core.IO.Globbing.Nodes
 {
-    [DebuggerDisplay("**")]
-    internal sealed class RecursiveWildcardSegment : MatchableNode
+    [DebuggerDisplay("./")]
+    internal sealed class RelativeRootNode : GlobNode
     {
         [DebuggerStepThrough]
         public override void Accept(GlobVisitor globber, GlobVisitorContext context)
         {
-            globber.VisitRecursiveWildcardSegment(this, context);
-        }
-
-        public override bool IsMatch(string value)
-        {
-            return true;
+            globber.VisitRelativeRoot(this, context);
         }
     }
 }

--- a/src/Cake.Core/IO/Globbing/Nodes/Segments/BraceExpansionSegment.cs
+++ b/src/Cake.Core/IO/Globbing/Nodes/Segments/BraceExpansionSegment.cs
@@ -1,0 +1,15 @@
+﻿namespace Cake.Core.IO.Globbing.Nodes.Segments
+{
+    internal sealed class BraceExpansionSegment : PathSegment
+    {
+        public override string Value { get; }
+
+        public override string Regex { get; }
+
+        public BraceExpansionSegment(string value)
+        {
+            Value = $"{{{value}}}";
+            Regex = $"({value})".Replace(",", "|");
+        }
+    }
+}

--- a/src/Cake.Core/IO/Globbing/Nodes/Segments/BracketWildcardSegment.cs
+++ b/src/Cake.Core/IO/Globbing/Nodes/Segments/BracketWildcardSegment.cs
@@ -1,0 +1,20 @@
+﻿namespace Cake.Core.IO.Globbing.Nodes.Segments
+{
+    internal sealed class BracketWildcardSegment : PathSegment
+    {
+        public override string Value { get; }
+
+        public override string Regex => Value;
+
+        public BracketWildcardSegment(string content)
+        {
+            if (content.StartsWith("!"))
+            {
+                // Content is negated.
+                content = content.TrimStart('!').Insert(0, "^");
+            }
+
+            Value = $"[{content}]";
+        }
+    }
+}

--- a/src/Cake.Core/IO/Globbing/Nodes/Segments/CharacterWildcardSegment.cs
+++ b/src/Cake.Core/IO/Globbing/Nodes/Segments/CharacterWildcardSegment.cs
@@ -1,0 +1,9 @@
+﻿namespace Cake.Core.IO.Globbing.Nodes.Segments
+{
+    internal sealed class CharacterWildcardSegment : PathSegment
+    {
+        public override string Value => "?";
+
+        public override string Regex => ".{1}";
+    }
+}

--- a/src/Cake.Core/IO/Globbing/Nodes/Segments/PathSegment.cs
+++ b/src/Cake.Core/IO/Globbing/Nodes/Segments/PathSegment.cs
@@ -1,0 +1,8 @@
+﻿namespace Cake.Core.IO.Globbing.Nodes.Segments
+{
+    internal abstract class PathSegment
+    {
+        public abstract string Regex { get; }
+        public abstract string Value { get; }
+    }
+}

--- a/src/Cake.Core/IO/Globbing/Nodes/Segments/TextSegment.cs
+++ b/src/Cake.Core/IO/Globbing/Nodes/Segments/TextSegment.cs
@@ -1,0 +1,15 @@
+﻿namespace Cake.Core.IO.Globbing.Nodes.Segments
+{
+    internal sealed class TextSegment : PathSegment
+    {
+        public override string Value { get; }
+
+        public override string Regex { get; }
+
+        public TextSegment(string text)
+        {
+            Value = text;
+            Regex = Value.Replace("+", "\\+").Replace(".", "\\.");
+        }
+    }
+}

--- a/src/Cake.Core/IO/Globbing/Nodes/Segments/WildcardSegment.cs
+++ b/src/Cake.Core/IO/Globbing/Nodes/Segments/WildcardSegment.cs
@@ -1,0 +1,9 @@
+﻿namespace Cake.Core.IO.Globbing.Nodes.Segments
+{
+    internal sealed class WildcardSegment : PathSegment
+    {
+        public override string Value => "*";
+
+        public override string Regex => ".*";
+    }
+}

--- a/src/Cake.Core/IO/Globbing/Nodes/UnixRootNode.cs
+++ b/src/Cake.Core/IO/Globbing/Nodes/UnixRootNode.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 namespace Cake.Core.IO.Globbing.Nodes
 {
     [DebuggerDisplay("$")]
-    internal sealed class UnixRoot : GlobNode
+    internal sealed class UnixRootNode : GlobNode
     {
         [DebuggerStepThrough]
         public override void Accept(GlobVisitor visitor, GlobVisitorContext context)

--- a/src/Cake.Core/IO/Globbing/Nodes/WildcardNode.cs
+++ b/src/Cake.Core/IO/Globbing/Nodes/WildcardNode.cs
@@ -6,13 +6,18 @@ using System.Diagnostics;
 
 namespace Cake.Core.IO.Globbing.Nodes
 {
-    [DebuggerDisplay(".")]
-    internal sealed class CurrentSegment : GlobNode
+    [DebuggerDisplay("*")]
+    internal sealed class WildcardNode : MatchableNode
     {
         [DebuggerStepThrough]
         public override void Accept(GlobVisitor visitor, GlobVisitorContext context)
         {
-            visitor.VisitCurrent(this, context);
+            visitor.VisitWildcardSegmentNode(this, context);
+        }
+
+        public override bool IsMatch(string value)
+        {
+            return true;
         }
     }
 }

--- a/src/Cake.Core/IO/Globbing/Nodes/WindowsRootNode.cs
+++ b/src/Cake.Core/IO/Globbing/Nodes/WindowsRootNode.cs
@@ -8,17 +8,13 @@ using System.Diagnostics;
 namespace Cake.Core.IO.Globbing.Nodes
 {
     [DebuggerDisplay("{Drive,nq}:")]
-    internal sealed class WindowsRoot : GlobNode
+    internal sealed class WindowsRootNode : GlobNode
     {
         public string Drive { get; }
 
-        public WindowsRoot(string drive)
+        public WindowsRootNode(string drive)
         {
-            if (drive == null)
-            {
-                throw new ArgumentNullException(nameof(drive));
-            }
-            Drive = drive;
+            Drive = drive ?? throw new ArgumentNullException(nameof(drive));
         }
 
         [DebuggerStepThrough]

--- a/tests/integration/Cake.Common/IO/GlobbingAliases.cake
+++ b/tests/integration/Cake.Common/IO/GlobbingAliases.cake
@@ -1,0 +1,235 @@
+#load "./../../utilities/xunit.cake"
+#load "./../../utilities/paths.cake"
+#load "./../../utilities/io.cake"
+
+//////////////////////////////////////////////////////////////////////////////
+
+public static void AssertFiles(this FilePathCollection collection, params FilePath[] files)
+{
+    Assert.NotNull(collection);
+    Assert.Equal(files.Length, collection.Count);
+    foreach(var file in files)
+    {
+        Assert.True(collection.Contains(file, PathComparer.Default), $"Expected '{file}' to be found by globber.");
+    }
+}
+
+public static void AssertDirectories(this DirectoryPathCollection collection, params DirectoryPath[] directories)
+{
+    Assert.NotNull(collection);
+    Assert.Equal(directories.Length, collection.Count);
+    foreach(var directory in directories)
+    {
+        Assert.True(collection.Contains(directory, PathComparer.Default), $"Expected '{directory}' to be found by globber.");
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+Task("Cake.Common.IO.GlobbingAliases.GetFiles.Wildcard")
+    .Does(context =>
+{
+    // Given
+    var root = EnsureDirectoryExist($"{Paths.Temp}/Cake.Common.IO.GlobbingAliases/wildcard");
+    var foobar = EnsureFileExist(root.CombineWithFilePath("foobar.txt"));
+    var foobaz = EnsureFileExist(root.CombineWithFilePath("foobaz.txt"));
+    var foobax = EnsureFileExist(root.CombineWithFilePath("foobax.txt"));
+
+    // When
+    var files = GetFiles($"{root}/*");
+
+    // Then
+    files.AssertFiles(foobar, foobaz, foobax);
+});
+
+Task("Cake.Common.IO.GlobbingAliases.GetDirectories.Wildcard")
+    .Does(context =>
+{
+    // Given
+    var root = EnsureDirectoryExist($"{Paths.Temp}/Cake.Common.IO.GlobbingAliases/wildcard");
+    var foobar = EnsureDirectoryExist(root.Combine("foobar"));
+    var foobaz = EnsureDirectoryExist(root.Combine("foobaz"));
+    var foobax = EnsureDirectoryExist(root.Combine("foobax"));
+
+    // When
+    var directories = GetDirectories($"{root}/*");
+
+    // Then
+    directories.AssertDirectories(foobar, foobaz, foobax);
+});
+
+Task("Cake.Common.IO.GlobbingAliases.GetFiles.RecursiveWildcard")
+    .Does(context =>
+{
+    // Given
+    var root = EnsureDirectoryExist($"{Paths.Temp}/Cake.Common.IO.GlobbingAliases/recursivewildcard");
+    var first = EnsureFileExist(root.CombineWithFilePath("foo/bar/qux.txt"));
+    var second = EnsureFileExist(root.CombineWithFilePath("bar/qux.txt"));
+    var third = EnsureFileExist(root.CombineWithFilePath("bar/foo/baz.txt"));
+
+    // When
+    var files = GetFiles($"{root}/**/qux.txt");
+
+    // Then
+    files.AssertFiles(first, second);
+});
+
+Task("Cake.Common.IO.GlobbingAliases.GetDirectories.RecursiveWildcard")
+    .Does(context =>
+{
+    // Given
+    var root = EnsureDirectoryExist($"{Paths.Temp}/Cake.Common.IO.GlobbingAliases/recursivewildcard");
+    var first = EnsureDirectoryExist(root.Combine("foo/bar/qux"));
+    var second = EnsureDirectoryExist(root.Combine("bar/qux"));
+    var third = EnsureDirectoryExist(root.Combine("bar/foo/baz"));
+
+    // When
+    var files = GetDirectories($"{root}/**/qux");
+
+    // Then
+    files.AssertDirectories(first, second);
+});
+
+Task("Cake.Common.IO.GlobbingAliases.GetFiles.CharacterWildcard")
+    .Does(context =>
+{
+    // Given
+    var root = EnsureDirectoryExist($"{Paths.Temp}/Cake.Common.IO.GlobbingAliases/characterwildcard");
+    var foobar = EnsureFileExist(root.CombineWithFilePath("foobar.txt"));
+    var foobaz = EnsureFileExist(root.CombineWithFilePath("foobaz.txt"));
+    var foobax = EnsureFileExist(root.CombineWithFilePath("foobax.txt"));
+
+    // When
+    var files = GetFiles($"{root}/fooba?.txt");
+
+    // Then
+    files.AssertFiles(foobar, foobaz, foobax);
+});
+
+Task("Cake.Common.IO.GlobbingAliases.GetDirectories.CharacterWildcard")
+    .Does(context =>
+{
+    // Given
+    var root = EnsureDirectoryExist($"{Paths.Temp}/Cake.Common.IO.GlobbingAliases/characterwildcard");
+    var foobar = EnsureDirectoryExist(root.Combine("foobar"));
+    var foobaz = EnsureDirectoryExist(root.Combine("foobaz"));
+    var foobax = EnsureDirectoryExist(root.Combine("foobax"));
+
+    // When
+    var files = GetDirectories($"{root}/fooba?");
+
+    // Then
+    files.AssertDirectories(foobar, foobaz, foobax);
+});
+
+Task("Cake.Common.IO.GlobbingAliases.GetFiles.BracketWildcard")
+    .Does(context =>
+{
+    // Given
+    var root = EnsureDirectoryExist($"{Paths.Temp}/Cake.Common.IO.GlobbingAliases/bracketwildcard");
+    var foobar = EnsureFileExist(root.CombineWithFilePath("foobar.txt"));
+    var foobaz = EnsureFileExist(root.CombineWithFilePath("foobaz.txt"));
+    var foobax = EnsureFileExist(root.CombineWithFilePath("foobax.txt"));
+
+    // When
+    var files = GetFiles($"{root}/fooba[rz].txt");
+
+    // Then
+    files.AssertFiles(foobar, foobaz);
+});
+
+Task("Cake.Common.IO.GlobbingAliases.GetDirectories.BracketWildcard")
+    .Does(context =>
+{
+    // Given
+    var root = EnsureDirectoryExist($"{Paths.Temp}/Cake.Common.IO.GlobbingAliases/bracketwildcard");
+    var foobar = EnsureDirectoryExist(root.Combine("foobar"));
+    var foobaz = EnsureDirectoryExist(root.Combine("foobaz"));
+    var foobax = EnsureDirectoryExist(root.Combine("foobax"));
+
+    // When
+    var files = GetDirectories($"{root}/fooba[rz]");
+
+    // Then
+    files.AssertDirectories(foobar, foobaz);
+});
+
+Task("Cake.Common.IO.GlobbingAliases.GetFiles.BraceExpansion")
+    .Does(() =>
+{
+    // Given
+    var root = EnsureDirectoryExist($"{Paths.Temp}/Cake.Common.IO.GlobbingAliases/braceexpansion");
+    var foobar = EnsureFileExist(root.CombineWithFilePath("foobar.txt"));
+    var foobaz = EnsureFileExist(root.CombineWithFilePath("foobaz.txt"));
+    var foobax = EnsureFileExist(root.CombineWithFilePath("foobax.txt"));
+
+    // When
+    var files = GetFiles($"{root}/foo{{bar,bax}}.txt");
+
+    // Then
+    files.AssertFiles(foobar, foobax);
+});
+
+Task("Cake.Common.IO.GlobbingAliases.GetDirectories.BraceExpansion")
+    .Does(() =>
+{
+    // Given
+    var root = EnsureDirectoryExist($"{Paths.Temp}/Cake.Common.IO.GlobbingAliases/braceexpansion");
+    var foobar = EnsureDirectoryExist(root.Combine("foobar"));
+    var foobaz = EnsureDirectoryExist(root.Combine("foobaz"));
+    var foobax = EnsureDirectoryExist(root.Combine("foobax"));
+
+    // When
+    var files = GetDirectories($"{root}/foo{{bar,bax}}");
+
+    // Then
+    files.AssertDirectories(foobar, foobax);
+});
+
+Task("Cake.Common.IO.GlobbingAliases.GetFiles.BraceExpansionNegation")
+    .Does(() =>
+{
+    // Given
+    var root = EnsureDirectoryExist($"{Paths.Temp}/Cake.Common.IO.GlobbingAliases/braceexpansionnegation");
+    var foobar = EnsureFileExist(root.CombineWithFilePath("foobar.txt"));
+    var foobaz = EnsureFileExist(root.CombineWithFilePath("foobaz.txt"));
+    var foobax = EnsureFileExist(root.CombineWithFilePath("foobax.txt"));
+
+    // When
+    var files = GetFiles($"{root}/fooba[!x].txt");
+
+    // Then
+    files.AssertFiles(foobar, foobaz);
+});
+
+Task("Cake.Common.IO.GlobbingAliases.GetDirectories.BraceExpansionNegation")
+    .Does(() =>
+{
+    // Given
+    var root = EnsureDirectoryExist($"{Paths.Temp}/Cake.Common.IO.GlobbingAliases/braceexpansionnegation");
+    var foobar = EnsureDirectoryExist(root.Combine("foobar"));
+    var foobaz = EnsureDirectoryExist(root.Combine("foobaz"));
+    var foobax = EnsureDirectoryExist(root.Combine("foobax"));
+
+    // When
+    var files = GetDirectories($"{root}/fooba[!x]");
+
+    // Then
+    files.AssertDirectories(foobar, foobaz);
+});
+
+//////////////////////////////////////////////////////////////////////////////
+
+Task("Cake.Common.IO.GlobbingAliases")
+    .IsDependentOn("Cake.Common.IO.GlobbingAliases.GetFiles.Wildcard")
+    .IsDependentOn("Cake.Common.IO.GlobbingAliases.GetDirectories.Wildcard")
+    .IsDependentOn("Cake.Common.IO.GlobbingAliases.GetFiles.RecursiveWildcard")
+    .IsDependentOn("Cake.Common.IO.GlobbingAliases.GetDirectories.RecursiveWildcard")
+    .IsDependentOn("Cake.Common.IO.GlobbingAliases.GetFiles.CharacterWildcard")
+    .IsDependentOn("Cake.Common.IO.GlobbingAliases.GetDirectories.CharacterWildcard")
+    .IsDependentOn("Cake.Common.IO.GlobbingAliases.GetFiles.BracketWildcard")
+    .IsDependentOn("Cake.Common.IO.GlobbingAliases.GetDirectories.BracketWildcard")
+    .IsDependentOn("Cake.Common.IO.GlobbingAliases.GetFiles.BraceExpansion")
+    .IsDependentOn("Cake.Common.IO.GlobbingAliases.GetDirectories.BraceExpansion")
+    .IsDependentOn("Cake.Common.IO.GlobbingAliases.GetFiles.BraceExpansionNegation")
+    .IsDependentOn("Cake.Common.IO.GlobbingAliases.GetDirectories.BraceExpansionNegation");

--- a/tests/integration/build.cake
+++ b/tests/integration/build.cake
@@ -12,6 +12,7 @@
 #load "./Cake.Common/IO/DirectoryAliases.cake"
 #load "./Cake.Common/IO/FileAliases.cake"
 #load "./Cake.Common/IO/FileAsync.cake"
+#load "./Cake.Common/IO/GlobbingAliases.cake"
 #load "./Cake.Common/IO/ZipAliases.cake"
 #load "./Cake.Common/ReleaseNotesAliases.cake"
 #load "./Cake.Common/Security/SecurityAliases.cake"
@@ -57,6 +58,7 @@ Task("Cake.Common")
     .IsDependentOn("Cake.Common.IO.DirectoryAliases")
     .IsDependentOn("Cake.Common.IO.FileAliases")
     .IsDependentOn("Cake.Common.IO.FileAsync")
+    .IsDependentOn("Cake.Common.IO.GlobbingAliases")
     .IsDependentOn("Cake.Common.IO.ZipAliases")
     .IsDependentOn("Cake.Common.ReleaseNotesAliases")
     .IsDependentOn("Cake.Common.Security.SecurityAliases")

--- a/tests/integration/utilities/io.cake
+++ b/tests/integration/utilities/io.cake
@@ -1,9 +1,10 @@
-public void EnsureDirectoryExist(DirectoryPath path)
+public DirectoryPath EnsureDirectoryExist(DirectoryPath path)
 {
     if(!System.IO.Directory.Exists(path.FullPath))
     {
         System.IO.Directory.CreateDirectory(path.FullPath);
     }
+    return path;
 }
 
 public void EnsureDirectoriesExist(IEnumerable<DirectoryPath> paths)
@@ -14,15 +15,17 @@ public void EnsureDirectoriesExist(IEnumerable<DirectoryPath> paths)
     }
 }
 
-public void EnsureFileExist(FilePath path, string message = "Hello World!")
+public FilePath EnsureFileExist(FilePath path, string message = "Hello World!")
 {
     if(!System.IO.File.Exists(path.FullPath))
     {
+        EnsureDirectoryExist(path.GetDirectory());
         using (var writer = System.IO.File.CreateText(path.FullPath))
         {
             writer.WriteLine(message);
         }
     }
+    return path;
 }
 
 public void EnsureFilesExist(IEnumerable<FilePath> paths)


### PR DESCRIPTION
* [x] Bracket wildcard
  - [x] Specific: `ba[rz]` that matches "bar" or "baz"
  - [x] Ranges: `ba[a-zA-z]` or `ba[1-3]` that matches "baa" or "ba1" among others
* [x] [Brace expansion](https://en.wikipedia.org/wiki/Bash_(Unix_shell)#Brace_expansion): `foo{bar,baz}` that would match "foobar" and "foobaz"
  - No sequences though
* [x] Negation in bracket wildcards (i.e `[!Cc]at` that would match "bat" but not "cat" or "Cat")

Closes #2201 