### PR TITLE
Log debug messages for tools resolver

### DIFF
--- a/src/Cake.Core.Tests/Fixtures/NuGetToolResolverFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/NuGetToolResolverFixture.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.Core.IO.NuGet;
 using Cake.Core.Tooling;
@@ -22,7 +23,7 @@ namespace Cake.Core.Tests.Fixtures
             Tools = new ToolLocator(
                 Environment,
                 new ToolRepository(Environment),
-                new ToolResolutionStrategy(FileSystem, Environment, new Globber(FileSystem, Environment), new FakeConfiguration()));
+                new ToolResolutionStrategy(FileSystem, Environment, new Globber(FileSystem, Environment), new FakeConfiguration(), new NullLog()));
         }
 
         public FilePath Resolve()

--- a/src/Cake.Core.Tests/Fixtures/ToolResolutionStrategyFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/ToolResolutionStrategyFixture.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
 using Cake.Testing;
@@ -27,7 +28,7 @@ namespace Cake.Core.Tests.Fixtures
 
         public FilePath Resolve(string name)
         {
-            var strategy = new ToolResolutionStrategy(FileSystem, Environment, Globber, Configuration);
+            var strategy = new ToolResolutionStrategy(FileSystem, Environment, Globber, Configuration, new NullLog());
             return strategy.Resolve(Repository, name);
         }
     }

--- a/src/Cake.Core.Tests/Unit/Tooling/ToolResolutionStrategyTests.cs
+++ b/src/Cake.Core.Tests/Unit/Tooling/ToolResolutionStrategyTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.Core.Tests.Fixtures;
 using Cake.Core.Tooling;
@@ -201,7 +202,7 @@ namespace Cake.Core.Tests.Unit.Tooling
                     return fixture.FileSystem.GetFile(path);
                 });
 
-                var strategy = new ToolResolutionStrategy(fileSystem, fixture.Environment, fixture.Globber, fixture.Configuration);
+                var strategy = new ToolResolutionStrategy(fileSystem, fixture.Environment, fixture.Globber, fixture.Configuration, new NullLog());
 
                 // When
                 var result = strategy.Resolve(fixture.Repository, "tool.exe");

--- a/src/Cake.Core/Tooling/ToolResolutionStrategy.cs
+++ b/src/Cake.Core/Tooling/ToolResolutionStrategy.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Cake.Core.Configuration;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 
 namespace Cake.Core.Tooling
@@ -19,6 +20,7 @@ namespace Cake.Core.Tooling
         private readonly ICakeEnvironment _environment;
         private readonly IGlobber _globber;
         private readonly ICakeConfiguration _configuration;
+        private readonly ICakeLog _log;
         private readonly object _lock;
         private List<DirectoryPath> _path;
 
@@ -29,11 +31,13 @@ namespace Cake.Core.Tooling
         /// <param name="environment">The environment.</param>
         /// <param name="globber">The globber.</param>
         /// <param name="configuration">The configuration.</param>
+        /// <param name="log">The log.</param>
         public ToolResolutionStrategy(
             IFileSystem fileSystem,
             ICakeEnvironment environment,
             IGlobber globber,
-            ICakeConfiguration configuration)
+            ICakeConfiguration configuration,
+            ICakeLog log)
         {
             if (fileSystem == null)
             {
@@ -52,6 +56,7 @@ namespace Cake.Core.Tooling
             _environment = environment;
             _globber = globber;
             _configuration = configuration;
+            _log = log;
             _lock = new object();
         }
 
@@ -122,6 +127,7 @@ namespace Cake.Core.Tooling
                     {
                         if (_fileSystem.Exist(file))
                         {
+                            _log.Verbose($"Resolved toolpath {file}");
                             return file.MakeAbsolute(_environment);
                         }
                     }
@@ -130,6 +136,9 @@ namespace Cake.Core.Tooling
                     }
                 }
 
+                var allPaths = string.Join(",", _path);
+                _log.Verbose($"Could not resolve path for tool \"{tool}\" using these directories:");
+                _log.Verbose(allPaths);
                 return null;
             }
         }

--- a/src/Cake.Core/Tooling/ToolResolutionStrategy.cs
+++ b/src/Cake.Core/Tooling/ToolResolutionStrategy.cs
@@ -127,7 +127,7 @@ namespace Cake.Core.Tooling
                     {
                         if (_fileSystem.Exist(file))
                         {
-                            _log.Verbose($"Resolved toolpath {file}");
+                            _log.Verbose($"Resolved tool to path {file}");
                             return file.MakeAbsolute(_environment);
                         }
                     }

--- a/src/Cake.Core/Tooling/ToolResolutionStrategy.cs
+++ b/src/Cake.Core/Tooling/ToolResolutionStrategy.cs
@@ -127,7 +127,7 @@ namespace Cake.Core.Tooling
                     {
                         if (_fileSystem.Exist(file))
                         {
-                            _log.Verbose($"Resolved tool to path {file}");
+                            _log.Debug($"Resolved tool to path {file}");
                             return file.MakeAbsolute(_environment);
                         }
                     }
@@ -137,8 +137,7 @@ namespace Cake.Core.Tooling
                 }
 
                 var allPaths = string.Join(",", _path);
-                _log.Verbose($"Could not resolve path for tool \"{tool}\" using these directories:");
-                _log.Verbose(allPaths);
+                _log.Debug($"Could not resolve path for tool \"{tool}\" using these directories: {allPaths}");
                 return null;
             }
         }

--- a/src/Cake.Testing/Fixtures/ToolFixture`2.cs
+++ b/src/Cake.Testing/Fixtures/ToolFixture`2.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
 
@@ -78,7 +79,7 @@ namespace Cake.Testing.Fixtures
             FileSystem = new FakeFileSystem(Environment);
             Globber = new Globber(FileSystem, Environment);
             Configuration = new FakeConfiguration();
-            Tools = new ToolLocator(Environment, new ToolRepository(Environment), new ToolResolutionStrategy(FileSystem, Environment, Globber, Configuration));
+            Tools = new ToolLocator(Environment, new ToolRepository(Environment), new ToolResolutionStrategy(FileSystem, Environment, Globber, Configuration, new NullLog()));
 
             // ReSharper disable once VirtualMemberCallInConstructor
             DefaultToolPath = GetDefaultToolPath(toolFilename);


### PR DESCRIPTION
This PR adds verbose logging for the tools resolver, which may help troubleshoot errors related to executing tools. 

Sample output:
```
========================================
Default
========================================
Executing task: Default
Could not resolve path for tool "octo.exe" using these directories:
/sbin,/bin,/usr/games,/usr/local/games,/snap/bin,/home/trond/.dotnet
Could not resolve path for tool "dotnet-octo" using these directories:
/sbin,/bin,/usr/games,/usr/local/games,/snap/bin,/home/trond/.dotnet
Could not resolve path for tool "dotnet-octo.exe" using these directories:
/sbin,/bin,/usr/games,/usr/local/games,/snap/bin,/home/trond/.dotnet
An error occurred when executing task 'Default'.
```
The logging is a bit verbose, but it could prove useful to troubleshoot, and its only shown if diagnostic(debug) logging is enabled while the build fails.