### PR TITLE
GH-2578: Support version ranges for referenced nuget packages

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -664,7 +664,7 @@ Task("Run-Integration-Tests")
             },
             Arguments = {
                 ["target"] = Argument("integration-tests-target", "Run-All-Tests"),
-                ["verbosity"] = "quiet",
+                ["verbosity"] = "diagnostic",
                 ["platform"] = parameters.IsRunningOnWindows ? "windows" : "posix",
                 ["customarg"] = "hello"
             }

--- a/src/Cake.NuGet/Install/NuGetPackageInstaller.cs
+++ b/src/Cake.NuGet/Install/NuGetPackageInstaller.cs
@@ -278,10 +278,14 @@ namespace Cake.NuGet.Install
                     {
                         foundVersion = foundVersions.FirstOrDefault();
                     }
+                    if (foundVersion == null)
+                    {
+                        continue;
+                    }
 
                     // Find the highest possible version
                     version = version ?? foundVersion;
-                    if (foundVersion != null && foundVersion > version)
+                    if (foundVersion > version)
                     {
                         version = foundVersion;
                     }

--- a/tests/integration/Cake.Nuget/NugetPackageInstaller.cake
+++ b/tests/integration/Cake.Nuget/NugetPackageInstaller.cake
@@ -12,7 +12,10 @@ Task("Cake.Nuget.Install.NugetPackageInstaller.VersionPinFull")
             throw new Exception(""VersionPinFull failed"");
     ";
 
-    CakeExecuteExpression(script);
+    CakeExecuteExpression(script,
+        new CakeSettings {
+            Verbosity = Context.Log.Verbosity
+        });
 });
 
 Task("Cake.Nuget.Install.NugetPackageInstaller.VersionPinRange.InclusiveExclusive")
@@ -31,7 +34,10 @@ Task("Cake.Nuget.Install.NugetPackageInstaller.VersionPinRange.InclusiveExclusiv
             throw new Exception(""VersionPinRange.InclusiveExclusive failed"");
     ";
 
-    CakeExecuteExpression(script);
+    CakeExecuteExpression(script,
+        new CakeSettings {
+            Verbosity = Context.Log.Verbosity
+        });
 });
 
 Task("Cake.Nuget.Install.NugetPackageInstaller.VersionPinRange.InclusiveInclusive")
@@ -50,7 +56,10 @@ Task("Cake.Nuget.Install.NugetPackageInstaller.VersionPinRange.InclusiveInclusiv
             throw new Exception(""VersionPinRange.InclusiveInclusive failed"");
     ";
 
-    CakeExecuteExpression(script);
+    CakeExecuteExpression(script,
+        new CakeSettings {
+            Verbosity = Context.Log.Verbosity
+        });
 });
 
 Task("Cake.Nuget.Install.NugetPackageInstaller.VersionPinRange.Wildcard")
@@ -69,7 +78,10 @@ Task("Cake.Nuget.Install.NugetPackageInstaller.VersionPinRange.Wildcard")
             throw new Exception(""VersionPinRange.Wildcard failed"");
     ";
 
-    CakeExecuteExpression(script);
+    CakeExecuteExpression(script,
+        new CakeSettings {
+            Verbosity = Context.Log.Verbosity
+        });
 });
 
 //////////////////////////////////////////////////////////////////////////////

--- a/tests/integration/Cake.Nuget/NugetPackageInstaller.cake
+++ b/tests/integration/Cake.Nuget/NugetPackageInstaller.cake
@@ -1,0 +1,81 @@
+Task("Cake.Nuget.Install.NugetPackageInstaller.VersionPinFull")
+    .Does(()=>
+{
+    var script = $@"#addin nuget:?package=Serilog&version=2.7.1
+        
+        string fileVersion = System.Diagnostics.FileVersionInfo.GetVersionInfo(typeof(Serilog.LoggerConfiguration).Assembly.Location).FileVersion; 
+
+        Information(""Requested nuget version: 2.7.1"");
+        Information(""Loaded nuget version: "" + fileVersion);
+        
+        if(!string.Equals(fileVersion, ""2.7.1.0""))
+            throw new Exception(""VersionPinFull failed"");
+    ";
+
+    CakeExecuteExpression(script);
+});
+
+Task("Cake.Nuget.Install.NugetPackageInstaller.VersionPinRange.InclusiveExclusive")
+    .Does(()=>
+{
+    var script = $@"#addin nuget:?package=Serilog&version=[2.5.0,2.6.0)
+        
+        string fileVersion = System.Diagnostics.FileVersionInfo.GetVersionInfo(typeof(Serilog.LoggerConfiguration).Assembly.Location).FileVersion; 
+
+        Information(""Requested nuget version: [2.5.0,2.6.0)"");
+        Information(""Loaded nuget version: "" + fileVersion);
+        
+        var parsedVersion = Version.Parse(fileVersion);
+
+        if(parsedVersion < new Version(2, 5, 0) || parsedVersion >= new Version(2, 6, 0))
+            throw new Exception(""VersionPinRange.InclusiveExclusive failed"");
+    ";
+
+    CakeExecuteExpression(script);
+});
+
+Task("Cake.Nuget.Install.NugetPackageInstaller.VersionPinRange.InclusiveInclusive")
+    .Does(()=>
+{
+    var script = $@"#addin nuget:?package=Serilog&version=[2.3.0,2.4.0]
+        
+        string fileVersion = System.Diagnostics.FileVersionInfo.GetVersionInfo(typeof(Serilog.LoggerConfiguration).Assembly.Location).FileVersion; 
+
+        Information(""Requested nuget version: [2.3.0,2.4.0]"");
+        Information(""Loaded nuget version: "" + fileVersion);
+        
+        var parsedVersion = Version.Parse(fileVersion);
+
+        if(parsedVersion < new Version(2, 3, 0) || parsedVersion > new Version(2, 4, 0))
+            throw new Exception(""VersionPinRange.InclusiveInclusive failed"");
+    ";
+
+    CakeExecuteExpression(script);
+});
+
+Task("Cake.Nuget.Install.NugetPackageInstaller.VersionPinRange.Wildcard")
+    .Does(()=>
+{
+    var script = $@"#addin nuget:?package=Serilog&version=[2.2.*,2.3.0)
+        
+        string fileVersion = System.Diagnostics.FileVersionInfo.GetVersionInfo(typeof(Serilog.LoggerConfiguration).Assembly.Location).FileVersion; 
+
+        Information(""Requested nuget version: [2.2.*,2.3.0)"");
+        Information(""Loaded nuget version: "" + fileVersion);
+        
+        var parsedVersion = Version.Parse(fileVersion);
+
+        if(parsedVersion < new Version(2, 2, 0) || parsedVersion >= new Version(2, 3, 0))
+            throw new Exception(""VersionPinRange.Wildcard failed"");
+    ";
+
+    CakeExecuteExpression(script);
+});
+
+//////////////////////////////////////////////////////////////////////////////
+
+Task("Cake.Nuget.NugetPackageInstaller")
+    .IsDependentOn("Cake.Nuget.Install.NugetPackageInstaller.VersionPinFull")
+    .IsDependentOn("Cake.Nuget.Install.NugetPackageInstaller.VersionPinRange.InclusiveExclusive")
+    .IsDependentOn("Cake.Nuget.Install.NugetPackageInstaller.VersionPinRange.InclusiveInclusive")
+    .IsDependentOn("Cake.Nuget.Install.NugetPackageInstaller.VersionPinRange.Wildcard");

--- a/tests/integration/build.cake
+++ b/tests/integration/build.cake
@@ -35,6 +35,7 @@
 #load "./Cake.Core/Scripting/UsingDirective.cake"
 #load "./Cake.Core/Tooling/ToolLocator.cake"
 #load "./Cake.Core/CakeAliases.cake"
+#load "./Cake.Nuget/NugetPackageInstaller.cake"
 
 //////////////////////////////////////////////////
 // ARGUMENTS
@@ -79,10 +80,14 @@ Task("Cake.Common")
     .IsDependentOn("Cake.Common.Tools.NuGet.NuGetAliases")
     .IsDependentOn("Cake.Common.Tools.TextTransform.TextTransformAliases");
 
+Task("Cake.Nuget")
+    .IsDependentOn("Cake.Nuget.NugetPackageInstaller");
+
 Task("Run-All-Tests")
     .IsDependentOn("Setup-Tests")
     .IsDependentOn("Cake.Core")
-    .IsDependentOn("Cake.Common");
+    .IsDependentOn("Cake.Common")
+    .IsDependentOn("Cake.Nuget");
 
 //////////////////////////////////////////////////
 


### PR DESCRIPTION
Extended the version pinning support of the nuget package installer to also support version ranges.

Would support formats like the following to indicate you want to stay on major version 1 but ok to get minor/fix updates.
#addin nuget:?package=Cake.Foo&version=[1.0.0,2.0.0)

Our usecase is for a set of shared buildscripts which will be used across several projects. We'd like to version pin on major changes but still allow bugfixes to go through without having to change all the projects. This isn't currently possible.

Note: this code isn't really covered by any unit test - I'm also not really sure on how to add one to specifically test this.

