### PR TITLE
GH2474 Refactor TeamCityProvider.BuildProblem method

### DIFF
--- a/src/Cake.Common.Tests/Unit/Build/TeamCity/TeamCityProviderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TeamCity/TeamCityProviderTests.cs
@@ -128,5 +128,26 @@ namespace Cake.Common.Tests.Unit.Build.TeamCity
                     fixture.Log.AggregateLogMessages());
             }
         }
+
+        public sealed class TheBuildProblemMethod
+        {
+            [Theory]
+            [InlineData("A build problem", "identity_id", "description='A build problem' identity='identity_id'")]
+            [InlineData("A build problem", "", "description='A build problem'")]
+            [InlineData("A build problem", null, "description='A build problem'")]
+            public void BuildProblem_Should_Write_To_The_Log_Correctly(string description, string identity, string expected)
+            {
+                // Given
+                var fixture = new TeamCityFixture();
+                var teamCity = fixture.CreateTeamCityService();
+
+                // When
+                teamCity.BuildProblem(description, identity);
+
+                // Then
+                Assert.Equal($"##teamcity[buildProblem {expected}]" + Environment.NewLine,
+                    fixture.Log.AggregateLogMessages());
+            }
+        }
     }
 }

--- a/src/Cake.Common/Build/TeamCity/TeamCityProvider.cs
+++ b/src/Cake.Common/Build/TeamCity/TeamCityProvider.cs
@@ -263,11 +263,13 @@ namespace Cake.Common.Build.TeamCity
         /// <param name="identity">Build identity.</param>
         public void BuildProblem(string description, string identity)
         {
-            WriteServiceMessage("buildProblem", new Dictionary<string, string>
+            var tokens = new Dictionary<string, string> { { "description", description } };
+            if (!string.IsNullOrEmpty(identity))
             {
-                { "description", description },
-                { "identity", identity }
-            });
+                tokens.Add("identity", identity);
+            }
+
+            WriteServiceMessage("buildProblem", tokens);
         }
 
         /// <summary>


### PR DESCRIPTION
This addresses GH-2474 and brings the `BuildProblem` method to be more consistent with the expected usage within TeamCity.

This change will suppress the "identity" token if the value provided is null or empty.  This directory resolves the issue of the provider attempting to sanitize a null reference on a value that, per Jetbrains documentation, is not required for the `buildProblem` service message