### PR TITLE
GH2445: Implement generic overloads of OnError

### DIFF
--- a/src/Cake.Core.Tests/Unit/CakeTaskBuilderExtensionsTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeTaskBuilderExtensionsTests.cs
@@ -482,18 +482,130 @@ namespace Cake.Core.Tests.Unit
 
         public sealed class TheOnErrorMethod
         {
-            [Fact]
-            public void Should_Set_The_Error_Handler()
+            public sealed class WithData
             {
-                // Given
-                var task = new CakeTask("task");
-                var builder = new CakeTaskBuilder(task);
+                public sealed class WithContext
+                {
+                    public sealed class WithException
+                    {
+                        [Fact]
+                        public void Should_Set_The_Error_Handler()
+                        {
+                            // Given
+                            var task = new CakeTask("task");
+                            var builder = new CakeTaskBuilder(task);
 
-                // When
-                builder.OnError(exception => { });
+                            // When
+                            builder.OnError<string>((exception, context, data) => { });
 
-                // Then
-                Assert.NotNull(builder.Target.ErrorHandler);
+                            // Then
+                            Assert.NotNull(builder.Target.ErrorHandler);
+                            Assert.IsType<Action<Exception, ICakeContext>>(builder.Target.ErrorHandler);
+                        }
+                    }
+                }
+
+                public sealed class WithoutContext
+                {
+                    public sealed class WithException
+                    {
+                        [Fact]
+                        public void Should_Set_The_Error_Handler()
+                        {
+                            // Given
+                            var task = new CakeTask("task");
+                            var builder = new CakeTaskBuilder(task);
+
+                            // When
+                            builder.OnError((Exception exception, string data) => { });
+
+                            // Then
+                            Assert.NotNull(builder.Target.ErrorHandler);
+                            Assert.IsType<Action<Exception, ICakeContext>>(builder.Target.ErrorHandler);
+                        }
+                    }
+
+                    public sealed class WithoutException
+                    {
+                        [Fact]
+                        public void Should_Set_The_Error_Handler()
+                        {
+                            // Given
+                            var task = new CakeTask("task");
+                            var builder = new CakeTaskBuilder(task);
+
+                            // When
+                            builder.OnError<string>(data => { });
+
+                            // Then
+                            Assert.NotNull(builder.Target.ErrorHandler);
+                            Assert.IsType<Action<Exception, ICakeContext>>(builder.Target.ErrorHandler);
+                        }
+                    }
+                }
+            }
+
+            public sealed class WithoutData
+            {
+                public sealed class WithContext
+                {
+                    public sealed class WithException
+                    {
+                        [Fact]
+                        public void Should_Set_The_Error_Handler()
+                        {
+                            // Given
+                            var task = new CakeTask("task");
+                            var builder = new CakeTaskBuilder(task);
+
+                            // When
+                            builder.OnError((exception, context) => { });
+
+                            // Then
+                            Assert.NotNull(builder.Target.ErrorHandler);
+                            Assert.IsType<Action<Exception, ICakeContext>>(builder.Target.ErrorHandler);
+                        }
+                    }
+                }
+
+                public sealed class WithoutContext
+                {
+                    public sealed class WithException
+                    {
+                        [Fact]
+                        public void Should_Set_The_Error_Handler()
+                        {
+                            // Given
+                            var task = new CakeTask("task");
+                            var builder = new CakeTaskBuilder(task);
+
+                            // When
+                            builder.OnError(exception => { });
+
+                            // Then
+                            Assert.NotNull(builder.Target.ErrorHandler);
+                            Assert.IsType<Action<Exception, ICakeContext>>(builder.Target.ErrorHandler);
+                        }
+                    }
+
+                    public sealed class WithoutException
+                    {
+                        [Fact]
+                        public void Should_Set_The_Error_Handler()
+                        {
+                            // Given
+                            var task = new CakeTask("task");
+                            var builder = new CakeTaskBuilder(task);
+
+                            // When
+                            builder.OnError(() => { });
+
+                            // Then
+                            Assert.NotNull(builder.Target.ErrorHandler);
+                            Assert.IsType<Action<Exception, ICakeContext>>(builder.Target.ErrorHandler);
+                        }
+                    }
+                }
             }
         }
 

--- a/src/Cake.Core.Tests/Unit/CakeTaskTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeTaskTests.cs
@@ -155,10 +155,11 @@ namespace Cake.Core.Tests.Unit
                 var task = new CakeTask("task");
 
                 // When
-                task.SetErrorHandler(e => { });
+                task.SetErrorHandler((e, c) => { });
 
                 // Then
                 Assert.NotNull(task.ErrorHandler);
+                Assert.IsType<Action<Exception, ICakeContext>>(task.ErrorHandler);
             }
 
             [Fact]
@@ -166,10 +167,10 @@ namespace Cake.Core.Tests.Unit
             {
                 // Given
                 var task = new CakeTask("task");
-                task.SetErrorHandler(e => { });
+                task.SetErrorHandler((e, c) => { });
 
                 // When
-                var result = Record.Exception(() => task.SetErrorHandler(e => { }));
+                var result = Record.Exception(() => task.SetErrorHandler((e, c) => { }));
 
                 // Then
                 Assert.IsType<CakeException>(result);

--- a/src/Cake.Core/CakeEngine.cs
+++ b/src/Cake.Core/CakeEngine.cs
@@ -350,7 +350,7 @@ namespace Cake.Core
                 // Got an error handler?
                 if (task.ErrorHandler != null)
                 {
-                    HandleErrors(strategy, task.ErrorHandler, exception);
+                    HandleErrors(strategy, task.ErrorHandler, exception, context);
                 }
                 else
                 {
@@ -456,11 +456,11 @@ namespace Cake.Core
             }
         }
 
-        private void HandleErrors(IExecutionStrategy strategy, Action<Exception> errorHandler, Exception exception)
+        private void HandleErrors(IExecutionStrategy strategy, Action<Exception, ICakeContext> errorHandler, Exception exception, ICakeContext context)
         {
             try
             {
-                strategy.HandleErrors(errorHandler, exception);
+                strategy.HandleErrors(errorHandler, exception, context);
             }
             catch (Exception errorHandlerException)
             {

--- a/src/Cake.Core/CakeTask.cs
+++ b/src/Cake.Core/CakeTask.cs
@@ -48,7 +48,7 @@ namespace Cake.Core
         /// Gets or sets the error handler.
         /// </summary>
         /// <value>The error handler.</value>
-        public Action<Exception> ErrorHandler { get; set; }
+        public Action<Exception, ICakeContext> ErrorHandler { get; set; }
 
         /// <summary>
         /// Gets or sets the error reporter.

--- a/src/Cake.Core/CakeTaskBuilder.Errors.cs
+++ b/src/Cake.Core/CakeTaskBuilder.Errors.cs
@@ -53,6 +53,17 @@ namespace Cake.Core
         /// <returns>The same <see cref="CakeTaskBuilder"/> instance so that multiple calls can be chained.</returns>
         public static CakeTaskBuilder OnError(this CakeTaskBuilder builder, Action<Exception> errorHandler)
         {
+            return OnError(builder, (exception, context) => errorHandler(exception));
+        }
+
+        /// <summary>
+        /// Adds an error handler to be executed if an exception occurs in the task.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="errorHandler">The error handler.</param>
+        /// <returns>The same <see cref="CakeTaskBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static CakeTaskBuilder OnError(this CakeTaskBuilder builder, Action<Exception, ICakeContext> errorHandler)
+        {
             if (builder == null)
             {
                 throw new ArgumentNullException(nameof(builder));
@@ -60,6 +71,49 @@ namespace Cake.Core
 
             builder.Target.SetErrorHandler(errorHandler);
             return builder;
+        }
+
+        /// <summary>
+        /// Adds an error handler to be executed if an exception occurs in the task.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="errorHandler">The error handler.</param>
+        /// <typeparam name="TData">The extra data to operate with inside the error handler.</typeparam>
+        /// <returns>The same <see cref="CakeTaskBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static CakeTaskBuilder OnError<TData>(this CakeTaskBuilder builder, Action<TData> errorHandler)
+            where TData : class
+        {
+            return OnError<TData>(builder, (exception, data) => errorHandler(data));
+        }
+
+        /// <summary>
+        /// Adds an error handler to be executed if an exception occurs in the task.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="errorHandler">The error handler.</param>
+        /// <typeparam name="TData">The extra data to operate with inside the error handler.</typeparam>
+        /// <returns>The same <see cref="CakeTaskBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static CakeTaskBuilder OnError<TData>(this CakeTaskBuilder builder, Action<Exception, TData> errorHandler)
+            where TData : class
+        {
+            return OnError<TData>(builder, (exception, context, data) => errorHandler(exception, data));
+        }
+
+        /// <summary>
+        /// Adds an error handler to be executed if an exception occurs in the task.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="errorHandler">The error handler.</param>
+        /// <typeparam name="TData">The extra data to operate with inside the error handler.</typeparam>
+        /// <returns>The same <see cref="CakeTaskBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static CakeTaskBuilder OnError<TData>(this CakeTaskBuilder builder, Action<Exception, ICakeContext, TData> errorHandler)
+            where TData : class
+        {
+            return OnError(builder, (exception, context) =>
+            {
+                var data = context.Data.Get<TData>();
+                errorHandler(exception, context, data);
+            });
         }
 
         /// <summary>

--- a/src/Cake.Core/CakeTaskExtensions.cs
+++ b/src/Cake.Core/CakeTaskExtensions.cs
@@ -64,7 +64,7 @@ namespace Cake.Core
         /// <param name="errorHandler">The error handler.</param>
         /// <exception cref="CakeException">There can only be one error handler per task.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="errorHandler"/> is null.</exception>
-        public static void SetErrorHandler(this CakeTask task, Action<Exception> errorHandler)
+        public static void SetErrorHandler(this CakeTask task, Action<Exception, ICakeContext> errorHandler)
         {
             if (task.ErrorHandler != null)
             {

--- a/src/Cake.Core/DefaultExecutionStrategy.cs
+++ b/src/Cake.Core/DefaultExecutionStrategy.cs
@@ -124,9 +124,10 @@ namespace Cake.Core
         /// </summary>
         /// <param name="action">The action.</param>
         /// <param name="exception">The exception.</param>
-        public void HandleErrors(Action<Exception> action, Exception exception)
+        /// <param name="context">The context.</param>
+        public void HandleErrors(Action<Exception, ICakeContext> action, Exception exception, ICakeContext context)
         {
-            action?.Invoke(exception);
+            action?.Invoke(exception, context);
         }
 
         /// <summary>

--- a/src/Cake.Core/IExecutionStrategy.cs
+++ b/src/Cake.Core/IExecutionStrategy.cs
@@ -53,7 +53,8 @@ namespace Cake.Core
         /// </summary>
         /// <param name="action">The action.</param>
         /// <param name="exception">The exception.</param>
-        void HandleErrors(Action<Exception> action, Exception exception);
+        /// <param name="context">The context.</param>
+        void HandleErrors(Action<Exception, ICakeContext> action, Exception exception, ICakeContext context);
 
         /// <summary>
         /// Invokes the finally handler.

--- a/src/Cake/Scripting/DryRunExecutionStrategy.cs
+++ b/src/Cake/Scripting/DryRunExecutionStrategy.cs
@@ -49,7 +49,7 @@ namespace Cake.Scripting
         {
         }
 
-        public void HandleErrors(Action<Exception> action, Exception exception)
+        public void HandleErrors(Action<Exception, ICakeContext> action, Exception exception, ICakeContext context)
         {
         }
 


### PR DESCRIPTION
Fixes #2445.

In this attempt, I ended up modifying the type of the `ErrorHandler` property of the `CakeTask` class from `Action<Exception>` to `Action<Exception, ICakeContext>`. Let me know if this is not appropriate.