### PR TITLE
Log working dir

### DIFF
--- a/src/Cake.Core.Tests/Unit/IO/ProcessRunnerTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/ProcessRunnerTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.IO;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.Core.Tests.Fixtures;
@@ -161,7 +160,7 @@ namespace Cake.Core.Tests.Unit.IO
                 // Then
                 fixture.Log
                     .Received(1)
-                    .Verbose(Verbosity.Diagnostic, "Executing: {0}", $"\"/Program Files/Cake.exe\" [REDACTED] in working directory: {System.IO.Path.DirectorySeparatorChar}Working");
+                    .Verbose(Verbosity.Diagnostic, "Executing: {0}", $"\"/Program Files/Cake.exe\" [REDACTED] in working directory: /Working");
             }
 
             [RuntimeFact(TestRuntime.CoreClr)]

--- a/src/Cake.Core.Tests/Unit/IO/ProcessRunnerTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/ProcessRunnerTests.cs
@@ -11,7 +11,6 @@ using Cake.Testing.Xunit;
 using NSubstitute;
 using Xunit;
 
-
 namespace Cake.Core.Tests.Unit.IO
 {
     public sealed class ProcessRunnerTests

--- a/src/Cake.Core.Tests/Unit/IO/ProcessRunnerTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/ProcessRunnerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.IO;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.Core.Tests.Fixtures;
@@ -9,7 +10,7 @@ using Cake.Core.Tooling;
 using Cake.Testing.Xunit;
 using NSubstitute;
 using Xunit;
-using System.IO;
+
 
 namespace Cake.Core.Tests.Unit.IO
 {

--- a/src/Cake.Core.Tests/Unit/IO/ProcessRunnerTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/ProcessRunnerTests.cs
@@ -9,6 +9,7 @@ using Cake.Core.Tooling;
 using Cake.Testing.Xunit;
 using NSubstitute;
 using Xunit;
+using System.IO;
 
 namespace Cake.Core.Tests.Unit.IO
 {
@@ -160,7 +161,7 @@ namespace Cake.Core.Tests.Unit.IO
                 // Then
                 fixture.Log
                     .Received(1)
-                    .Verbose(Verbosity.Diagnostic, "Executing: {0}", "\"/Program Files/Cake.exe\" [REDACTED]");
+                    .Verbose(Verbosity.Diagnostic, "Executing: {0}", $"\"/Program Files/Cake.exe\" [REDACTED] in working directory: {System.IO.Path.DirectorySeparatorChar}Working");
             }
 
             [RuntimeFact(TestRuntime.CoreClr)]

--- a/src/Cake.Core/IO/ProcessRunner.cs
+++ b/src/Cake.Core/IO/ProcessRunner.cs
@@ -124,13 +124,6 @@ namespace Cake.Core.IO
             }
 #endif
 
-            if (!settings.Silent)
-            {
-                // Log the filename and arguments.
-                var message = string.Concat(fileName, " ", arguments.RenderSafe().TrimEnd());
-                _log.Verbose(_showCommandLine ? _log.Verbosity : Verbosity.Diagnostic, "Executing: {0}", message);
-            }
-
             // Create the process start info.
             var info = new ProcessStartInfo(fileName)
             {
@@ -141,10 +134,24 @@ namespace Cake.Core.IO
             };
 
             // Allow working directory?
+            var workingDirLog = string.Empty;
             if (!settings.NoWorkingDirectory)
             {
                 var workingDirectory = settings.WorkingDirectory ?? _environment.WorkingDirectory;
                 info.WorkingDirectory = workingDirectory.MakeAbsolute(_environment).FullPath;
+                workingDirLog = info.WorkingDirectory;
+            }
+
+            if (!settings.Silent)
+            {
+                // Log the filename and arguments.
+                var message = string.Concat(fileName, " ", arguments.RenderSafe().TrimEnd());
+                if (!string.IsNullOrEmpty(workingDirLog))
+                {
+                    message = string.Concat(message, " in working directory: ", workingDirLog);
+                }
+
+                _log.Verbose(_showCommandLine ? _log.Verbosity : Verbosity.Diagnostic, "Executing: {0}", message);
             }
 
             // Add environment variables


### PR DESCRIPTION
This PR adds the working dir to the verbose log output for "Executing: <process>" to help chase down build issues related to build paths.

Full disclosure: I'm not a .Net dev, so this PR is probably not the best way to do it. Feedback welcome.
