### PR TITLE
GH2484: Add Spaces support to Octopus Deploy settings and octo.exe aliases

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctoCreateReleaseTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctoCreateReleaseTests.cs
@@ -855,6 +855,22 @@ namespace Cake.Common.Tests.Unit.Tools.OctopusDeploy
                              "--server http://octopus --apiKey API-12345 " +
                              "--progress", result.Args);
             }
+
+            [Fact]
+            public void Should_Add_Space_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseCreatorFixture();
+                fixture.Settings.Space = "spacename";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create-release --project \"testProject\" " +
+                             "--server http://octopus --apiKey API-12345 " +
+                             "--space \"spacename\"", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctoDeployPromoteTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctoDeployPromoteTests.cs
@@ -442,6 +442,21 @@ namespace Cake.Common.Tests.Unit.Tools.OctopusDeploy
                              " --tenanttag=\"Tag1\"" +
                              " --tenanttag=\"Tag2\"", result.Args);
             }
+
+            [Fact]
+            public void Should_Add_Space_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployReleasePromoterFixture();
+                fixture.Settings.Space = "spacename";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters +
+                             " --space \"spacename\"", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctoDeployReleaseTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctoDeployReleaseTests.cs
@@ -456,6 +456,20 @@ namespace Cake.Common.Tests.Unit.Tools.OctopusDeploy
                 // Then
                 Assert.Equal(MinimalParameters + " --channel \"somechannel\"", result.Args);
             }
+
+            [Fact]
+            public void Should_Add_Space_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployReleaseDeployerFixture();
+                fixture.Settings.Space = @"spacename";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(MinimalParameters + " --space \"spacename\"", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctoPushTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctoPushTests.cs
@@ -238,6 +238,22 @@ namespace Cake.Common.Tests.Unit.Tools.OctopusDeploy
             }
 
             [Fact]
+            public void Should_Add_Space_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeployPusherFixture();
+                fixture.Settings.Space = "spacename";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("push --package \"/Working/MyPackage.1.0.0.zip\" " +
+                             "--package \"/Working/MyOtherPackage.1.0.1.nupkg\" " +
+                             "--server http://octopus --apiKey API-12345 --space \"spacename\"", result.Args);
+            }
+
+            [Fact]
             public void Should_Throw_If_Octo_Executable_Was_Not_Found()
             {
                 // Given

--- a/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctopusDeploymentQueryTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctopusDeploymentQueryTests.cs
@@ -93,6 +93,22 @@ namespace Cake.Common.Tests.Unit.Tools.OctopusDeploy
             }
 
             [Fact]
+            public void Should_Add_Space_To_Query_Filter_If_Not_Null()
+            {
+                // Given
+                var fixture = new OctopusDeploymentQuerierFixture();
+                fixture.Settings.TenantName = "Tenant A";
+                fixture.Settings.Space = "spacename";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("list-deployments --tenant \"Tenant A\" --number 1 " +
+                             "--server http://octopus --apiKey API-12345 --space \"spacename\"", result.Args);
+            }
+
+            [Fact]
             public void Should_Map_All_Query_Filter_Options()
             {
                 // Given

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployArgumentBuilder.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployArgumentBuilder.cs
@@ -104,6 +104,8 @@ namespace Cake.Common.Tools.OctopusDeploy
             {
                 Builder.Append("--enableServiceMessages");
             }
+
+            AppendArgumentIfNotNull("space", Settings.Space);
         }
     }
 }

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusDeploySettings.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusDeploySettings.cs
@@ -58,5 +58,10 @@ namespace Cake.Common.Tools.OctopusDeploy
         /// Gets or sets a value indicating whether the enable service messages flag is set
         /// </summary>
         public bool EnableServiceMessages { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of a space within which this command will be executed. The default space will be used if it is omitted.
+        /// </summary>
+        public string Space { get; set; }
     }
 }


### PR DESCRIPTION
This adds the `--space YourSpaceName` parameter to the `OctopusDeployCommonToolSettings` and updates the implementation in `OctopusDeployArgumentBuilder`.    This covers all aliases that are currently implemented except `pack`, which doesn't accept the optional space qualifier.

As noted in the issue, this will require users to use at least v5.2.0 of `octo.exe`.