### PR TITLE
Updating Newtonsoft.Json nuget package version to latest stable

### DIFF
--- a/src/Cake.Core/Cake.Core.csproj
+++ b/src/Cake.Core/Cake.Core.csproj
@@ -16,7 +16,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="*" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>
   <!-- .NET Framework packages -->

--- a/src/Cake.NuGet/Cake.NuGet.csproj
+++ b/src/Cake.NuGet/Cake.NuGet.csproj
@@ -25,6 +25,6 @@
     <PackageReference Include="NuGet.Packaging" Version="5.0.0" />
     <PackageReference Include="NuGet.Resolver" Version="5.0.0" />
     <PackageReference Include="NuGet.Common" Version="5.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Using the * notation for version spec (latest stable version).
This will bring in the latest stable version at compile time, and reference that.
Related to #2116, which is not resolved on dotnet core, and causes exceptions when referencing Newtonsoft.Json.