### PR TITLE
GH1384: Add support to pass Func<IFile,bool> to globbing aliases

### DIFF
--- a/src/Cake.Core.Tests/Fixtures/GlobberFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/GlobberFixture.cs
@@ -125,10 +125,15 @@ namespace Cake.Core.Tests.Fixtures
             return Match(pattern, null);
         }
 
-        public Path[] Match(string pattern, Func<IFileSystemInfo, bool> predicate)
+        public Path[] Match(string pattern, Func<IFileSystemInfo, bool> directoryPredicate)
+        {
+            return Match(pattern, directoryPredicate, null);
+        }
+
+        public Path[] Match(string pattern, Func<IFileSystemInfo, bool> directoryPredicate, Func<IFile, bool> filePredicate)
         {
             return new Globber(FileSystem, Environment)
-                .Match(pattern, new GlobberSettings { Predicate = predicate })
+                .Match(pattern, new GlobberSettings { Predicate = directoryPredicate, FilePredicate = filePredicate })
                 .ToArray();
         }
     }

--- a/src/Cake.Core.Tests/Unit/IO/Globbing/GlobberTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/Globbing/GlobberTests.cs
@@ -41,7 +41,7 @@ namespace Cake.Core.Tests.Unit.IO.Globbing
 
         public sealed class TheMatchMethod
         {
-            public sealed class WithPredicate
+            public sealed class WithDirectoryPredicate
             {
                 [Fact]
                 public void Should_Return_Paths_Not_Affected_By_Walker_Hints()
@@ -87,6 +87,56 @@ namespace Cake.Core.Tests.Unit.IO.Globbing
 
                     // Then
                     Assert.Empty(result);
+                }
+            }
+
+            public sealed class WithFilePredicate
+            {
+                [Fact]
+                public void Should_Return_Only_Files_Matching_Predicate()
+                {
+                    // Given
+                    var fixture = GlobberFixture.UnixLike();
+                    var predicate = new Func<IFile, bool>(i => i.Path.FullPath.EndsWith(".c"));
+
+                    // When
+                    var result = fixture.Match("/Working/**/*.*", null, predicate);
+
+                    // Then
+                    Assert.Equal(5, result.Length);
+                    AssertEx.ContainsFilePath(result, "/Working/Foo/Bar/Qux.c");
+                    AssertEx.ContainsFilePath(result, "/Working/Foo/Bar/Qex.c");
+                    AssertEx.ContainsFilePath(result, "/Working/Foo/Baz/Qux.c");
+                    AssertEx.ContainsFilePath(result, "/Working/Foo/Bar/Baz/Qux.c");
+                    AssertEx.ContainsFilePath(result, "/Working/Bar/Qux.c");
+                }
+            }
+
+            public sealed class WithDirectoryAndFilePredicate
+            {
+                [Fact]
+                public void Should_Return_Only_Files_Matching_Predicate()
+                {
+                    // Given
+                    var fixture = GlobberFixture.UnixLike();
+                    var directoryPredicate = new Func<IFileSystemInfo, bool>(i => i.Path.FullPath.Contains("/Working"));
+                    var filePredicate = new Func<IFile, bool>(i => !i.Path.FullPath.EndsWith(".dll"));
+
+                    // When
+                    var result = fixture.Match("./**/*.*", directoryPredicate, filePredicate);
+
+                    // Then
+                    Assert.Equal(10, result.Length);
+                    AssertEx.ContainsFilePath(result, "/Working/Foo/Bar/Qux.c");
+                    AssertEx.ContainsFilePath(result, "/Working/Foo/Bar/Qex.c");
+                    AssertEx.ContainsFilePath(result, "/Working/Foo/Bar/Qux.h");
+                    AssertEx.ContainsFilePath(result, "/Working/Foo/Baz/Qux.c");
+                    AssertEx.ContainsFilePath(result, "/Working/Foo/Bar/Baz/Qux.c");
+                    AssertEx.ContainsFilePath(result, "/Working/Bar/Qux.c");
+                    AssertEx.ContainsFilePath(result, "/Working/Bar/Qux.h");
+                    AssertEx.ContainsFilePath(result, "/Working/foobar.rs");
+                    AssertEx.ContainsFilePath(result, "/Working/foobaz.rs");
+                    AssertEx.ContainsFilePath(result, "/Working/foobax.rs");
                 }
             }
 

--- a/src/Cake.Core/IO/GlobberSettings.cs
+++ b/src/Cake.Core/IO/GlobberSettings.cs
@@ -13,6 +13,11 @@ namespace Cake.Core.IO
         public Func<IDirectory, bool> Predicate { get; set; }
 
         /// <summary>
+        /// Gets or sets the filter used to filter files based on file system information.
+        /// </summary>
+        public Func<IFile, bool> FilePredicate { get; set; }
+
+        /// <summary>
         /// Gets or sets whether or not globbing is case sensitive or not.
         /// If not set, the default value for the operating system will be used.
         /// </summary>

--- a/src/Cake.Core/IO/Globbing/GlobVisitor.cs
+++ b/src/Cake.Core/IO/Globbing/GlobVisitor.cs
@@ -21,7 +21,7 @@ namespace Cake.Core.IO.Globbing
 
         public IEnumerable<IFileSystemInfo> Walk(GlobNode node, GlobberSettings settings)
         {
-            var context = new GlobVisitorContext(_fileSystem, _environment, settings.Predicate);
+            var context = new GlobVisitorContext(_fileSystem, _environment, settings.Predicate, settings.FilePredicate);
             node.Accept(this, context);
             return context.Results;
         }
@@ -112,7 +112,7 @@ namespace Cake.Core.IO.Globbing
                         // Then it must be a file (if it exist).
                         var filePath = context.Path.CombineWithFilePath(segment);
                         var file = context.FileSystem.GetFile(filePath);
-                        if (file.Exists)
+                        if (file.Exists && context.ShouldInclude(file))
                         {
                             // File
                             context.AddResult(file);
@@ -240,7 +240,7 @@ namespace Cake.Core.IO.Globbing
                 foreach (var file in current.GetFiles("*", option))
                 {
                     var lastPath = file.Path.Segments.Last();
-                    if (node.IsMatch(lastPath))
+                    if (node.IsMatch(lastPath) && context.ShouldInclude(file))
                     {
                         result.Add(file);
                     }

--- a/src/Cake.Core/IO/Globbing/GlobVisitorContext.cs
+++ b/src/Cake.Core/IO/Globbing/GlobVisitorContext.cs
@@ -11,7 +11,8 @@ namespace Cake.Core.IO.Globbing
     internal sealed class GlobVisitorContext
     {
         private readonly List<string> _pathParts;
-        private readonly Func<IDirectory, bool> _predicate;
+        private readonly Func<IDirectory, bool> _directoryPredicate;
+        private readonly Func<IFile, bool> _filePredicate;
 
         internal DirectoryPath Path { get; private set; }
         public IFileSystem FileSystem { get; }
@@ -21,11 +22,13 @@ namespace Cake.Core.IO.Globbing
         public GlobVisitorContext(
             IFileSystem fileSystem,
             ICakeEnvironment environment,
-            Func<IDirectory, bool> predicate)
+            Func<IDirectory, bool> directoryPredicate,
+            Func<IFile, bool> filePredicate)
         {
             FileSystem = fileSystem;
             Environment = environment;
-            _predicate = predicate;
+            _directoryPredicate = directoryPredicate;
+            _filePredicate = filePredicate;
             Results = new List<IFileSystemInfo>();
             _pathParts = new List<string>();
         }
@@ -71,9 +74,18 @@ namespace Cake.Core.IO.Globbing
 
         public bool ShouldTraverse(IDirectory info)
         {
-            if (_predicate != null)
+            if (_directoryPredicate != null)
             {
-                return _predicate(info);
+                return _directoryPredicate(info);
+            }
+            return true;
+        }
+
+        public bool ShouldInclude(IFile file)
+        {
+            if (_filePredicate != null)
+            {
+                return _filePredicate(file);
             }
             return true;
         }


### PR DESCRIPTION
This satisfies the feature/enhancement described in GH-1384 by adding the member to the `GlobberSettings` type and wires in
all the necessary logic, providing a clean implementation
that relies on default values (null) and a single point of entry
for invocation to provide a flexible solution without the syntactic
overhead.

This refactors/revisits a [previous attempt](https://github.com/kcamp/cake/tree/GH-1384-old) to achieve the same.

Earlier work was based on methods/implementations that would have
come to rely on method overloads (before the `GlobberSettings`
implementation was added).  Now that the settings type exists,
this represents a much stronger feature/change without any potential
risk for backward compatibility.

i.e., an implicitly typed predicate specified as `IFileSystemInfo`
would have created ambiguity between the desired pairing of overloads -
`GetFiles(string pattern, Func<IFile, bool> predicate)`
and
`GetFiles(string pattern, Func<IDirectory,bool> predicate)`
which would have resulted in unpredictable behavior.


