### PR TITLE
GH2610: Add check for DynamicAttribute to support extensions returnin…

### DIFF
--- a/src/Cake.Core.Tests/Data/MethodAliasGeneratorData.cs
+++ b/src/Cake.Core.Tests/Data/MethodAliasGeneratorData.cs
@@ -240,5 +240,11 @@ namespace Cake.Core.Tests.Data
         {
             throw new NotImplementedException();
         }
+
+        [CakeMethodAlias]
+        public static dynamic NonGeneric_ExtensionMethodWithDynamicReturnValue(this ICakeContext context)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Cake.Core.Tests/Data/PropertyAliasGeneratorData.cs
+++ b/src/Cake.Core.Tests/Data/PropertyAliasGeneratorData.cs
@@ -44,6 +44,12 @@ namespace Cake.Core.Tests.Data
             return 42;
         }
 
+        [CakePropertyAlias]
+        public static dynamic NonCached_Dynamic_Type(this ICakeContext context)
+        {
+            return new { };
+        }
+
         [CakePropertyAlias(Cache = true)]
         public static string Cached_Reference_Type(this ICakeContext context)
         {
@@ -54,6 +60,12 @@ namespace Cake.Core.Tests.Data
         public static bool Cached_Value_Type(this ICakeContext context)
         {
             return true;
+        }
+
+        [CakePropertyAlias(Cache = true)]
+        public static dynamic Cached_Dynamic_Type(this ICakeContext context)
+        {
+            return new { };
         }
 
         [CakePropertyAlias]

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithDynamicReturnValue
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Methods/NonGeneric_ExtensionMethodWithDynamicReturnValue
@@ -1,0 +1,4 @@
+﻿public dynamic NonGeneric_ExtensionMethodWithDynamicReturnValue()
+{
+    return Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithDynamicReturnValue(Context);
+}

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Properties/Cached_Dynamic_Type
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Properties/Cached_Dynamic_Type
@@ -1,0 +1,12 @@
+﻿private dynamic _Cached_Dynamic_Type;
+public dynamic Cached_Dynamic_Type
+{
+    get
+    {
+        if (_Cached_Dynamic_Type==null)
+        {
+            _Cached_Dynamic_Type = Cake.Core.Tests.Data.PropertyAliasGeneratorData.Cached_Dynamic_Type(Context);
+        }
+        return _Cached_Dynamic_Type;
+    }
+}

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Properties/NonCached_Dynamic_Type
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/Expected/Properties/NonCached_Dynamic_Type
@@ -1,0 +1,7 @@
+﻿public dynamic NonCached_Dynamic_Type
+{
+    get
+    {
+        return Cake.Core.Tests.Data.PropertyAliasGeneratorData.NonCached_Dynamic_Type(Context);
+    }
+}

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/MethodAliasGeneratorTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/MethodAliasGeneratorTests.cs
@@ -55,6 +55,7 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
             [InlineData("NonGeneric_ExtensionMethodWithOutputParameter")]
             [InlineData("NonGeneric_ExtensionMethodWithGenericCollectionOfNestedType")]
             [InlineData("NonGeneric_ExtensionMethodWithParameterAttributes")]
+            [InlineData("NonGeneric_ExtensionMethodWithDynamicReturnValue")]
             public void Should_Return_Correct_Generated_Code_For_Non_Generic_Methods(string name)
             {
                 // Given

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/PropertyAliasGeneratorTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/PropertyAliasGeneratorTests.cs
@@ -112,6 +112,7 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
 
             [Theory]
             [InlineData("NonCached_Value_Type")]
+            [InlineData("NonCached_Dynamic_Type")]
             public void Should_Return_Correct_Generated_Code_For_Non_Cached_Properties(string name)
             {
                 // Given
@@ -127,6 +128,7 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
             [Theory]
             [InlineData("Cached_Reference_Type")]
             [InlineData("Cached_Value_Type")]
+            [InlineData("Cached_Dynamic_Type")]
             public void Should_Return_Correct_Generated_Code_For_Cached_Properties(string name)
             {
                 // Given

--- a/src/Cake.Core/Scripting/CodeGen/MethodAliasGenerator.cs
+++ b/src/Cake.Core/Scripting/CodeGen/MethodAliasGenerator.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Cake.Core.Annotations;
 
@@ -148,9 +149,13 @@ namespace Cake.Core.Scripting.CodeGen
 
         private static string GetReturnType(MethodInfo method)
         {
-            return method.ReturnType == typeof(void)
-                ? "void"
-                    : method.ReturnType.GetFullName();
+            if (method.ReturnType == typeof(void))
+            {
+                return "void";
+            }
+
+            var isDynamic = method.ReturnTypeCustomAttributes.GetCustomAttributes(typeof(DynamicAttribute), true).Any();
+            return isDynamic ? "dynamic" : method.ReturnType.GetFullName();
         }
 
         private static IEnumerable<string> GetProxyParameters(IEnumerable<ParameterInfo> parameters, bool includeType)

--- a/src/Cake.Core/Scripting/CodeGen/PropertyAliasGenerator.cs
+++ b/src/Cake.Core/Scripting/CodeGen/PropertyAliasGenerator.cs
@@ -251,7 +251,8 @@ namespace Cake.Core.Scripting.CodeGen
 
         private static string GetReturnType(MethodInfo method)
         {
-            return method.ReturnType.GetFullName();
+            var isDynamic = method.ReturnTypeCustomAttributes.GetCustomAttributes(typeof(DynamicAttribute), true).Any();
+            return isDynamic ? "dynamic" : method.ReturnType.GetFullName();
         }
 
         private static string GetObsoleteMessage(MethodInfo method, ObsoleteAttribute attribute)

--- a/tests/integration/Cake.Core/Scripting/AddinDirective.cake
+++ b/tests/integration/Cake.Core/Scripting/AddinDirective.cake
@@ -11,6 +11,8 @@ Task("Cake.Core.Scripting.AddinDirective.LoadNetStandardAddin")
     var script = $@"#addin nuget:{Paths.Resources}/Cake.Core/Scripting/netstandard2.addin/bin/Release?package=netstandard2.addin&version=1.0.0
         Information(""Magic number: {0}"", GetMagicNumber(false));
         Information(""The answer to life: {0}"", TheAnswerToLife);
+        Information(""Get Dynamic Magic Number: {0}"", GetDynamicMagicNumber(false).MagicNumber);
+        Information(""Dynamic Magic Number: {0}"", TheDynamicAnswerToLife.TheAnswerToLife);
     ";
 
     CakeExecuteExpression(script,

--- a/tests/integration/resources/Cake.Core/Scripting/netstandard2.addin/MyCakeExtension.cs
+++ b/tests/integration/resources/Cake.Core/Scripting/netstandard2.addin/MyCakeExtension.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Dynamic;
 using Cake.Core;
 using Cake.Core.Annotations;
 
@@ -25,5 +26,21 @@ public static class MyCakeExtension
     public static int TheAnswerToLife(this ICakeContext context)
     {
         return 42;
+    }
+
+    [CakePropertyAlias(Cache = true)]
+    public static dynamic TheDynamicAnswerToLife(this ICakeContext context)
+    {
+        dynamic value =  new ExpandoObject();
+        value.TheAnswerToLife = context.TheAnswerToLife();
+        return value;
+    }
+
+    [CakeMethodAlias]
+    public static dynamic GetDynamicMagicNumber(this ICakeContext context, bool value)
+    {
+        dynamic result =  new ExpandoObject();
+        result.MagicNumber = context.GetMagicNumber(value);
+        return result;
     }
 }


### PR DESCRIPTION
This addresses the issue described in GH-2610.  This change adds the necessary checks for `DynamicAttribute` on the return type metadata for those properties/methods returning `dynamic`.

I think test coverage is appropriate & covers the various paths; please advise if there are any changes to tests or implementation desired.
