### PR TITLE
GH2306: Add VSTestReportPath to DotNetCoreTestSettings

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Test/DotNetCoreTesterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Test/DotNetCoreTesterTests.cs
@@ -118,12 +118,13 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Test
                 fixture.Settings.Logger = @"trx;LogFileName=/Working/logfile.trx";
                 fixture.Settings.DiagnosticFile = "./artifacts/logging/diagnostics.txt";
                 fixture.Settings.ResultsDirectory = "./tests/";
+                fixture.Settings.VSTestReportPath = "./tests/TestResults.xml";
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("test --settings \"/Working/demo.runsettings\" --filter \"Priority = 1\" --test-adapter-path \"/Working/custom-test-adapter\" --logger \"trx;LogFileName=/Working/logfile.trx\" --output \"/Working/artifacts\" --framework dnxcore50 --configuration Release --diag \"/Working/artifacts/logging/diagnostics.txt\" --no-build --no-restore --results-directory \"/Working/tests\"", result.Args);
+                Assert.Equal("test --settings \"/Working/demo.runsettings\" --filter \"Priority = 1\" --test-adapter-path \"/Working/custom-test-adapter\" --logger \"trx;LogFileName=/Working/logfile.trx\" --output \"/Working/artifacts\" --framework dnxcore50 --configuration Release --diag \"/Working/artifacts/logging/diagnostics.txt\" --no-build --no-restore --results-directory \"/Working/tests\" --logger trx;LogFileName=\"/Working/tests/TestResults.xml\"", result.Args);
             }
 
             [Fact]

--- a/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTestSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTestSettings.cs
@@ -72,5 +72,10 @@ namespace Cake.Common.Tools.DotNetCore.Test
         /// Gets or sets the results directory. This setting is only available from 2.0.0 upward.
         /// </summary>
         public DirectoryPath ResultsDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the file path to write VSTest reports to.
+        /// </summary>
+        public FilePath VSTestReportPath { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTester.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTester.cs
@@ -133,6 +133,11 @@ namespace Cake.Common.Tools.DotNetCore.Test
                 builder.AppendQuoted(settings.ResultsDirectory.MakeAbsolute(_environment).FullPath);
             }
 
+            if (settings.VSTestReportPath != null)
+            {
+                builder.AppendSwitchQuoted($"--logger trx;LogFileName", "=", settings.VSTestReportPath.MakeAbsolute(_environment).FullPath);
+            }
+
             return builder;
         }
     }


### PR DESCRIPTION
* fixes #2306

