### PR TITLE
Fix missing parenthesis and missing setting.

### DIFF
--- a/src/Cake.Common/ProcessAliases.cs
+++ b/src/Cake.Common/ProcessAliases.cs
@@ -156,7 +156,8 @@ namespace Cake.Common
         ///         "ping",
         ///         new ProcessSettings {
         ///             Arguments = "localhost",
-        ///             RedirectStandardOutput = true
+        ///             RedirectStandardOutput = true,
+        ///             RedirectStandardError = true
         ///         },
         ///         out redirectedStandardOutput,
         ///         out redirectedErrorOutput
@@ -171,7 +172,7 @@ namespace Cake.Common
         ///     throw new Exception(
         ///         string.Format(
         ///             "Errors occurred: {0}",
-        ///             string.Join(", ", redirectedErrorOutput));
+        ///             string.Join(", ", redirectedErrorOutput)));
         /// }
         ///
         /// // This should output 0 as valid arguments supplied


### PR DESCRIPTION
Small fixes in documentation. Example of StartProcess with redirecting output.