### PR TITLE
GH2535: Rename octo.exe to Octo.exe

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/OctopusDeployPackerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/OctopusDeployPackerFixture.cs
@@ -12,7 +12,7 @@ namespace Cake.Common.Tests.Fixtures.Tools
         public string Id { get; set; }
 
         public OctopusDeployPackerFixture()
-            : base("octo.exe")
+            : base("Octo.exe")
         {
         }
 

--- a/src/Cake.Common.Tests/Fixtures/Tools/OctopusDeployPusherFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/OctopusDeployPusherFixture.cs
@@ -18,7 +18,7 @@ namespace Cake.Common.Tests.Fixtures.Tools
         public List<FilePath> Packages { get; set; }
 
         public OctopusDeployPusherFixture()
-            : base("octo.exe")
+            : base("Octo.exe")
         {
             Packages = new List<FilePath>
             {

--- a/src/Cake.Common.Tests/Fixtures/Tools/OctopusDeployReleaseCreatorFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/OctopusDeployReleaseCreatorFixture.cs
@@ -12,7 +12,7 @@ namespace Cake.Common.Tests.Fixtures.Tools
         public string ProjectName { get; set; }
 
         public OctopusDeployReleaseCreatorFixture()
-            : base("octo.exe")
+            : base("Octo.exe")
         {
             ProjectName = "testProject";
 

--- a/src/Cake.Common.Tests/Fixtures/Tools/OctopusDeployReleaseDeployerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/OctopusDeployReleaseDeployerFixture.cs
@@ -20,7 +20,7 @@ namespace Cake.Common.Tests.Fixtures.Tools
         internal string ReleaseNumber { get; set; }
 
         public OctopusDeployReleaseDeployerFixture()
-            : base("octo.exe")
+            : base("Octo.exe")
         {
             Server = "http://octopus";
             ApiKey = "API-12345";

--- a/src/Cake.Common.Tests/Fixtures/Tools/OctopusDeployReleasePromoterFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/OctopusDeployReleasePromoterFixture.cs
@@ -20,7 +20,7 @@ namespace Cake.Common.Tests.Fixtures.Tools
         internal string DeployTo { get; set; }
 
         public OctopusDeployReleasePromoterFixture()
-            : base("octo.exe")
+            : base("Octo.exe")
         {
             Server = "http://octopus";
             ApiKey = "API-12345";

--- a/src/Cake.Common.Tests/Fixtures/Tools/OctopusDeploymentQuerierFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/OctopusDeploymentQuerierFixture.cs
@@ -14,7 +14,7 @@ namespace Cake.Common.Tests.Fixtures.Tools
         internal string ApiKey { get; set; }
 
         public OctopusDeploymentQuerierFixture()
-            : base("octo.exe")
+            : base("Octo.exe")
         {
             Server = "http://octopus";
             ApiKey = "API-12345";

--- a/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctoCreateReleaseTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctoCreateReleaseTests.cs
@@ -86,8 +86,8 @@ namespace Cake.Common.Tests.Unit.Tools.OctopusDeploy
             }
 
             [Theory]
-            [InlineData("/bin/tools/octopus/octo.exe", "/bin/tools/octopus/octo.exe")]
-            [InlineData("./tools/octopus/octo.exe", "/Working/tools/octopus/octo.exe")]
+            [InlineData("/bin/tools/octopus/Octo.exe", "/bin/tools/octopus/Octo.exe")]
+            [InlineData("./tools/octopus/Octo.exe", "/Working/tools/octopus/Octo.exe")]
             public void Should_Use_Octo_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
             {
                 // Given
@@ -103,7 +103,7 @@ namespace Cake.Common.Tests.Unit.Tools.OctopusDeploy
             }
 
             [WindowsTheory]
-            [InlineData("C:/octopusDeploy/octo.exe", "C:/octopusDeploy/octo.exe")]
+            [InlineData("C:/octopusDeploy/Octo.exe", "C:/octopusDeploy/Octo.exe")]
             public void Should_Use_Octo_Executable_From_Tool_Path_If_Provided_On_Windows(string toolPath, string expected)
             {
                 // Given
@@ -128,7 +128,7 @@ namespace Cake.Common.Tests.Unit.Tools.OctopusDeploy
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/Working/tools/octo.exe", result.Path.FullPath);
+                Assert.Equal("/Working/tools/Octo.exe", result.Path.FullPath);
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctoPushTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctoPushTests.cs
@@ -268,8 +268,8 @@ namespace Cake.Common.Tests.Unit.Tools.OctopusDeploy
             }
 
             [Theory]
-            [InlineData("/bin/tools/octopus/octo.exe", "/bin/tools/octopus/octo.exe")]
-            [InlineData("./tools/octopus/octo.exe", "/Working/tools/octopus/octo.exe")]
+            [InlineData("/bin/tools/octopus/Octo.exe", "/bin/tools/octopus/Octo.exe")]
+            [InlineData("./tools/octopus/Octo.exe", "/Working/tools/octopus/Octo.exe")]
             public void Should_Use_Octo_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
             {
                 // Given
@@ -285,7 +285,7 @@ namespace Cake.Common.Tests.Unit.Tools.OctopusDeploy
             }
 
             [WindowsTheory]
-            [InlineData("C:/octopusDeploy/octo.exe", "C:/octopusDeploy/octo.exe")]
+            [InlineData("C:/octopusDeploy/Octo.exe", "C:/octopusDeploy/Octo.exe")]
             public void Should_Use_Octo_Executable_From_Tool_Path_If_Provided_On_Windows(string toolPath, string expected)
             {
                 // Given
@@ -310,7 +310,7 @@ namespace Cake.Common.Tests.Unit.Tools.OctopusDeploy
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/Working/tools/octo.exe", result.Path.FullPath);
+                Assert.Equal("/Working/tools/Octo.exe", result.Path.FullPath);
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctopusDeploymentQueryTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/OctopusDeploy/OctopusDeploymentQueryTests.cs
@@ -143,8 +143,8 @@ namespace Cake.Common.Tests.Unit.Tools.OctopusDeploy
             }
 
             [Theory]
-            [InlineData("/bin/tools/octopus/octo.exe", "/bin/tools/octopus/octo.exe")]
-            [InlineData("./tools/octopus/octo.exe", "/Working/tools/octopus/octo.exe")]
+            [InlineData("/bin/tools/octopus/Octo.exe", "/bin/tools/octopus/Octo.exe")]
+            [InlineData("./tools/octopus/Octo.exe", "/Working/tools/octopus/Octo.exe")]
             public void Should_Use_Octo_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
             {
                 // Given
@@ -160,7 +160,7 @@ namespace Cake.Common.Tests.Unit.Tools.OctopusDeploy
             }
 
             [WindowsTheory]
-            [InlineData("C:/octopusDeploy/octo.exe", "C:/octopusDeploy/octo.exe")]
+            [InlineData("C:/octopusDeploy/Octo.exe", "C:/octopusDeploy/Octo.exe")]
             public void Should_Use_Octo_Executable_From_Tool_Path_If_Provided_On_Windows(string toolPath, string expected)
             {
                 // Given
@@ -185,7 +185,7 @@ namespace Cake.Common.Tests.Unit.Tools.OctopusDeploy
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/Working/tools/octo.exe", result.Path.FullPath);
+                Assert.Equal("/Working/tools/Octo.exe", result.Path.FullPath);
             }
 
             [Fact]

--- a/src/Cake.Common/Tools/OctopusDeploy/DeploymentQueryResultParser.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/DeploymentQueryResultParser.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 namespace Cake.Common.Tools.OctopusDeploy
 {
     /// <summary>
-    /// Parses the Console Output of the octo.exe call when called with list-deployments
+    /// Parses the Console Output of the Octo.exe call when called with list-deployments
     /// </summary>
     public class DeploymentQueryResultParser
     {

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployTool.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployTool.cs
@@ -49,7 +49,7 @@ namespace Cake.Common.Tools.OctopusDeploy
         /// <returns>The tool executable name.</returns>
         protected override IEnumerable<string> GetToolExecutableNames()
         {
-            return new[] { "octo.exe", "dotnet-octo", "dotnet-octo.exe" };
+            return new[] { "Octo.exe", "dotnet-octo", "dotnet-octo.exe" };
         }
     }
 }


### PR DESCRIPTION
Fixes bug discussed in #2535 

Renamed to `Octo.exe` in the tests where the tool path is set explicitly to keep it consistent across the repo.