### PR TITLE
GH2514: Add additional report types to ReportGenerator

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/ReportGenerator/ReportGeneratorRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/ReportGenerator/ReportGeneratorRunnerTests.cs
@@ -170,9 +170,11 @@ namespace Cake.Common.Tests.Unit.Tools.ReportGenerator
             [InlineData("CsvSummary", 10)]
             [InlineData("HtmlChart", 11)]
             [InlineData("HtmlInline", 12)]
-            [InlineData("HtmlInlineAzurePipelines", 13)]
+            [InlineData("HtmlInline_AzurePipelines", 13)]
             [InlineData("PngChart", 14)]
             [InlineData("MHtml", 15)]
+            [InlineData("SonarQube", 16)]
+            [InlineData("HtmlInline_AzurePipelines_Dark", 17)]
             public void Should_Set_Report_Types(string expected, int enumValue)
             {
                 // Given

--- a/src/Cake.Common/Tools/ReportGenerator/ReportGeneratorReportType.cs
+++ b/src/Cake.Common/Tools/ReportGenerator/ReportGeneratorReportType.cs
@@ -72,7 +72,7 @@ namespace Cake.Common.Tools.ReportGenerator
         /// <summary>
         /// Same as HTMLInline but with modified CSS that matches the look and feel of Azure Pipelines.
         /// </summary>
-        HtmlInlineAzurePipelines = 13,
+        HtmlInline_AzurePipelines = 13,
 
         /// <summary>
         /// A single PNG file containing a chart with historic coverage information.
@@ -82,6 +82,22 @@ namespace Cake.Common.Tools.ReportGenerator
         /// <summary>
         /// Same as HTML but packaged into a single MHTML file.
         /// </summary>
-        MHtml = 15
+        MHtml = 15,
+
+        /// <summary>
+        /// Creates xml report in SonarQube 'Generic Test Data' format.
+        /// </summary>
+        /// <remarks>
+        /// Requires ReportGenerator 4.0.6+
+        /// </remarks>
+        SonarQube = 16,
+
+        /// <summary>
+        /// Same as HTMLInline but with modified CSS that matches the dark look and feel of Azure Pipelines.
+        /// </summary>
+        /// <remarks>
+        /// Requires ReportGenerator 4.0.10+
+        /// </remarks>
+        HtmlInline_AzurePipelines_Dark = 17
     }
 }


### PR DESCRIPTION
- Also correct `HtmlInline_AzurePipelines`

Fixes #2514