### PR TITLE
GH2551: Implement the NoImplicitTarget property and extension method in MSBuild

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -610,6 +610,37 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             }
 
             [Fact]
+            public void Should_Not_Append_Targets_If_No_Implicit_Target_Is_True_And_No_Targets_Provided()
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows);
+                fixture.Settings.NoImplicitTarget = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/v:normal " +
+                             "\"C:/Working/src/Solution.sln\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_Targets_If_No_Implicit_Target_Is_True_And_Targets_Provided()
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows);
+                fixture.Settings.NoImplicitTarget = true;
+                fixture.Settings.WithTarget("A");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/v:normal /target:A " +
+                             "\"C:/Working/src/Solution.sln\"", result.Args);
+            }
+
+            [Fact]
             public void Should_Use_Node_Reuse_If_Specified()
             {
                 // Given

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsExtensionsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsExtensionsTests.cs
@@ -322,6 +322,37 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             }
         }
 
+        public sealed class TheNoImplicitTargetMethod
+        {
+            [Theory]
+            [InlineData(true)]
+            [InlineData(false)]
+            public void Should_Set_No_Implicit_Target(bool noImplicitTarget)
+            {
+                // Given
+                var settings = new MSBuildSettings();
+
+                // When
+                settings.SetNoImplicitTarget(noImplicitTarget);
+
+                // Then
+                Assert.Equal(noImplicitTarget, settings.NoImplicitTarget);
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new MSBuildSettings();
+
+                // When
+                var result = settings.SetNoImplicitTarget(true);
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
         public sealed class TheSetRestoreLockedModeMethod
         {
             [Theory]

--- a/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
@@ -116,8 +116,12 @@ namespace Cake.Common.Tools.MSBuild
             }
             else
             {
-                // Use default target.
-                builder.Append("/target:Build");
+                // Should use implicit target?
+                if (!settings.NoImplicitTarget.GetValueOrDefault())
+                {
+                    // Use default target.
+                    builder.Append("/target:Build");
+                }
             }
 
             if (settings.Loggers.Count > 0)

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
@@ -95,6 +95,13 @@ namespace Cake.Common.Tools.MSBuild
         public bool? NoLogo { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether implicit target should be passed to MSBuild.
+        /// If set to true, no targets will be specified.
+        /// If set to false, and no targets specified, Build target will be passed by default.
+        /// </summary>
+        public bool? NoImplicitTarget { get; set; }
+
+        /// <summary>
         /// Gets or sets the amount of information to display in the build log.
         /// Each logger displays events based on the verbosity level that you set for that logger.
         /// </summary>

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
@@ -207,6 +207,22 @@ namespace Cake.Common.Tools.MSBuild
         }
 
         /// <summary>
+        /// Sets whether or not any targets should be passed to MSBuild.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="noImplicitTarget"><c>true</c> if no implicit target should be passed to MSBuild; otherwise <c>false</c>.</param>
+        /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static MSBuildSettings SetNoImplicitTarget(this MSBuildSettings settings, bool noImplicitTarget)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            settings.NoImplicitTarget = noImplicitTarget;
+            return settings;
+        }
+
+        /// <summary>
         /// Sets the build log verbosity.
         /// </summary>
         /// <param name="settings">The settings.</param>


### PR DESCRIPTION
Tackling issue #2551.

Brief summary of changes:
- Added `NoImplicitTarget `property to MSBuild;
- Added `SetNoImplicitTarget()` extension method to get/set the property mentioned above;
- Added some tests to validate the relevant scenarios for this change.

Some behavior details:
- If the developer provides no targets (meaning doesn't use `WithTarget()`) and doesn't use `NoImplicitTarget`, MSBuild will be called with `/target:Build`, keeping the current behavior;
- If the developer provides no targets (meaning doesn't use `WithTarget()`) and sets `NoImplicitTarget` to true, MSBuild will be called with no targets at all;
- If the developer provides targets (using `WithTarget()`) the provided targets will be used regardless of the value of `NoImplicitTarget`.