### PR TITLE
GH2429: Add build system provider property

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Build/TFBuildFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/TFBuildFixture.cs
@@ -4,7 +4,6 @@
 
 using Cake.Common.Build.TFBuild;
 using Cake.Core;
-using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.Testing;
 using NSubstitute;
@@ -26,13 +25,17 @@ namespace Cake.Common.Tests.Fixtures.Build
             Log = new FakeLog();
         }
 
-        public void IsRunningOnTFS()
+        public void IsRunningOnTFS() => IsRunningOnAzurePipelines();
+
+        public void IsRunningOnVSTS() => IsRunningOnAzurePipelinesHosted();
+
+        public void IsRunningOnAzurePipelines()
         {
             Environment.GetEnvironmentVariable("TF_BUILD").Returns("True");
             Environment.GetEnvironmentVariable("AGENT_NAME").Returns("On Premises");
         }
 
-        public void IsRunningOnVSTS()
+        public void IsRunningOnAzurePipelinesHosted()
         {
             Environment.GetEnvironmentVariable("TF_BUILD").Returns("True");
             Environment.GetEnvironmentVariable("AGENT_NAME").Returns("Hosted Agent");

--- a/src/Cake.Common.Tests/Unit/Build/BuildSystemTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/BuildSystemTests.cs
@@ -64,7 +64,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, null, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, null, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider));
 
                 // Then
                 AssertEx.IsArgumentNullException(result, "teamCityProvider");
@@ -87,7 +87,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, null, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, null, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider));
 
                 // Then
                 AssertEx.IsArgumentNullException(result, "myGetProvider");
@@ -110,7 +110,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, null, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, null, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider));
 
                 // Then
                 AssertEx.IsArgumentNullException(result, "bambooProvider");
@@ -133,7 +133,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 // When
-                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, null,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider));
+                var result = Record.Exception(() => new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, null, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider));
 
                 // Then
                 AssertEx.IsArgumentNullException(result, "continuaCIProvider");
@@ -321,7 +321,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 appVeyorProvider.IsRunningOnAppVeyor.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnAppVeyor;
@@ -351,7 +351,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 teamCityProvider.IsRunningOnTeamCity.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnTeamCity;
@@ -381,7 +381,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 myGetProvider.IsRunningOnMyGet.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnMyGet;
@@ -411,7 +411,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 bambooProvider.IsRunningOnBamboo.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnBamboo;
@@ -441,7 +441,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 continuaCIProvider.IsRunningOnContinuaCI.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnContinuaCI;
@@ -471,7 +471,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 jenkinsProvider.IsRunningOnJenkins.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnJenkins;
@@ -501,7 +501,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 bitriseProvider.IsRunningOnBitrise.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnBitrise;
@@ -531,7 +531,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 travisCIProvider.IsRunningOnTravisCI.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnTravisCI;
@@ -561,7 +561,7 @@ namespace Cake.Common.Tests.Unit.Build
                 var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
                 bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnBitbucketPipelines;
@@ -631,36 +631,6 @@ namespace Cake.Common.Tests.Unit.Build
             }
         }
 
-        public sealed class TheIsRunningOnVSTSProperty
-        {
-            [Fact]
-            public void Should_Return_True_If_Running_On_VSTS()
-            {
-                // Given
-                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
-                var teamCityProvider = Substitute.For<ITeamCityProvider>();
-                var myGetProvider = Substitute.For<IMyGetProvider>();
-                var bambooProvider = Substitute.For<IBambooProvider>();
-                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
-                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
-                var bitriseProvider = Substitute.For<IBitriseProvider>();
-                var travisCIProvider = Substitute.For<ITravisCIProvider>();
-                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
-                var goCDProvider = Substitute.For<IGoCDProvider>();
-                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
-                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
-
-                tfBuildProvider.IsRunningOnVSTS.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
-
-                // When
-                var result = buildSystem.IsRunningOnVSTS;
-
-                // Then
-                Assert.True(result);
-            }
-        }
-
         public sealed class TheIsRunningOnTFSProperty
         {
             [Fact]
@@ -680,21 +650,23 @@ namespace Cake.Common.Tests.Unit.Build
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
                 var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
+#pragma warning disable 618
                 tfBuildProvider.IsRunningOnTFS.Returns(true);
                 var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
                 var result = buildSystem.IsRunningOnTFS;
+#pragma warning restore 618
 
                 // Then
                 Assert.True(result);
             }
         }
 
-        public sealed class TheIsLocalBuildProperty
+        public sealed class TheIsRunningOnVSTSProperty
         {
             [Fact]
-            public void Should_Return_False_If_Running_On_AppVeyor()
+            public void Should_Return_True_If_Running_On_VSTS()
             {
                 // Given
                 var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
@@ -710,523 +682,198 @@ namespace Cake.Common.Tests.Unit.Build
                 var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
                 var tfBuildProvider = Substitute.For<ITFBuildProvider>();
 
-                appVeyorProvider.IsRunningOnAppVeyor.Returns(true);
-                teamCityProvider.IsRunningOnTeamCity.Returns(false);
-                myGetProvider.IsRunningOnMyGet.Returns(false);
-                bambooProvider.IsRunningOnBamboo.Returns(false);
-                continuaCIProvider.IsRunningOnContinuaCI.Returns(false);
-                jenkinsProvider.IsRunningOnJenkins.Returns(false);
-                bitriseProvider.IsRunningOnBitrise.Returns(false);
-                travisCIProvider.IsRunningOnTravisCI.Returns(false);
-                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
-                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
-                tfBuildProvider.IsRunningOnVSTS.Returns(false);
-                tfBuildProvider.IsRunningOnTFS.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
-
-                // When
-                var result = buildSystem.IsLocalBuild;
-
-                // Then
-                Assert.False(result);
-            }
-
-            [Fact]
-            public void Should_Return_False_If_Running_On_TeamCity()
-            {
-                // Given
-                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
-                var teamCityProvider = Substitute.For<ITeamCityProvider>();
-                var myGetProvider = Substitute.For<IMyGetProvider>();
-                var bambooProvider = Substitute.For<IBambooProvider>();
-                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
-                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
-                var bitriseProvider = Substitute.For<IBitriseProvider>();
-                var travisCIProvider = Substitute.For<ITravisCIProvider>();
-                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
-                var goCDProvider = Substitute.For<IGoCDProvider>();
-                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
-                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
-
-                appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
-                teamCityProvider.IsRunningOnTeamCity.Returns(true);
-                myGetProvider.IsRunningOnMyGet.Returns(false);
-                bambooProvider.IsRunningOnBamboo.Returns(false);
-                continuaCIProvider.IsRunningOnContinuaCI.Returns(false);
-                jenkinsProvider.IsRunningOnJenkins.Returns(false);
-                bitriseProvider.IsRunningOnBitrise.Returns(false);
-                travisCIProvider.IsRunningOnTravisCI.Returns(false);
-                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
-                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
-                tfBuildProvider.IsRunningOnVSTS.Returns(false);
-                tfBuildProvider.IsRunningOnTFS.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
-
-                // When
-                var result = buildSystem.IsLocalBuild;
-
-                // Then
-                Assert.False(result);
-            }
-
-            [Fact]
-            public void Should_Return_False_If_Running_On_MyGet()
-            {
-                // Given
-                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
-                var teamCityProvider = Substitute.For<ITeamCityProvider>();
-                var myGetProvider = Substitute.For<IMyGetProvider>();
-                var bambooProvider = Substitute.For<IBambooProvider>();
-                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
-                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
-                var bitriseProvider = Substitute.For<IBitriseProvider>();
-                var travisCIProvider = Substitute.For<ITravisCIProvider>();
-                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
-                var goCDProvider = Substitute.For<IGoCDProvider>();
-                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
-                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
-
-                appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
-                teamCityProvider.IsRunningOnTeamCity.Returns(false);
-                myGetProvider.IsRunningOnMyGet.Returns(true);
-                bambooProvider.IsRunningOnBamboo.Returns(false);
-                continuaCIProvider.IsRunningOnContinuaCI.Returns(false);
-                jenkinsProvider.IsRunningOnJenkins.Returns(false);
-                bitriseProvider.IsRunningOnBitrise.Returns(false);
-                travisCIProvider.IsRunningOnTravisCI.Returns(false);
-                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
-                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
-                tfBuildProvider.IsRunningOnVSTS.Returns(false);
-                tfBuildProvider.IsRunningOnTFS.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
-
-                // When
-                var result = buildSystem.IsLocalBuild;
-
-                // Then
-                Assert.False(result);
-            }
-
-            [Fact]
-            public void Should_Return_False_If_Running_On_Bamboo()
-            {
-                // Given
-                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
-                var teamCityProvider = Substitute.For<ITeamCityProvider>();
-                var myGetProvider = Substitute.For<IMyGetProvider>();
-                var bambooProvider = Substitute.For<IBambooProvider>();
-                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
-                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
-                var bitriseProvider = Substitute.For<IBitriseProvider>();
-                var travisCIProvider = Substitute.For<ITravisCIProvider>();
-                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
-                var goCDProvider = Substitute.For<IGoCDProvider>();
-                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
-                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
-
-                appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
-                teamCityProvider.IsRunningOnTeamCity.Returns(false);
-                myGetProvider.IsRunningOnMyGet.Returns(false);
-                bambooProvider.IsRunningOnBamboo.Returns(true);
-                continuaCIProvider.IsRunningOnContinuaCI.Returns(false);
-                jenkinsProvider.IsRunningOnJenkins.Returns(false);
-                bitriseProvider.IsRunningOnBitrise.Returns(false);
-                travisCIProvider.IsRunningOnTravisCI.Returns(false);
-                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
-                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
-                tfBuildProvider.IsRunningOnVSTS.Returns(false);
-                tfBuildProvider.IsRunningOnTFS.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
-
-                // When
-                var result = buildSystem.IsLocalBuild;
-
-                // Then
-                Assert.False(result);
-            }
-
-            [Fact]
-            public void Should_Return_False_If_Running_On_ContinuaCI()
-            {
-                // Given
-                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
-                var teamCityProvider = Substitute.For<ITeamCityProvider>();
-                var myGetProvider = Substitute.For<IMyGetProvider>();
-                var bambooProvider = Substitute.For<IBambooProvider>();
-                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
-                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
-                var bitriseProvider = Substitute.For<IBitriseProvider>();
-                var travisCIProvider = Substitute.For<ITravisCIProvider>();
-                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
-                var goCDProvider = Substitute.For<IGoCDProvider>();
-                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
-                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
-
-                appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
-                teamCityProvider.IsRunningOnTeamCity.Returns(false);
-                myGetProvider.IsRunningOnMyGet.Returns(false);
-                bambooProvider.IsRunningOnBamboo.Returns(false);
-                continuaCIProvider.IsRunningOnContinuaCI.Returns(true);
-                jenkinsProvider.IsRunningOnJenkins.Returns(false);
-                bitriseProvider.IsRunningOnBitrise.Returns(false);
-                travisCIProvider.IsRunningOnTravisCI.Returns(false);
-                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
-                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
-                tfBuildProvider.IsRunningOnVSTS.Returns(false);
-                tfBuildProvider.IsRunningOnTFS.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
-
-                // When
-                var result = buildSystem.IsLocalBuild;
-
-                // Then
-                Assert.False(result);
-            }
-
-            [Fact]
-            public void Should_Return_False_If_Running_On_Jenkins()
-            {
-                // Given
-                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
-                var teamCityProvider = Substitute.For<ITeamCityProvider>();
-                var myGetProvider = Substitute.For<IMyGetProvider>();
-                var bambooProvider = Substitute.For<IBambooProvider>();
-                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
-                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
-                var bitriseProvider = Substitute.For<IBitriseProvider>();
-                var travisCIProvider = Substitute.For<ITravisCIProvider>();
-                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
-                var goCDProvider = Substitute.For<IGoCDProvider>();
-                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
-                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
-
-                appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
-                teamCityProvider.IsRunningOnTeamCity.Returns(false);
-                myGetProvider.IsRunningOnMyGet.Returns(false);
-                bambooProvider.IsRunningOnBamboo.Returns(false);
-                continuaCIProvider.IsRunningOnContinuaCI.Returns(false);
-                jenkinsProvider.IsRunningOnJenkins.Returns(true);
-                bitriseProvider.IsRunningOnBitrise.Returns(false);
-                travisCIProvider.IsRunningOnTravisCI.Returns(false);
-                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
-                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
-                tfBuildProvider.IsRunningOnVSTS.Returns(false);
-                tfBuildProvider.IsRunningOnTFS.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
-
-                // When
-                var result = buildSystem.IsLocalBuild;
-
-                // Then
-                Assert.False(result);
-            }
-
-            [Fact]
-            public void Should_Return_False_If_Running_On_Bitrise()
-            {
-                // Given
-                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
-                var teamCityProvider = Substitute.For<ITeamCityProvider>();
-                var myGetProvider = Substitute.For<IMyGetProvider>();
-                var bambooProvider = Substitute.For<IBambooProvider>();
-                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
-                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
-                var bitriseProvider = Substitute.For<IBitriseProvider>();
-                var travisCIProvider = Substitute.For<ITravisCIProvider>();
-                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
-                var goCDProvider = Substitute.For<IGoCDProvider>();
-                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
-                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
-
-                appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
-                teamCityProvider.IsRunningOnTeamCity.Returns(false);
-                myGetProvider.IsRunningOnMyGet.Returns(false);
-                bambooProvider.IsRunningOnBamboo.Returns(false);
-                continuaCIProvider.IsRunningOnContinuaCI.Returns(false);
-                jenkinsProvider.IsRunningOnJenkins.Returns(false);
-                bitriseProvider.IsRunningOnBitrise.Returns(true);
-                travisCIProvider.IsRunningOnTravisCI.Returns(false);
-                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
-                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
-                tfBuildProvider.IsRunningOnVSTS.Returns(false);
-                tfBuildProvider.IsRunningOnTFS.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
-
-                // When
-                var result = buildSystem.IsLocalBuild;
-
-                // Then
-                Assert.False(result);
-            }
-
-            [Fact]
-            public void Should_Return_False_If_Running_On_TravisCI()
-            {
-                // Given
-                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
-                var teamCityProvider = Substitute.For<ITeamCityProvider>();
-                var myGetProvider = Substitute.For<IMyGetProvider>();
-                var bambooProvider = Substitute.For<IBambooProvider>();
-                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
-                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
-                var bitriseProvider = Substitute.For<IBitriseProvider>();
-                var travisCIProvider = Substitute.For<ITravisCIProvider>();
-                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
-                var goCDProvider = Substitute.For<IGoCDProvider>();
-                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
-                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
-
-                appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
-                teamCityProvider.IsRunningOnTeamCity.Returns(false);
-                myGetProvider.IsRunningOnMyGet.Returns(false);
-                bambooProvider.IsRunningOnBamboo.Returns(false);
-                continuaCIProvider.IsRunningOnContinuaCI.Returns(false);
-                jenkinsProvider.IsRunningOnJenkins.Returns(false);
-                bitriseProvider.IsRunningOnBitrise.Returns(false);
-                travisCIProvider.IsRunningOnTravisCI.Returns(true);
-                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
-                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
-                tfBuildProvider.IsRunningOnVSTS.Returns(false);
-                tfBuildProvider.IsRunningOnTFS.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
-
-                // When
-                var result = buildSystem.IsLocalBuild;
-
-                // Then
-                Assert.False(result);
-            }
-
-            [Fact]
-            public void Should_Return_False_If_Running_On_BitbucketPipelines()
-            {
-                // Given
-                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
-                var teamCityProvider = Substitute.For<ITeamCityProvider>();
-                var myGetProvider = Substitute.For<IMyGetProvider>();
-                var bambooProvider = Substitute.For<IBambooProvider>();
-                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
-                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
-                var bitriseProvider = Substitute.For<IBitriseProvider>();
-                var travisCIProvider = Substitute.For<ITravisCIProvider>();
-                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
-                var goCDProvider = Substitute.For<IGoCDProvider>();
-                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
-                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
-
-                appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
-                teamCityProvider.IsRunningOnTeamCity.Returns(false);
-                myGetProvider.IsRunningOnMyGet.Returns(false);
-                bambooProvider.IsRunningOnBamboo.Returns(false);
-                continuaCIProvider.IsRunningOnContinuaCI.Returns(false);
-                jenkinsProvider.IsRunningOnJenkins.Returns(false);
-                bitriseProvider.IsRunningOnBitrise.Returns(false);
-                travisCIProvider.IsRunningOnTravisCI.Returns(false);
-                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(true);
-                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
-                tfBuildProvider.IsRunningOnVSTS.Returns(false);
-                tfBuildProvider.IsRunningOnTFS.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
-
-                // When
-                var result = buildSystem.IsLocalBuild;
-
-                // Then
-                Assert.False(result);
-            }
-
-            [Fact]
-            public void Should_Return_False_If_Running_On_GoCD()
-            {
-                // Given
-                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
-                var teamCityProvider = Substitute.For<ITeamCityProvider>();
-                var myGetProvider = Substitute.For<IMyGetProvider>();
-                var bambooProvider = Substitute.For<IBambooProvider>();
-                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
-                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
-                var bitriseProvider = Substitute.For<IBitriseProvider>();
-                var travisCIProvider = Substitute.For<ITravisCIProvider>();
-                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
-                var goCDProvider = Substitute.For<IGoCDProvider>();
-                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
-                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
-
-                appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
-                teamCityProvider.IsRunningOnTeamCity.Returns(false);
-                myGetProvider.IsRunningOnMyGet.Returns(false);
-                bambooProvider.IsRunningOnBamboo.Returns(false);
-                continuaCIProvider.IsRunningOnContinuaCI.Returns(false);
-                jenkinsProvider.IsRunningOnJenkins.Returns(false);
-                bitriseProvider.IsRunningOnBitrise.Returns(false);
-                travisCIProvider.IsRunningOnTravisCI.Returns(false);
-                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
-                goCDProvider.IsRunningOnGoCD.Returns(true);
-                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
-                tfBuildProvider.IsRunningOnVSTS.Returns(false);
-                tfBuildProvider.IsRunningOnTFS.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
-
-                // When
-                var result = buildSystem.IsLocalBuild;
-
-                // Then
-                Assert.False(result);
-            }
-
-            [Fact]
-            public void Should_Return_False_If_Running_On_GitLabCI()
-            {
-                // Given
-                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
-                var teamCityProvider = Substitute.For<ITeamCityProvider>();
-                var myGetProvider = Substitute.For<IMyGetProvider>();
-                var bambooProvider = Substitute.For<IBambooProvider>();
-                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
-                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
-                var bitriseProvider = Substitute.For<IBitriseProvider>();
-                var travisCIProvider = Substitute.For<ITravisCIProvider>();
-                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
-                var goCDProvider = Substitute.For<IGoCDProvider>();
-                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
-                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
-
-                appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
-                teamCityProvider.IsRunningOnTeamCity.Returns(false);
-                myGetProvider.IsRunningOnMyGet.Returns(false);
-                bambooProvider.IsRunningOnBamboo.Returns(false);
-                continuaCIProvider.IsRunningOnContinuaCI.Returns(false);
-                jenkinsProvider.IsRunningOnJenkins.Returns(false);
-                bitriseProvider.IsRunningOnBitrise.Returns(false);
-                travisCIProvider.IsRunningOnTravisCI.Returns(false);
-                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
-                goCDProvider.IsRunningOnGoCD.Returns(false);
-                gitlabCIProvider.IsRunningOnGitLabCI.Returns(true);
-                tfBuildProvider.IsRunningOnVSTS.Returns(false);
-                tfBuildProvider.IsRunningOnTFS.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
-
-                // When
-                var result = buildSystem.IsLocalBuild;
-
-                // Then
-                Assert.False(result);
-            }
-
-            [Fact]
-            public void Should_Return_False_If_Running_On_VSTS()
-            {
-                // Given
-                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
-                var teamCityProvider = Substitute.For<ITeamCityProvider>();
-                var myGetProvider = Substitute.For<IMyGetProvider>();
-                var bambooProvider = Substitute.For<IBambooProvider>();
-                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
-                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
-                var bitriseProvider = Substitute.For<IBitriseProvider>();
-                var travisCIProvider = Substitute.For<ITravisCIProvider>();
-                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
-                var goCDProvider = Substitute.For<IGoCDProvider>();
-                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
-                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
-
-                appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
-                teamCityProvider.IsRunningOnTeamCity.Returns(false);
-                myGetProvider.IsRunningOnMyGet.Returns(false);
-                bambooProvider.IsRunningOnBamboo.Returns(false);
-                continuaCIProvider.IsRunningOnContinuaCI.Returns(false);
-                jenkinsProvider.IsRunningOnJenkins.Returns(false);
-                bitriseProvider.IsRunningOnBitrise.Returns(false);
-                travisCIProvider.IsRunningOnTravisCI.Returns(false);
-                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
-                goCDProvider.IsRunningOnGoCD.Returns(false);
-                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
+#pragma warning disable 618
                 tfBuildProvider.IsRunningOnVSTS.Returns(true);
-                tfBuildProvider.IsRunningOnTFS.Returns(false);
                 var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
 
                 // When
-                var result = buildSystem.IsLocalBuild;
-
-                // Then
-                Assert.False(result);
-            }
-
-            [Fact]
-            public void Should_Return_False_If_Running_On_TFS()
-            {
-                // Given
-                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
-                var teamCityProvider = Substitute.For<ITeamCityProvider>();
-                var myGetProvider = Substitute.For<IMyGetProvider>();
-                var bambooProvider = Substitute.For<IBambooProvider>();
-                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
-                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
-                var bitriseProvider = Substitute.For<IBitriseProvider>();
-                var travisCIProvider = Substitute.For<ITravisCIProvider>();
-                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
-                var goCDProvider = Substitute.For<IGoCDProvider>();
-                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
-                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
-
-                appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
-                teamCityProvider.IsRunningOnTeamCity.Returns(false);
-                myGetProvider.IsRunningOnMyGet.Returns(false);
-                bambooProvider.IsRunningOnBamboo.Returns(false);
-                continuaCIProvider.IsRunningOnContinuaCI.Returns(false);
-                jenkinsProvider.IsRunningOnJenkins.Returns(false);
-                bitriseProvider.IsRunningOnBitrise.Returns(false);
-                travisCIProvider.IsRunningOnTravisCI.Returns(false);
-                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
-                goCDProvider.IsRunningOnGoCD.Returns(false);
-                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
-                tfBuildProvider.IsRunningOnVSTS.Returns(false);
-                tfBuildProvider.IsRunningOnTFS.Returns(true);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
-
-                // When
-                var result = buildSystem.IsLocalBuild;
-
-                // Then
-                Assert.False(result);
-            }
-
-            [Fact]
-            public void Should_Return_True_If_Not_Running_On_Any()
-            {
-                // Given
-                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
-                var teamCityProvider = Substitute.For<ITeamCityProvider>();
-                var myGetProvider = Substitute.For<IMyGetProvider>();
-                var bambooProvider = Substitute.For<IBambooProvider>();
-                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
-                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
-                var bitriseProvider = Substitute.For<IBitriseProvider>();
-                var travisCIProvider = Substitute.For<ITravisCIProvider>();
-                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
-                var goCDProvider = Substitute.For<IGoCDProvider>();
-                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
-                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
-
-                appVeyorProvider.IsRunningOnAppVeyor.Returns(false);
-                teamCityProvider.IsRunningOnTeamCity.Returns(false);
-                myGetProvider.IsRunningOnMyGet.Returns(false);
-                bambooProvider.IsRunningOnBamboo.Returns(false);
-                continuaCIProvider.IsRunningOnContinuaCI.Returns(false);
-                bitriseProvider.IsRunningOnBitrise.Returns(false);
-                travisCIProvider.IsRunningOnTravisCI.Returns(false);
-                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(false);
-                goCDProvider.IsRunningOnGoCD.Returns(false);
-                gitlabCIProvider.IsRunningOnGitLabCI.Returns(false);
-                tfBuildProvider.IsRunningOnVSTS.Returns(false);
-                tfBuildProvider.IsRunningOnTFS.Returns(false);
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider,  jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
-
-                // When
-                var result = buildSystem.IsLocalBuild;
+                var result = buildSystem.IsRunningOnVSTS;
+#pragma warning restore 618
 
                 // Then
                 Assert.True(result);
+            }
+        }
+
+        public sealed class TheIsRunningOnAzurePipelinesProperty
+        {
+            [Fact]
+            public void Should_Return_True_If_Running_On_AzurePipelines()
+            {
+                // Given
+                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
+                var teamCityProvider = Substitute.For<ITeamCityProvider>();
+                var myGetProvider = Substitute.For<IMyGetProvider>();
+                var bambooProvider = Substitute.For<IBambooProvider>();
+                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
+                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
+                var bitriseProvider = Substitute.For<IBitriseProvider>();
+                var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
+                var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
+
+                tfBuildProvider.IsRunningOnAzurePipelines.Returns(true);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
+
+                // When
+                var result = buildSystem.IsRunningOnAzurePipelines;
+
+                // Then
+                Assert.True(result);
+            }
+        }
+
+        public sealed class TheIsRunningOnAzurePipelinesHostedProperty
+        {
+            [Fact]
+            public void Should_Return_True_If_Running_On_AzurePipelinesHosted()
+            {
+                // Given
+                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
+                var teamCityProvider = Substitute.For<ITeamCityProvider>();
+                var myGetProvider = Substitute.For<IMyGetProvider>();
+                var bambooProvider = Substitute.For<IBambooProvider>();
+                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
+                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
+                var bitriseProvider = Substitute.For<IBitriseProvider>();
+                var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
+                var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
+
+                tfBuildProvider.IsRunningOnAzurePipelinesHosted.Returns(true);
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
+
+                // When
+                var result = buildSystem.IsRunningOnAzurePipelinesHosted;
+
+                // Then
+                Assert.True(result);
+            }
+        }
+
+        public sealed class TheProviderProperty
+        {
+            [Theory]
+            [InlineData(false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, BuildProvider.Local)]
+            [InlineData(true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, BuildProvider.AppVeyor)]
+            [InlineData(false, true, false, false, false, false, false, false, false, false, false, false, false, false, false, BuildProvider.TeamCity)]
+            [InlineData(false, false, true, false, false, false, false, false, false, false, false, false, false, false, false, BuildProvider.MyGet)]
+            [InlineData(false, false, false, true, false, false, false, false, false, false, false, false, false, false, false, BuildProvider.Bamboo)]
+            [InlineData(false, false, false, false, true, false, false, false, false, false, false, false, false, false, false, BuildProvider.ContinuaCI)]
+            [InlineData(false, false, false, false, false, true, false, false, false, false, false, false, false, false, false, BuildProvider.Jenkins)]
+            [InlineData(false, false, false, false, false, false, true, false, false, false, false, false, false, false, false, BuildProvider.Bitrise)]
+            [InlineData(false, false, false, false, false, false, false, true, false, false, false, false, false, false, false, BuildProvider.TravisCI)]
+            [InlineData(false, false, false, false, false, false, false, false, true, false, false, false, false, false, false, BuildProvider.BitbucketPipelines)]
+            [InlineData(false, false, false, false, false, false, false, false, false, true, false, false, false, false, false, BuildProvider.GoCD)]
+            [InlineData(false, false, false, false, false, false, false, false, false, false, true, false, false, false, false, BuildProvider.GitLabCI)]
+            [InlineData(false, false, false, false, false, false, false, false, false, false, false, true, false, true, false, BuildProvider.AzurePipelines)] // tfs
+            [InlineData(false, false, false, false, false, false, false, false, false, false, false, false, true, false, true, BuildProvider.AzurePipelinesHosted)] // vsts
+            [InlineData(false, false, false, false, false, false, false, false, false, false, false, false, false, true, false, BuildProvider.AzurePipelines)]
+            [InlineData(false, false, false, false, false, false, false, false, false, false, false, true, false, false, true, BuildProvider.AzurePipelinesHosted)]
+            public void Should_Return_Provider_If_Running_On_Provider(bool appVeyor, bool teamCity, bool myGet, bool bamboo, bool continuaCI, bool jenkins, bool bitrise, bool travisCI, bool bitbucketPipelines, bool goCD, bool gitlabCI, bool tfs, bool vsts, bool azurePipelines, bool azurePipelinesHosted, BuildProvider provider)
+            {
+                // Given
+                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
+                var teamCityProvider = Substitute.For<ITeamCityProvider>();
+                var myGetProvider = Substitute.For<IMyGetProvider>();
+                var bambooProvider = Substitute.For<IBambooProvider>();
+                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
+                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
+                var bitriseProvider = Substitute.For<IBitriseProvider>();
+                var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
+                var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
+
+                appVeyorProvider.IsRunningOnAppVeyor.Returns(appVeyor);
+                teamCityProvider.IsRunningOnTeamCity.Returns(teamCity);
+                myGetProvider.IsRunningOnMyGet.Returns(myGet);
+                bambooProvider.IsRunningOnBamboo.Returns(bamboo);
+                continuaCIProvider.IsRunningOnContinuaCI.Returns(continuaCI);
+                jenkinsProvider.IsRunningOnJenkins.Returns(jenkins);
+                bitriseProvider.IsRunningOnBitrise.Returns(bitrise);
+                travisCIProvider.IsRunningOnTravisCI.Returns(travisCI);
+                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(bitbucketPipelines);
+                goCDProvider.IsRunningOnGoCD.Returns(goCD);
+                gitlabCIProvider.IsRunningOnGitLabCI.Returns(gitlabCI);
+#pragma warning disable 618
+                tfBuildProvider.IsRunningOnTFS.Returns(tfs);
+                tfBuildProvider.IsRunningOnVSTS.Returns(vsts);
+#pragma warning restore 618
+                tfBuildProvider.IsRunningOnAzurePipelines.Returns(azurePipelines);
+                tfBuildProvider.IsRunningOnAzurePipelinesHosted.Returns(azurePipelinesHosted);
+
+                // When
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
+
+                // Then
+                Assert.Equal(provider, buildSystem.Provider);
+            }
+        }
+
+        public sealed class TheIsLocalBuildProperty
+        {
+            [Theory]
+            [InlineData(false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true)]
+            [InlineData(true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false)]
+            [InlineData(false, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false)]
+            [InlineData(false, false, true, false, false, false, false, false, false, false, false, false, false, false, false, false)]
+            [InlineData(false, false, false, true, false, false, false, false, false, false, false, false, false, false, false, false)]
+            [InlineData(false, false, false, false, true, false, false, false, false, false, false, false, false, false, false, false)]
+            [InlineData(false, false, false, false, false, true, false, false, false, false, false, false, false, false, false, false)]
+            [InlineData(false, false, false, false, false, false, true, false, false, false, false, false, false, false, false, false)]
+            [InlineData(false, false, false, false, false, false, false, true, false, false, false, false, false, false, false, false)]
+            [InlineData(false, false, false, false, false, false, false, false, true, false, false, false, false, false, false, false)]
+            [InlineData(false, false, false, false, false, false, false, false, false, true, false, false, false, false, false, false)]
+            [InlineData(false, false, false, false, false, false, false, false, false, false, true, false, false, false, false, false)]
+            [InlineData(false, false, false, false, false, false, false, false, false, false, false, true, false, true, false, false)] // tfs
+            [InlineData(false, false, false, false, false, false, false, false, false, false, false, false, true, false, true, false)] // vsts
+            [InlineData(false, false, false, false, false, false, false, false, false, false, false, false, false, true, false, false)]
+            [InlineData(false, false, false, false, false, false, false, false, false, false, false, true, false, false, true, false)]
+            public void Should_Return_False_If_Running_On_Provider(bool appVeyor, bool teamCity, bool myGet, bool bamboo, bool continuaCI, bool jenkins, bool bitrise, bool travisCI, bool bitbucketPipelines, bool goCD, bool gitlabCI, bool tfs, bool vsts, bool azurePipelines, bool azurePipelinesHosted, bool isLocalBuild)
+            {
+                // Given
+                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
+                var teamCityProvider = Substitute.For<ITeamCityProvider>();
+                var myGetProvider = Substitute.For<IMyGetProvider>();
+                var bambooProvider = Substitute.For<IBambooProvider>();
+                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
+                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
+                var bitriseProvider = Substitute.For<IBitriseProvider>();
+                var travisCIProvider = Substitute.For<ITravisCIProvider>();
+                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
+                var goCDProvider = Substitute.For<IGoCDProvider>();
+                var gitlabCIProvider = Substitute.For<IGitLabCIProvider>();
+                var tfBuildProvider = Substitute.For<ITFBuildProvider>();
+
+                appVeyorProvider.IsRunningOnAppVeyor.Returns(appVeyor);
+                teamCityProvider.IsRunningOnTeamCity.Returns(teamCity);
+                myGetProvider.IsRunningOnMyGet.Returns(myGet);
+                bambooProvider.IsRunningOnBamboo.Returns(bamboo);
+                continuaCIProvider.IsRunningOnContinuaCI.Returns(continuaCI);
+                jenkinsProvider.IsRunningOnJenkins.Returns(jenkins);
+                bitriseProvider.IsRunningOnBitrise.Returns(bitrise);
+                travisCIProvider.IsRunningOnTravisCI.Returns(travisCI);
+                bitbucketPipelinesProvider.IsRunningOnBitbucketPipelines.Returns(bitbucketPipelines);
+                goCDProvider.IsRunningOnGoCD.Returns(goCD);
+                gitlabCIProvider.IsRunningOnGitLabCI.Returns(gitlabCI);
+#pragma warning disable 618
+                tfBuildProvider.IsRunningOnTFS.Returns(tfs);
+                tfBuildProvider.IsRunningOnVSTS.Returns(vsts);
+#pragma warning restore 618
+                tfBuildProvider.IsRunningOnAzurePipelines.Returns(azurePipelines);
+                tfBuildProvider.IsRunningOnAzurePipelinesHosted.Returns(azurePipelinesHosted);
+
+                // When
+                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitlabCIProvider, tfBuildProvider);
+
+                // Then
+                Assert.Equal(isLocalBuild, buildSystem.IsLocalBuild);
             }
         }
     }

--- a/src/Cake.Common.Tests/Unit/Build/TFBuild/TFBuildProviderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TFBuild/TFBuildProviderTests.cs
@@ -36,38 +36,6 @@ namespace Cake.Common.Tests.Unit.Build.TFBuild
             }
         }
 
-        public sealed class TheIsRunningOnVSTSProperty
-        {
-            [Fact]
-            public void Should_Return_True_If_Running_On_VSTS()
-            {
-                // Given
-                var fixture = new TFBuildFixture();
-                fixture.IsRunningOnVSTS();
-                var vsts = fixture.CreateTFBuildService();
-
-                // When
-                var result = vsts.IsRunningOnVSTS;
-
-                // Then
-                Assert.True(result);
-            }
-
-            [Fact]
-            public void Should_Return_False_If_Not_Running_On_VSTS()
-            {
-                // Given
-                var fixture = new TFBuildFixture();
-                var vsts = fixture.CreateTFBuildService();
-
-                // When
-                var result = vsts.IsRunningOnVSTS;
-
-                // Then
-                Assert.False(result);
-            }
-        }
-
         public sealed class TheIsRunningOnTFSProperty
         {
             [Fact]
@@ -76,10 +44,12 @@ namespace Cake.Common.Tests.Unit.Build.TFBuild
                 // Given
                 var fixture = new TFBuildFixture();
                 fixture.IsRunningOnTFS();
-                var vsts = fixture.CreateTFBuildService();
+                var tfBuild = fixture.CreateTFBuildService();
 
                 // When
-                var result = vsts.IsRunningOnTFS;
+#pragma warning disable 618
+                var result = tfBuild.IsRunningOnTFS;
+#pragma warning restore 618
 
                 // Then
                 Assert.True(result);
@@ -90,10 +60,112 @@ namespace Cake.Common.Tests.Unit.Build.TFBuild
             {
                 // Given
                 var fixture = new TFBuildFixture();
-                var vsts = fixture.CreateTFBuildService();
+                var tfBuild = fixture.CreateTFBuildService();
 
                 // When
-                var result = vsts.IsRunningOnTFS;
+#pragma warning disable 618
+                var result = tfBuild.IsRunningOnTFS;
+#pragma warning restore 618
+
+                // Then
+                Assert.False(result);
+            }
+        }
+
+        public sealed class TheIsRunningOnVSTSProperty
+        {
+            [Fact]
+            public void Should_Return_True_If_Running_On_VSTS()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                fixture.IsRunningOnVSTS();
+                var tfBuild = fixture.CreateTFBuildService();
+
+                // When
+#pragma warning disable 618
+                var result = tfBuild.IsRunningOnVSTS;
+#pragma warning restore 618
+
+                // Then
+                Assert.True(result);
+            }
+
+            [Fact]
+            public void Should_Return_False_If_Not_Running_On_VSTS()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var tfBuild = fixture.CreateTFBuildService();
+
+                // When
+#pragma warning disable 618
+                var result = tfBuild.IsRunningOnVSTS;
+#pragma warning restore 618
+
+                // Then
+                Assert.False(result);
+            }
+        }
+
+        public sealed class TheIsRunningOnAzurePipelinesProperty
+        {
+            [Fact]
+            public void Should_Return_True_If_Running_On_AzurePipelines()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                fixture.IsRunningOnAzurePipelines();
+                var tfBuild = fixture.CreateTFBuildService();
+
+                // When
+                var result = tfBuild.IsRunningOnAzurePipelines;
+
+                // Then
+                Assert.True(result);
+            }
+
+            [Fact]
+            public void Should_Return_False_If_Not_Running_On_AzurePipelines()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var tfBuild = fixture.CreateTFBuildService();
+
+                // When
+                var result = tfBuild.IsRunningOnAzurePipelines;
+
+                // Then
+                Assert.False(result);
+            }
+        }
+
+        public sealed class TheIsRunningOnAzurePipelinesHostedProperty
+        {
+            [Fact]
+            public void Should_Return_True_If_Running_On_AzurePipelinesHosted()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                fixture.IsRunningOnAzurePipelinesHosted();
+                var tfBuild = fixture.CreateTFBuildService();
+
+                // When
+                var result = tfBuild.IsRunningOnAzurePipelinesHosted;
+
+                // Then
+                Assert.True(result);
+            }
+
+            [Fact]
+            public void Should_Return_False_If_Not_Running_On_AzurePipelinesHosted()
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                var tfBuild = fixture.CreateTFBuildService();
+
+                // When
+                var result = tfBuild.IsRunningOnAzurePipelinesHosted;
 
                 // Then
                 Assert.False(result);
@@ -107,10 +179,10 @@ namespace Cake.Common.Tests.Unit.Build.TFBuild
             {
                 // Given
                 var fixture = new TFBuildFixture();
-                var vsts = fixture.CreateTFBuildService();
+                var tfBuild = fixture.CreateTFBuildService();
 
                 // When
-                var result = vsts.Environment;
+                var result = tfBuild.Environment;
 
                 // Then
                 Assert.NotNull(result);

--- a/src/Cake.Common/Build/BuildProvider.cs
+++ b/src/Cake.Common/Build/BuildProvider.cs
@@ -1,0 +1,85 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Cake.Common.Build
+{
+    /// <summary>
+    /// Represents a build provider.
+    /// </summary>
+    [Flags]
+    public enum BuildProvider
+    {
+        /// <summary>
+        /// Local build provider.
+        /// </summary>
+        Local = 0,
+
+        /// <summary>
+        /// AppVeyor build provider.
+        /// </summary>
+        AppVeyor = 1,
+
+        /// <summary>
+        /// TeamCity build provider.
+        /// </summary>
+        TeamCity = 2,
+
+        /// <summary>
+        /// MyGet build provider.
+        /// </summary>
+        MyGet = 4,
+
+        /// <summary>
+        /// Bamboo build provider.
+        /// </summary>
+        Bamboo = 8,
+
+        /// <summary>
+        /// ContinuaCI build provider.
+        /// </summary>
+        ContinuaCI = 16,
+
+        /// <summary>
+        /// Jenkins build provider.
+        /// </summary>
+        Jenkins = 32,
+
+        /// <summary>
+        /// Bitrise build provider.
+        /// </summary>
+        Bitrise = 64,
+
+        /// <summary>
+        /// TravisCI build provider.
+        /// </summary>
+        TravisCI = 128,
+
+        /// <summary>
+        /// BitbucketPipelines build provider.
+        /// </summary>
+        BitbucketPipelines = 256,
+
+        /// <summary>
+        /// GoCD build provider.
+        /// </summary>
+        GoCD = 512,
+
+        /// <summary>
+        /// GitLabCI build provider.
+        /// </summary>
+        GitLabCI = 1024,
+
+        /// <summary>
+        /// AzurePipelines build provider.
+        /// </summary>
+        AzurePipelines = 2048,
+
+        /// <summary>
+        /// AzurePipelinesHosted build provider.
+        /// </summary>
+        AzurePipelinesHosted = 4096
+    }
+}

--- a/src/Cake.Common/Build/BuildSystem.cs
+++ b/src/Cake.Common/Build/BuildSystem.cs
@@ -114,6 +114,22 @@ namespace Cake.Common.Build
             GoCD = goCDProvider;
             GitLabCI = gitlabCIProvider;
             TFBuild = tfBuildProvider;
+
+            Provider = (AppVeyor.IsRunningOnAppVeyor ? BuildProvider.AppVeyor : BuildProvider.Local)
+                | (TeamCity.IsRunningOnTeamCity ? BuildProvider.TeamCity : BuildProvider.Local)
+                | (MyGet.IsRunningOnMyGet ? BuildProvider.MyGet : BuildProvider.Local)
+                | (Bamboo.IsRunningOnBamboo ? BuildProvider.Bamboo : BuildProvider.Local)
+                | (ContinuaCI.IsRunningOnContinuaCI ? BuildProvider.ContinuaCI : BuildProvider.Local)
+                | (Jenkins.IsRunningOnJenkins ? BuildProvider.Jenkins : BuildProvider.Local)
+                | (Bitrise.IsRunningOnBitrise ? BuildProvider.Bitrise : BuildProvider.Local)
+                | (TravisCI.IsRunningOnTravisCI ? BuildProvider.TravisCI : BuildProvider.Local)
+                | (BitbucketPipelines.IsRunningOnBitbucketPipelines ? BuildProvider.BitbucketPipelines : BuildProvider.Local)
+                | (GoCD.IsRunningOnGoCD ? BuildProvider.GoCD : BuildProvider.Local)
+                | (GitLabCI.IsRunningOnGitLabCI ? BuildProvider.GitLabCI : BuildProvider.Local)
+                | (TFBuild.IsRunningOnAzurePipelines ? BuildProvider.AzurePipelines : BuildProvider.Local)
+                | (TFBuild.IsRunningOnAzurePipelinesHosted ? BuildProvider.AzurePipelinesHosted : BuildProvider.Local);
+
+            IsLocalBuild = Provider == BuildProvider.Local;
         }
 
         /// <summary>
@@ -464,23 +480,6 @@ namespace Cake.Common.Build
         public bool IsRunningOnGitLabCI => GitLabCI.IsRunningOnGitLabCI;
 
         /// <summary>
-        /// Gets a value indicating whether this instance is running on VSTS.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// if(BuildSystem.IsRunningOnVSTS)
-        /// {
-        ///     // Get the build commit hash.
-        ///     var commitHash = BuildSystem.TFBuild.Environment.Repository.SourceVersion;
-        /// }
-        /// </code>
-        /// </example>
-        /// <value>
-        /// <c>true</c> if this instance is running on VSTS; otherwise, <c>false</c>.
-        /// </value>
-        public bool IsRunningOnVSTS => TFBuild.IsRunningOnVSTS;
-
-        /// <summary>
         /// Gets a value indicating whether this instance is running on TFS.
         /// </summary>
         /// <example>
@@ -495,7 +494,60 @@ namespace Cake.Common.Build
         /// <value>
         /// <c>true</c> if this instance is running on TFS; otherwise, <c>false</c>.
         /// </value>
+        [Obsolete("Please use BuildSystem.IsRunningOnAzurePipelines instead.")]
         public bool IsRunningOnTFS => TFBuild.IsRunningOnTFS;
+
+        /// <summary>
+        /// Gets a value indicating whether this instance is running on VSTS.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// if(BuildSystem.IsRunningOnVSTS)
+        /// {
+        ///     // Get the build commit hash.
+        ///     var commitHash = BuildSystem.TFBuild.Environment.Repository.SourceVersion;
+        /// }
+        /// </code>
+        /// </example>
+        /// <value>
+        /// <c>true</c> if this instance is running on VSTS; otherwise, <c>false</c>.
+        /// </value>
+        [Obsolete("Please use BuildSystem.IsRunningOnAzurePipelinesHosted instead.")]
+        public bool IsRunningOnVSTS => TFBuild.IsRunningOnVSTS;
+
+        /// <summary>
+        /// Gets a value indicating whether this instance is running on Azure Pipelines.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// if(BuildSystem.IsRunningOnAzurePipelines)
+        /// {
+        ///     // Get the build commit hash.
+        ///     var commitHash = BuildSystem.TFBuild.Environment.Repository.SourceVersion;
+        /// }
+        /// </code>
+        /// </example>
+        /// <value>
+        /// <c>true</c> if this instance is running on Azure Pipelines; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsRunningOnAzurePipelines => TFBuild.IsRunningOnAzurePipelines;
+
+        /// <summary>
+        /// Gets a value indicating whether this instance is running on hosted Azure Pipelines.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// if(BuildSystem.IsRunningOnAzurePipelinesHosted)
+        /// {
+        ///     // Get the build commit hash.
+        ///     var commitHash = BuildSystem.TFBuild.Environment.Repository.SourceVersion;
+        /// }
+        /// </code>
+        /// </example>
+        /// <value>
+        /// <c>true</c> if this instance is running on hosted Azure Pipelines; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsRunningOnAzurePipelinesHosted => TFBuild.IsRunningOnAzurePipelinesHosted;
 
         /// <summary>
         /// Gets the TF Build Provider.
@@ -510,6 +562,12 @@ namespace Cake.Common.Build
         /// </code>
         /// </example>
         public ITFBuildProvider TFBuild { get; }
+
+        /// <summary>
+        /// Gets the current build provider.
+        /// </summary>
+        /// <value>The current build provider.</value>
+        public BuildProvider Provider { get; }
 
         /// <summary>
         /// Gets a value indicating whether the current build is local build.
@@ -530,6 +588,6 @@ namespace Cake.Common.Build
         /// <value>
         ///   <c>true</c> if the current build is local build; otherwise, <c>false</c>.
         /// </value>
-        public bool IsLocalBuild => !(IsRunningOnAppVeyor || IsRunningOnTeamCity || IsRunningOnMyGet || IsRunningOnBamboo || IsRunningOnContinuaCI || IsRunningOnJenkins || IsRunningOnBitrise || IsRunningOnTravisCI || IsRunningOnBitbucketPipelines || IsRunningOnGoCD || IsRunningOnGitLabCI || IsRunningOnTFS || IsRunningOnVSTS);
+        public bool IsLocalBuild { get; }
     }
 }

--- a/src/Cake.Common/Build/TFBuild/ITFBuildProvider.cs
+++ b/src/Cake.Common/Build/TFBuild/ITFBuildProvider.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Cake.Common.Build.TFBuild.Data;
 
 namespace Cake.Common.Build.TFBuild
@@ -12,20 +13,38 @@ namespace Cake.Common.Build.TFBuild
     public interface ITFBuildProvider
     {
         /// <summary>
-        /// Gets a value indicating whether the current build is running on VSTS.
-        /// </summary>
-        /// <value>
-        /// <c>true</c> if the current build is running on VSTS; otherwise, <c>false</c>.
-        /// </value>
-        bool IsRunningOnVSTS { get; }
-
-        /// <summary>
         /// Gets a value indicating whether the current build is running on TFS.
         /// </summary>
         /// <value>
         /// <c>true</c> if the current build is running on TFS; otherwise, <c>false</c>.
         /// </value>
+        [Obsolete("Please use ITFBuildProvider.IsRunningOnAzurePipelines instead.")]
         bool IsRunningOnTFS { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the current build is running on VSTS.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the current build is running on VSTS; otherwise, <c>false</c>.
+        /// </value>
+        [Obsolete("Please use ITFBuildProvider.IsRunningOnAzurePipelinesHosted instead.")]
+        bool IsRunningOnVSTS { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the current build is running on Azure Pipelines.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the current build is running on Azure Pipelines; otherwise, <c>false</c>.
+        /// </value>
+        bool IsRunningOnAzurePipelines { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the current build is running on hosted Azure Pipelines.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the current build is running on hosted Azure Pipelines; otherwise, <c>false</c>.
+        /// </value>
+        bool IsRunningOnAzurePipelinesHosted { get; }
 
         /// <summary>
         /// Gets the TF Build environment.

--- a/src/Cake.Common/Build/TFBuild/TFBuildProvider.cs
+++ b/src/Cake.Common/Build/TFBuild/TFBuildProvider.cs
@@ -37,22 +37,40 @@ namespace Cake.Common.Build.TFBuild
         }
 
         /// <summary>
-        /// Gets a value indicating whether the current build is running on VSTS.
-        /// </summary>
-        /// <value>
-        /// <c>true</c> if the current build is running on VSTS; otherwise, <c>false</c>.
-        /// </value>
-        public bool IsRunningOnVSTS
-            => !string.IsNullOrWhiteSpace(_environment.GetEnvironmentVariable("TF_BUILD")) && IsHostedAgent;
-
-        /// <summary>
         /// Gets a value indicating whether the current build is running on TFS.
         /// </summary>
         /// <value>
         /// <c>true</c> if the current build is running on TFS; otherwise, <c>false</c>.
         /// </value>
-        public bool IsRunningOnTFS
+        [Obsolete("Please use TFBuildProvider.IsRunningOnAzurePipelines instead.")]
+        public bool IsRunningOnTFS => IsRunningOnAzurePipelines;
+
+        /// <summary>
+        /// Gets a value indicating whether the current build is running on VSTS.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the current build is running on VSTS; otherwise, <c>false</c>.
+        /// </value>
+        [Obsolete("Please use TFBuildProvider.IsRunningOnAzurePipelinesHosted instead.")]
+        public bool IsRunningOnVSTS => IsRunningOnAzurePipelinesHosted;
+
+        /// <summary>
+        /// Gets a value indicating whether the current build is running on Azure Pipelines.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the current build is running on Azure Pipelines; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsRunningOnAzurePipelines
             => !string.IsNullOrWhiteSpace(_environment.GetEnvironmentVariable("TF_BUILD")) && !IsHostedAgent;
+
+        /// <summary>
+        /// Gets a value indicating whether the current build is running on hosted Azure Pipelines.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the current build is running on hosted Azure Pipelines; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsRunningOnAzurePipelinesHosted
+            => !string.IsNullOrWhiteSpace(_environment.GetEnvironmentVariable("TF_BUILD")) && IsHostedAgent;
 
         /// <summary>
         /// Gets the TF Build environment.

--- a/src/Cake.sln.DotSettings
+++ b/src/Cake.sln.DotSettings
@@ -23,6 +23,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_EMBEDDED_STATEMENT_ON_SAME_LINE/@EntryValue">NEVER</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SIMPLE_EMBEDDED_STATEMENT_STYLE/@EntryValue">LINE_BREAK</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_WITHIN_SINGLE_LINE_ARRAY_INITIALIZER_BRACES/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CD/@EntryIndexedValue">CI</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CI/@EntryIndexedValue">CI</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CLS/@EntryIndexedValue">CLS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DNU/@EntryIndexedValue">DNU</s:String>
@@ -54,7 +55,9 @@
 	<s:Boolean x:Key="/Default/ReSpeller/UserDictionaries/=en_005Fus/Words/=apikey/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/ReSpeller/UserDictionaries/=en_005Fus/Words/=appveyor/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/ReSpeller/UserDictionaries/=en_005Fus/Words/=Attrs/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/ReSpeller/UserDictionaries/=en_005Fus/Words/=Bitbucket/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/ReSpeller/UserDictionaries/=en_005Fus/Words/=bitness/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/ReSpeller/UserDictionaries/=en_005Fus/Words/=Bitrise/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/ReSpeller/UserDictionaries/=en_005Fus/Words/=choco/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/ReSpeller/UserDictionaries/=en_005Fus/Words/=chucknorris/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/ReSpeller/UserDictionaries/=en_005Fus/Words/=Collapser/@EntryIndexedValue">True</s:Boolean>

--- a/src/Cake.sln.DotSettings
+++ b/src/Cake.sln.DotSettings
@@ -23,7 +23,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_EMBEDDED_STATEMENT_ON_SAME_LINE/@EntryValue">NEVER</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SIMPLE_EMBEDDED_STATEMENT_STYLE/@EntryValue">LINE_BREAK</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_WITHIN_SINGLE_LINE_ARRAY_INITIALIZER_BRACES/@EntryValue">True</s:Boolean>
-	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CD/@EntryIndexedValue">CI</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CD/@EntryIndexedValue">CD</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CI/@EntryIndexedValue">CI</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CLS/@EntryIndexedValue">CLS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DNU/@EntryIndexedValue">DNU</s:String>

--- a/tests/integration/setup.cake
+++ b/tests/integration/setup.cake
@@ -7,7 +7,7 @@
 // SETUP
 //////////////////////////////////////////////////
 
-Setup(setupContext => 
+Setup(setupContext =>
 {
     setupContext.Log.Information("Running regular setup.");
 });
@@ -17,10 +17,11 @@ Setup<ScriptContext>(setupContext =>
     // Output information from setup task
     setupContext.Log.Information(
         Verbosity.Quiet,
-        "Performing setup initated by {0} ({1} tasks to be executed beginning with {2})",
+        "Performing setup initated by {0} ({1} tasks to be executed beginning with {2}, performing {3} build)",
         setupContext.TargetTask?.Name,
         setupContext.TasksToExecute?.Count,
-        setupContext.TasksToExecute?.Select(task => task.Name).FirstOrDefault()
+        setupContext.TasksToExecute?.Select(task => task.Name).FirstOrDefault(),
+        BuildSystem.Provider
         );
 
     // Perform artifact cleanup
@@ -41,45 +42,45 @@ Setup<AlternativeScriptContext>(setupContext =>
 //////////////////////////////////////////////////
 
 Task("Can-Access-Typed-Data")
-    .Does<ScriptContext>(data => 
+    .Does<ScriptContext>(data =>
 {
     Assert.True(data.Initialized);
 });
 
 Task("Can-Access-Typed-Data-On-Alternative-Context")
-    .Does<AlternativeScriptContext>(data => 
+    .Does<AlternativeScriptContext>(data =>
 {
     Assert.True(data.EnginesStarted);
 });
 
 Task("Can-Access-Typed-Data-Async")
-    .Does<ScriptContext>(async data => 
+    .Does<ScriptContext>(async data =>
 {
     await System.Threading.Tasks.Task.Delay(0);
 });
 
 Task("Can-Access-Typed-Data-With-Context")
-    .Does<ScriptContext>((context, data) => 
+    .Does<ScriptContext>((context, data) =>
 {
     Assert.True(data.Initialized);
 });
 
 Task("Can-Access-Typed-Data-With-Context-Async")
-    .Does<ScriptContext>(async (context, data) => 
+    .Does<ScriptContext>(async (context, data) =>
 {
     await System.Threading.Tasks.Task.Delay(0);
 });
 
 Task("Can-Access-Typed-Data-WithCriteria-True")
     .WithCriteria<ScriptContext>((context, data) => data.Initialized)
-    .Does<ScriptContext>(data => 
+    .Does<ScriptContext>(data =>
 {
     Assert.True(data.Initialized);
 });
 
 Task("Can-Access-Typed-Data-WithCriteria-False-Message")
     .WithCriteria<ScriptContext>((context, data) => !data.Initialized, "Should only run if not initialized.")
-    .Does<ScriptContext>(data => 
+    .Does<ScriptContext>(data =>
 {
     Assert.False(data.Initialized);
 });


### PR DESCRIPTION
Fixes #2429.
- Added `BuildProvider` enum flags
- Added `Provider` property; initialized in `ctor`
- Changed `IsLocalBuild` property to use `Provider` property; initialized in `ctor`
- Added `AzurePipelines` and `AzurePipelinesHosted`
- Deprecated all things `TFS` and `VSTS` with `Obsolete` attribute
- Used xUnit theories to reduce unit tests surface area