### PR TITLE
Call GetAwaiter().GetResult() in NuGetPackageInstaller

### DIFF
--- a/src/Cake.NuGet/Install/NuGetPackageInstaller.cs
+++ b/src/Cake.NuGet/Install/NuGetPackageInstaller.cs
@@ -134,7 +134,7 @@ namespace Cake.NuGet.Install
                 projectContext,
                 sourceRepositoryProvider.GetPrimaryRepositories(),
                 sourceRepositoryProvider.GetRepositories(),
-                CancellationToken.None).Result;
+                CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
 
             // Then install the packages.
             packageManager.ExecuteNuGetProjectActionsAsync(


### PR DESCRIPTION
Avoids any exceptions being wrapped in AggregateException, which results in end-user getting the actual underlying error displayed should an exception being thrown

Fixes #2249

Given the following Cake file:

```
#load "nuget:https://www.nuget.org/api/v2?package=Cake.Foo&version=1.2.3"

var target = Argument("target", "Default");

Task("Default")
  .Does(() =>
{
  Information("Hello World!");
  
});

RunTarget(target);
```

Without this change, you get the following output

```
C:/dev/git/cake-version-test/build.cake:1: One or more errors occurred.
Error: Errors occurred while analyzing script.
```

After this change, you get:

```
C:/dev/git/cake-version-test/build.cake:1: Unable to find version '1.2.3' of package 'Cake.Foo'.
Error: Errors occurred while analyzing script.
```
