### PR TITLE
GH2275: Correctly reference runtime libraries from addins

### DIFF
--- a/src/Cake.Core/Reflection/AssemblyLoader.cs
+++ b/src/Cake.Core/Reflection/AssemblyLoader.cs
@@ -29,7 +29,7 @@ namespace Cake.Core.Reflection
         public Assembly Load(FilePath path, bool verify)
         {
             var assembly = AssemblyHelper.LoadAssembly(_environment, _fileSystem, path);
-            if (verify)
+            if (verify && assembly != null)
             {
                 _verifier.Verify(assembly);
             }

--- a/src/Cake.Core/Scripting/ScriptRunner.cs
+++ b/src/Cake.Core/Scripting/ScriptRunner.cs
@@ -169,7 +169,11 @@ namespace Cake.Core.Scripting
                 if (host.Context.FileSystem.Exist(referencePath))
                 {
                     var assembly = _assemblyLoader.Load(referencePath, true);
-                    assemblies.Add(assembly);
+
+                    if (assembly != null)
+                    {
+                        assemblies.Add(assembly);
+                    }
                 }
                 else
                 {

--- a/src/Cake.NuGet.Tests/Fixtures/NuGetContentResolverFixture.cs
+++ b/src/Cake.NuGet.Tests/Fixtures/NuGetContentResolverFixture.cs
@@ -28,6 +28,7 @@ namespace Cake.NuGet.Tests.Fixtures
             Environment = FakeEnvironment.CreateUnixEnvironment();
             Environment.Runtime.BuiltFramework = new FrameworkName(framework);
             Environment.Runtime.Runtime = runtime;
+            Environment.Runtime.IsCoreClr = runtime == Runtime.CoreClr;
 
             FileSystem = new FakeFileSystem(Environment);
             Globber = new Globber(FileSystem, Environment);

--- a/src/Cake.NuGet/Cake.NuGet.csproj
+++ b/src/Cake.NuGet/Cake.NuGet.csproj
@@ -26,5 +26,16 @@
     <PackageReference Include="NuGet.Resolver" Version="5.3.0" />
     <PackageReference Include="NuGet.Common" Version="5.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.0.0" />
   </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="2.2.2" GeneratePathProperty="true">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <EmbeddedResource  Include="$(PkgMicrosoft_NETCore_Platforms)\runtime.json">
+      <Link>runtime.json</Link>
+    </EmbeddedResource>
+  </ItemGroup>
+
 </Project>

--- a/src/Cake.NuGet/Cake.NuGet.csproj
+++ b/src/Cake.NuGet/Cake.NuGet.csproj
@@ -19,21 +19,21 @@
   </ItemGroup>
   <!-- Global packages -->
   <ItemGroup>
-    <PackageReference Include="NuGet.Frameworks" Version="5.3.0" />
-    <PackageReference Include="NuGet.Versioning" Version="5.3.0" />
-    <PackageReference Include="NuGet.Protocol" Version="5.3.0" />
-    <PackageReference Include="NuGet.Packaging" Version="5.3.0" />
-    <PackageReference Include="NuGet.Resolver" Version="5.3.0" />
-    <PackageReference Include="NuGet.Common" Version="5.3.0" />
+    <PackageReference Include="NuGet.Frameworks" Version="5.4.0" />
+    <PackageReference Include="NuGet.Versioning" Version="5.4.0" />
+    <PackageReference Include="NuGet.Protocol" Version="5.4.0" />
+    <PackageReference Include="NuGet.Packaging" Version="5.4.0" />
+    <PackageReference Include="NuGet.Resolver" Version="5.4.0" />
+    <PackageReference Include="NuGet.Common" Version="5.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.0.0" />
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="2.2.2" GeneratePathProperty="true">
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="3.1.0" GeneratePathProperty="true">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <EmbeddedResource  Include="$(PkgMicrosoft_NETCore_Platforms)\runtime.json">
+    <EmbeddedResource Include="$(PkgMicrosoft_NETCore_Platforms)\runtime.json">
       <Link>runtime.json</Link>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
- Fixes #2275

~~Don't know if this is the right direction to go. Basically we *should* load the runtime libs based on the current RID if running .NET Core. Problem is there's a whole lot of them (see [list or runtimes](https://github.com/dotnet/corefx/blob/7e56d8bd8b224d834b782a98bfd7035f71c3f547/pkg/Microsoft.NETCore.Platforms/runtime.json)  and [docs](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog)).~~

~~@daveaglick do you have anything to add? Maybe we should consult our friends at NuGet?~~

Went with the route of correctly findint runtime assemblies and loading them, including native libraries.