### PR TITLE
GH2061: NuGetPack: Fix the issue when the settings overwrite the .nuspec

### DIFF
--- a/src/Cake.Common.Tests/Properties/Resources.resx
+++ b/src/Cake.Common.Tests/Properties/Resources.resx
@@ -899,8 +899,6 @@ EndGlobal</value>
     &lt;version&gt;1.0.0&lt;/version&gt;
     &lt;authors&gt;Author #1,Author #2&lt;/authors&gt;
     &lt;description&gt;The description&lt;/description&gt;
-    &lt;developmentDependency&gt;false&lt;/developmentDependency&gt;
-    &lt;requireLicenseAcceptance&gt;false&lt;/requireLicenseAcceptance&gt;
     &lt;dependencies&gt;
       &lt;group targetFramework="net452"&gt;
         &lt;dependency id="Test1" version="1.0.0" /&gt;

--- a/src/Cake.Common/Tools/NuGet/Pack/NuGetPackSettings.cs
+++ b/src/Cake.Common/Tools/NuGet/Pack/NuGetPackSettings.cs
@@ -148,7 +148,7 @@ namespace Cake.Common.Tools.NuGet.Pack
         /// <value>
         ///   <c>true</c> if a development dependency; otherwise, <c>false</c>.
         /// </value>
-        public bool DevelopmentDependency { get; set; }
+        public bool? DevelopmentDependency { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether users has to accept the package license.
@@ -156,7 +156,7 @@ namespace Cake.Common.Tools.NuGet.Pack
         /// <value>
         /// <c>true</c> if users has to accept the package license; otherwise, <c>false</c>.
         /// </value>
-        public bool RequireLicenseAcceptance { get; set; }
+        public bool? RequireLicenseAcceptance { get; set; }
 
         /// <summary>
         /// Gets or sets the package files.

--- a/src/Cake.Common/Tools/NuGet/Pack/NuspecTransformer.cs
+++ b/src/Cake.Common/Tools/NuGet/Pack/NuspecTransformer.cs
@@ -200,9 +200,9 @@ namespace Cake.Common.Tools.NuGet.Pack
             return value?.ToString().TrimEnd('/');
         }
 
-        private static string ToString(bool value)
+        private static string ToString(bool? value)
         {
-            return value.ToString().ToLowerInvariant();
+            return value?.ToString().ToLowerInvariant();
         }
 
         private static string ToCommaSeparatedString(IEnumerable<string> values)


### PR DESCRIPTION
I noticed that there was a bug in the `NuGetPack` alias that would always overwrite the  `developmentDependency` and `requireLicenseAcceptance` values of the .nuspec. This probably has to do with the fact that the setting is `bool` and this always has a default value.

See this issue: #2061

To fix this, I changed it to `bool?` wich has a default of `null`, which is handled correctly.

BUT, this may be a BREAKING change since `bool` -> `bool?` just fine, but not the other way around. As a result, this may need more thought. But, since we are cool, and with it, I think this is a bug since I just discovered that my values were overwritten _and almost went out save for our automated checks we have at the door_.

~_Apologies for not submitting the PR according to the guidelines because I was doing this on the go via the online editor. If this turns out to be more that the two changes, I will see if I can get this according to standards when I get the opportunity - or maybe someone has a fix already._~