### PR TITLE
Added support for MSBuild16.

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/MSBuildRunnerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/MSBuildRunnerFixture.cs
@@ -34,6 +34,8 @@ namespace Cake.Common.Tests.Fixtures.Tools
                 "/Program86/MSBuild/14.0/Bin/amd64/MSBuild.exe",
                 "/Program86/Microsoft Visual Studio/2017/Enterprise/MSBuild/15.0/Bin/MSBuild.exe",
                 "/Program86/Microsoft Visual Studio/2017/Enterprise/MSBuild/15.0/Bin/amd64/MSBuild.exe",
+                "/Program86/Microsoft Visual Studio/2019/Preview/MSBuild/Current/Bin/MSBuild.exe",
+                "/Program86/Microsoft Visual Studio/2019/Preview/MSBuild/Current/Bin/amd64/MSBuild.exe",
                 "/usr/bin/msbuild",
                 "/Library/Frameworks/Mono.framework/Versions/Current/Commands/msbuild"
             };

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -137,6 +137,25 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             }
 
             [Theory]
+            [InlineData(MSBuildToolVersion.VS2019, PlatformTarget.x64, PlatformFamily.Windows, false, "/Program86/Microsoft Visual Studio/2019/Preview/MSBuild/Current/Bin/amd64/MSBuild.exe")]
+            [InlineData(MSBuildToolVersion.VS2019, PlatformTarget.x86, PlatformFamily.Windows, false, "/Program86/Microsoft Visual Studio/2019/Preview/MSBuild/Current/Bin/MSBuild.exe")]
+            [InlineData(MSBuildToolVersion.VS2019, PlatformTarget.x64, PlatformFamily.Linux, false, "/usr/bin/msbuild")]
+            [InlineData(MSBuildToolVersion.VS2019, PlatformTarget.x64, PlatformFamily.OSX, false, "/Library/Frameworks/Mono.framework/Versions/Current/Commands/msbuild")]
+            public void Should_Get_Correct_Path_To_MSBuild_Version_16(MSBuildToolVersion version, PlatformTarget target, PlatformFamily family, bool is64BitOperativeSystem, string expected)
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(is64BitOperativeSystem, family);
+                fixture.Settings.ToolVersion = version;
+                fixture.Settings.PlatformTarget = target;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Path.FullPath);
+            }
+
+            [Theory]
             [InlineData(MSBuildToolVersion.NET40, PlatformTarget.MSIL, true, "/Windows/Microsoft.NET/Framework64/v4.0.30319/MSBuild.exe")]
             [InlineData(MSBuildToolVersion.NET40, PlatformTarget.MSIL, false, "/Windows/Microsoft.NET/Framework/v4.0.30319/MSBuild.exe")]
             [InlineData(MSBuildToolVersion.NET45, PlatformTarget.MSIL, true, "/Windows/Microsoft.NET/Framework64/v4.0.30319/MSBuild.exe")]

--- a/src/Cake.Common/Tools/DotNetCore/MSBuild/MSBuildArgumentBuilderExtensions.cs
+++ b/src/Cake.Common/Tools/DotNetCore/MSBuild/MSBuildArgumentBuilderExtensions.cs
@@ -224,6 +224,8 @@ namespace Cake.Common.Tools.DotNetCore.MSBuild
                     return "14.0";
                 case MSBuildVersion.MSBuild15:
                     return "15.0";
+                case MSBuildVersion.MSBuild16:
+                    return "16.0";
                 default:
                     throw new ArgumentOutOfRangeException(nameof(toolVersion), toolVersion, "Invalid value");
             }

--- a/src/Cake.Common/Tools/MSBuild/MSBuildResolver.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildResolver.cs
@@ -59,6 +59,7 @@ namespace Cake.Common.Tools.MSBuild
         {
             var versions = new[]
             {
+                // MSBuildVersion.MSBuild16, /*Since it's still in preview, do not search unless specified. Uncomment after stable version released*/
                 MSBuildVersion.MSBuild15,
                 MSBuildVersion.MSBuild14,
                 MSBuildVersion.MSBuild12,
@@ -82,6 +83,8 @@ namespace Cake.Common.Tools.MSBuild
         {
             switch (version)
             {
+                case MSBuildVersion.MSBuild16:
+                    return GetVisualStudio2019Path(fileSystem, environment, buildPlatform);
                 case MSBuildVersion.MSBuild15:
                     return GetVisualStudio2017Path(fileSystem, environment, buildPlatform);
                 case MSBuildVersion.MSBuild14:
@@ -152,6 +155,43 @@ namespace Cake.Common.Tools.MSBuild
                 }
             }
             return visualStudio2017Path.Combine("Microsoft Visual Studio/2017/Professional/MSBuild/15.0/Bin");
+        }
+
+        private static DirectoryPath GetVisualStudio2019Path(IFileSystem fileSystem, ICakeEnvironment environment,
+            MSBuildPlatform buildPlatform)
+        {
+            var vsEditions = new[]
+            {
+                "Enterprise",
+                "Professional",
+                "Community",
+                "BuildTools",
+                "Preview" // Remove after stable version released
+            };
+
+            var visualStudio2019Path = environment.GetSpecialPath(SpecialPath.ProgramFilesX86);
+
+            foreach (var edition in vsEditions)
+            {
+                // Get the bin path.
+                var binPath = visualStudio2019Path.Combine(string.Concat("Microsoft Visual Studio/2019/", edition, "/MSBuild/Current/Bin")); // Change from Current to 16.0 after stable version released
+                if (fileSystem.Exist(binPath))
+                {
+                    if (buildPlatform == MSBuildPlatform.Automatic)
+                    {
+                        if (environment.Platform.Is64Bit)
+                        {
+                            binPath = binPath.Combine("amd64");
+                        }
+                    }
+                    if (buildPlatform == MSBuildPlatform.x64)
+                    {
+                        binPath = binPath.Combine("amd64");
+                    }
+                    return binPath;
+                }
+            }
+            return visualStudio2019Path.Combine("Microsoft Visual Studio/2019/Professional/MSBuild/16.0/Bin");
         }
 
         private static DirectoryPath GetFrameworkPath(ICakeEnvironment environment, MSBuildPlatform buildPlatform, string version)

--- a/src/Cake.Common/Tools/MSBuild/MSBuildToolVersion.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildToolVersion.cs
@@ -92,6 +92,11 @@ namespace Cake.Common.Tools.MSBuild
         /// <summary>
         /// MSBuild tool version: <c>Visual Studio 2017</c>
         /// </summary>
-        VS2017 = 6
+        VS2017 = 6,
+
+        /// <summary>
+        /// MSBuild tool version: <c>Visual Studio 2019</c>
+        /// </summary>
+        VS2019 = 7
     }
 }

--- a/src/Cake.Common/Tools/MSBuild/MSBuildVersion.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildVersion.cs
@@ -25,6 +25,9 @@ namespace Cake.Common.Tools.MSBuild
         MSBuild14 = 5,
 
         /// <summary>Version 15.0</summary>
-        MSBuild15 = 6
+        MSBuild15 = 6,
+
+        /// <summary>Version 16.0</summary>
+        MSBuild16 = 7
     }
 }


### PR DESCRIPTION
Fixes #2398.

This is working for the current version of VS 2019 (preview1), but could break in future version, so as of right now, it is not used when Default(latest) is set. You have to force it to use MSBuild16.