### PR TITLE
Updating netcoreapp to 2.1

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -179,7 +179,7 @@ Task("Run-Unit-Tests")
         // .NET Core
         DotNetCoreTest(project.FullPath, new DotNetCoreTestSettings
         {
-            Framework = "netcoreapp2.0",
+            Framework = "netcoreapp2.1",
             NoBuild = true,
             NoRestore = true,
             Configuration = parameters.Configuration,
@@ -222,7 +222,7 @@ Task("Copy-Files")
     // .NET Core
     DotNetCorePublish("./src/Cake/Cake.csproj", new DotNetCorePublishSettings
     {
-        Framework = "netcoreapp2.0",
+        Framework = "netcoreapp2.1",
         NoRestore = true,
         Configuration = parameters.Configuration,
         OutputDirectory = parameters.Paths.Directories.ArtifactsBinNetCore,
@@ -235,7 +235,7 @@ Task("Copy-Files")
 
     // Copy Cake.XML (since publish does not do this anymore)
     CopyFileToDirectory("./src/Cake/bin/" + parameters.Configuration + "/net461/Cake.xml", parameters.Paths.Directories.ArtifactsBinFullFx);
-    CopyFileToDirectory("./src/Cake/bin/" + parameters.Configuration + "/netcoreapp2.0/Cake.xml", parameters.Paths.Directories.ArtifactsBinNetCore);
+    CopyFileToDirectory("./src/Cake/bin/" + parameters.Configuration + "/netcoreapp2.1/Cake.xml", parameters.Paths.Directories.ArtifactsBinNetCore);
 });
 
 Task("Validate-Version")

--- a/src/Cake.Common.Tests/Cake.Common.Tests.csproj
+++ b/src/Cake.Common.Tests/Cake.Common.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Cake.Common.Tests</AssemblyName>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp2.1</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsCakeTestProject>true</IsCakeTestProject>
   </PropertyGroup>

--- a/src/Cake.Core.Tests/Cake.Core.Tests.csproj
+++ b/src/Cake.Core.Tests/Cake.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Cake.Core.Tests</AssemblyName>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp2.1</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsCakeTestProject>true</IsCakeTestProject>
   </PropertyGroup>

--- a/src/Cake.NuGet.Tests/Cake.NuGet.Tests.csproj
+++ b/src/Cake.NuGet.Tests/Cake.NuGet.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Cake.NuGet.Tests</AssemblyName>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsCakeTestProject>true</IsCakeTestProject>
   </PropertyGroup>

--- a/src/Cake.Tests/Cake.Tests.csproj
+++ b/src/Cake.Tests/Cake.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Cake.Tests</AssemblyName>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsCakeTestProject>true</IsCakeTestProject>
   </PropertyGroup>

--- a/src/Cake/Cake.csproj
+++ b/src/Cake/Cake.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Cake</AssemblyName>
-    <TargetFrameworks Condition=" '$(PackAsTool)' != 'true'">net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(PackAsTool)' != 'true'">net461;netcoreapp2.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <PlatformTarget>AnyCpu</PlatformTarget>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Resolves an issue I was observing when trying to reference System.ComponentModel.Annotations 4.5.0 under dotnet core (could not load assembly).
This will match the netcoreapp version used for Cake.Tool.csproj (the cake dotnet tool).