### PR TITLE
GH2310: Make TestRuntime a Flags enum

### DIFF
--- a/src/Cake.Common.Tests/Unit/XML/XmlPokeTests.cs
+++ b/src/Cake.Common.Tests/Unit/XML/XmlPokeTests.cs
@@ -142,7 +142,7 @@ namespace Cake.Common.Tests.Unit.XML
                 Assert.False(fixture.TestIsUTF8WithBOM());
             }
 
-            [RuntimeFact(TestRuntime.Clr)]
+            [Fact]
             public void Should_Change_Attribute_From_Xml_File_With_Dtd()
             {
                 // Given
@@ -156,20 +156,6 @@ namespace Cake.Common.Tests.Unit.XML
                 Assert.True(fixture.TestIsValue(
                     "/plist/dict/string/text()",
                     "Cake Version"));
-            }
-
-            [RuntimeFact(TestRuntime.CoreClr)]
-            public void Should_Throw_On_Net_Core_Change_Attribute_From_Xml_File_With_Dtd()
-            {
-                // Given
-                var fixture = new XmlPokeFixture(xmlWithDtd: true);
-                fixture.Settings.DtdProcessing = XmlDtdProcessing.Parse;
-
-                // When
-                var result = Record.Exception(() => fixture.Poke("/plist/dict/string", "Cake Version"));
-
-                // Then
-                AssertEx.IsCakeException(result, "DtdProcessing is not available on .NET Core.");
             }
 
             [Fact]

--- a/src/Cake.Testing.Xunit/TestRuntime.cs
+++ b/src/Cake.Testing.Xunit/TestRuntime.cs
@@ -6,9 +6,10 @@ using System;
 
 namespace Cake.Testing.Xunit
 {
+    [Flags]
     public enum TestRuntime
     {
-        Clr,
-        CoreClr
+        Clr = 1,
+        CoreClr = 2
     }
 }


### PR DESCRIPTION
* fixes #2310

Before fix
```
Test run for C:\temp\dev\gh\devlead\cake\src\Cake.Core.Tests\bin\Debug\netcoreapp2.0\Cake.Core.Tests.dll(.NETCoreApp,Version=v2.0)
Microsoft (R) Test Execution Command Line Tool Version 15.8.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
[xUnit.net 00:00:01.0911952]     Cake.Core.Tests.Unit.CakeRuntimeTests+TheBuiltFrameworkroperty.Should_Return_Correct_Result_For_CoreClr [SKIP]
Skipped  Cake.Core.Tests.Unit.CakeRuntimeTests+TheBuiltFrameworkroperty.Should_Return_Correct_Result_For_CoreClr
```
after
```
Skipped  Cake.Core.Tests.Unit.CakeRuntimeTests+TheExecutingFrameworkProperty.Should_Return_Correct_Result_For_Clr
```