### PR TITLE
GH2663: Add support for Inno Setup 6

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/InnoSetupFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/InnoSetupFixture.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Cake.Common.Tools.InnoSetup;
 using Cake.Core.IO;
 using Cake.Testing;
@@ -16,55 +17,73 @@ namespace Cake.Common.Tests.Fixtures.Tools
 
         public FilePath ScriptPath { get; set; }
 
-        public FilePath InstalledToolPath { get; private set; }
+        public Dictionary<InnoSetupVersion, FilePath> InstalledToolPaths { get; private set; }
 
         public InnoSetupFixture()
             : base("iscc.exe")
         {
             ScriptPath = new FilePath("./Test.iss");
+            InstalledToolPaths = new Dictionary<InnoSetupVersion, FilePath>();
             Registry = Substitute.For<IRegistry>();
-        }
-
-        public void GivenToolIsInstalledX86()
-        {
-            ConfigureInstalledLocation(false);
-        }
-
-        public void GivenToolIsInstalledX64()
-        {
-            ConfigureInstalledLocation(true);
-        }
-
-        private void ConfigureInstalledLocation(bool is64Bit)
-        {
-            string registryKeyPath = is64Bit
-                ? @"SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Inno Setup 5_is1"
-                : @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Inno Setup 5_is1";
-
-            DirectoryPath installLocation = is64Bit
-                ? "/programfiles(x86)/innosetup"
-                : "/programfiles/innosetup";
-
-            InstalledToolPath = installLocation.CombineWithFilePath("iscc.exe");
-
-            var innoSetupKey = Substitute.For<IRegistryKey>();
-            innoSetupKey.GetValue("InstallLocation").Returns(installLocation.FullPath);
-
             var hklm = Substitute.For<IRegistryKey>();
-            hklm.OpenKey(registryKeyPath).Returns(innoSetupKey);
-
             Registry.LocalMachine.Returns(hklm);
+        }
 
-            FileSystem.CreateDirectory(installLocation);
-            FileSystem.CreateFile(InstalledToolPath);
-
+        public void GivenToolIsInstalled(bool is64Bit, InnoSetupVersion version)
+        {
             Environment.Platform.Is64Bit = is64Bit;
+            ConfigureInstalledLocation(is64Bit, version);
         }
 
         protected override void RunTool()
         {
             var tool = new InnoSetupRunner(FileSystem, Registry, Environment, ProcessRunner, Tools);
             tool.Run(ScriptPath, Settings);
+        }
+
+        private void ConfigureInstalledLocation(bool is64Bit, InnoSetupVersion version)
+        {
+            var registryKeyPath = GetRegistryKeyPath(is64Bit, version);
+            var installLocation = GetInstallLocation(is64Bit, version);
+
+            var installedToolPath = installLocation.CombineWithFilePath("iscc.exe");
+            InstalledToolPaths.Add(version, installLocation.CombineWithFilePath("iscc.exe"));
+
+            var innoSetupKey = Substitute.For<IRegistryKey>();
+            innoSetupKey.GetValue("InstallLocation").Returns(installLocation.FullPath);
+
+            Registry.LocalMachine.OpenKey(registryKeyPath).Returns(innoSetupKey);
+
+            FileSystem.CreateDirectory(installLocation);
+            FileSystem.CreateFile(installedToolPath);
+        }
+
+        private static string GetRegistryKeyPath(bool is64Bit, InnoSetupVersion version)
+        {
+            var softwareKeyPath = is64Bit ? @"SOFTWARE\Wow6432Node\" : @"SOFTWARE\";
+            switch (version)
+            {
+                case InnoSetupVersion.InnoSetup6:
+                    return $@"{softwareKeyPath}Microsoft\Windows\CurrentVersion\Uninstall\Inno Setup 6_is1";
+                case InnoSetupVersion.InnoSetup5:
+                    return $@"{softwareKeyPath}Microsoft\Windows\CurrentVersion\Uninstall\Inno Setup 5_is1";
+                default:
+                    return null;
+            }
+        }
+
+        private static DirectoryPath GetInstallLocation(bool is64Bit, InnoSetupVersion version)
+        {
+            var programFiles = is64Bit ? "/Program Files (x86)/" : "/Program Files/";
+            switch (version)
+            {
+                case InnoSetupVersion.InnoSetup6:
+                    return $@"{programFiles}Inno Setup 6";
+                case InnoSetupVersion.InnoSetup5:
+                    return $@"{programFiles}Inno Setup 5";
+                default:
+                    return null;
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/InnoSetup/InnoSetupRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/InnoSetup/InnoSetupRunnerTests.cs
@@ -105,34 +105,62 @@ namespace Cake.Common.Tests.Unit.Tools.InnoSetup
                 Assert.Equal("/Working/tools/iscc.exe", result.Path.FullPath);
             }
 
-            [WindowsFact]
-            public void Should_Find_InnoSetup_Runner_In_Installation_Path_If_Tool_Path_Not_Provided_x86()
+            [WindowsTheory]
+            [InlineData(true, InnoSetupVersion.InnoSetup5)]
+            [InlineData(true, InnoSetupVersion.InnoSetup6)]
+            [InlineData(false, InnoSetupVersion.InnoSetup5)]
+            [InlineData(false, InnoSetupVersion.InnoSetup6)]
+            public void Should_Find_InnoSetup_Runner_In_Installation_Path_If_Tool_Path_Not_Provided(bool is64Bit, InnoSetupVersion version)
             {
                 // Given
                 var fixture = new InnoSetupFixture();
                 fixture.GivenDefaultToolDoNotExist();
-                fixture.GivenToolIsInstalledX86();
+                fixture.GivenToolIsInstalled(is64Bit, version);
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal(fixture.InstalledToolPath.FullPath, result.Path.FullPath);
+                Assert.Equal(fixture.InstalledToolPaths[version].FullPath, result.Path.FullPath);
             }
 
-            [WindowsFact]
-            public void Should_Find_InnoSetup_Runner_In_Installation_Path_If_Tool_Path_Not_Provided_x64()
+            [WindowsTheory]
+            [InlineData(true)]
+            [InlineData(false)]
+            public void Should_Use_Newest_InnoSetup_Version_If_Version_And_Tool_Path_Are_Not_Provided(bool is64Bit)
             {
                 // Given
                 var fixture = new InnoSetupFixture();
                 fixture.GivenDefaultToolDoNotExist();
-                fixture.GivenToolIsInstalledX64();
+                fixture.GivenToolIsInstalled(is64Bit, InnoSetupVersion.InnoSetup5);
+                fixture.GivenToolIsInstalled(is64Bit, InnoSetupVersion.InnoSetup6);
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal(fixture.InstalledToolPath.FullPath, result.Path.FullPath);
+                Assert.Equal(fixture.InstalledToolPaths[InnoSetupVersion.InnoSetup6].FullPath, result.Path.FullPath);
+            }
+
+            [WindowsTheory]
+            [InlineData(true, InnoSetupVersion.InnoSetup5)]
+            [InlineData(true, InnoSetupVersion.InnoSetup6)]
+            [InlineData(false, InnoSetupVersion.InnoSetup5)]
+            [InlineData(false, InnoSetupVersion.InnoSetup6)]
+            public void Should_Use_Provided_InnoSetup_Version_When_Tool_Path_Is_Not_Provided(bool is64Bit, InnoSetupVersion version)
+            {
+                // Given
+                var fixture = new InnoSetupFixture();
+                fixture.GivenDefaultToolDoNotExist();
+                fixture.GivenToolIsInstalled(is64Bit, InnoSetupVersion.InnoSetup5);
+                fixture.GivenToolIsInstalled(is64Bit, InnoSetupVersion.InnoSetup6);
+                fixture.Settings.Version = version;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(fixture.InstalledToolPaths[version].FullPath, result.Path.FullPath);
             }
 
             [Fact]

--- a/src/Cake.Common/Tools/InnoSetup/InnoSetupSettings.cs
+++ b/src/Cake.Common/Tools/InnoSetup/InnoSetupSettings.cs
@@ -42,6 +42,11 @@ namespace Cake.Common.Tools.InnoSetup
         public InnoSetupQuietMode QuietMode { get; set; }
 
         /// <summary>
+        /// Gets or sets the version of Inno Setup to be used with this command. By default the highest installed version of Inno Setup is used.
+        /// </summary>
+        public InnoSetupVersion? Version { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="InnoSetupSettings"/> class with the default settings.
         /// </summary>
         public InnoSetupSettings()

--- a/src/Cake.Common/Tools/InnoSetup/InnoSetupVersion.cs
+++ b/src/Cake.Common/Tools/InnoSetup/InnoSetupVersion.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Tools.InnoSetup
+{
+    /// <summary>
+    /// Represents the supported major versions of Inno Setup.
+    /// </summary>
+    public enum InnoSetupVersion
+    {
+        /// <summary>Version 5.x</summary>
+        InnoSetup5 = 5,
+
+        /// <summary>Version 6.x</summary>
+        InnoSetup6 = 6
+    }
+}


### PR DESCRIPTION
This PR adds support for the new Inno Setup 6. By default the newest available version is used, the version to use can also be set by using the Version property on the settings class.