### PR TITLE
(build) Skip MyGet & Choco on Azure DevOps

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -705,6 +705,9 @@ Task("Travis")
 Task("ReleaseNotes")
   .IsDependentOn("Create-Release-Notes");
 
+Task("AzureDevOps")
+  .IsDependentOn(parameters.IsRunningOnWindows ? "Create-Chocolatey-Packages" : "Package");
+
 //////////////////////////////////////////////////////////////////////
 // EXECUTION
 //////////////////////////////////////////////////////////////////////

--- a/build/parameters.cake
+++ b/build/parameters.cake
@@ -43,8 +43,8 @@ public class BuildParameters
     {
         get
         {
-            return !IsLocalBuild && !IsPullRequest && IsMainCakeRepo
-                && (IsTagged || IsDevelopCakeBranch);
+            return false; /* !IsLocalBuild && !IsPullRequest && IsMainCakeRepo
+                && (IsTagged || IsDevelopCakeBranch);*/
         }
     }
 


### PR DESCRIPTION
* Skip MyGet push
* Create chocoloatey packages on AzureDevops if on Windows.