### PR TITLE
GH2332: Add overloads for uploading artifact directories to Azure Pipelines

### DIFF
--- a/src/Cake.Common.Tests/Unit/Build/TFBuild/TFBuildCommandTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TFBuild/TFBuildCommandTests.cs
@@ -335,6 +335,36 @@ namespace Cake.Common.Tests.Unit.Build.TFBuild
             }
 
             [Fact]
+            public void Should_Upload_Directory_As_Container()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+                var path = DirectoryPath.FromString("./artifacts/Packages").MakeAbsolute(fixture.Environment).FullPath;
+
+                // When
+                service.Commands.UploadArtifactDirectory("./artifacts/Packages");
+
+                // Then
+                Assert.Contains(fixture.Log.Entries, m => m.Message == $"##vso[artifact.upload containerfolder=Packages;artifactname=Packages;]{path}");
+            }
+
+            [Fact]
+            public void Should_Upload_Directory_As_Container_Artifact()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+                var path = DirectoryPath.FromString("./artifacts/Packages").MakeAbsolute(fixture.Environment).FullPath;
+
+                // When
+                service.Commands.UploadArtifactDirectory("./artifacts/Packages", "NuGet");
+
+                // Then
+                Assert.Contains(fixture.Log.Entries, m => m.Message == $"##vso[artifact.upload containerfolder=NuGet;artifactname=NuGet;]{path}");
+            }
+
+            [Fact]
             public void Should_Upload_Build_Log()
             {
                 // Given

--- a/src/Cake.Common.Tests/Unit/Build/TFBuild/TFBuildCommandTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TFBuild/TFBuildCommandTests.cs
@@ -335,6 +335,20 @@ namespace Cake.Common.Tests.Unit.Build.TFBuild
             }
 
             [Fact]
+            public void UploadArtifactDirectory_Should_Throw_If_Directory_Is_Null()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+
+                // When
+                var result = Record.Exception(() => service.Commands.UploadArtifactDirectory(null));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "directory");
+            }
+
+            [Fact]
             public void Should_Upload_Directory_As_Container()
             {
                 // Given
@@ -347,6 +361,34 @@ namespace Cake.Common.Tests.Unit.Build.TFBuild
 
                 // Then
                 Assert.Contains(fixture.Log.Entries, m => m.Message == $"##vso[artifact.upload containerfolder=Packages;artifactname=Packages;]{path}");
+            }
+
+            [Fact]
+            public void UploadArtifactDirectory_With_ArtifactName_Should_Throw_If_Directory_Is_Null()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+
+                // When
+                var result = Record.Exception(() => service.Commands.UploadArtifactDirectory(null, "Packages"));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "directory");
+            }
+
+            [Fact]
+            public void UploadArtifactDirectory_Should_Throw_If_ArtifactName_Is_Null()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var service = fixture.CreateTFBuildService();
+
+                // When
+                var result = Record.Exception(() => service.Commands.UploadArtifactDirectory("./artifacts/Packages", null));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "artifactName");
             }
 
             [Fact]

--- a/src/Cake.Common/Build/TFBuild/ITFBuildCommands.cs
+++ b/src/Cake.Common/Build/TFBuild/ITFBuildCommands.cs
@@ -150,6 +150,19 @@ namespace Cake.Common.Build.TFBuild
         void UploadArtifact(string folderName, FilePath file, string artifactName);
 
         /// <summary>
+        /// Upload local directory as a container folder, and create an artifact.
+        /// </summary>
+        /// <param name="directory">Path to the local directory.</param>
+        void UploadArtifactDirectory(DirectoryPath directory);
+
+        /// <summary>
+        /// Upload local directory as a container folder, and create an artifact with the specified name.
+        /// </summary>
+        /// <param name="directory">Path to the local directory.</param>
+        /// <param name="artifactName">The artifact name.</param>
+        void UploadArtifactDirectory(DirectoryPath directory, string artifactName);
+
+        /// <summary>
         /// Upload additional log to build container's <c>logs/tool</c> folder.
         /// </summary>
         /// <param name="logFile">The log file.</param>

--- a/src/Cake.Common/Build/TFBuild/TFBuildCommands.cs
+++ b/src/Cake.Common/Build/TFBuild/TFBuildCommands.cs
@@ -280,6 +280,22 @@ namespace Cake.Common.Build.TFBuild
             }, file.MakeAbsolute(_environment).FullPath);
         }
 
+        /// <inheritdoc />
+        public void UploadArtifactDirectory(DirectoryPath directory)
+        {
+            UploadArtifactDirectory(directory, directory.GetDirectoryName());
+        }
+
+        /// <inheritdoc />
+        public void UploadArtifactDirectory(DirectoryPath directory, string artifactName)
+        {
+            WriteLoggingCommand("artifact.upload", new Dictionary<string, string>
+            {
+                ["containerfolder"] = artifactName,
+                ["artifactname"] = artifactName
+            }, directory.MakeAbsolute(_environment).FullPath);
+        }
+
         /// <summary>
         /// Upload additional log to build container's <c>logs/tool</c> folder.
         /// </summary>

--- a/src/Cake.Common/Build/TFBuild/TFBuildCommands.cs
+++ b/src/Cake.Common/Build/TFBuild/TFBuildCommands.cs
@@ -283,12 +283,27 @@ namespace Cake.Common.Build.TFBuild
         /// <inheritdoc />
         public void UploadArtifactDirectory(DirectoryPath directory)
         {
+            if (directory == null)
+            {
+                throw new ArgumentNullException(nameof(directory));
+            }
+
             UploadArtifactDirectory(directory, directory.GetDirectoryName());
         }
 
         /// <inheritdoc />
         public void UploadArtifactDirectory(DirectoryPath directory, string artifactName)
         {
+            if (directory == null)
+            {
+                throw new ArgumentNullException(nameof(directory));
+            }
+
+            if (artifactName == null)
+            {
+                throw new ArgumentNullException(nameof(artifactName));
+            }
+
             WriteLoggingCommand("artifact.upload", new Dictionary<string, string>
             {
                 ["containerfolder"] = artifactName,


### PR DESCRIPTION
Added `UploadArtifactDirectory` commands for uploading directory artifacts to Azure Pipelines. The new method name was required to avoid conflicts with existing `UploadArtifact` commands since both `FilePath` and `DirectoryPath` have implicit conversion from `string`.

Fixes #2332