### PR TITLE
GH2524: Added support for XSL arguments in XmlTransform

### DIFF
--- a/src/Cake.Common.Tests/Properties/Resources.Designer.cs
+++ b/src/Cake.Common.Tests/Properties/Resources.Designer.cs
@@ -973,5 +973,44 @@ namespace Cake.Common.Tests.Properties {
                 return ResourceManager.GetString("XmlTransformation_Xsl", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
+        ///&lt;xsl:stylesheet xmlns:xsl=&quot;http://www.w3.org/1999/XSL/Transform&quot; version=&quot;1.0&quot;&gt;
+        ///&lt;xsl:output method=&quot;html&quot; encoding=&quot;utf-8&quot;/&gt;
+        ///&lt;xsl:param name=&quot;BackgroundColor&quot;&gt;&lt;/xsl:param&gt;
+        ///&lt;xsl:param name=&quot;Color&quot;&gt;&lt;/xsl:param&gt;
+        ///
+        ///&lt;xsl:template match=&quot;/&quot;&gt;
+        ///&lt;html&gt;
+        ///    &lt;body style=&quot;font-family:Arial;font-size:12pt;background-color:#EEEEEE&quot;&gt;
+        ///        &lt;xsl:for-each select=&quot;breakfast_menu/food&quot;&gt;
+        ///            &lt;div style=&quot;background-color:{$BackgroundColor};color:{$Color};padding:4px&quot;&gt;
+        ///   [rest of string was truncated]&quot;;.
+        /// </summary>
+        public static string XmlTransformationWithArguments_Xsl {
+            get {
+                return ResourceManager.GetString("XmlTransformationWithArguments_Xsl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
+        ///&lt;xsl:stylesheet xmlns:xsl=&quot;http://www.w3.org/1999/XSL/Transform&quot; xmlns:input=&quot;http://example.com&quot; exclude-result-prefixes=&quot;input&quot; version=&quot;1.0&quot;&gt;
+        ///&lt;xsl:output method=&quot;html&quot; encoding=&quot;utf-8&quot;/&gt;
+        ///&lt;xsl:param name=&quot;input:BackgroundColor&quot;&gt;&lt;/xsl:param&gt;
+        ///&lt;xsl:param name=&quot;input:Color&quot;&gt;&lt;/xsl:param&gt;
+        ///
+        ///&lt;xsl:template match=&quot;/&quot;&gt;
+        ///&lt;html&gt;
+        ///    &lt;body style=&quot;font-family:Arial;font-size:12pt;background-color:#EEEEEE&quot;&gt;
+        ///        &lt;xsl:for-each select=&quot;breakfast_menu/food&quot;&gt;
+        ///            &lt;di [rest of string was truncated]&quot;;.
+        /// </summary>
+        public static string XmlTransformationWithArgumentsAndNamespace_Xsl {
+            get {
+                return ResourceManager.GetString("XmlTransformationWithArgumentsAndNamespace_Xsl", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Cake.Common.Tests/Properties/Resources.resx
+++ b/src/Cake.Common.Tests/Properties/Resources.resx
@@ -1433,4 +1433,72 @@ Global
 	EndGlobalSection
 EndGlobal</value>
   </data>
+  <data name="XmlTransformationWithArguments_Xsl" xml:space="preserve">
+    <value>&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"&gt;
+&lt;xsl:output method="html" encoding="utf-8"/&gt;
+&lt;xsl:param name="BackgroundColor"&gt;&lt;/xsl:param&gt;
+&lt;xsl:param name="Color"&gt;&lt;/xsl:param&gt;
+
+&lt;xsl:template match="/"&gt;
+&lt;html&gt;
+    &lt;body style="font-family:Arial;font-size:12pt;background-color:#EEEEEE"&gt;
+        &lt;xsl:for-each select="breakfast_menu/food"&gt;
+            &lt;div style="background-color:{$BackgroundColor};color:{$Color};padding:4px"&gt;
+                &lt;span style="font-weight:bold"&gt;
+                    &lt;xsl:value-of select="name" /&gt;
+                    -
+                &lt;/span&gt;
+                &lt;xsl:value-of select="price" /&gt;
+            &lt;/div&gt;
+            &lt;div style="margin-left:20px;margin-bottom:1em;font-size:10pt"&gt;
+                &lt;p&gt;
+                    &lt;xsl:value-of select="description" /&gt;
+                    &lt;span style="font-style:italic"&gt;
+                        (
+                        &lt;xsl:value-of select="calories" /&gt;
+                        calories per serving)
+                    &lt;/span&gt;
+                &lt;/p&gt;
+            &lt;/div&gt;
+        &lt;/xsl:for-each&gt;
+    &lt;/body&gt;
+&lt;/html&gt;
+&lt;/xsl:template&gt;
+&lt;/xsl:stylesheet&gt;</value>
+  </data>
+  <data name="XmlTransformationWithArgumentsAndNamespace_Xsl" xml:space="preserve">
+    <value>&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:input="http://example.com" exclude-result-prefixes="input" version="1.0"&gt;
+&lt;xsl:output method="html" encoding="utf-8"/&gt;
+&lt;xsl:param name="input:BackgroundColor"&gt;&lt;/xsl:param&gt;
+&lt;xsl:param name="input:Color"&gt;&lt;/xsl:param&gt;
+
+&lt;xsl:template match="/"&gt;
+&lt;html&gt;
+    &lt;body style="font-family:Arial;font-size:12pt;background-color:#EEEEEE"&gt;
+        &lt;xsl:for-each select="breakfast_menu/food"&gt;
+            &lt;div style="background-color:{$input:BackgroundColor};color:{$input:Color};padding:4px"&gt;
+                &lt;span style="font-weight:bold"&gt;
+                    &lt;xsl:value-of select="name" /&gt;
+                    -
+                &lt;/span&gt;
+                &lt;xsl:value-of select="price" /&gt;
+            &lt;/div&gt;
+            &lt;div style="margin-left:20px;margin-bottom:1em;font-size:10pt"&gt;
+                &lt;p&gt;
+                    &lt;xsl:value-of select="description" /&gt;
+                    &lt;span style="font-style:italic"&gt;
+                        (
+                        &lt;xsl:value-of select="calories" /&gt;
+                        calories per serving)
+                    &lt;/span&gt;
+                &lt;/p&gt;
+            &lt;/div&gt;
+        &lt;/xsl:for-each&gt;
+    &lt;/body&gt;
+&lt;/html&gt;
+&lt;/xsl:template&gt;
+&lt;/xsl:stylesheet&gt;</value>
+  </data>
 </root>

--- a/src/Cake.Common.Tests/Unit/XML/XmlTransformationTests.cs
+++ b/src/Cake.Common.Tests/Unit/XML/XmlTransformationTests.cs
@@ -5,6 +5,7 @@
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Xml.Xsl;
 using Cake.Common.Tests.Fixtures;
 using Cake.Common.Tests.Properties;
 using Cake.Common.Xml;
@@ -220,6 +221,56 @@ namespace Cake.Common.Tests.Unit.XML
 
                 // Then
                 AssertEx.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_XslArguments_Was_Null()
+            {
+                // Given
+                var xml = Resources.XmlTransformation_Xml;
+                var xsl = Resources.XmlTransformation_Xsl;
+
+                // When
+                var result = Record.Exception(() => XmlTransformation.Transform(xsl, null, xml));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "arguments");
+            }
+
+            [Fact]
+            public void Should_Transform_Xml_String_And_Xsl_String_WithArguments_To_Result_String()
+            {
+                // Given
+                var xml = Resources.XmlTransformation_Xml;
+                var xsl = Resources.XmlTransformationWithArguments_Xsl;
+                var htm = Resources.XmlTransformation_Htm_NoXmlDeclaration;
+                var arguments = new XsltArgumentList();
+                arguments.AddParam("BackgroundColor", string.Empty, "teal");
+                arguments.AddParam("Color", string.Empty, "white");
+
+                // When
+                var result = XmlTransformation.Transform(xsl, arguments, xml);
+
+                // Then
+                Assert.Equal(htm, result, ignoreLineEndingDifferences: true);
+            }
+
+            [Fact]
+            public void Should_Transform_Xml_String_And_Xsl_String_WithArgumentsAndNamespace_To_Result_String()
+            {
+                // Given
+                var xml = Resources.XmlTransformation_Xml;
+                var xsl = Resources.XmlTransformationWithArgumentsAndNamespace_Xsl;
+                var htm = Resources.XmlTransformation_Htm_NoXmlDeclaration;
+                var arguments = new XsltArgumentList();
+                arguments.AddParam("BackgroundColor", "http://example.com", "teal");
+                arguments.AddParam("Color", "http://example.com", "white");
+
+                // When
+                var result = XmlTransformation.Transform(xsl, arguments, xml);
+
+                // Then
+                Assert.Equal(htm, result, ignoreLineEndingDifferences: true);
             }
         }
     }

--- a/src/Cake.Common.Tests/Unit/XML/XmlTransformationTests.cs
+++ b/src/Cake.Common.Tests/Unit/XML/XmlTransformationTests.cs
@@ -89,7 +89,7 @@ namespace Cake.Common.Tests.Unit.XML
                 var result = Record.Exception(() => fixture.Transform());
 
                 // Then
-                AssertEx.IsExceptionWithMessage<FileNotFoundException>(result, "XML File not found.");
+                AssertEx.IsExceptionWithMessage<FileNotFoundException>(result, "XML file not found.");
             }
 
             [Fact]
@@ -105,7 +105,7 @@ namespace Cake.Common.Tests.Unit.XML
                 var result = Record.Exception(() => fixture.Transform());
 
                 // Then
-                AssertEx.IsExceptionWithMessage<FileNotFoundException>(result, "Xsl File not found.");
+                AssertEx.IsExceptionWithMessage<FileNotFoundException>(result, "XSL file not found.");
             }
 
             [Fact]
@@ -210,7 +210,7 @@ namespace Cake.Common.Tests.Unit.XML
             }
 
             [Fact]
-            public void Should_Throw_If_String_Settings_Was_Null()
+            public void Should_Throw_If_Xml_Transformation_Settings_Was_Null()
             {
                 // Given
                 var xml = Resources.XmlTransformation_Xml;
@@ -224,17 +224,21 @@ namespace Cake.Common.Tests.Unit.XML
             }
 
             [Fact]
-            public void Should_Throw_If_XslArguments_Was_Null()
+            public void Should_Not_Throw_If_Xsl_Argument_List_Was_Null()
             {
                 // Given
                 var xml = Resources.XmlTransformation_Xml;
                 var xsl = Resources.XmlTransformation_Xsl;
+                XmlTransformationSettings xmlTransformationSettings = new XmlTransformationSettings
+                {
+                    XsltArgumentList = null
+                };
 
                 // When
-                var result = Record.Exception(() => XmlTransformation.Transform(xsl, null, xml));
+                var result = Record.Exception(() => XmlTransformation.Transform(xsl, xml, xmlTransformationSettings));
 
                 // Then
-                AssertEx.IsArgumentNullException(result, "arguments");
+                Assert.Null(result);
             }
 
             [Fact]
@@ -244,12 +248,17 @@ namespace Cake.Common.Tests.Unit.XML
                 var xml = Resources.XmlTransformation_Xml;
                 var xsl = Resources.XmlTransformationWithArguments_Xsl;
                 var htm = Resources.XmlTransformation_Htm_NoXmlDeclaration;
-                var arguments = new XsltArgumentList();
-                arguments.AddParam("BackgroundColor", string.Empty, "teal");
-                arguments.AddParam("Color", string.Empty, "white");
+                XmlTransformationSettings xmlTransformationSettings = new XmlTransformationSettings
+                {
+                    OmitXmlDeclaration = true,
+                    Encoding = new UTF8Encoding(false),
+                    XsltArgumentList = new XsltArgumentList()
+                };
+                xmlTransformationSettings.XsltArgumentList.AddParam("BackgroundColor", string.Empty, "teal");
+                xmlTransformationSettings.XsltArgumentList.AddParam("Color", string.Empty, "white");
 
                 // When
-                var result = XmlTransformation.Transform(xsl, arguments, xml);
+                var result = XmlTransformation.Transform(xsl, xml, xmlTransformationSettings);
 
                 // Then
                 Assert.Equal(htm, result, ignoreLineEndingDifferences: true);
@@ -262,12 +271,17 @@ namespace Cake.Common.Tests.Unit.XML
                 var xml = Resources.XmlTransformation_Xml;
                 var xsl = Resources.XmlTransformationWithArgumentsAndNamespace_Xsl;
                 var htm = Resources.XmlTransformation_Htm_NoXmlDeclaration;
-                var arguments = new XsltArgumentList();
-                arguments.AddParam("BackgroundColor", "http://example.com", "teal");
-                arguments.AddParam("Color", "http://example.com", "white");
+                XmlTransformationSettings xmlTransformationSettings = new XmlTransformationSettings
+                {
+                    OmitXmlDeclaration = true,
+                    Encoding = new UTF8Encoding(false),
+                    XsltArgumentList = new XsltArgumentList()
+                };
+                xmlTransformationSettings.XsltArgumentList.AddParam("BackgroundColor", "http://example.com", "teal");
+                xmlTransformationSettings.XsltArgumentList.AddParam("Color", "http://example.com", "white");
 
                 // When
-                var result = XmlTransformation.Transform(xsl, arguments, xml);
+                var result = XmlTransformation.Transform(xsl, xml, xmlTransformationSettings);
 
                 // Then
                 Assert.Equal(htm, result, ignoreLineEndingDifferences: true);

--- a/src/Cake.Common/Polyfill/XmlTransformationHelper.cs
+++ b/src/Cake.Common/Polyfill/XmlTransformationHelper.cs
@@ -9,11 +9,11 @@ namespace Cake.Common.Polyfill
 {
     internal static class XmlTransformationHelper
     {
-        public static void Transform(XmlReader xsl, XmlReader xml, XmlWriter result)
+        public static void Transform(XmlReader xsl, XsltArgumentList arguments, XmlReader xml, XmlWriter result)
         {
             var xslTransform = new XslCompiledTransform();
             xslTransform.Load(xsl);
-            xslTransform.Transform(xml, result);
+            xslTransform.Transform(xml, arguments, result);
         }
     }
 }

--- a/src/Cake.Common/Xml/XmlTransformation.cs
+++ b/src/Cake.Common/Xml/XmlTransformation.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Text;
 using System.Xml;
+using System.Xml.Xsl;
 using Cake.Common.Polyfill;
 using Cake.Core;
 using Cake.Core.IO;
@@ -31,7 +32,8 @@ namespace Cake.Common.Xml
                 Encoding = new UTF8Encoding(false)
             };
 
-            return Transform(xsl, xml, settings);
+            var arguments = new XsltArgumentList();
+            return Transform(xsl, arguments, xml, settings);
         }
 
         /// <summary>
@@ -43,9 +45,46 @@ namespace Cake.Common.Xml
         /// <returns>Transformed XML string.</returns>
         public static string Transform(string xsl, string xml, XmlTransformationSettings settings)
         {
+            var arguments = new XsltArgumentList();
+            return Transform(xsl, arguments, xml, settings);
+        }
+
+        /// <summary>
+        /// Performs XML XSL transformation.
+        /// </summary>
+        /// <param name="xsl">XML style sheet.</param>
+        /// <param name="arguments">XSLT argument list.</param>
+        /// <param name="xml">XML data.</param>
+        /// <returns>Transformed XML string.</returns>
+        public static string Transform(string xsl, XsltArgumentList arguments, string xml)
+        {
+            var settings = new XmlTransformationSettings
+            {
+                OmitXmlDeclaration = true,
+                Encoding = new UTF8Encoding(false)
+            };
+
+            return Transform(xsl, arguments, xml, settings);
+        }
+
+        /// <summary>
+        /// Performs XML XSL transformation.
+        /// </summary>
+        /// <param name="xsl">XML style sheet.</param>
+        /// <param name="arguments">XSLT argument list.</param>
+        /// <param name="xml">XML data.</param>
+        /// <param name="settings">Settings for result file xml transformation.</param>
+        /// <returns>Transformed XML string.</returns>
+        public static string Transform(string xsl, XsltArgumentList arguments, string xml, XmlTransformationSettings settings)
+        {
             if (string.IsNullOrWhiteSpace(xsl))
             {
                 throw new ArgumentNullException(nameof(xsl), "Null or empty XML style sheet supplied.");
+            }
+
+            if (arguments == null)
+            {
+                throw new ArgumentNullException(nameof(arguments), "Null XSLT argument list supplied.");
             }
 
             if (string.IsNullOrWhiteSpace(xml))
@@ -64,7 +103,7 @@ namespace Cake.Common.Xml
             {
                 using (var result = new MemoryStream())
                 {
-                    Transform(xslReader, xmlReader, result, settings.XmlWriterSettings);
+                    Transform(xslReader, arguments, xmlReader, result, settings.XmlWriterSettings);
                     result.Position = 0;
                     return settings.Encoding.GetString(result.ToArray());
                 }
@@ -81,7 +120,8 @@ namespace Cake.Common.Xml
         public static void Transform(IFileSystem fileSystem, FilePath xslPath, FilePath xmlPath, FilePath resultPath)
         {
             var settings = new XmlTransformationSettings();
-            Transform(fileSystem, xslPath, xmlPath, resultPath, settings);
+            var arguments = new XsltArgumentList();
+            Transform(fileSystem, xslPath, arguments, xmlPath, resultPath, settings);
         }
 
         /// <summary>
@@ -94,6 +134,35 @@ namespace Cake.Common.Xml
         /// <param name="settings">Settings for result file xml transformation.</param>
         public static void Transform(IFileSystem fileSystem, FilePath xslPath, FilePath xmlPath, FilePath resultPath, XmlTransformationSettings settings)
         {
+            var arguments = new XsltArgumentList();
+            Transform(fileSystem, xslPath, arguments, xmlPath, resultPath, settings);
+        }
+
+        /// <summary>
+        /// Performs XML XSL transformation.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="xslPath">Path to xml style sheet.</param>
+        /// <param name="arguments">XSLT argument list.</param>
+        /// <param name="xmlPath">Path xml data.</param>
+        /// <param name="resultPath">Transformation result path.</param>
+        public static void Transform(IFileSystem fileSystem, FilePath xslPath, XsltArgumentList arguments, FilePath xmlPath, FilePath resultPath)
+        {
+            var settings = new XmlTransformationSettings();
+            Transform(fileSystem, xslPath, arguments, xmlPath, resultPath, settings);
+        }
+
+        /// <summary>
+        /// Performs XML XSL transformation.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="xslPath">Path to xml style sheet.</param>
+        /// <param name="arguments">XSLT argument list.</param>
+        /// <param name="xmlPath">Path xml data.</param>
+        /// <param name="resultPath">Transformation result path.</param>
+        /// <param name="settings">Settings for result file xml transformation.</param>
+        public static void Transform(IFileSystem fileSystem, FilePath xslPath, XsltArgumentList arguments, FilePath xmlPath, FilePath resultPath, XmlTransformationSettings settings)
+        {
             if (fileSystem == null)
             {
                 throw new ArgumentNullException(nameof(fileSystem), "Null filesystem supplied.");
@@ -102,6 +171,11 @@ namespace Cake.Common.Xml
             if (xslPath == null)
             {
                 throw new ArgumentNullException(nameof(xslPath), "Null XML style sheet path supplied.");
+            }
+
+            if (arguments == null)
+            {
+                throw new ArgumentNullException(nameof(arguments), "Null XSLT argument list supplied.");
             }
 
             if (xmlPath == null)
@@ -149,8 +223,7 @@ namespace Cake.Common.Xml
                     xmlReader = XmlReader.Create(xmlStream);
 
                 var resultWriter = XmlWriter.Create(resultStream, settings.XmlWriterSettings);
-
-                Transform(xslReader, xmlReader, resultWriter);
+                Transform(xslReader, arguments, xmlReader, resultWriter);
             }
         }
 
@@ -158,14 +231,20 @@ namespace Cake.Common.Xml
         /// Performs XML XSL transformation.
         /// </summary>
         /// <param name="xsl">XML style sheet.</param>
+        /// <param name="arguments">XSLT argument list.</param>
         /// <param name="xml">XML data.</param>
         /// <param name="result">Transformation result.</param>
         /// <param name="settings">Optional settings for result file xml writer.</param>
-        private static void Transform(TextReader xsl, TextReader xml, Stream result, XmlWriterSettings settings = null)
+        private static void Transform(TextReader xsl, XsltArgumentList arguments, TextReader xml, Stream result, XmlWriterSettings settings = null)
         {
             if (xsl == null)
             {
                 throw new ArgumentNullException(nameof(xsl), "Null XML style sheet supplied.");
+            }
+
+            if (arguments == null)
+            {
+                throw new ArgumentNullException(nameof(arguments), "Null XSLT argument list supplied.");
             }
 
             if (xml == null)
@@ -186,20 +265,26 @@ namespace Cake.Common.Xml
             var xslXmlReader = XmlReader.Create(xsl);
             var xmlXmlReader = XmlReader.Create(xml);
             var resultXmlTextWriter = XmlWriter.Create(result, settings);
-            Transform(xslXmlReader, xmlXmlReader, resultXmlTextWriter);
+            Transform(xslXmlReader, arguments, xmlXmlReader, resultXmlTextWriter);
         }
 
         /// <summary>
         /// Performs XML XSL transformation.
         /// </summary>
         /// <param name="xsl">XML style sheet.</param>
+        /// <param name="arguments">XSLT argument list.</param>
         /// <param name="xml">XML data.</param>
         /// <param name="result">Transformation result.</param>
-        private static void Transform(XmlReader xsl, XmlReader xml, XmlWriter result)
+        private static void Transform(XmlReader xsl, XsltArgumentList arguments, XmlReader xml, XmlWriter result)
         {
             if (xsl == null)
             {
                 throw new ArgumentNullException(nameof(xsl), "Null XML style sheet supplied.");
+            }
+
+            if (arguments == null)
+            {
+                throw new ArgumentNullException(nameof(arguments), "Null XSLT argument list supplied.");
             }
 
             if (xml == null)
@@ -212,7 +297,7 @@ namespace Cake.Common.Xml
                 throw new ArgumentNullException(nameof(result), "Null result supplied.");
             }
 
-            XmlTransformationHelper.Transform(xsl, xml, result);
+            XmlTransformationHelper.Transform(xsl, arguments, xml, result);
         }
     }
 }

--- a/src/Cake.Common/Xml/XmlTransformation.cs
+++ b/src/Cake.Common/Xml/XmlTransformation.cs
@@ -32,8 +32,7 @@ namespace Cake.Common.Xml
                 Encoding = new UTF8Encoding(false)
             };
 
-            var arguments = new XsltArgumentList();
-            return Transform(xsl, arguments, xml, settings);
+            return Transform(xsl, xml, settings);
         }
 
         /// <summary>
@@ -41,50 +40,13 @@ namespace Cake.Common.Xml
         /// </summary>
         /// <param name="xsl">XML style sheet.</param>
         /// <param name="xml">XML data.</param>
-        /// <param name="settings">Settings for result file xml transformation.</param>
+        /// <param name="settings">Settings for result file XML transformation.</param>
         /// <returns>Transformed XML string.</returns>
         public static string Transform(string xsl, string xml, XmlTransformationSettings settings)
-        {
-            var arguments = new XsltArgumentList();
-            return Transform(xsl, arguments, xml, settings);
-        }
-
-        /// <summary>
-        /// Performs XML XSL transformation.
-        /// </summary>
-        /// <param name="xsl">XML style sheet.</param>
-        /// <param name="arguments">XSLT argument list.</param>
-        /// <param name="xml">XML data.</param>
-        /// <returns>Transformed XML string.</returns>
-        public static string Transform(string xsl, XsltArgumentList arguments, string xml)
-        {
-            var settings = new XmlTransformationSettings
-            {
-                OmitXmlDeclaration = true,
-                Encoding = new UTF8Encoding(false)
-            };
-
-            return Transform(xsl, arguments, xml, settings);
-        }
-
-        /// <summary>
-        /// Performs XML XSL transformation.
-        /// </summary>
-        /// <param name="xsl">XML style sheet.</param>
-        /// <param name="arguments">XSLT argument list.</param>
-        /// <param name="xml">XML data.</param>
-        /// <param name="settings">Settings for result file xml transformation.</param>
-        /// <returns>Transformed XML string.</returns>
-        public static string Transform(string xsl, XsltArgumentList arguments, string xml, XmlTransformationSettings settings)
         {
             if (string.IsNullOrWhiteSpace(xsl))
             {
                 throw new ArgumentNullException(nameof(xsl), "Null or empty XML style sheet supplied.");
-            }
-
-            if (arguments == null)
-            {
-                throw new ArgumentNullException(nameof(arguments), "Null XSLT argument list supplied.");
             }
 
             if (string.IsNullOrWhiteSpace(xml))
@@ -103,7 +65,7 @@ namespace Cake.Common.Xml
             {
                 using (var result = new MemoryStream())
                 {
-                    Transform(xslReader, arguments, xmlReader, result, settings.XmlWriterSettings);
+                    Transform(xslReader, settings.XsltArgumentList, xmlReader, result, settings.XmlWriterSettings);
                     result.Position = 0;
                     return settings.Encoding.GetString(result.ToArray());
                 }
@@ -114,54 +76,24 @@ namespace Cake.Common.Xml
         /// Performs XML XSL transformation.
         /// </summary>
         /// <param name="fileSystem">The file system.</param>
-        /// <param name="xslPath">Path to xml style sheet.</param>
-        /// <param name="xmlPath">Path xml data.</param>
+        /// <param name="xslPath">Path to XML style sheet.</param>
+        /// <param name="xmlPath">Path XML data.</param>
         /// <param name="resultPath">Transformation result path.</param>
         public static void Transform(IFileSystem fileSystem, FilePath xslPath, FilePath xmlPath, FilePath resultPath)
         {
             var settings = new XmlTransformationSettings();
-            var arguments = new XsltArgumentList();
-            Transform(fileSystem, xslPath, arguments, xmlPath, resultPath, settings);
+            Transform(fileSystem, xslPath, xmlPath, resultPath, settings);
         }
 
         /// <summary>
         /// Performs XML XSL transformation.
         /// </summary>
         /// <param name="fileSystem">The file system.</param>
-        /// <param name="xslPath">Path to xml style sheet.</param>
-        /// <param name="xmlPath">Path xml data.</param>
+        /// <param name="xslPath">Path to XML style sheet.</param>
+        /// <param name="xmlPath">Path XML data.</param>
         /// <param name="resultPath">Transformation result path.</param>
-        /// <param name="settings">Settings for result file xml transformation.</param>
+        /// <param name="settings">Settings for result file XML transformation.</param>
         public static void Transform(IFileSystem fileSystem, FilePath xslPath, FilePath xmlPath, FilePath resultPath, XmlTransformationSettings settings)
-        {
-            var arguments = new XsltArgumentList();
-            Transform(fileSystem, xslPath, arguments, xmlPath, resultPath, settings);
-        }
-
-        /// <summary>
-        /// Performs XML XSL transformation.
-        /// </summary>
-        /// <param name="fileSystem">The file system.</param>
-        /// <param name="xslPath">Path to xml style sheet.</param>
-        /// <param name="arguments">XSLT argument list.</param>
-        /// <param name="xmlPath">Path xml data.</param>
-        /// <param name="resultPath">Transformation result path.</param>
-        public static void Transform(IFileSystem fileSystem, FilePath xslPath, XsltArgumentList arguments, FilePath xmlPath, FilePath resultPath)
-        {
-            var settings = new XmlTransformationSettings();
-            Transform(fileSystem, xslPath, arguments, xmlPath, resultPath, settings);
-        }
-
-        /// <summary>
-        /// Performs XML XSL transformation.
-        /// </summary>
-        /// <param name="fileSystem">The file system.</param>
-        /// <param name="xslPath">Path to xml style sheet.</param>
-        /// <param name="arguments">XSLT argument list.</param>
-        /// <param name="xmlPath">Path xml data.</param>
-        /// <param name="resultPath">Transformation result path.</param>
-        /// <param name="settings">Settings for result file xml transformation.</param>
-        public static void Transform(IFileSystem fileSystem, FilePath xslPath, XsltArgumentList arguments, FilePath xmlPath, FilePath resultPath, XmlTransformationSettings settings)
         {
             if (fileSystem == null)
             {
@@ -171,11 +103,6 @@ namespace Cake.Common.Xml
             if (xslPath == null)
             {
                 throw new ArgumentNullException(nameof(xslPath), "Null XML style sheet path supplied.");
-            }
-
-            if (arguments == null)
-            {
-                throw new ArgumentNullException(nameof(arguments), "Null XSLT argument list supplied.");
             }
 
             if (xmlPath == null)
@@ -200,12 +127,12 @@ namespace Cake.Common.Xml
 
             if (!xslFile.Exists)
             {
-                throw new FileNotFoundException("Xsl File not found.", xslFile.Path.FullPath);
+                throw new FileNotFoundException("XSL file not found.", xslFile.Path.FullPath);
             }
 
             if (!xmlFile.Exists)
             {
-                throw new FileNotFoundException("XML File not found.", xmlFile.Path.FullPath);
+                throw new FileNotFoundException("XML file not found.", xmlFile.Path.FullPath);
             }
 
             if (!settings.Overwrite && resultFile.Exists)
@@ -223,7 +150,7 @@ namespace Cake.Common.Xml
                     xmlReader = XmlReader.Create(xmlStream);
 
                 var resultWriter = XmlWriter.Create(resultStream, settings.XmlWriterSettings);
-                Transform(xslReader, arguments, xmlReader, resultWriter);
+                Transform(xslReader, settings.XsltArgumentList, xmlReader, resultWriter);
             }
         }
 
@@ -234,17 +161,12 @@ namespace Cake.Common.Xml
         /// <param name="arguments">XSLT argument list.</param>
         /// <param name="xml">XML data.</param>
         /// <param name="result">Transformation result.</param>
-        /// <param name="settings">Optional settings for result file xml writer.</param>
+        /// <param name="settings">Optional settings for result file XML writer.</param>
         private static void Transform(TextReader xsl, XsltArgumentList arguments, TextReader xml, Stream result, XmlWriterSettings settings = null)
         {
             if (xsl == null)
             {
                 throw new ArgumentNullException(nameof(xsl), "Null XML style sheet supplied.");
-            }
-
-            if (arguments == null)
-            {
-                throw new ArgumentNullException(nameof(arguments), "Null XSLT argument list supplied.");
             }
 
             if (xml == null)
@@ -280,11 +202,6 @@ namespace Cake.Common.Xml
             if (xsl == null)
             {
                 throw new ArgumentNullException(nameof(xsl), "Null XML style sheet supplied.");
-            }
-
-            if (arguments == null)
-            {
-                throw new ArgumentNullException(nameof(arguments), "Null XSLT argument list supplied.");
             }
 
             if (xml == null)

--- a/src/Cake.Common/Xml/XmlTransformationSettings.cs
+++ b/src/Cake.Common/Xml/XmlTransformationSettings.cs
@@ -4,6 +4,7 @@
 
 using System.Text;
 using System.Xml;
+using System.Xml.Xsl;
 using Cake.Common.Polyfill;
 
 namespace Cake.Common.Xml
@@ -127,6 +128,11 @@ namespace Cake.Common.Xml
             get { return XmlWriterSettings.WriteEndDocumentOnClose; }
             set { XmlWriterSettings.WriteEndDocumentOnClose = value; }
         }
+
+        /// <summary>
+        /// Gets or sets an argument list for XSL transformation.
+        /// </summary>
+        public XsltArgumentList XsltArgumentList { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="XmlTransformationSettings"/> class.


### PR DESCRIPTION
fixes #2524

I added two overloaded XmlTransform methods that accept XsltArgumentList as arguments for XSL tranformation.  Also new unit tests were added - I tried to use existing input/output sample data as much as possible so there are only two new XSL definitions (with arguments) needed.