### PR TITLE
GH2575: Fix dynamic C# issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ mono:
   - 5.12.0
   - 5.20.1
 
-dotnet: 2.1.603
+dotnet: 2.1.701
 
 before_install:
   - git fetch --unshallow # Travis always does a shallow clone, but GitVersion needs the full history including branches and tags

--- a/build.cake
+++ b/build.cake
@@ -633,9 +633,12 @@ Task("Create-Release-Notes")
 });
 
 Task("Prepare-Integration-Tests")
-    .IsDependentOn("Validate-Version")
+    .IsDependentOn("Create-NuGet-Packages")
     .Does(() =>
 {
+   Unzip(parameters.Paths.Directories.NuGetRoot.CombineWithFilePath($"Cake.Tool.{parameters.Version.SemVersion}.nupkg"),
+        parameters.Paths.Directories.IntegrationTestsBinTool);
+
    CopyDirectory(parameters.Paths.Directories.ArtifactsBinFullFx, parameters.Paths.Directories.IntegrationTestsBinFullFx);
    CopyDirectory(parameters.Paths.Directories.ArtifactsBinNetCore, parameters.Paths.Directories.IntegrationTestsBinNetCore);
 });
@@ -645,6 +648,7 @@ Task("Run-Integration-Tests")
     .DeferOnError()
     .DoesForEach(
         ()=> new[] {
+            GetFiles($"{parameters.Paths.Directories.IntegrationTestsBinTool.FullPath}/**/Cake.dll").Single(),
             parameters.Paths.Directories.IntegrationTestsBinFullFx.CombineWithFilePath("Cake.exe"),
             parameters.Paths.Directories.IntegrationTestsBinNetCore.CombineWithFilePath("Cake.dll")
         },

--- a/build/paths.cake
+++ b/build/paths.cake
@@ -37,6 +37,7 @@ public class BuildPaths
         var integrationTestsBin = context.MakeAbsolute(context.Directory("./tests/integration/tools"));
         var integrationTestsBinFullFx = integrationTestsBin.Combine("Cake");
         var integrationTestsBinNetCore = integrationTestsBin.Combine("Cake.CoreCLR");
+        var integrationTestsBinTool = integrationTestsBin.Combine("Cake.Tool");
 
         // Directories
         var buildDirectories = new BuildDirectories(
@@ -47,7 +48,8 @@ public class BuildPaths
             artifactsBinFullFx,
             artifactsBinNetCore,
             integrationTestsBinFullFx,
-            integrationTestsBinNetCore);
+            integrationTestsBinNetCore,
+            integrationTestsBinTool);
 
         // Files
         var buildFiles = new BuildFiles(
@@ -93,6 +95,7 @@ public class BuildDirectories
     public DirectoryPath ArtifactsBinNetCore { get; }
     public DirectoryPath IntegrationTestsBinFullFx { get; }
     public DirectoryPath IntegrationTestsBinNetCore { get; }
+    public DirectoryPath IntegrationTestsBinTool { get; }
     public ICollection<DirectoryPath> ToClean { get; }
 
     public BuildDirectories(
@@ -103,7 +106,8 @@ public class BuildDirectories
         DirectoryPath artifactsBinFullFx,
         DirectoryPath artifactsBinNetCore,
         DirectoryPath integrationTestsBinFullFx,
-        DirectoryPath integrationTestsBinNetCore
+        DirectoryPath integrationTestsBinNetCore,
+        DirectoryPath integrationTestsBinTool
         )
     {
         Artifacts = artifactsDir;
@@ -114,6 +118,7 @@ public class BuildDirectories
         ArtifactsBinNetCore = artifactsBinNetCore;
         IntegrationTestsBinFullFx = integrationTestsBinFullFx;
         IntegrationTestsBinNetCore = integrationTestsBinNetCore;
+        IntegrationTestsBinTool = integrationTestsBinTool;
         ToClean = new[] {
             Artifacts,
             TestResults,
@@ -122,7 +127,8 @@ public class BuildDirectories
             ArtifactsBinFullFx,
             ArtifactsBinNetCore,
             IntegrationTestsBinFullFx,
-            IntegrationTestsBinNetCore
+            IntegrationTestsBinNetCore,
+            IntegrationTestsBinTool
         };
     }
 }

--- a/src/Cake.Core/Cake.Core.csproj
+++ b/src/Cake.Core/Cake.Core.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>
   <!-- .NET Framework packages -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/src/Cake.Core/Scripting/ScriptConventions.cs
+++ b/src/Cake.Core/Scripting/ScriptConventions.cs
@@ -62,6 +62,7 @@ namespace Cake.Core.Scripting
             var result = new HashSet<Assembly>(new SimpleAssemblyComparer());
             result.Add(typeof(Action).GetTypeInfo().Assembly); // mscorlib or System.Private.Core
             result.Add(typeof(IQueryable).GetTypeInfo().Assembly); // System.Core or System.Linq.Expressions
+            result.Add(typeof(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo).Assembly); // Dynamic support
 
             // Load other Cake-related assemblies that we need.
             var cakeAssemblies = LoadCakeAssemblies(root);

--- a/src/Cake/Cake.csproj
+++ b/src/Cake/Cake.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
   <!-- Global packages -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.1.0" />
     <PackageReference Include="Autofac" Version="4.6.2" />
   </ItemGroup>
 </Project>

--- a/tests/integration/Cake.Core/Scripting/Dynamic.cake
+++ b/tests/integration/Cake.Core/Scripting/Dynamic.cake
@@ -1,0 +1,10 @@
+using System.Dynamic;
+
+Task("Cake.Core.Scripting.Dynamic")
+    .Does(() =>
+{
+    dynamic result = new ExpandoObject();
+    result.Result = true;
+
+    Assert.True(result.Result);
+});

--- a/tests/integration/build.cake
+++ b/tests/integration/build.cake
@@ -28,6 +28,7 @@
 #load "./Cake.Common/Tools/TextTransform/TextTransformAliases.cake"
 #load "./Cake.Core/Scripting/AddinDirective.cake"
 #load "./Cake.Core/Scripting/DefineDirective.cake"
+#load "./Cake.Core/Scripting/Dynamic.cake"
 #load "./Cake.Core/Scripting/HttpClient.cake"
 #load "./Cake.Core/Scripting/LoadDirective.cake"
 #load "./Cake.Core/Scripting/SystemCollections.cake"
@@ -48,6 +49,7 @@ var target = Argument<string>("target", "Run-All-Tests");
 Task("Cake.Core")
     .IsDependentOn("Cake.Core.Scripting.AddinDirective")
     .IsDependentOn("Cake.Core.Scripting.DefineDirective")
+    .IsDependentOn("Cake.Core.Scripting.Dynamic")
     .IsDependentOn("Cake.Core.Scripting.HttpClient")
     .IsDependentOn("Cake.Core.Scripting.LoadDirective")
     .IsDependentOn("Cake.Core.Scripting.SystemCollections")


### PR DESCRIPTION
* fixes use of dynamic with newer versions of Microsoft.CodeAnalysis.CSharp.Scripting
* updates Microsoft.CodeAnalysis.CSharp.Scripting  to 3.1.0
* adds Cake.Tool to Integration tests
* fixes #2575
