### PR TITLE
GH2519: Changes for stable Visual Studio 2019 release

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/MSBuildRunnerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/MSBuildRunnerFixture.cs
@@ -34,8 +34,8 @@ namespace Cake.Common.Tests.Fixtures.Tools
                 "/Program86/MSBuild/14.0/Bin/amd64/MSBuild.exe",
                 "/Program86/Microsoft Visual Studio/2017/Enterprise/MSBuild/15.0/Bin/MSBuild.exe",
                 "/Program86/Microsoft Visual Studio/2017/Enterprise/MSBuild/15.0/Bin/amd64/MSBuild.exe",
-                "/Program86/Microsoft Visual Studio/2019/Preview/MSBuild/Current/Bin/MSBuild.exe",
-                "/Program86/Microsoft Visual Studio/2019/Preview/MSBuild/Current/Bin/amd64/MSBuild.exe",
+                "/Program86/Microsoft Visual Studio/2019/Professional/MSBuild/Current/Bin/MSBuild.exe",
+                "/Program86/Microsoft Visual Studio/2019/Professional/MSBuild/Current/Bin/amd64/MSBuild.exe",
                 "/usr/bin/msbuild",
                 "/Library/Frameworks/Mono.framework/Versions/Current/Commands/msbuild"
             };

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -137,8 +137,8 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             }
 
             [Theory]
-            [InlineData(MSBuildToolVersion.VS2019, PlatformTarget.x64, PlatformFamily.Windows, false, "/Program86/Microsoft Visual Studio/2019/Preview/MSBuild/Current/Bin/amd64/MSBuild.exe")]
-            [InlineData(MSBuildToolVersion.VS2019, PlatformTarget.x86, PlatformFamily.Windows, false, "/Program86/Microsoft Visual Studio/2019/Preview/MSBuild/Current/Bin/MSBuild.exe")]
+            [InlineData(MSBuildToolVersion.VS2019, PlatformTarget.x64, PlatformFamily.Windows, false, "/Program86/Microsoft Visual Studio/2019/Professional/MSBuild/Current/Bin/amd64/MSBuild.exe")]
+            [InlineData(MSBuildToolVersion.VS2019, PlatformTarget.x86, PlatformFamily.Windows, false, "/Program86/Microsoft Visual Studio/2019/Professional/MSBuild/Current/Bin/MSBuild.exe")]
             [InlineData(MSBuildToolVersion.VS2019, PlatformTarget.x64, PlatformFamily.Linux, false, "/usr/bin/msbuild")]
             [InlineData(MSBuildToolVersion.VS2019, PlatformTarget.x64, PlatformFamily.OSX, false, "/Library/Frameworks/Mono.framework/Versions/Current/Commands/msbuild")]
             public void Should_Get_Correct_Path_To_MSBuild_Version_16(MSBuildToolVersion version, PlatformTarget target, PlatformFamily family, bool is64BitOperativeSystem, string expected)

--- a/src/Cake.Common/Tools/MSBuild/MSBuildResolver.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildResolver.cs
@@ -59,7 +59,7 @@ namespace Cake.Common.Tools.MSBuild
         {
             var versions = new[]
             {
-                // MSBuildVersion.MSBuild16, /*Since it's still in preview, do not search unless specified. Uncomment after stable version released*/
+                MSBuildVersion.MSBuild16,
                 MSBuildVersion.MSBuild15,
                 MSBuildVersion.MSBuild14,
                 MSBuildVersion.MSBuild12,
@@ -165,8 +165,7 @@ namespace Cake.Common.Tools.MSBuild
                 "Enterprise",
                 "Professional",
                 "Community",
-                "BuildTools",
-                "Preview" // Remove after stable version released
+                "BuildTools"
             };
 
             var visualStudio2019Path = environment.GetSpecialPath(SpecialPath.ProgramFilesX86);


### PR DESCRIPTION
Changes regarding the release of Visual Studio 2019.
Fixes #2519