### PR TITLE
Enabling use of Newtonsoft.Json > 11.0.2

### DIFF
--- a/src/Cake.Core.Tests/Unit/CakeRuntimeTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeRuntimeTests.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Cake.Testing.Xunit;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Cake.Core.Tests.Unit
 {
@@ -16,6 +17,13 @@ namespace Cake.Core.Tests.Unit
     {
         public sealed class TheBuiltFrameworkProperty
         {
+            private ITestOutputHelper TestOutputHelper { get; }
+
+            public TheBuiltFrameworkProperty(ITestOutputHelper testOutputHelper)
+            {
+                TestOutputHelper = testOutputHelper;
+            }
+
             [RuntimeFact(TestRuntime.CoreClr)]
             public void Should_Return_Correct_Result_For_CoreClr()
             {
@@ -31,29 +39,48 @@ namespace Cake.Core.Tests.Unit
 #elif !NETCOREAPP
                 Assert.Equal(".NETStandard,Version=v2.0", framework.FullName);
 #else
-                try
-                {
-                    Assert.Equal(".NETCoreApp,Version=v" +
-
+                var expect = string.Concat(".NETCoreApp,Version=v",
 #if NETCOREAPP2_0
-                    "2.0",
+                                "2.0");
 #elif NETCOREAPP2_1
-                    "2.1",
+                                "2.1");
 #elif NETCOREAPP2_2
-                    "2.2",
+                                "2.2");
 #elif NETCOREAPP3_0
-                    "3.0",
+                                "3.0");
 #endif
-                        framework.FullName);
-                }
-                catch
+                // ToDo: Enable mocking runtime resolution, temp work around for missing runtimes.
+                switch (expect)
                 {
-                    // Temp fix for if only netcore3 installed
-                    if (!StringComparer.Ordinal.Equals(framework.FullName, ".NETCoreApp,Version=v3.0"))
+                    case ".NETCoreApp,Version=v2.0":
                     {
-                        throw;
+                        switch (framework.FullName)
+                        {
+                            case ".NETCoreApp,Version=v2.1":
+                            case ".NETCoreApp,Version=v3.0":
+                                {
+                                    TestOutputHelper.WriteLine("Expect changed from {0} to {1}.", expect, framework.FullName);
+                                    expect = framework.FullName;
+                                    break;
+                                }
+                        }
+                        break;
+                    }
+                    case ".NETCoreApp,Version=v2.1":
+                    {
+                        switch (framework.FullName)
+                        {
+                            case ".NETCoreApp,Version=v3.0":
+                            {
+                                TestOutputHelper.WriteLine("Expect changed from {0} to {1}.", expect, framework.FullName);
+                                expect = framework.FullName;
+                                break;
+                            }
+                        }
+                        break;
                     }
                 }
+                Assert.Equal(expect, framework.FullName);
 #endif
             }
         }

--- a/src/Cake.Core/Cake.Core.csproj
+++ b/src/Cake.Core/Cake.Core.csproj
@@ -15,8 +15,6 @@
   <!-- .NET Core packages -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>
   <!-- .NET Framework packages -->

--- a/src/Cake.NuGet/Cake.NuGet.csproj
+++ b/src/Cake.NuGet/Cake.NuGet.csproj
@@ -25,6 +25,6 @@
     <PackageReference Include="NuGet.Packaging" Version="5.3.0" />
     <PackageReference Include="NuGet.Resolver" Version="5.3.0" />
     <PackageReference Include="NuGet.Common" Version="5.3.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
As per https://github.com/cake-build/cake/issues/2606

- Removed superfluous dependencies in `Cake.Core`
- Updating reference to `Newtonsoft.Json` in `Cake.NuGet` to 12.0.2