### PR TITLE
Null string should convert to null path object

### DIFF
--- a/src/Cake.Core.Tests/Unit/IO/DirectoryPathTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/DirectoryPathTests.cs
@@ -12,6 +12,22 @@ namespace Cake.Core.Tests.Unit.IO
 {
     public sealed class DirectoryPathTests
     {
+        public sealed class TheConversionFromStringOperator
+        {
+            [Fact]
+            public void Null_String_Converts_To_Null_DirectoryPath()
+            {
+                // Given
+                const string nullString = null;
+
+                // When
+                var path = (DirectoryPath)nullString;
+
+                // Then
+                Assert.Null(path);
+            }
+        }
+
         public sealed class TheGetDirectoryNameMethod
         {
             [WindowsTheory]

--- a/src/Cake.Core.Tests/Unit/IO/FilePathTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/FilePathTests.cs
@@ -12,6 +12,22 @@ namespace Cake.Core.Tests.Unit.IO
 {
     public sealed class FilePathTests
     {
+        public sealed class TheConversionFromStringOperator
+        {
+            [Fact]
+            public void Null_String_Converts_To_Null_FilePath()
+            {
+                // Given
+                const string nullString = null;
+
+                // When
+                var path = (FilePath)nullString;
+
+                // Then
+                Assert.Null(path);
+            }
+        }
+
         public sealed class TheHasExtensionProperty
         {
             [Theory]


### PR DESCRIPTION
Tests for #2481.

While https://github.com/cake-build/cake/pull/2482 was still exactly the right thing to do, the exception was actually not thrown by FromString called by the operator. What actually was happening was that `new FilePath(null)` was returned from the operator. `new FilePath(null)` is a time bomb that causes the ArgumentNullException to happen much later:

https://github.com/cake-build/cake/blob/020d6d3324bf7f35004ccbd3bfcb1d95e9cdfc8d/src/Cake.Common/Tools/VSTest/VSTestRunner.cs#L70-L72

https://github.com/cake-build/cake/blob/020d6d3324bf7f35004ccbd3bfcb1d95e9cdfc8d/src/Cake.Core/IO/FilePath.cs#L125-L132

https://github.com/cake-build/cake/blob/020d6d3324bf7f35004ccbd3bfcb1d95e9cdfc8d/src/Cake.Core/IO/DirectoryPath.cs#L60-L64