### PR TITLE
GH2294: Add fluent API to enable MSBuild binary logger

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -946,6 +946,20 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 Assert.Equal("/v:normal /target:Build /bl:mylog.binlog;ProjectImports=ZipFile \"C:/Working/src/Solution.sln\"", result.Args);
             }
 
+            [Fact]
+            public void Should_Use_Binary_Logging_If_Enabled()
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows);
+                fixture.Settings.EnableBinaryLogger("mylog.binlog", MSBuildBinaryLogImports.ZipFile);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/v:normal /target:Build /bl:mylog.binlog;ProjectImports=ZipFile \"C:/Working/src/Solution.sln\"", result.Args);
+            }
+
             [Theory]
             [InlineData("Value1,Value2", "/v:normal /p:Property=Value1%2CValue2 /target:Build \"C:/Working/src/Solution.sln\"")]
             [InlineData("Value1;Value2", "/v:normal /p:Property=Value1%3BValue2 /target:Build \"C:/Working/src/Solution.sln\"")]

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
@@ -293,6 +293,96 @@ namespace Cake.Common.Tools.MSBuild
         }
 
         /// <summary>
+        /// Enables the binary logger with all the default settings.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static MSBuildSettings EnableBinaryLogger(this MSBuildSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            settings.BinaryLogger = new MSBuildBinaryLogSettings
+            {
+                Enabled = true,
+                Imports = MSBuildBinaryLogImports.None,
+            };
+
+            return settings;
+        }
+
+        /// <summary>
+        /// Enables the binary logger with the specified log file name and imports.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="fileName">The log file name.</param>
+        /// <param name="imports">The imports.</param>
+        /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static MSBuildSettings EnableBinaryLogger(this MSBuildSettings settings, string fileName, MSBuildBinaryLogImports imports)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            settings.BinaryLogger = new MSBuildBinaryLogSettings
+            {
+                Enabled = true,
+                FileName = fileName,
+                Imports = imports,
+            };
+
+            return settings;
+        }
+
+        /// <summary>
+        /// Enables the binary logger with the specified log file name and no imports.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="fileName">The log file name.</param>
+        /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static MSBuildSettings EnableBinaryLogger(this MSBuildSettings settings, string fileName)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            settings.BinaryLogger = new MSBuildBinaryLogSettings
+            {
+                Enabled = true,
+                FileName = fileName,
+                Imports = MSBuildBinaryLogImports.None,
+            };
+
+            return settings;
+        }
+
+        /// <summary>
+        /// Enables the binary logger with the specified imports and default file name.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="imports">The imports.</param>
+        /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static MSBuildSettings EnableBinaryLogger(this MSBuildSettings settings, MSBuildBinaryLogImports imports)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            settings.BinaryLogger = new MSBuildBinaryLogSettings
+            {
+                Enabled = true,
+                Imports = imports,
+            };
+
+            return settings;
+        }
+
+        /// <summary>
         /// Treat warnings as errors, if no codes specified all errors will be treated as errors.
         /// </summary>
         /// <param name="settings">The settings.</param>


### PR DESCRIPTION
There's a fluent API on MSBuildSettings to set file loggers.
It would be nice to also have a fluent API on MSBuildSettings to enable the binary logger.

Fixes #2294 
