### PR TITLE
add MSBuildSettings.NoLogo (fixes issue #1976)

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -636,6 +636,21 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             }
 
             [Fact]
+            public void Should_Use_No_Logo_If_Specified()
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows);
+                fixture.Settings.NoLogo = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/nologo /v:normal /target:Build " +
+                             "\"C:/Working/src/Solution.sln\"", result.Args);
+            }
+
+            [Fact]
             public void Should_Append_Targets_To_Process_Arguments()
             {
                 // Given

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsExtensionsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsExtensionsTests.cs
@@ -291,6 +291,37 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             }
         }
 
+        public sealed class TheNoLogoMethod
+        {
+            [Theory]
+            [InlineData(true)]
+            [InlineData(false)]
+            public void Should_Set_No_Logo(bool noLogo)
+            {
+                // Given
+                var settings = new MSBuildSettings();
+
+                // When
+                settings.SetNoLogo(noLogo);
+
+                // Then
+                Assert.Equal(noLogo, settings.NoLogo);
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new MSBuildSettings();
+
+                // When
+                var result = settings.SetNoLogo(true);
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
         public sealed class TheSetVerbosityMethod
         {
             [Theory]

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsTests.cs
@@ -140,6 +140,19 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             }
         }
 
+        public sealed class TheNoLogoProperty
+        {
+            [Fact]
+            public void Should_Be_Null_By_Default()
+            {
+                // Given
+                var settings = new MSBuildSettings();
+
+                // Then
+                Assert.Null(settings.NoLogo);
+            }
+        }
+
         public sealed class TheLoggersProperty
         {
             [Fact]

--- a/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
@@ -70,6 +70,12 @@ namespace Cake.Common.Tools.MSBuild
                 builder.Append("/noconlog");
             }
 
+            // Set the no logo flag.
+            if (settings.NoLogo.GetValueOrDefault())
+            {
+                builder.Append("/nologo");
+            }
+
             // Set the verbosity.
             builder.Append(string.Format(CultureInfo.InvariantCulture, "/v:{0}", settings.Verbosity.GetMSBuildVerbosityName()));
 

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
@@ -90,6 +90,11 @@ namespace Cake.Common.Tools.MSBuild
         public bool? NoConsoleLogger { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to show copyright information at the start of the program.
+        /// </summary>
+        public bool? NoLogo { get; set; }
+
+        /// <summary>
         /// Gets or sets the amount of information to display in the build log.
         /// Each logger displays events based on the verbosity level that you set for that logger.
         /// </summary>

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
@@ -191,6 +191,22 @@ namespace Cake.Common.Tools.MSBuild
         }
 
         /// <summary>
+        /// Sets whether or not copyright information at the start of the program should be shown.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="noLogo"><c>true</c> if no copyright information at the start of the program should be shown; otherwise <c>false</c>.</param>
+        /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static MSBuildSettings SetNoLogo(this MSBuildSettings settings, bool noLogo)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            settings.NoLogo = noLogo;
+            return settings;
+        }
+
+        /// <summary>
         /// Sets the build log verbosity.
         /// </summary>
         /// <param name="settings">The settings.</param>


### PR DESCRIPTION
- [x] adds "/noLogo" to MsBuild
- [x] adds ExtensionMethod to MSBuildSettings
- [x] has unit tests

All changes are made according to "NoConsoleLogger".