### PR TITLE
GH2432: Fix TFBuildAgentInfo.IsHosted for Azure Pipelines

### DIFF
--- a/src/Cake.Common/Build/TFBuild/Data/TFBuildAgentInfo.cs
+++ b/src/Cake.Common/Build/TFBuild/Data/TFBuildAgentInfo.cs
@@ -79,6 +79,6 @@ namespace Cake.Common.Build.TFBuild.Data
         /// <value>
         /// <c>true</c> if the current agent is a hosted agent; otherwise, <c>false</c>.
         /// </value>
-        public bool IsHosted => Name == "Hosted Agent";
+        public bool IsHosted => Name != null && Name.StartsWith("Hosted");
     }
 }


### PR DESCRIPTION
Another fix for #2432.

I did a quick test with [Cake v0.33.0-alpha0016](https://www.myget.org/feed/cake/package/nuget/Cake/0.33.0-alpha0016) and everything works as expected, but then I noticed another environment variable I missed with my previous changes. [BuildSystem.TFBuild.Environment.Agent.IsHosted](https://dev.azure.com/gitfool/Cake.Dungeon/_build/results?buildId=16&view=logs&jobId=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb&taskId=8ef82b3b-1feb-5bbd-06f6-b1f7b5467f03&lineStart=172&lineEnd=173&colStart=1&colEnd=1) is `false` but should be `true`, if only it checked for just the `Hosted` prefix.