### PR TITLE
GH2087: log nested aggregate exceptions

### DIFF
--- a/src/Cake/Program.cs
+++ b/src/Cake/Program.cs
@@ -100,7 +100,7 @@ namespace Cake
                 var aex = ex as AggregateException;
                 if (aex != null)
                 {
-                    foreach (var exception in aex.InnerExceptions)
+                    foreach (var exception in aex.Flatten().InnerExceptions)
                     {
                         log.Error("\t{0}", exception.Message);
                     }


### PR DESCRIPTION
https://github.com/cake-build/cake/issues/2087

When the exception thrown in a task is actually a nested `AggregateException`, the output log is:

```
An error occurred when executing task 'taskName'.
Error: One or more errors occurred.
	One or more errors occurred.
```

The first occurence of `One or more errors occurred.` is the message of the parent `AggregateException`. The second occurence is the message if the inner exception, which is itself another `AggregateException`.

Here we add a call to `.Flatten()`. This creates a new single instance of `AggregateException` without nesting, so that the last log line will now show the actual inner exception message.

Reference: https://docs.microsoft.com/en-us/dotnet/api/system.aggregateexception.flatten?view=netframework-4.7.2
