### PR TITLE
GH820: Add global override to show process command-line

### DIFF
--- a/src/Cake.Core/Constants.cs
+++ b/src/Cake.Core/Constants.cs
@@ -16,6 +16,7 @@ namespace Cake.Core
             public const string SkipVerification = "Settings_SkipVerification";
             public const string SkipPackageVersionCheck = "Settings_SkipPackageVersionCheck";
             public const string NoMonoCoersion = "Settings_NoMonoCoersion";
+            public const string ShowProcessCommandLine = "Settings_ShowProcessCommandLine";
         }
 
         public static class Paths

--- a/src/Cake.Core/IO/ProcessRunner.cs
+++ b/src/Cake.Core/IO/ProcessRunner.cs
@@ -23,6 +23,7 @@ namespace Cake.Core.IO
         private readonly IToolLocator _tools;
         private readonly ICakeConfiguration _configuration;
         private readonly bool _noMonoCoersion;
+        private readonly bool _showCommandLine;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ProcessRunner" /> class.
@@ -42,6 +43,8 @@ namespace Cake.Core.IO
 
             var noMonoCoersion = configuration.GetValue(Constants.Settings.NoMonoCoersion);
             _noMonoCoersion = noMonoCoersion != null && noMonoCoersion.Equals("true", StringComparison.OrdinalIgnoreCase);
+            var showCommandLine = configuration.GetValue(Constants.Settings.ShowProcessCommandLine);
+            _showCommandLine = showCommandLine != null && showCommandLine.Equals("true", StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -125,7 +128,7 @@ namespace Cake.Core.IO
             {
                 // Log the filename and arguments.
                 var message = string.Concat(fileName, " ", arguments.RenderSafe().TrimEnd());
-                _log.Verbose(Verbosity.Diagnostic, "Executing: {0}", message);
+                _log.Verbose(_showCommandLine ? _log.Verbosity : Verbosity.Diagnostic, "Executing: {0}", message);
             }
 
             // Create the process start info.


### PR DESCRIPTION
Following up from #2457, I can cleanly address #820 with a global setting that temporarily overrides the process runner log level.

Example usage:
```
$env:Cake_Settings_ShowProcessCommandLine='true';  .\build.ps1
```