### PR TITLE
GH2337: Fix TFBuildCommand Directory Separator Character

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Build/TFBuildFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/TFBuildFixture.cs
@@ -22,19 +22,20 @@ namespace Cake.Common.Tests.Fixtures.Build
             Environment = Substitute.For<ICakeEnvironment>();
             Environment.WorkingDirectory.Returns("C:\\build\\CAKE-CAKE-JOB1");
             Environment.GetEnvironmentVariable("TF_BUILD").Returns((string)null);
+            Environment.Platform.Family.Returns(PlatformFamily.Windows);
             Log = new FakeLog();
-        }
-
-        public void IsRunningOnVSTS()
-        {
-            Environment.GetEnvironmentVariable("TF_BUILD").Returns("True");
-            Environment.GetEnvironmentVariable("AGENT_NAME").Returns("Hosted Agent");
         }
 
         public void IsRunningOnTFS()
         {
             Environment.GetEnvironmentVariable("TF_BUILD").Returns("True");
             Environment.GetEnvironmentVariable("AGENT_NAME").Returns("On Premises");
+        }
+
+        public void IsRunningOnVSTS()
+        {
+            Environment.GetEnvironmentVariable("TF_BUILD").Returns("True");
+            Environment.GetEnvironmentVariable("AGENT_NAME").Returns("Hosted Agent");
         }
 
         public TFBuildProvider CreateTFBuildService() => new TFBuildProvider(Environment, Log);

--- a/src/Cake.Common.Tests/Unit/Build/TFBuild/TFBuildCommandTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TFBuild/TFBuildCommandTests.cs
@@ -465,11 +465,103 @@ namespace Cake.Common.Tests.Unit.Build.TFBuild
                     PublishRunAttachments = true,
                     TestRunner = TFTestRunnerType.XUnit,
                     TestRunTitle = "Cake Test Run 1 [master]",
-                    TestResultsFiles = new string[]
+                    TestResultsFiles = new FilePath[]
                      {
-                         FilePath.FromString("./artifacts/resultsXUnit.trx").ToString(),
-                         FilePath.FromString("./artifacts/resultsJs.trx").ToString()
+                         "./artifacts/resultsXUnit.trx",
+                         "./artifacts/resultsJs.trx"
                      }
+                };
+
+                // When
+                service.Commands.PublishTestResults(data);
+
+                // Then
+                const string expected = @"##vso[results.publish type=XUnit;mergeResults=true;platform=x86;config=Debug;runTitle='Cake Test Run 1 [master]';publishRunAttachments=true;resultFiles=C:\build\CAKE-CAKE-JOB1\artifacts\resultsXUnit.trx,C:\build\CAKE-CAKE-JOB1\artifacts\resultsJs.trx;]";
+                var actual = fixture.Log.Entries.FirstOrDefault();
+                Assert.Equal(expected.Replace('\\', System.IO.Path.DirectorySeparatorChar), actual?.Message);
+            }
+
+            [Fact]
+            public void Should_Publish_Test_Results_If_File_Path_Is_Relative()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+                var data = new TFBuildPublishTestResultsData
+                {
+                    Configuration = "Debug",
+                    MergeTestResults = true,
+                    Platform = "x86",
+                    PublishRunAttachments = true,
+                    TestRunner = TFTestRunnerType.XUnit,
+                    TestRunTitle = "Cake Test Run 1 [master]",
+                    TestResultsFiles = new FilePath[]
+                    {
+                        "./artifacts/resultsXUnit.trx",
+                        "./artifacts/resultsJs.trx"
+                    }
+                };
+
+                // When
+                service.Commands.PublishTestResults(data);
+
+                // Then
+                const string expected = @"##vso[results.publish type=XUnit;mergeResults=true;platform=x86;config=Debug;runTitle='Cake Test Run 1 [master]';publishRunAttachments=true;resultFiles=C:\build\CAKE-CAKE-JOB1\artifacts\resultsXUnit.trx,C:\build\CAKE-CAKE-JOB1\artifacts\resultsJs.trx;]";
+                var actual = fixture.Log.Entries.FirstOrDefault();
+                Assert.Equal(expected.Replace('\\', System.IO.Path.DirectorySeparatorChar), actual?.Message);
+            }
+
+            [Fact]
+            public void Should_Publish_Test_Results_If_File_Path_Is_Absolute()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                fixture.Environment.WorkingDirectory.Returns("/build/CAKE-CAKE-JOB1");
+                fixture.Environment.Platform.Family.Returns(PlatformFamily.OSX);
+                var service = fixture.CreateTFBuildService();
+                var data = new TFBuildPublishTestResultsData
+                {
+                    Configuration = "Debug",
+                    MergeTestResults = true,
+                    Platform = "x86",
+                    PublishRunAttachments = true,
+                    TestRunner = TFTestRunnerType.XUnit,
+                    TestRunTitle = "Cake Test Run 1 [master]",
+                    TestResultsFiles = new FilePath[]
+                    {
+                        "/build/CAKE-CAKE-JOB1/artifacts/resultsXUnit.trx",
+                        "/build/CAKE-CAKE-JOB1/artifacts/resultsJs.trx"
+                    }
+                };
+
+                // When
+                service.Commands.PublishTestResults(data);
+
+                // Then
+                const string expected = @"##vso[results.publish type=XUnit;mergeResults=true;platform=x86;config=Debug;runTitle='Cake Test Run 1 [master]';publishRunAttachments=true;resultFiles=/build/CAKE-CAKE-JOB1/artifacts/resultsXUnit.trx,/build/CAKE-CAKE-JOB1/artifacts/resultsJs.trx;]";
+                var actual = fixture.Log.Entries.FirstOrDefault();
+                Assert.Equal(expected.Replace('/', System.IO.Path.DirectorySeparatorChar), actual?.Message);
+            }
+
+            [WindowsFact]
+            public void Should_Publish_Test_Results_If_File_Path_Is_Absolute_Windows()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+                var data = new TFBuildPublishTestResultsData
+                {
+                    Configuration = "Debug",
+                    MergeTestResults = true,
+                    Platform = "x86",
+                    PublishRunAttachments = true,
+                    TestRunner = TFTestRunnerType.XUnit,
+                    TestRunTitle = "Cake Test Run 1 [master]",
+                    TestResultsFiles = new FilePath[]
+                    {
+                        "C:\\build\\CAKE-CAKE-JOB1\\artifacts\\resultsXUnit.trx",
+                        "C:\\build\\CAKE-CAKE-JOB1\\artifacts\\resultsJs.trx"
+                    }
                 };
 
                 // When
@@ -481,6 +573,8 @@ namespace Cake.Common.Tests.Unit.Build.TFBuild
                 Assert.Equal(expected, actual?.Message);
             }
 
+            // TODO: Windows Fact, OSX Fact
+            // TODO: TestResultFilePaths
             [Fact]
             public void Should_Publish_Code_Coverage()
             {

--- a/src/Cake.Common/Build/TFBuild/Data/TFBuildPublishTestResultsData.cs
+++ b/src/Cake.Common/Build/TFBuild/Data/TFBuildPublishTestResultsData.cs
@@ -23,7 +23,7 @@ namespace Cake.Common.Build.TFBuild.Data
         /// <summary>
         /// Gets or sets the list of Test Result files to publish.
         /// </summary>
-        public string[] TestResultsFiles { get; set; }
+        public ICollection<FilePath> TestResultsFiles { get; set; } = new List<FilePath>();
 
         /// <summary>
         /// Gets or Sets whether to merge all Test Result Files into one run
@@ -85,8 +85,15 @@ namespace Cake.Common.Build.TFBuild.Data
             }
             if (TestResultsFiles != null && TestResultsFiles.Any())
             {
-                properties.Add("resultFiles", string.Join(",", TestResultsFiles.Select(filePath => new FilePath(filePath).MakeAbsolute(environment).FullPath.Replace("/", "\\"))));
+                properties.Add("resultFiles",
+                    string.Join(",",
+                        TestResultsFiles.Select(filePath =>
+                            filePath
+                                .MakeAbsolute(environment)
+                                .FullPath
+                                .Replace(filePath.Separator, System.IO.Path.DirectorySeparatorChar))));
             }
+
             return properties;
         }
     }


### PR DESCRIPTION
Resolves #2337 
- Changed type for TestResultsFiles from string[] to ICollection<FilePath>
- Changed selector to only call make absolute on relative paths
- Added Tests for Relative Paths and Absolute paths
- Added tests showing FilePath can be created implicitly from string