### PR TITLE
Update confusing GitVersionVerbosity docs

### DIFF
--- a/src/Cake.Common/Tools/GitVersion/GitVersionVerbosity.cs
+++ b/src/Cake.Common/Tools/GitVersion/GitVersionVerbosity.cs
@@ -15,22 +15,22 @@ namespace Cake.Common.Tools.GitVersion
         None,
 
         /// <summary>
-        /// Only log error messages.
+        /// Log error messages.
         /// </summary>
         Error,
 
         /// <summary>
-        /// Only log wanring messages.
+        /// Log error and warning messages.
         /// </summary>
         Warn,
 
         /// <summary>
-        /// Only log info messages.
+        /// Log error, warning and info messages.
         /// </summary>
         Info,
 
         /// <summary>
-        /// Only log debug messages.
+        /// Log error, warning, info and debug messages (log all).
         /// </summary>
         Debug
     }


### PR DESCRIPTION
Since the docs said: "only log info", I assumed this was a flagged enum, but according to the source, it's not:

https://github.com/cake-build/cake/blob/main/src/Cake.Common/Tools/GitVersion/GitVersionRunner.cs
