### PR TITLE
Add possibility to filter results of the nugetlist command

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/NuGet/List/NuGetListFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/NuGet/List/NuGetListFixture.cs
@@ -24,6 +24,20 @@ namespace Cake.Common.Tests.Fixtures.Tools.NuGet.List
             });
         }
 
+        public void GivenMultibleVersionsInPackageResult()
+        {
+            ProcessRunner.Process.SetStandardOutput(new string[]
+            {
+                "Cake 0.31.0-alpha0075",
+                "Cake 0.30.0",
+                "Cake 0.22.2",
+                "Cake.Core 0.30.0",
+                "Cake.Core 0.22.2",
+                "Cake.CoreCLR 0.30.0",
+                "Cake.CoreCLR 0.22.2",
+            });
+        }
+
         protected override void RunTool()
         {
             var tool = new NuGetList(FileSystem, Environment, ProcessRunner, Tools, Resolver);

--- a/src/Cake.Common.Tests/Unit/Tools/NuGet/List/NuGetListTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NuGet/List/NuGetListTests.cs
@@ -1,9 +1,9 @@
-﻿using Cake.Common.Tests.Fixtures.Tools.NuGet.List;
+﻿using System;
+using System.Collections.Generic;
+using Cake.Common.Tests.Fixtures.Tools.NuGet.List;
 using Cake.Common.Tools.NuGet.List;
 using Cake.Testing;
 using Cake.Testing.Xunit;
-using System;
-using System.Collections.Generic;
 using Xunit;
 
 namespace Cake.Common.Tests.Unit.Tools.NuGet.List

--- a/src/Cake.Common.Tests/Unit/Tools/NuGet/List/NuGetListTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NuGet/List/NuGetListTests.cs
@@ -2,6 +2,8 @@
 using Cake.Common.Tools.NuGet.List;
 using Cake.Testing;
 using Cake.Testing.Xunit;
+using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Cake.Common.Tests.Unit.Tools.NuGet.List
@@ -345,6 +347,35 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.List
                     {
                         Assert.Equal(item.Name, "Cake.Core");
                         Assert.Equal(item.Version, "0.30.0");
+                    });
+            }
+
+            [Fact]
+            public void Should_Return_Filtered_List_From_Filter_Predicates()
+            {
+                // Given
+                var fixture = new NuGetListFixture
+                {
+                    PackageId = "Cake.Core",
+                };
+
+                fixture.Settings.FilterPredicates = new List<Func<NuGetListItem, bool>>()
+                {
+                    item => item.Name.StartsWith("Cak"),
+                    item => item.Version.Contains("alpha"),
+                };
+
+                fixture.GivenMultibleVersionsInPackageResult();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Collection(fixture.Result,
+                    item =>
+                    {
+                        Assert.Equal(item.Name, "Cake");
+                        Assert.Equal(item.Version, "0.31.0-alpha0075");
                     });
             }
         }

--- a/src/Cake.Common.Tests/Unit/Tools/NuGet/List/NuGetListTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NuGet/List/NuGetListTests.cs
@@ -271,6 +271,82 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.List
                         Assert.Equal(item.Version, "0.22.2");
                     });
             }
+
+            [Fact]
+            public void Should_Return_Filtered_List_By_PackageVersion_Of_NuGetListItems()
+            {
+                // Given
+                var fixture = new NuGetListFixture
+                {
+                    PackageId = "Cake.Core",
+                };
+
+                fixture.Settings.AllVersions = true;
+                fixture.Settings.VersionFilters = new[]
+                {
+                    "0.30.0",
+                    "0.31.0-alpha0075"
+                };
+
+                fixture.GivenMultibleVersionsInPackageResult();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Collection(fixture.Result,
+                    item =>
+                    {
+                        Assert.Equal(item.Name, "Cake");
+                        Assert.Equal(item.Version, "0.31.0-alpha0075");
+                    },
+                    item =>
+                    {
+                        Assert.Equal(item.Name, "Cake");
+                        Assert.Equal(item.Version, "0.30.0");
+                    },
+                    item =>
+                    {
+                        Assert.Equal(item.Name, "Cake.Core");
+                        Assert.Equal(item.Version, "0.30.0");
+                    },
+                    item =>
+                    {
+                        Assert.Equal(item.Name, "Cake.CoreCLR");
+                        Assert.Equal(item.Version, "0.30.0");
+                    });
+            }
+
+            [Fact]
+            public void Should_Return_Filtered_List_By_PackageId_And_Version_Of_NuGetListItems()
+            {
+                // Given
+                var fixture = new NuGetListFixture
+                {
+                    PackageId = "Cake.Core",
+                };
+
+                fixture.Settings.AllVersions = true;
+                fixture.Settings.PackageIdComparison = PackageIdCompare.Equals;
+                fixture.Settings.VersionFilters = new[]
+                {
+                    "0.30.0",
+                    "0.31.0-alpha0075"
+                };
+
+                fixture.GivenMultibleVersionsInPackageResult();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Collection(fixture.Result,
+                    item =>
+                    {
+                        Assert.Equal(item.Name, "Cake.Core");
+                        Assert.Equal(item.Version, "0.30.0");
+                    });
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/NuGet/List/NuGetListTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NuGet/List/NuGetListTests.cs
@@ -1,4 +1,5 @@
 ﻿using Cake.Common.Tests.Fixtures.Tools.NuGet.List;
+using Cake.Common.Tools.NuGet.List;
 using Cake.Testing;
 using Cake.Testing.Xunit;
 using Xunit;
@@ -242,6 +243,31 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.List
                     item =>
                     {
                         Assert.Equal(item.Name, "Cake.CoreCLR");
+                        Assert.Equal(item.Version, "0.22.2");
+                    });
+            }
+
+            [Fact]
+            public void Should_Return_Filtered_List_By_PackageId_Of_NuGetListItems()
+            {
+                // Given
+                var fixture = new NuGetListFixture
+                {
+                    PackageId = "Cake.Core",
+                };
+
+                fixture.Settings.PackageIdComparison = PackageIdCompare.Equals;
+
+                fixture.GivenNormalPackageResult();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Collection(fixture.Result,
+                    item =>
+                    {
+                        Assert.Equal(item.Name, "Cake.Core");
                         Assert.Equal(item.Version, "0.22.2");
                     });
             }

--- a/src/Cake.Common/Tools/NuGet/List/NuGetList.cs
+++ b/src/Cake.Common/Tools/NuGet/List/NuGetList.cs
@@ -69,7 +69,17 @@ namespace Cake.Common.Tools.NuGet.List
             Run(settings, GetHasArguments(packageId, settings), processSettings,
                 process => result = process.GetStandardOutput());
 
-            return result.Select(line => ConvertToNuGetListItem(line)).ToList();
+            return FilterResults(packageId, settings, result.Select(line => ConvertToNuGetListItem(line))).ToList();
+        }
+
+        private IEnumerable<NuGetListItem> FilterResults(string packageId, NuGetListSettings settings, IEnumerable<NuGetListItem> nugetListItems)
+        {
+            if (settings.PackageIdComparison == PackageIdCompare.Equals)
+            {
+                return nugetListItems.Where(i => string.Equals(i.Name, packageId, StringComparison.OrdinalIgnoreCase));
+            }
+
+            return nugetListItems;
         }
 
         private NuGetListItem ConvertToNuGetListItem(string line)

--- a/src/Cake.Common/Tools/NuGet/List/NuGetList.cs
+++ b/src/Cake.Common/Tools/NuGet/List/NuGetList.cs
@@ -81,13 +81,18 @@ namespace Cake.Common.Tools.NuGet.List
                 filterPredicates.Add(item => string.Equals(item.Name, packageId, StringComparison.OrdinalIgnoreCase));
             }
 
-            if (settings.VersionFilters.Any())
+            if (settings.VersionFilters?.Count > 0)
             {
                 // Only one version has to be match
                 filterPredicates.Add(
                     item => settings.VersionFilters.Any(
                         versionFilter =>
                             string.Equals(item.Version, versionFilter, StringComparison.OrdinalIgnoreCase)));
+            }
+
+            if (settings.FilterPredicates?.Count > 0)
+            {
+                filterPredicates.AddRange(settings.FilterPredicates);
             }
 
             return nugetListItems.Where(item => filterPredicates.All(predicate => predicate(item)));

--- a/src/Cake.Common/Tools/NuGet/List/NuGetListSettings.cs
+++ b/src/Cake.Common/Tools/NuGet/List/NuGetListSettings.cs
@@ -38,5 +38,10 @@ namespace Cake.Common.Tools.NuGet.List
         /// Gets or sets the way to resolve a Package ID
         /// </summary>
         public PackageIdCompare PackageIdComparison { get; set; }
+
+        /// <summary>
+        /// Gets or sets a list of package versions to filter for.
+        /// </summary>
+        public ICollection<string> VersionFilters { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/NuGet/List/NuGetListSettings.cs
+++ b/src/Cake.Common/Tools/NuGet/List/NuGetListSettings.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
 
@@ -43,5 +44,10 @@ namespace Cake.Common.Tools.NuGet.List
         /// Gets or sets a list of package versions to filter for.
         /// </summary>
         public ICollection<string> VersionFilters { get; set; }
+
+        /// <summary>
+        /// Gets or sets multiple predicates to filter <see cref="NuGetListItem"/>
+        /// </summary>
+        public ICollection<Func<NuGetListItem, bool>> FilterPredicates { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/NuGet/List/NuGetListSettings.cs
+++ b/src/Cake.Common/Tools/NuGet/List/NuGetListSettings.cs
@@ -33,5 +33,10 @@ namespace Cake.Common.Tools.NuGet.List
         /// Gets or sets a list of packages sources to search.
         /// </summary>
         public ICollection<string> Source { get; set; }
+
+        /// <summary>
+        /// Gets or sets the way to resolve a Package ID
+        /// </summary>
+        public PackageIdCompare PackageIdComparison { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/NuGet/List/PackageIdCompare.cs
+++ b/src/Cake.Common/Tools/NuGet/List/PackageIdCompare.cs
@@ -1,0 +1,18 @@
+﻿namespace Cake.Common.Tools.NuGet.List
+{
+    /// <summary>
+    /// Define how to handle Comparison of package ID
+    /// </summary>
+    public enum PackageIdCompare
+    {
+        /// <summary>
+        /// Package ID Contains a text to find
+        /// </summary>
+        Contains = 0,
+
+        /// <summary>
+        /// Package ID text to find must be equals
+        /// </summary>
+        Equals = 1,
+    }
+}


### PR DESCRIPTION
When i list the available packages form a Azure DevOps Nuget feed, is actualy the problem, the packageid in the command to filter for, is not enouth. 

The example shows the Problem:
```
   var packageList = NuGetList("mypackage", new NuGetListSettings()
   {
      Prerelease = true,
      AllVersions = true,
      Source = new []  { "MyDevOpsPackageFeed" },
   });
```

This returns a List like:
- MyPackage 1.0.0
- MyPackage 1.0.1
- MyPackage 1.1.0-alpha
- MyPackage.Utils 2.0.0
- MyPackage.Utils 1.0.0
- MyPackage.Analyzer 1.0.0

What i relay wont was 
- MyPackage 1.0.0
- MyPackage 1.0.1
- MyPackage 1.1.0-alpha

In this PR i have add the possibility:
- to filter of a equals match of packageId
- to filter for a specific version
- to filter of own creaded predicates

I think this is a way to fill the hole of the missing cli tool functionality.