### PR TITLE
GH2608: Correctly identifies extra hosted agents in Azure Pipelines

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Build/TFBuildFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/TFBuildFixture.cs
@@ -35,10 +35,10 @@ namespace Cake.Common.Tests.Fixtures.Build
             Environment.GetEnvironmentVariable("AGENT_NAME").Returns("On Premises");
         }
 
-        public void IsRunningOnAzurePipelinesHosted()
+        public void IsRunningOnAzurePipelinesHosted(string agentHostName = "Hosted Agent")
         {
             Environment.GetEnvironmentVariable("TF_BUILD").Returns("True");
-            Environment.GetEnvironmentVariable("AGENT_NAME").Returns("Hosted Agent");
+            Environment.GetEnvironmentVariable("AGENT_NAME").Returns(agentHostName);
         }
 
         public TFBuildProvider CreateTFBuildService() => new TFBuildProvider(Environment, Log);

--- a/src/Cake.Common.Tests/Unit/Build/TFBuild/TFBuildProviderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TFBuild/TFBuildProviderTests.cs
@@ -170,6 +170,23 @@ namespace Cake.Common.Tests.Unit.Build.TFBuild
                 // Then
                 Assert.False(result);
             }
+
+            [Theory]
+            [InlineData("Hosted Agent 2")]
+            [InlineData("Azure Pipelines 3")]
+            public void Should_Return_True_If_Running_On_AzurePipelinesExtraAgent(string agentName)
+            {
+                // Given
+                var fixture = new TFBuildFixture();
+                fixture.IsRunningOnAzurePipelinesHosted(agentName);
+                var tfBuild = fixture.CreateTFBuildService();
+
+                // When
+                var result = tfBuild.IsRunningOnAzurePipelinesHosted;
+
+                // Then
+                Assert.True(result);
+            }
         }
 
         public sealed class TheEnvironmentProperty

--- a/src/Cake.Common/Build/TFBuild/Data/TFBuildAgentInfo.cs
+++ b/src/Cake.Common/Build/TFBuild/Data/TFBuildAgentInfo.cs
@@ -106,6 +106,6 @@ namespace Cake.Common.Build.TFBuild.Data
         /// <value>
         /// <c>true</c> if the current agent is a hosted agent; otherwise, <c>false</c>.
         /// </value>
-        public bool IsHosted => Name != null && Name.StartsWith("Hosted");
+        public bool IsHosted => Name != null && (Name.StartsWith("Hosted") || Name.StartsWith("Azure Pipelines"));
     }
 }

--- a/src/Cake.Common/Build/TFBuild/TFBuildProvider.cs
+++ b/src/Cake.Common/Build/TFBuild/TFBuildProvider.cs
@@ -94,8 +94,6 @@ namespace Cake.Common.Build.TFBuild
         /// <value>
         /// <c>true</c> if the current build is running on a hosted agent; otherwise, <c>false</c>.
         /// </value>
-        private bool IsHostedAgent
-            => !string.IsNullOrWhiteSpace(_environment.GetEnvironmentVariable("AGENT_NAME")) &&
-                _environment.GetEnvironmentVariable("AGENT_NAME").StartsWith("Hosted");
+        private bool IsHostedAgent => Environment.Agent.IsHosted;
     }
 }


### PR DESCRIPTION
Fixes #2608 by regarding any agent with an `AGENT_NAME` that starts with `Hosted Agent` or `Azure Pipelines` as a hosted agent, and merges that logic into the `TFBuildAgentInfo.IsHosted` property so it's consistent with the internal logic.

This actually seems a little far-reaching so in future we might want to change to using the value of `SYSTEM_SERVERTYPE` once we know what that variable actually *does*.