### PR TITLE
GH2400: Add globber pattern support to the #load directive

### DIFF
--- a/src/Cake.Core.Tests/Fixtures/GlobberFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/GlobberFixture.cs
@@ -83,6 +83,7 @@ namespace Cake.Core.Tests.Fixtures
             var filesystem = new FakeFileSystem(environment);
 
             // Directories
+            filesystem.CreateDirectory("/RootDir");
             filesystem.CreateDirectory("/Working");
             filesystem.CreateDirectory("/Working/Foo");
             filesystem.CreateDirectory("/Working/Foo/Bar");
@@ -94,6 +95,7 @@ namespace Cake.Core.Tests.Fixtures
             filesystem.CreateDirectory("/嵌套/目录");
 
             // Files
+            filesystem.CreateFile("/RootFile.sh");
             filesystem.CreateFile("/Working/Foo/Bar/Qux.c");
             filesystem.CreateFile("/Working/Foo/Bar/Qex.c");
             filesystem.CreateFile("/Working/Foo/Bar/Qux.h");

--- a/src/Cake.Core.Tests/Fixtures/ScriptAnalyzerFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/ScriptAnalyzerFixture.cs
@@ -20,9 +20,11 @@ namespace Cake.Core.Tests.Fixtures
         public ICakeLog Log { get; set; }
         public List<ILoadDirectiveProvider> Providers { get; set; }
 
-        public ScriptAnalyzerFixture()
+        public ScriptAnalyzerFixture(bool windows = false)
         {
-            Environment = FakeEnvironment.CreateUnixEnvironment();
+            Environment = windows
+                ? FakeEnvironment.CreateWindowsEnvironment()
+                : FakeEnvironment.CreateUnixEnvironment();
             FileSystem = new FakeFileSystem(Environment);
             Globber = new Globber(FileSystem, Environment);
             Log = Substitute.For<ICakeLog>();

--- a/src/Cake.Core.Tests/Fixtures/ScriptAnalyzerFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/ScriptAnalyzerFixture.cs
@@ -16,6 +16,7 @@ namespace Cake.Core.Tests.Fixtures
     {
         public FakeFileSystem FileSystem { get; set; }
         public FakeEnvironment Environment { get; set; }
+        public IGlobber Globber { get; set; }
         public ICakeLog Log { get; set; }
         public List<ILoadDirectiveProvider> Providers { get; set; }
 
@@ -23,8 +24,14 @@ namespace Cake.Core.Tests.Fixtures
         {
             Environment = FakeEnvironment.CreateUnixEnvironment();
             FileSystem = new FakeFileSystem(Environment);
+            Globber = new Globber(FileSystem, Environment);
             Log = Substitute.For<ICakeLog>();
             Providers = new List<ILoadDirectiveProvider>();
+        }
+
+        public void AddFileLoadDirectiveProvider()
+        {
+            Providers.Add(new FileLoadDirectiveProvider(Globber, Log));
         }
 
         public ScriptAnalyzer CreateAnalyzer()

--- a/src/Cake.Core.Tests/Fixtures/ScriptRunnerFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/ScriptRunnerFixture.cs
@@ -46,7 +46,7 @@ namespace Cake.Core.Tests.Fixtures
             Environment = FakeEnvironment.CreateUnixEnvironment();
             FileSystem = new FakeFileSystem(Environment);
             FileSystem.CreateFile(Script.MakeAbsolute(Environment)).SetContent(Source);
-            Globber = Substitute.For<IGlobber>();
+            Globber = new Globber(FileSystem, Environment);
 
             Configuration = Substitute.For<ICakeConfiguration>();
             AliasFinder = Substitute.For<IScriptAliasFinder>();
@@ -57,7 +57,7 @@ namespace Cake.Core.Tests.Fixtures
             Engine = Substitute.For<IScriptEngine>();
             Engine.CreateSession(Arg.Any<IScriptHost>()).Returns(Session);
 
-            ScriptAnalyzer = new ScriptAnalyzer(FileSystem, Environment, Log, new[] { new FileLoadDirectiveProvider() });
+            ScriptAnalyzer = new ScriptAnalyzer(FileSystem, Environment, Log, new[] { new FileLoadDirectiveProvider(Globber, Log) });
             ScriptProcessor = Substitute.For<IScriptProcessor>();
             ScriptConventions = new ScriptConventions(FileSystem, AssemblyLoader);
 

--- a/src/Cake.Core.Tests/Unit/IO/Globbing/GlobberTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/Globbing/GlobberTests.cs
@@ -241,33 +241,37 @@ namespace Cake.Core.Tests.Unit.IO.Globbing
                 Assert.Equal("Visiting a parent that is a recursive wildcard is not supported.", result?.Message);
             }
 
-            [Fact]
-            public void Should_Return_Single_Path_For_Absolute_File_Path_Without_Glob_Pattern()
+            [Theory]
+            [InlineData("/RootFile.sh")]
+            [InlineData("/Working/Foo/Bar/Qux.c")]
+            public void Should_Return_Single_Path_For_Absolute_File_Path_Without_Glob_Pattern(string pattern)
             {
                 // Given
                 var fixture = GlobberFixture.UnixLike();
 
                 // When
-                var result = fixture.Match("/Working/Foo/Bar/Qux.c");
+                var result = fixture.Match(pattern);
 
                 // Then
                 Assert.Single(result);
                 Assert.IsType<FilePath>(result[0]);
-                AssertEx.ContainsFilePath(result, "/Working/Foo/Bar/Qux.c");
+                AssertEx.ContainsFilePath(result, pattern);
             }
 
-            [Fact]
-            public void Should_Return_Single_Path_For_Absolute_Directory_Path_Without_Glob_Pattern()
+            [Theory]
+            [InlineData("/RootDir")]
+            [InlineData("/Working/Foo/Bar")]
+            public void Should_Return_Single_Path_For_Absolute_Directory_Path_Without_Glob_Pattern(string pattern)
             {
                 // Given
                 var fixture = GlobberFixture.UnixLike();
 
                 // When
-                var result = fixture.Match("/Working/Foo/Bar");
+                var result = fixture.Match(pattern);
 
                 // Then
                 Assert.Single(result);
-                AssertEx.ContainsDirectoryPath(result, "/Working/Foo/Bar");
+                AssertEx.ContainsDirectoryPath(result, pattern);
             }
 
             [Fact]
@@ -428,32 +432,52 @@ namespace Cake.Core.Tests.Unit.IO.Globbing
                 AssertEx.ContainsDirectoryPath(result, "/Working/Bar");
             }
 
-            [Fact]
-            public void Should_Include_Files_In_Root_Folder_When_Using_Recursive_Wildcard()
+            [Theory]
+            [InlineData("/*.sh", "/RootFile.sh")]
+            [InlineData("/Foo/*.baz", "/Foo/Bar.baz")]
+            public void Should_Include_Files_In_Root_Folder_When_Using_Wildcard(string pattern, string file)
             {
                 // Given
                 var fixture = GlobberFixture.UnixLike();
 
                 // When
-                var result = fixture.Match("/Foo/**/Bar.baz");
+                var result = fixture.Match(pattern);
 
                 // Then
                 Assert.Single(result);
-                AssertEx.ContainsFilePath(result, "/Foo/Bar.baz");
+                AssertEx.ContainsFilePath(result, file);
             }
 
-            [Fact]
-            public void Should_Include_Folder_In_Root_Folder_When_Using_Recursive_Wildcard()
+            [Theory]
+            [InlineData("/**/RootFile.sh", "/RootFile.sh")]
+            [InlineData("/Foo/**/Bar.baz", "/Foo/Bar.baz")]
+            public void Should_Include_Files_In_Root_Folder_When_Using_Recursive_Wildcard(string pattern, string file)
             {
                 // Given
                 var fixture = GlobberFixture.UnixLike();
 
                 // When
-                var result = fixture.Match("/Foo/**/Bar");
+                var result = fixture.Match(pattern);
 
                 // Then
                 Assert.Single(result);
-                AssertEx.ContainsDirectoryPath(result, "/Foo/Bar");
+                AssertEx.ContainsFilePath(result, file);
+            }
+
+            [Theory]
+            [InlineData("/**/RootDir", "/RootDir")]
+            [InlineData("/Foo/**/Bar", "/Foo/Bar")]
+            public void Should_Include_Folder_In_Root_Folder_When_Using_Recursive_Wildcard(string pattern, string folder)
+            {
+                // Given
+                var fixture = GlobberFixture.UnixLike();
+
+                // When
+                var result = fixture.Match(pattern);
+
+                // Then
+                Assert.Single(result);
+                AssertEx.ContainsDirectoryPath(result, folder);
             }
 
             [Fact]

--- a/src/Cake.Core.Tests/Unit/Scripting/Analysis/ScriptAnalyzerTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/Analysis/ScriptAnalyzerTests.cs
@@ -332,7 +332,7 @@ namespace Cake.Core.Tests.Unit.Scripting.Analysis
             {
                 // Given
                 var fixture = new ScriptAnalyzerFixture();
-                fixture.Providers.Add(new FileLoadDirectiveProvider());
+                fixture.AddFileLoadDirectiveProvider();
                 fixture.GivenScriptExist("/Working/script.cake", "#load \"local:?pat\"");
 
                 // When
@@ -354,7 +354,7 @@ namespace Cake.Core.Tests.Unit.Scripting.Analysis
             {
                 // Given
                 var fixture = new ScriptAnalyzerFixture();
-                fixture.Providers.Add(new FileLoadDirectiveProvider());
+                fixture.AddFileLoadDirectiveProvider();
                 fixture.GivenScriptExist("/Working/script.cake", "#load \"local:?path=script2.cake\"");
                 fixture.GivenScriptExist("/Working/script2.cake", "\n#load \"local:?path=1&path=2\"");
 

--- a/src/Cake.Core.Tests/Unit/Scripting/Processors/LoadDirectiveProcessorTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/Processors/LoadDirectiveProcessorTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Core.Scripting.Processors.Loading;
 using Cake.Core.Tests.Fixtures;
 using Cake.Testing.Xunit;
 using Xunit;
@@ -246,22 +245,22 @@ namespace Cake.Core.Tests.Unit.Scripting.Processors
         }
 
         [WindowsTheory]
-        [InlineData("#load \"c:/utils.cake\"")]
-        [InlineData("#load \"local:?path=c:/utils.cake\"")]
+        [InlineData("#load \"C:/utils.cake\"")]
+        [InlineData("#load \"local:?path=C:/utils.cake\"")]
         public void Should_Process_WindowsAbsolutePath_Script_Reference_Found_In_Source(string source)
         {
             // Given
-            var fixture = new ScriptAnalyzerFixture();
+            var fixture = new ScriptAnalyzerFixture(windows: true);
             fixture.AddFileLoadDirectiveProvider();
-            fixture.GivenScriptExist("/Working/script.cake", source);
-            fixture.GivenScriptExist("c:/utils.cake", "Console.WriteLine();");
+            fixture.GivenScriptExist("C:/Working/script.cake", source);
+            fixture.GivenScriptExist("C:/utils.cake", "Console.WriteLine();");
 
             // When
-            var result = fixture.Analyze("/Working/script.cake");
+            var result = fixture.Analyze("C:/Working/script.cake");
 
             // Then
             Assert.Equal(1, result.Script.Includes.Count);
-            Assert.Equal("c:/utils.cake", result.Script.Includes[0].Path.FullPath);
+            Assert.Equal("C:/utils.cake", result.Script.Includes[0].Path.FullPath);
         }
 
         [WindowsTheory]
@@ -270,17 +269,17 @@ namespace Cake.Core.Tests.Unit.Scripting.Processors
         public void Should_Process_WindowsRelativePath_Script_Reference_Found_In_Source(string source)
         {
             // Given
-            var fixture = new ScriptAnalyzerFixture();
+            var fixture = new ScriptAnalyzerFixture(windows: true);
             fixture.AddFileLoadDirectiveProvider();
-            fixture.GivenScriptExist("/Working/script.cake", source);
-            fixture.GivenScriptExist("/Working/test/utils.cake", "Console.WriteLine();");
+            fixture.GivenScriptExist("C:/Working/script.cake", source);
+            fixture.GivenScriptExist("C:/Working/test/utils.cake", "Console.WriteLine();");
 
             // When
-            var result = fixture.Analyze("/Working/script.cake");
+            var result = fixture.Analyze("C:/Working/script.cake");
 
             // Then
             Assert.Equal(1, result.Script.Includes.Count);
-            Assert.Equal("/Working/test/utils.cake", result.Script.Includes[0].Path.FullPath);
+            Assert.Equal("C:/Working/test/utils.cake", result.Script.Includes[0].Path.FullPath);
         }
     }
 }

--- a/src/Cake.Core/IO/Globbing/GlobVisitor.cs
+++ b/src/Cake.Core/IO/Globbing/GlobVisitor.cs
@@ -138,7 +138,7 @@ namespace Cake.Core.IO.Globbing
                         {
                             if (node.Next != null)
                             {
-                                context.Push(candidate.Path.FullPath.Substring(path.Path.FullPath.Length + 1));
+                                context.Push(candidate.Path.FullPath.Substring(path.Path.FullPath.Length + (path.Path.FullPath.Length > 1 ? 1 : 0)));
                                 node.Next.Accept(this, context);
                                 context.Pop();
                             }
@@ -154,7 +154,7 @@ namespace Cake.Core.IO.Globbing
 
         public void VisitUnixRoot(UnixRootNode node, GlobVisitorContext context)
         {
-            context.Push(string.Empty);
+            context.Push("/");
             node.Next.Accept(this, context);
             context.Pop();
         }
@@ -173,7 +173,7 @@ namespace Cake.Core.IO.Globbing
             {
                 foreach (var candidate in FindCandidates(path.Path, node, context, SearchScope.Current))
                 {
-                    context.Push(candidate.Path.FullPath.Substring(path.Path.FullPath.Length + 1));
+                    context.Push(candidate.Path.FullPath.Substring(path.Path.FullPath.Length + (path.Path.FullPath.Length > 1 ? 1 : 0)));
                     if (node.Next != null)
                     {
                         node.Next.Accept(this, context);

--- a/src/Cake.Core/IO/Globbing/GlobVisitorContext.cs
+++ b/src/Cake.Core/IO/Globbing/GlobVisitorContext.cs
@@ -60,6 +60,12 @@ namespace Cake.Core.IO.Globbing
                 var path = string.Concat(@"\\", string.Join(@"\", _pathParts.Skip(1)));
                 return new DirectoryPath(path);
             }
+            if (_pathParts.Count > 0 && _pathParts[0] == "/")
+            {
+                // Unix root path
+                var path = string.Concat("/", string.Join("/", _pathParts.Skip(1)));
+                return new DirectoryPath(path);
+            }
             else
             {
                 // Regular path

--- a/src/Cake.Core/IO/Globbing/Nodes/UnixRootNode.cs
+++ b/src/Cake.Core/IO/Globbing/Nodes/UnixRootNode.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace Cake.Core.IO.Globbing.Nodes
 {
-    [DebuggerDisplay("$")]
+    [DebuggerDisplay("/")]
     internal sealed class UnixRootNode : GlobNode
     {
         [DebuggerStepThrough]

--- a/tests/integration/Cake.Core/Scripting/LoadDirective.cake
+++ b/tests/integration/Cake.Core/Scripting/LoadDirective.cake
@@ -9,5 +9,7 @@ Task("Cake.Core.Scripting.LoadDirective.WithSpaces")
 
 //////////////////////////////////////////////////////////////////////////////
 
-Task("Cake.Core.Scripting.LoadDirective")
+var loadDirectiveTask = Task("Cake.Core.Scripting.LoadDirective")
     .IsDependentOn("Cake.Core.Scripting.LoadDirective.WithSpaces");
+
+#load "../../resources/Cake.Core/Scripting/Globber/**/no*.cake"

--- a/tests/integration/resources/Cake.Core/Scripting/Globber/nothrow.cake
+++ b/tests/integration/resources/Cake.Core/Scripting/Globber/nothrow.cake
@@ -1,0 +1,7 @@
+Task("Cake.Core.Scripting.LoadDirective.Globber.NoThrow")
+    .Does(() =>
+{
+});
+
+loadDirectiveTask
+    .IsDependentOn("Cake.Core.Scripting.LoadDirective.Globber.NoThrow");

--- a/tests/integration/resources/Cake.Core/Scripting/Globber/throws.cake
+++ b/tests/integration/resources/Cake.Core/Scripting/Globber/throws.cake
@@ -1,0 +1,8 @@
+Task("Cake.Core.Scripting.LoadDirective.Globber.Throws")
+    .Does(() =>
+{
+    throw new InvalidOperationException();
+});
+
+loadDirectiveTask
+    .IsDependentOn("Cake.Core.Scripting.LoadDirective.Globber.Throws");


### PR DESCRIPTION
Fixes #2400. @patriksvensson almost there; a couple of the existing unit tests are failing though:

- [LoadDirectiveProcessorTests.cs#L168](https://github.com/gitfool/cake/blob/2ed89ca5be268818a58c3b4840a199aba0bd6af1/src/Cake.Core.Tests/Unit/Scripting/Processors/LoadDirectiveProcessorTests.cs#L168)
- [LoadDirectiveProcessorTests.cs#L206](https://github.com/gitfool/cake/blob/2ed89ca5be268818a58c3b4840a199aba0bd6af1/src/Cake.Core.Tests/Unit/Scripting/Processors/LoadDirectiveProcessorTests.cs#L206)

In both cases the globber is processing absolute paths that don't have any globber patterns in them and returning no files. Any ideas how to handle that?