### PR TITLE
GH2618: Added support for VS2019 in MSTest runner

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSTest/MSTestRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSTest/MSTestRunnerTests.cs
@@ -97,6 +97,9 @@ namespace Cake.Common.Tests.Unit.Tools.MSTest
         [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2017/Enterprise/Common7/IDE/mstest.exe")]
         [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2017/Professional/Common7/IDE/mstest.exe")]
         [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2017/Community/Common7/IDE/mstest.exe")]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2019/Enterprise/Common7/IDE/mstest.exe")]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2019/Professional/Common7/IDE/mstest.exe")]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2019/Community/Common7/IDE/mstest.exe")]
         public void Should_Use_Available_Tool_Path(string existingToolPath)
         {
             // Given

--- a/src/Cake.Common/Tools/MSTest/MSTestRunner.cs
+++ b/src/Cake.Common/Tools/MSTest/MSTestRunner.cs
@@ -114,7 +114,7 @@ namespace Cake.Common.Tools.MSTest
         /// <returns>The default tool path.</returns>
         protected override IEnumerable<FilePath> GetAlternativeToolPaths(MSTestSettings settings)
         {
-            foreach (var yearAndEdition in new[] { "2017/Enterprise", "2017/Professional", "2017/Community" })
+            foreach (var yearAndEdition in new[] { "2017/Enterprise", "2017/Professional", "2017/Community", "2019/Enterprise", "2019/Professional", "2019/Community" })
             {
                 var path = GetYearAndEditionToolPath(yearAndEdition);
                 if (_fileSystem.Exist(path))


### PR DESCRIPTION
This pull request fixes #2618 

When running Cake on a machine with only VS2019 available (any version) the correct path to the MSTest runner was not found as the path resolution method didn't account for VS2019.

The 3 editions of VS2019 have been added to the collection of paths and new test cases have been added to the unit tests.