### PR TITLE
GH2270: Added RedirectedStandardOutputHandler and RedirectedStandar…

### DIFF
--- a/src/Cake.Core.Tests/Fixtures/ProcessWrapperFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/ProcessWrapperFixture.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Diagnostics;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using NSubstitute;
+
+namespace Cake.Core.Tests.Fixtures
+{
+    internal sealed class ProcessWrapperFixture
+    {
+        public Process Process { get; set; }
+        public ICakeLog Log { get; set; }
+        public Func<string, string> FilterOutput { get; set; }
+        public Func<string, string> FilterError { get; set; }
+        public Func<string, string> StandartOutputHandler { get; set; }
+        public Func<string, string> StandardErrorHandler { get; set; }
+
+        public ProcessWrapperFixture()
+        {
+            Log = Substitute.For<ICakeLog>();
+        }
+
+        public ProcessWrapper CreateProcessWrapper()
+        {
+            return new ProcessWrapper(Process, Log, FilterOutput, StandartOutputHandler, FilterError, StandardErrorHandler);
+        }
+    }
+}

--- a/src/Cake.Core.Tests/Unit/IO/ProcessSettingsTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/ProcessSettingsTests.cs
@@ -36,11 +36,21 @@ namespace Cake.Core.Tests.Unit.IO
             [Theory]
             [InlineData(true, true)]
             [InlineData(false, false)]
-            public void Should_Return_Settings_With_Correct_Output(bool value, bool expected)
+            public void Should_Return_Settings_With_Correct_StandardOutput(bool value, bool expected)
             {
                 var settings = new ProcessSettings().SetRedirectStandardOutput(value);
 
                 Assert.Equal(expected, settings.RedirectStandardOutput);
+            }
+
+            [Theory]
+            [InlineData(true, true)]
+            [InlineData(false, false)]
+            public void Should_Return_Settings_With_Correct_StandardError(bool value, bool expected)
+            {
+                var settings = new ProcessSettings().SetRedirectStandardError(value);
+
+                Assert.Equal(expected, settings.RedirectStandardError);
             }
 
             [Theory]

--- a/src/Cake.Core.Tests/Unit/IO/ProcessWrapperTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/ProcessWrapperTests.cs
@@ -1,0 +1,50 @@
+﻿using System.Diagnostics;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using Cake.Core.Tests.Fixtures;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Core.Tests.Unit.IO
+{
+    public sealed class ProcessWrapperTests
+    {
+        public sealed class The_StandardOutputReceived_Method
+        {
+            [Fact]
+            public void Should_Pass_StandardOutput_Through_Handler()
+            {
+                // Given
+                var receivedMessage = string.Empty;
+                var fixture = new ProcessWrapperFixture();
+                fixture.StandartOutputHandler = (s) => receivedMessage = s;
+                var wrapper = fixture.CreateProcessWrapper();
+
+                // When
+                wrapper.StandardOutputReceived("message");
+
+                // Then
+                Assert.Equal("message", receivedMessage);
+            }
+        }
+
+        public sealed class The_StandardErrorReceived_Method
+        {
+            [Fact]
+            public void Should_Pass_StandardError_Through_Handler()
+            {
+                // Given
+                var receivedMessage = string.Empty;
+                var fixture = new ProcessWrapperFixture();
+                fixture.StandardErrorHandler = (s) => receivedMessage = s;
+                var wrapper = fixture.CreateProcessWrapper();
+
+                // When
+                wrapper.StandardErrorReceived("message");
+
+                // Then
+                Assert.Equal("message", receivedMessage);
+            }
+        }
+    }
+}

--- a/src/Cake.Core/Extensions/ProcessSettingsExtensions.cs
+++ b/src/Cake.Core/Extensions/ProcessSettingsExtensions.cs
@@ -61,10 +61,44 @@ namespace Cake.Core
         }
 
         /// <summary>
-        /// Sets a value indicating whether the output of an application is written to the <see cref="P:System.Diagnostics.Process.StandardOutput"/> stream.
+        /// Sets a function that intercepts the standard output before being redirected. Use in conjunction with <see cref="ProcessSettings.RedirectStandardOutput"/>
         /// </summary>
         /// <param name="settings">The process settings.</param>
-        /// <param name="redirect">true if output should be written to <see cref="P:System.Diagnostics.Process.StandardOutput"/>; otherwise, false. The default is false.</param>
+        /// <param name="handler">The standard output handler.</param>
+        /// <returns>The same <see cref="ProcessSettings"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessSettings SetRedirectedStandardOutputHandler(this ProcessSettings settings, Func<string, string> handler)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            settings.RedirectedStandardOutputHandler = handler;
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets a function that intercepts the standard error before being redirected. Use in conjunction with <see cref="ProcessSettings.RedirectStandardOutput"/>
+        /// </summary>
+        /// <param name="settings">The process settings.</param>
+        /// <param name="handler">The standard error handler.</param>
+        /// <returns>The same <see cref="ProcessSettings"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessSettings SetRedirectedStandardErrorHandler(this ProcessSettings settings, Func<string, string> handler)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            settings.RedirectedStandardErrorHandler = handler;
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets a value indicating whether the output of an application is written to the standard output stream.
+        /// </summary>
+        /// <param name="settings">The process settings.</param>
+        /// <param name="redirect">true if output should be redirected; false if output should be written to the standard output stream. The default is false.</param>
         /// <returns>The same <see cref="ProcessSettings"/> instance so that multiple calls can be chained.</returns>
         public static ProcessSettings SetRedirectStandardOutput(this ProcessSettings settings, bool redirect)
         {
@@ -74,6 +108,23 @@ namespace Cake.Core
             }
 
             settings.RedirectStandardOutput = redirect;
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets a value indicating whether the standard error of an application is written to the standard error stream.
+        /// </summary>
+        /// <param name="settings">The process settings.</param>
+        /// <param name="redirect">true if error output should be redirected; false if error output should be written to the standard error stream. The default is false.</param>
+        /// <returns>The same <see cref="ProcessSettings"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessSettings SetRedirectStandardError(this ProcessSettings settings, bool redirect)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            settings.RedirectStandardError = redirect;
             return settings;
         }
 

--- a/src/Cake.Core/IO/ProcessSettings.cs
+++ b/src/Cake.Core/IO/ProcessSettings.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 
 namespace Cake.Core.IO
@@ -40,6 +41,16 @@ namespace Cake.Core.IO
         /// </summary>
         /// <value>true if output should be redirected; false if output should be written to the standard output stream. The default is false.</value>
         public bool RedirectStandardOutput { get; set; }
+
+        /// <summary>
+        /// Gets or sets a function that intercepts the error output before being redirected. Use in conjunction with <see cref="RedirectStandardError"/>
+        /// </summary>
+        public Func<string, string> RedirectedStandardErrorHandler { get; set; }
+
+        /// <summary>
+        /// Gets or sets a function that intercepts the standard output before being redirected. Use in conjunction with <see cref="RedirectStandardOutput"/>
+        /// </summary>
+        public Func<string, string> RedirectedStandardOutputHandler { get; set; }
 
         /// <summary>
         /// Gets or sets optional timeout, in milliseconds, to wait for the associated process to exit. The maximum is the largest possible value of a 32-bit integer, which represents infinity to the operating system.


### PR DESCRIPTION
Closes #2270 .

Added `RedirectedStandardOutputHandler` and `RedirectedStandardErrorHandler` to `ProcessSettings` and the corresponding extension methods.

Moved the redirection handling into `ProcessWrapper`, by adding `StandardOutputReceived` and `StandardErrorReceived` methods. This keeps the `ConcurrentQueue` completely inside `ProcessWrapper` and facilitates the integration of features that need to modify the current queueing behaviour of the output. (E.g. #2354 and #1485)
