### PR TITLE
Fix typo

### DIFF
--- a/src/Cake.Core/IO/ProcessWrapper.cs
+++ b/src/Cake.Core/IO/ProcessWrapper.cs
@@ -77,7 +77,7 @@ namespace Cake.Core.IO
                 {
                     continue;
                 }
-                _log.Debug(log => log("{0}", _filterOutput(line)));
+                _log.Debug(log => log("{0}", _filterError(line)));
                 yield return line;
             }
         }


### PR DESCRIPTION
I noticed what looks like a copy-paste typo in [Cake.Core/IO/ProcessWrapper.cs#L71](https://github.com/cake-build/cake/blob/develop/src/Cake.Core/IO/ProcessWrapper.cs#L71) when looking around the code for #2461.