### PR TITLE
GH2300: Make DotNetCoreTool projectPath optional

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Tool/DotNetCoreToolTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Tool/DotNetCoreToolTests.cs
@@ -15,18 +15,15 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Tool
         public sealed class TheToolMethod
         {
             [Fact]
-            public void Should_Throw_If_ProjectPath_IsNull()
+            public void Should_Not_Throw_If_ProjectPath_IsNull()
             {
                 // Given
                 var fixture = new DotNetCoreToolFixture();
+                fixture.Command = "cake";
                 fixture.ProjectPath = null;
-                fixture.GivenDefaultToolDoNotExist();
 
                 // When
-                var result = Record.Exception(() => fixture.Run());
-
-                // Then
-                AssertEx.IsArgumentNullException(result, "projectPath");
+                fixture.Run();
             }
 
             [Theory]

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -1057,7 +1057,62 @@ namespace Cake.Common.Tools.DotNetCore
         }
 
         /// <summary>
-        /// /// Execute an .NET Core Extensibility Tool.
+        /// Execute an .NET Core Extensibility Tool.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="command">The command to execute.</param>
+        /// <example>
+        /// <code>
+        ///     DotNetCoreTool("cake");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Tool")]
+        public static void DotNetCoreTool(this ICakeContext context, string command)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var arguments = new ProcessArgumentBuilder();
+            var settings = new DotNetCoreToolSettings();
+
+            context.DotNetCoreTool(null, command, arguments, settings);
+        }
+
+        /// <summary>
+        /// Execute an .NET Core Extensibility Tool.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="command">The command to execute.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        ///     DotNetCoreTool("cake"
+        ///             new DotNetCoreToolSettings {
+        ///                 DiagnosticOutput = true
+        ///             });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Tool")]
+        public static void DotNetCoreTool(this ICakeContext context, string command, DotNetCoreToolSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var arguments = new ProcessArgumentBuilder();
+
+            context.DotNetCoreTool(null, command, arguments, settings);
+        }
+
+        /// <summary>
+        /// Execute an .NET Core Extensibility Tool.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="projectPath">The project path.</param>

--- a/src/Cake.Common/Tools/DotNetCore/Tool/DotNetCoreToolRunner.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Tool/DotNetCoreToolRunner.cs
@@ -41,11 +41,6 @@ namespace Cake.Common.Tools.DotNetCore.Tool
         /// <param name="settings">The settings.</param>
         public void Execute(FilePath projectPath, string command, ProcessArgumentBuilder arguments, DotNetCoreToolSettings settings)
         {
-            if (projectPath == null)
-            {
-                throw new ArgumentNullException(nameof(projectPath));
-            }
-
             if (string.IsNullOrWhiteSpace(command))
             {
                 throw new ArgumentNullException(nameof(command));
@@ -57,7 +52,11 @@ namespace Cake.Common.Tools.DotNetCore.Tool
             }
 
             var processSettings = new ProcessSettings();
-            processSettings.WorkingDirectory = projectPath.GetDirectory();
+
+            if (projectPath != null)
+            {
+                processSettings.WorkingDirectory = projectPath.GetDirectory();
+            }
 
             RunCommand(settings, GetArguments(command, arguments, settings), processSettings);
         }


### PR DESCRIPTION
* Fixes #2300
* Adds overloads without projectPath.