### PR TITLE
GH2403: Use Mono 5.12.0 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ dist: trusty
 osx_image: xcode9.2
 
 mono:
-  - 5.10.0
+  - 5.12.0
 
 dotnet: 2.1.500
 


### PR DESCRIPTION
* Fixes #2403