### PR TITLE
GH2558: fix quote filename of binary logger

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -993,7 +993,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/v:normal /target:Build /bl:mylog.binlog;ProjectImports=ZipFile \"C:/Working/src/Solution.sln\"", result.Args);
+                Assert.Equal("/v:normal /target:Build /bl:\"mylog.binlog\";ProjectImports=ZipFile \"C:/Working/src/Solution.sln\"", result.Args);
             }
 
             [Fact]
@@ -1007,7 +1007,25 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/v:normal /target:Build /bl:mylog.binlog;ProjectImports=ZipFile \"C:/Working/src/Solution.sln\"", result.Args);
+                Assert.Equal("/v:normal /target:Build /bl:\"mylog.binlog\";ProjectImports=ZipFile \"C:/Working/src/Solution.sln\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Quote_Binary_Logging_FilePath()
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows);
+                fixture.Settings.BinaryLogger = new MSBuildBinaryLogSettings()
+                {
+                    Enabled = true,
+                    FileName = "C:/Working Directory/src folder/mylog.binlog"
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/v:normal /target:Build /bl:\"C:/Working Directory/src folder/mylog.binlog\" \"C:/Working/src/Solution.sln\"", result.Args);
             }
 
             [Theory]

--- a/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
@@ -150,7 +150,7 @@ namespace Cake.Common.Tools.MSBuild
                 string binaryOptions = null;
                 if (!string.IsNullOrEmpty(settings.BinaryLogger.FileName))
                 {
-                    binaryOptions = settings.BinaryLogger.FileName;
+                    binaryOptions = settings.BinaryLogger.FileName.Quote();
                 }
 
                 if (settings.BinaryLogger.Imports != MSBuildBinaryLogImports.Unspecified)


### PR DESCRIPTION
This PR should fix issue #2558.
It also includes unit tests.

I don't know if `MSBuildBinaryLogSettings.FileName` should really be of type `FilePath` instead of `string` like `MSBuildFileLogger.LogFile` is.