### PR TITLE
GH2456: Add logging aliases to override the log verbosity

### DIFF
--- a/src/Cake.Common/Build/TeamCity/TeamCityDisposableExtensions.cs
+++ b/src/Cake.Common/Build/TeamCity/TeamCityDisposableExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Cake.Core;
 
 namespace Cake.Common.Build.TeamCity
 {
@@ -12,11 +13,11 @@ namespace Cake.Common.Build.TeamCity
     public static class TeamCityDisposableExtensions
     {
         /// <summary>
-        /// Writes the start of a TeamCity message block, then returns a disposable that write the end on Dispose.
+        /// Writes the start of a TeamCity message block, then returns a disposable that writes the report block end on dispose.
         /// </summary>
         /// <param name="teamCityProvider">TeamCity provider.</param>
         /// <param name="blockName">The name of the report block.</param>
-        /// <returns>A disposable wrapper the writes the report block end.</returns>
+        /// <returns>A disposable that writes the report block end.</returns>
         public static IDisposable Block(this ITeamCityProvider teamCityProvider, string blockName)
         {
             if (teamCityProvider == null)
@@ -24,15 +25,15 @@ namespace Cake.Common.Build.TeamCity
                 throw new ArgumentNullException(nameof(teamCityProvider));
             }
             teamCityProvider.WriteStartBlock(blockName);
-            return new TeamCityActionDisposable(teamCityProvider, tc => tc.WriteEndBlock(blockName));
+            return Disposable.Create(() => teamCityProvider.WriteEndBlock(blockName));
         }
 
         /// <summary>
-        /// Writes the start of a TeamCity build block, then returns a disposable that write the end on Dispose.
+        /// Writes the start of a TeamCity build block, then returns a disposable that writes the build block end on dispose.
         /// </summary>
         /// <param name="teamCityProvider">TeamCity provider.</param>
         /// <param name="compilerName">The name of the build block.</param>
-        /// <returns>A disposable wrapper the writes the build block end.</returns>
+        /// <returns>A disposable that writes the build block end.</returns>
         public static IDisposable BuildBlock(this ITeamCityProvider teamCityProvider, string compilerName)
         {
             if (teamCityProvider == null)
@@ -40,35 +41,7 @@ namespace Cake.Common.Build.TeamCity
                 throw new ArgumentNullException(nameof(teamCityProvider));
             }
             teamCityProvider.WriteStartBuildBlock(compilerName);
-            return new TeamCityActionDisposable(teamCityProvider, tc => tc.WriteEndBuildBlock(compilerName));
-        }
-
-        /// <summary>
-        /// Disposable helper for writing TeamCity message blocks.
-        /// </summary>
-        internal sealed class TeamCityActionDisposable : IDisposable
-        {
-            private readonly ITeamCityProvider _teamCityProvider;
-            private readonly Action<ITeamCityProvider> _disposeAction;
-
-            /// <summary>
-            /// Initializes a new instance of the <see cref="TeamCityActionDisposable"/> class.
-            /// </summary>
-            /// <param name="teamCityProvider">TeamCity provider.</param>
-            /// <param name="disposeAction">The action to do on Dispose.</param>
-            public TeamCityActionDisposable(ITeamCityProvider teamCityProvider, Action<ITeamCityProvider> disposeAction)
-            {
-                _teamCityProvider = teamCityProvider;
-                _disposeAction = disposeAction;
-            }
-
-            /// <summary>
-            /// Writes the end block for this message block.
-            /// </summary>
-            public void Dispose()
-            {
-                _disposeAction(_teamCityProvider);
-            }
+            return Disposable.Create(() => teamCityProvider.WriteEndBuildBlock(compilerName));
         }
     }
 }

--- a/src/Cake.Common/Diagnostics/LoggingAliases.cs
+++ b/src/Cake.Common/Diagnostics/LoggingAliases.cs
@@ -444,5 +444,145 @@ namespace Cake.Common.Diagnostics
             }
             context.Log.Debug(value);
         }
+
+        /// <summary>
+        /// Sets the log verbosity to quiet and returns a disposable that restores the log verbosity on dispose.
+        /// </summary>
+        /// <param name="context">the context.</param>
+        /// <returns>A disposable that restores the log verbosity.</returns>
+        /// <example>
+        /// <code>
+        /// using (QuietVerbosity())
+        /// {
+        ///     Error("Show me.");
+        ///     Warning("Hide me.");
+        ///     Information("Hide me.");
+        ///     Verbose("Hide me.");
+        ///     Debug("Hide me.");
+        /// }
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Verbosity")]
+        public static IDisposable QuietVerbosity(this ICakeContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            return context.Log.QuietVerbosity();
+        }
+
+        /// <summary>
+        /// Sets the log verbosity to minimal and returns a disposable that restores the log verbosity on dispose.
+        /// </summary>
+        /// <param name="context">the context.</param>
+        /// <returns>A disposable that restores the log verbosity.</returns>
+        /// <example>
+        /// <code>
+        /// using (MinimalVerbosity())
+        /// {
+        ///     Error("Show me.");
+        ///     Warning("Show me.");
+        ///     Information("Hide me.");
+        ///     Verbose("Hide me.");
+        ///     Debug("Hide me.");
+        /// }
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Verbosity")]
+        public static IDisposable MinimalVerbosity(this ICakeContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            return context.Log.MinimalVerbosity();
+        }
+
+        /// <summary>
+        /// Sets the log verbosity to normal and returns a disposable that restores the log verbosity on dispose.
+        /// </summary>
+        /// <param name="context">the context.</param>
+        /// <returns>A disposable that restores the log verbosity.</returns>
+        /// <example>
+        /// <code>
+        /// using (NormalVerbosity())
+        /// {
+        ///     Error("Show me.");
+        ///     Warning("Show me.");
+        ///     Information("Show me.");
+        ///     Verbose("Hide me.");
+        ///     Debug("Hide me.");
+        /// }
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Verbosity")]
+        public static IDisposable NormalVerbosity(this ICakeContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            return context.Log.NormalVerbosity();
+        }
+
+        /// <summary>
+        /// Sets the log verbosity to verbose and returns a disposable that restores the log verbosity on dispose.
+        /// </summary>
+        /// <param name="context">the context.</param>
+        /// <returns>A disposable that restores the log verbosity.</returns>
+        /// <example>
+        /// <code>
+        /// using (VerboseVerbosity())
+        /// {
+        ///     Error("Show me.");
+        ///     Warning("Show me.");
+        ///     Information("Show me.");
+        ///     Verbose("Show me.");
+        ///     Debug("Hide me.");
+        /// }
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Verbosity")]
+        public static IDisposable VerboseVerbosity(this ICakeContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            return context.Log.VerboseVerbosity();
+        }
+
+        /// <summary>
+        /// Sets the log verbosity to diagnostic and returns a disposable that restores the log verbosity on dispose.
+        /// </summary>
+        /// <param name="context">the context.</param>
+        /// <returns>A disposable that restores the log verbosity.</returns>
+        /// <example>
+        /// <code>
+        /// using (DiagnosticVerbosity())
+        /// {
+        ///     Error("Show me.");
+        ///     Warning("Show me.");
+        ///     Information("Show me.");
+        ///     Verbose("Show me.");
+        ///     Debug("Show me.");
+        /// }
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Verbosity")]
+        public static IDisposable DiagnosticVerbosity(this ICakeContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            return context.Log.DiagnosticVerbosity();
+        }
     }
 }

--- a/src/Cake.Core.Tests/Unit/Diagnostics/LogExtensionsTests.cs
+++ b/src/Cake.Core.Tests/Unit/Diagnostics/LogExtensionsTests.cs
@@ -289,5 +289,227 @@ namespace Cake.Core.Tests.Unit.Diagnostics
                 Assert.Equal("Hello World", log.Message);
             }
         }
+
+        public sealed class TheQuietVerbosityMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Log_Null()
+            {
+                // When
+                var result = Record.Exception(() => LogExtensions.QuietVerbosity(null));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "log");
+            }
+
+            [Fact]
+            public void Should_Set_Log_Verbosity_To_Quiet()
+            {
+                // When
+                var log = new TestLog { Verbosity = Verbosity.Verbose };
+                log.QuietVerbosity();
+
+                // Then
+                Assert.Equal(Verbosity.Quiet, log.Verbosity);
+            }
+
+            [Fact]
+            public void Should_Return_Disposable_That_Restores_Log_Verbosity()
+            {
+                // When
+                var log = new TestLog { Verbosity = Verbosity.Verbose };
+                using (log.QuietVerbosity())
+                {
+                }
+
+                // Then
+                Assert.Equal(Verbosity.Verbose, log.Verbosity);
+            }
+        }
+
+        public sealed class TheMinimalVerbosityMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Log_Null()
+            {
+                // When
+                var result = Record.Exception(() => LogExtensions.MinimalVerbosity(null));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "log");
+            }
+
+            [Fact]
+            public void Should_Set_Log_Verbosity_To_Minimal()
+            {
+                // When
+                var log = new TestLog { Verbosity = Verbosity.Quiet };
+                log.MinimalVerbosity();
+
+                // Then
+                Assert.Equal(Verbosity.Minimal, log.Verbosity);
+            }
+
+            [Fact]
+            public void Should_Return_Disposable_That_Restores_Log_Verbosity()
+            {
+                // When
+                var log = new TestLog { Verbosity = Verbosity.Quiet };
+                using (log.MinimalVerbosity())
+                {
+                }
+
+                // Then
+                Assert.Equal(Verbosity.Quiet, log.Verbosity);
+            }
+        }
+
+        public sealed class TheNormalVerbosityMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Log_Null()
+            {
+                // When
+                var result = Record.Exception(() => LogExtensions.NormalVerbosity(null));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "log");
+            }
+
+            [Fact]
+            public void Should_Set_Log_Verbosity_To_Normal()
+            {
+                // When
+                var log = new TestLog { Verbosity = Verbosity.Quiet };
+                log.NormalVerbosity();
+
+                // Then
+                Assert.Equal(Verbosity.Normal, log.Verbosity);
+            }
+
+            [Fact]
+            public void Should_Return_Disposable_That_Restores_Log_Verbosity()
+            {
+                // When
+                var log = new TestLog { Verbosity = Verbosity.Quiet };
+                using (log.NormalVerbosity())
+                {
+                }
+
+                // Then
+                Assert.Equal(Verbosity.Quiet, log.Verbosity);
+            }
+        }
+
+        public sealed class TheVerboseVerbosityMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Log_Null()
+            {
+                // When
+                var result = Record.Exception(() => LogExtensions.VerboseVerbosity(null));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "log");
+            }
+
+            [Fact]
+            public void Should_Set_Log_Verbosity_To_Verbose()
+            {
+                // When
+                var log = new TestLog { Verbosity = Verbosity.Quiet };
+                log.VerboseVerbosity();
+
+                // Then
+                Assert.Equal(Verbosity.Verbose, log.Verbosity);
+            }
+
+            [Fact]
+            public void Should_Return_Disposable_That_Restores_Log_Verbosity()
+            {
+                // When
+                var log = new TestLog { Verbosity = Verbosity.Quiet };
+                using (log.VerboseVerbosity())
+                {
+                }
+
+                // Then
+                Assert.Equal(Verbosity.Quiet, log.Verbosity);
+            }
+        }
+
+        public sealed class TheDiagnosticVerbosityMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Log_Null()
+            {
+                // When
+                var result = Record.Exception(() => LogExtensions.DiagnosticVerbosity(null));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "log");
+            }
+
+            [Fact]
+            public void Should_Set_Log_Verbosity_To_Diagnostic()
+            {
+                // When
+                var log = new TestLog { Verbosity = Verbosity.Quiet };
+                log.DiagnosticVerbosity();
+
+                // Then
+                Assert.Equal(Verbosity.Diagnostic, log.Verbosity);
+            }
+
+            [Fact]
+            public void Should_Return_Disposable_That_Restores_Log_Verbosity()
+            {
+                // When
+                var log = new TestLog { Verbosity = Verbosity.Quiet };
+                using (log.DiagnosticVerbosity())
+                {
+                }
+
+                // Then
+                Assert.Equal(Verbosity.Quiet, log.Verbosity);
+            }
+        }
+
+        public sealed class TheWithVerbosityMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Log_Null()
+            {
+                // When
+                var result = Record.Exception(() => LogExtensions.WithVerbosity(null, Verbosity.Diagnostic));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "log");
+            }
+
+            [Fact]
+            public void Should_Set_Log_Verbosity_As_Specified()
+            {
+                // When
+                var log = new TestLog { Verbosity = Verbosity.Quiet };
+                log.WithVerbosity(Verbosity.Diagnostic);
+
+                // Then
+                Assert.Equal(Verbosity.Diagnostic, log.Verbosity);
+            }
+
+            [Fact]
+            public void Should_Return_Disposable_That_Restores_Log_Verbosity()
+            {
+                // When
+                var log = new TestLog { Verbosity = Verbosity.Quiet };
+                using (log.WithVerbosity(Verbosity.Diagnostic))
+                {
+                }
+
+                // Then
+                Assert.Equal(Verbosity.Quiet, log.Verbosity);
+            }
+        }
     }
 }

--- a/src/Cake.Core.Tests/Unit/DisposableTests.cs
+++ b/src/Cake.Core.Tests/Unit/DisposableTests.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace Cake.Core.Tests.Unit
+{
+    public sealed class DisposableTests
+    {
+        public sealed class TheCreateMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Disposer_Null()
+            {
+                // When
+                var result = Record.Exception(() => Disposable.Create(null));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "disposer");
+            }
+
+            [Fact]
+            public void Should_Return_Disposable_That_Invokes_Disposer_Once_Only()
+            {
+                // When
+                var disposed = 0;
+                var disposable = Disposable.Create(() => disposed++);
+                using (disposable)
+                {
+                }
+                disposable.Dispose();
+
+                // Then
+                Assert.Equal(1, disposed);
+            }
+        }
+    }
+}

--- a/src/Cake.Core/Diagnostics/LogExtensions.cs
+++ b/src/Cake.Core/Diagnostics/LogExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 namespace Cake.Core.Diagnostics
 {
     /// <summary>
@@ -361,6 +363,73 @@ namespace Cake.Core.Diagnostics
 
             LogActionEntry actionEntry = (format, args) => log.Write(verbosity, level, format, args);
             logAction(actionEntry);
+        }
+
+        /// <summary>
+        /// Sets the log verbosity to quiet and returns a disposable that restores the log verbosity on dispose.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <returns>A disposable that restores the log verbosity.</returns>
+        public static IDisposable QuietVerbosity(this ICakeLog log)
+        {
+            return log.WithVerbosity(Verbosity.Quiet);
+        }
+
+        /// <summary>
+        /// Sets the log verbosity to minimal and returns a disposable that restores the log verbosity on dispose.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <returns>A disposable that restores the log verbosity.</returns>
+        public static IDisposable MinimalVerbosity(this ICakeLog log)
+        {
+            return log.WithVerbosity(Verbosity.Minimal);
+        }
+
+        /// <summary>
+        /// Sets the log verbosity to normal and returns a disposable that restores the log verbosity on dispose.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <returns>A disposable that restores the log verbosity.</returns>
+        public static IDisposable NormalVerbosity(this ICakeLog log)
+        {
+            return log.WithVerbosity(Verbosity.Normal);
+        }
+
+        /// <summary>
+        /// Sets the log verbosity to verbose and returns a disposable that restores the log verbosity on dispose.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <returns>A disposable that restores the log verbosity.</returns>
+        public static IDisposable VerboseVerbosity(this ICakeLog log)
+        {
+            return log.WithVerbosity(Verbosity.Verbose);
+        }
+
+        /// <summary>
+        /// Sets the log verbosity to diagnostic and returns a disposable that restores the log verbosity on dispose.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <returns>A disposable that restores the log verbosity.</returns>
+        public static IDisposable DiagnosticVerbosity(this ICakeLog log)
+        {
+            return log.WithVerbosity(Verbosity.Diagnostic);
+        }
+
+        /// <summary>
+        /// Sets the log verbosity as specified and returns a disposable that restores the log verbosity on dispose.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="verbosity">The verbosity.</param>
+        /// <returns>A disposable that restores the log verbosity.</returns>
+        public static IDisposable WithVerbosity(this ICakeLog log, Verbosity verbosity)
+        {
+            if (log == null)
+            {
+                throw new ArgumentNullException(nameof(log));
+            }
+            var lastVerbosity = log.Verbosity;
+            log.Verbosity = verbosity;
+            return Disposable.Create(() => log.Verbosity = lastVerbosity);
         }
     }
 }

--- a/src/Cake.Core/Disposable.cs
+++ b/src/Cake.Core/Disposable.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Cake.Core
+{
+    /// <summary>
+    /// Disposable helper.
+    /// </summary>
+    public static class Disposable
+    {
+        static Disposable()
+        {
+            Empty = Create(() => { });
+        }
+
+        /// <summary>
+        /// Creates an anonymous disposable with the specified disposer action.
+        /// </summary>
+        /// <param name="disposer">The disposer action.</param>
+        /// <returns>The anonymous disposable.</returns>
+        public static IDisposable Create(Action disposer) => new AnonymousDisposable(disposer);
+
+        /// <summary>
+        /// An empty disposable; does nothing.
+        /// </summary>
+        public static readonly IDisposable Empty;
+
+        private sealed class AnonymousDisposable : IDisposable
+        {
+            public AnonymousDisposable(Action disposer)
+            {
+                _disposer = disposer ?? throw new ArgumentNullException(nameof(disposer));
+            }
+
+            public void Dispose()
+            {
+                _disposer?.Invoke();
+                _disposer = null;
+            }
+
+            private Action _disposer;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2456:
- Add `Disposable` helper for creating anonymous disposables
- Refactor `TeamCityDisposableExtensions` to use `Disposable` helper
- Add logging aliases and extension methods:
  - QuietVerbosity, MinimalVerbosity, NormalVerbosity, VerboseVerbosity, DiagnosticVerbosity

Example usage:
```c#
Task("Test")
    .Does(() =>
{
    Debug("Hide me");
    using (DiagnosticVerbosity())
    {
        Error("Show me.");
        Warning("Show me.");
        Information("Show me.");
        Verbose("Show me.");
        Debug("Show me.");
    }
    Debug("Hide me again");
});
```