### PR TITLE
GH2345: Add NonInteractive property to NuGetRestoreSettings

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/NuGet/Restore/NuGetRestoreSettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NuGet/Restore/NuGetRestoreSettingsTests.cs
@@ -30,6 +30,16 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Restore
                 // Then
                 Assert.False(settings.RequireConsent);
             }
+
+            [Fact]
+            public void Should_Set_NonInteractive_To_True_By_Default()
+            {
+                // Given, When
+                var settings = new NuGetRestoreSettings();
+
+                // Then
+                Assert.True(settings.NonInteractive);
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/NuGet/Restore/NuGetRestorerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NuGet/Restore/NuGetRestorerTests.cs
@@ -219,6 +219,20 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Restore
                              "-NonInteractive", result.Args);
             }
 
+            [Fact]
+            public void Should_Remove_NonInteractive_From_Arguments_If_False()
+            {
+                // Given
+                var fixture = new NuGetRestorerFixture();
+                fixture.Settings.NonInteractive = false;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("restore \"/Working/project.sln\"", result.Args);
+            }
+
             [Theory]
             [InlineData(NuGetVerbosity.Detailed, "restore \"/Working/project.sln\" -Verbosity detailed -NonInteractive")]
             [InlineData(NuGetVerbosity.Normal, "restore \"/Working/project.sln\" -Verbosity normal -NonInteractive")]

--- a/src/Cake.Common/Tools/NuGet/Restore/NuGetRestorer.cs
+++ b/src/Cake.Common/Tools/NuGet/Restore/NuGetRestorer.cs
@@ -121,7 +121,11 @@ namespace Cake.Common.Tools.NuGet.Restore
                 builder.Append(settings.MSBuildVersion.Value.GetNuGetMSBuildVersionString());
             }
 
-            builder.Append("-NonInteractive");
+            // NonInteractive?
+            if (settings.NonInteractive)
+            {
+                builder.Append("-NonInteractive");
+            }
 
             return builder;
         }

--- a/src/Cake.Common/Tools/NuGet/Restore/NugetRestoreSettings.cs
+++ b/src/Cake.Common/Tools/NuGet/Restore/NugetRestoreSettings.cs
@@ -72,5 +72,16 @@ namespace Cake.Common.Tools.NuGet.Restore
         /// </summary>
         /// <value>The version of MSBuild to be used with this command.</value>
         public NuGetMSBuildVersion? MSBuildVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not NuGet suppresses prompts for user input or confirmations.
+        /// </summary>
+        /// <remarks>
+        /// This setting is passed by NuGet.exe to any extensions such as authorization providers
+        /// </remarks>
+        /// <value>
+        /// <c>false</c> to allow NuGet to show prompts for user input or confirmations; otherwise, <c>true</c>.
+        /// </value>
+        public bool NonInteractive { get; set; } = true;
     }
 }


### PR DESCRIPTION
- Defaults to true (preserving current behaviour as the default)
- Setting to false means NuGet.exe is free to prompt for user input/confirmation (useful when run interactively and when combined with authorisation providers)

Implements #2345 
