### PR TITLE
GH2384: Add fallback path for mono msbuild if installed under homebrew on MacOS

### DIFF
--- a/src/Cake.Common/Tools/MSBuild/MSBuildResolver.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildResolver.cs
@@ -21,6 +21,13 @@ namespace Cake.Common.Tools.MSBuild
                     return macMSBuildPath;
                 }
 
+                var brewMSBuildPath = new FilePath("/usr/local/bin/msbuild");
+
+                if (fileSystem.Exist(brewMSBuildPath))
+                {
+                    return brewMSBuildPath;
+                }
+
                 throw new CakeException("Could not resolve MSBuild.");
             }
             else if (environment.Platform.Family == PlatformFamily.Linux)


### PR DESCRIPTION
This PR adds a fallback path to `/usr/local/bin/msbuild` in the MSBuild detector. If `mono` is installed via homebrew, `msbuild` is symlinked to this location by convention and is not located at the default `/Library/Frameworks...` path.
