### PR TITLE
 GH2393: Support attribute-decorated parameters in cake alias methods for codegen

### DIFF
--- a/src/Cake.Core.Tests/Data/MethodAliasGeneratorData.cs
+++ b/src/Cake.Core.Tests/Data/MethodAliasGeneratorData.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using Cake.Core.Annotations;
 
 namespace Cake.Core.Tests.Data
@@ -230,6 +231,12 @@ namespace Cake.Core.Tests.Data
 
         [CakeMethodAlias]
         public static void NonGeneric_ExtensionMethodWithGenericCollectionOfNestedType(this ICakeContext context, ICollection<Cake.Core.Tests.Data.MethodAliasGeneratorData.TestNestedEnum> items)
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+        public static void NonGeneric_ExtensionMethodWithParameterAttributes(this ICakeContext context, [CallerMemberName] string memberName = "", [CallerFilePath] string sourceFilePath = "", [CallerLineNumber] int sourceLineNumber = 0)
         {
             throw new NotImplementedException();
         }

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithParameterAttributes
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithParameterAttributes
@@ -1,0 +1,4 @@
+﻿public void NonGeneric_ExtensionMethodWithParameterAttributes([System.Runtime.CompilerServices.CallerMemberName] System.String memberName = "", [System.Runtime.CompilerServices.CallerFilePath] System.String sourceFilePath = "", [System.Runtime.CompilerServices.CallerLineNumber] System.Int32 sourceLineNumber = (System.Int32)0)
+{
+    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithParameterAttributes(Context, memberName, sourceFilePath, sourceLineNumber);
+}

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/MethodAliasGeneratorTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/MethodAliasGeneratorTests.cs
@@ -54,6 +54,7 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
             [InlineData("NonGeneric_ExtensionMethodWithReservedKeywordParameter")]
             [InlineData("NonGeneric_ExtensionMethodWithOutputParameter")]
             [InlineData("NonGeneric_ExtensionMethodWithGenericCollectionOfNestedType")]
+            [InlineData("NonGeneric_ExtensionMethodWithParameterAttributes")]
             public void Should_Return_Correct_Generated_Code_For_Non_Generic_Methods(string name)
             {
                 // Given

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/ParameterEmitterTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/ParameterEmitterTests.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
-using System.Resources;
+using System.Runtime.CompilerServices;
 using Cake.Core.Scripting.CodeGen;
 using Xunit;
 // ReSharper disable UnusedMember.Local
@@ -368,6 +368,14 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
             {
                 arg = 0;
             }
+
+            public static void OptionalStringWithAttribute([CallerMemberName] string memberName = "", [CallerFilePath] string sourceFilePath = "", [CallerLineNumber] int sourceLineNumber = 0)
+            {
+            }
+
+            public static void OptionalInt32WithAttribute([CallerLineNumber] int sourceLineNumber = 0)
+            {
+            }
         }
 
         [Theory]
@@ -457,6 +465,8 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
         [InlineData("OptionalNullableIntKeywordWithNullDefault", "System.Nullable<System.Int32> @new = null")]
         [InlineData("OutputParameterInterface", "out System.IDisposable arg")]
         [InlineData("OutputParameterInt32", "out System.Int32 arg")]
+        [InlineData("OptionalStringWithAttribute", "[System.Runtime.CompilerServices.CallerMemberName] System.String memberName = \"\"")]
+        [InlineData("OptionalInt32WithAttribute", "[System.Runtime.CompilerServices.CallerLineNumber] System.Int32 sourceLineNumber = (System.Int32)0")]
         public void Should_Return_Correct_Generated_Code_For_Method_Parameters(string methodName, string expected)
         {
             // Given

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/ParameterEmitterTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/ParameterEmitterTests.cs
@@ -14,11 +14,41 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
 {
     public sealed class ParameterEmitterTests
     {
-        private enum TestEnum
+        public enum TestEnum
         {
             None,
             Some,
             All
+        }
+
+        [AttributeUsageAttribute(AttributeTargets.Parameter)]
+        public sealed class TestParameterAttribute : Attribute
+        {
+            public TestParameterAttribute(string name)
+            {
+            }
+
+            public TestParameterAttribute(int number)
+            {
+            }
+
+            public TestParameterAttribute(TestEnum value)
+            {
+            }
+
+            public TestParameterAttribute(TestEnum[] values)
+            {
+            }
+
+            public TestParameterAttribute()
+            {
+            }
+
+            public string StringProperty { get; set; }
+
+            public int Int32Property { get; set; }
+
+            public TestEnum EnumProperty { get; set; }
         }
 
         private static class ParameterFixture
@@ -376,6 +406,34 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
             public static void OptionalInt32WithAttribute([CallerLineNumber] int sourceLineNumber = 0)
             {
             }
+
+            public static void RequiredStringWithCustomAttributeCalledWithInt32CtorParameter([TestParameter(19)] string value)
+            {
+            }
+
+            public static void RequiredStringWithCustomAttributeCalledWithStringCtorParameter([TestParameter("test")] string value)
+            {
+            }
+
+            public static void RequiredStringWithCustomAttributeCalledWithEnumCtorParameter([TestParameter(TestEnum.All)] string value)
+            {
+            }
+
+            public static void RequiredStringWithCustomAttributeCalledWithArrayCtorParameter([TestParameter(new[] { TestEnum.All, TestEnum.Some })] string value)
+            {
+            }
+
+            public static void RequiredStringWithCustomAttributeCalledWithInt32NamedArgument([TestParameter(Int32Property = 19)] string value)
+            {
+            }
+
+            public static void RequiredStringWithCustomAttributeCalledWithStringNamedArgument([TestParameter(StringProperty = "test")] string value)
+            {
+            }
+
+            public static void RequiredStringWithCustomAttributeCalledWithEnumNamedArgument([TestParameter(EnumProperty = TestEnum.All)] string value)
+            {
+            }
         }
 
         [Theory]
@@ -467,6 +525,13 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
         [InlineData("OutputParameterInt32", "out System.Int32 arg")]
         [InlineData("OptionalStringWithAttribute", "[System.Runtime.CompilerServices.CallerMemberName] System.String memberName = \"\"")]
         [InlineData("OptionalInt32WithAttribute", "[System.Runtime.CompilerServices.CallerLineNumber] System.Int32 sourceLineNumber = (System.Int32)0")]
+        [InlineData("RequiredStringWithCustomAttributeCalledWithInt32CtorParameter", "[Cake.Core.Tests.Unit.Scripting.CodeGen.ParameterEmitterTests.TestParameter((System.Int32)19)] System.String value")]
+        [InlineData("RequiredStringWithCustomAttributeCalledWithStringCtorParameter", "[Cake.Core.Tests.Unit.Scripting.CodeGen.ParameterEmitterTests.TestParameter(\"test\")] System.String value")]
+        [InlineData("RequiredStringWithCustomAttributeCalledWithEnumCtorParameter", "[Cake.Core.Tests.Unit.Scripting.CodeGen.ParameterEmitterTests.TestParameter((Cake.Core.Tests.Unit.Scripting.CodeGen.ParameterEmitterTests.TestEnum)2)] System.String value")]
+        [InlineData("RequiredStringWithCustomAttributeCalledWithArrayCtorParameter", "[Cake.Core.Tests.Unit.Scripting.CodeGen.ParameterEmitterTests.TestParameter(new Cake.Core.Tests.Unit.Scripting.CodeGen.ParameterEmitterTests.TestEnum[2] { (Cake.Core.Tests.Unit.Scripting.CodeGen.ParameterEmitterTests.TestEnum)2, (Cake.Core.Tests.Unit.Scripting.CodeGen.ParameterEmitterTests.TestEnum)1 })] System.String value")]
+        [InlineData("RequiredStringWithCustomAttributeCalledWithInt32NamedArgument", "[Cake.Core.Tests.Unit.Scripting.CodeGen.ParameterEmitterTests.TestParameter(Int32Property = (System.Int32)19)] System.String value")]
+        [InlineData("RequiredStringWithCustomAttributeCalledWithStringNamedArgument", "[Cake.Core.Tests.Unit.Scripting.CodeGen.ParameterEmitterTests.TestParameter(StringProperty = \"test\")] System.String value")]
+        [InlineData("RequiredStringWithCustomAttributeCalledWithEnumNamedArgument", "[Cake.Core.Tests.Unit.Scripting.CodeGen.ParameterEmitterTests.TestParameter(EnumProperty = (Cake.Core.Tests.Unit.Scripting.CodeGen.ParameterEmitterTests.TestEnum)2)] System.String value")]
         public void Should_Return_Correct_Generated_Code_For_Method_Parameters(string methodName, string expected)
         {
             // Given

--- a/tests/integration/Cake.Common/Diagnostics/LoggingAliases.cake
+++ b/tests/integration/Cake.Common/Diagnostics/LoggingAliases.cake
@@ -36,7 +36,8 @@ var logObjectMethods = new [] {
     new { Name = "Debug", Action = new Action<object>(Debug)}
 };
 
-var loggingAliasesTask = Task("Cake.Common.Diagnostics.LoggingAliases");
+var loggingAliasesTask = Task("Cake.Common.Diagnostics.LoggingAliases")
+                            .IsDependentOn("Cake.Common.Diagnostics.LoggingAliases.GetCallerInfo");
 
 Array.ForEach(
     verbosities,
@@ -144,3 +145,23 @@ Array.ForEach(
                                     }).Task.Name
                         ))
 );
+
+Task("Cake.Common.Diagnostics.LoggingAliases.GetCallerInfo")
+    .Does( ()=> {
+    // Given
+    ScriptCallerInfo callerInfoDSL;
+    ScriptCallerInfo callerInfo;
+
+    // When
+    CallerInfoTest(out callerInfoDSL, out callerInfo);
+
+    // Then
+    Assert.Equal(callerInfo.MemberName, callerInfoDSL.MemberName);
+    Assert.Equal(callerInfo.SourceFilePath.FullPath, callerInfoDSL.SourceFilePath.FullPath);
+    Assert.Equal(callerInfo.SourceLineNumber, callerInfoDSL.SourceLineNumber);
+});
+
+public void CallerInfoTest(out ScriptCallerInfo callerInfoDSL, out ScriptCallerInfo callerInfo)
+{
+    callerInfoDSL = GetCallerInfo(); callerInfo = Context.GetCallerInfo();
+}

--- a/tests/integration/utilities/xunit.cake
+++ b/tests/integration/utilities/xunit.cake
@@ -1,4 +1,4 @@
-#addin "nuget:?package=xunit.assert&version=2.3.1&prerelease"
+#addin "nuget:?package=xunit.assert&version=2.4.1"
 
 // Usings
 using Xunit;


### PR DESCRIPTION
This addresses the shortcomings in `ParameterEmitter.cs` that were identified in #2393.
I have left this branch as two separate commits for review.

The first commit (bf50ce3) provides an exact fix to the issue surfaced by `ScriptCallerAliases` and provides matching test coverage.  It's very possible that this is the extent of the fix required or desired, and in that case, we can modify the PR to reflect that.

The second commit took the starting logic from the first and attempted to craft a more complete solution, supporting a wider range of possible parameter decorations to include both normal constructor mechanics as well as named arguments.  Based on the test cases that were implemented, I think this provides a reasonable implementation (779acfa), but obviously there are many, many test cases that could be authored to tease that out with a bit more certainty.  If that is the desire, I would be happy to continue on with that work, but it seems that fixing an already-released feature to be semantically correct makes sense as a stopgap.

Let me know how you'd like to proceed.  