### PR TITLE
GH1875: Enable long path support on Windows 10

### DIFF
--- a/src/Cake/App.config
+++ b/src/Cake/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false;Switch.System.IO.BlockLongPaths=false" />
+  </runtime>
+</configuration>


### PR DESCRIPTION
As described in https://blogs.msdn.microsoft.com/jeremykuhne/2016/07/30/net-4-6-2-and-long-paths-on-windows-10/ 
Resolves #1875

Enables long path support on Windows 10 when:
- NuGet.exe v4.8.1 and above is used as external NuGet executable
- Long path support is enabled on the machine

Remarks:
- Windows 7 is not supported because does not support long paths
- I tried to upgrade the inprocess NuGet client to v4.8.0 but does not support long path's. So I removed the upgrade from my PR again
- I tried to add long path support to Cake's app.manifest but did not succeed (as described in the link above) - may anyone help me with that? Although I found that information that it may not work (tbc)