### PR TITLE
GH2302: Moves assembly resolver to outer scope.

### DIFF
--- a/src/Cake/CakeAssemblyResolver.cs
+++ b/src/Cake/CakeAssemblyResolver.cs
@@ -8,14 +8,14 @@ using System.Linq;
 using System.Reflection;
 using Cake.Core.Diagnostics;
 
-namespace Cake.Scripting.Roslyn
+namespace Cake
 {
-    internal sealed class ScriptAssemblyResolver : IDisposable
+    internal sealed class CakeAssemblyResolver : IDisposable
     {
         private readonly ICakeLog _log;
         private readonly HashSet<string> _resolvedNames = new HashSet<string>();
 
-        public ScriptAssemblyResolver(ICakeLog log)
+        public CakeAssemblyResolver(ICakeLog log)
         {
             _log = log;
             AppDomain.CurrentDomain.AssemblyResolve += AssemblyResolve;
@@ -29,6 +29,12 @@ namespace Cake.Scripting.Roslyn
         private Assembly AssemblyResolve(object sender, ResolveEventArgs args)
         {
             var name = new AssemblyName(args.Name);
+
+            // Omit resources
+            if (name.Name.EndsWith(".resources"))
+            {
+                return null;
+            }
 
             // Prevent recursion from the Assembly.Load() call inside
             if (_resolvedNames.Add(name.Name))

--- a/src/Cake/Program.cs
+++ b/src/Cake/Program.cs
@@ -76,9 +76,12 @@ namespace Cake
                     var loader = container.Resolve<ModuleLoader>();
                     loader.LoadModules(container, options);
 
-                    // Resolve and run the application.
-                    var application = container.Resolve<CakeApplication>();
-                    return application.Run(options);
+                    using (new CakeAssemblyResolver(container.Resolve<ICakeLog>()))
+                    {
+                        // Resolve and run the application.
+                        var application = container.Resolve<CakeApplication>();
+                        return application.Run(options);
+                    }
                 }
             }
             catch (Exception ex)

--- a/src/Cake/Scripting/Roslyn/RoslynScriptSession.cs
+++ b/src/Cake/Scripting/Roslyn/RoslynScriptSession.cs
@@ -124,10 +124,7 @@ namespace Cake.Scripting.Roslyn
                 throw new CakeException(message);
             }
 
-            using (new ScriptAssemblyResolver(_log))
-            {
-                roslynScript.RunAsync(_host).Wait();
-            }
+            roslynScript.RunAsync(_host).Wait();
         }
     }
 }


### PR DESCRIPTION
- Rename ScriptAssemblyResolver to CakeAssemblyResolver
- Omit .resources in assembly resolver
- Fixes #2302