### PR TITLE
GH2272: NuGet Inprocess usable with restricted internet access

### DIFF
--- a/src/Cake.NuGet/Cake.NuGet.csproj
+++ b/src/Cake.NuGet/Cake.NuGet.csproj
@@ -19,9 +19,9 @@
   </ItemGroup>
   <!-- Global packages -->
   <ItemGroup>
-    <PackageReference Include="NuGet.Frameworks" Version="4.7.0" />
-    <PackageReference Include="NuGet.Versioning" Version="4.7.0" />
-    <PackageReference Include="NuGet.ProjectModel" Version="4.7.0" />
+    <PackageReference Include="NuGet.Frameworks" Version="4.8.0" />
+    <PackageReference Include="NuGet.Versioning" Version="4.8.0" />
+    <PackageReference Include="NuGet.ProjectModel" Version="4.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
   <!-- .NET Core packages -->
@@ -30,6 +30,6 @@
   </ItemGroup>
   <!-- .NET Framework packages -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <PackageReference Include="NuGet.PackageManagement" Version="4.7.0" />
+    <PackageReference Include="NuGet.PackageManagement" Version="4.8.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Nuget 4.8 supports the _NUGET_CERT_REVOCATION_MODE="offline"_
Will make the in process nuget client usable in offline environments.

- Updated NuGet.* PackageReferences to 4.8.0

Relevant info: https://docs.microsoft.com/en-us/nuget/release-notes/nuget-4.8-rtm#known-issues

Resolves #2272 