### PR TITLE
GH2643: Cake&Cake.CoreCLR nuspec self-contained icon

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -196,6 +196,10 @@ Task("Copy-Files")
     CopyFileToDirectory("./LICENSE", parameters.Paths.Directories.ArtifactsBinFullFx);
     CopyFileToDirectory("./LICENSE", parameters.Paths.Directories.ArtifactsBinNetCore);
 
+    // Copy icon
+    CopyFileToDirectory("./nuspec/cake-medium.png", parameters.Paths.Directories.ArtifactsBinFullFx);
+    CopyFileToDirectory("./nuspec/cake-medium.png", parameters.Paths.Directories.ArtifactsBinNetCore);
+
     // Copy Cake.XML (since publish does not do this anymore)
     CopyFileToDirectory("./src/Cake/bin/" + parameters.Configuration + "/net461/Cake.xml", parameters.Paths.Directories.ArtifactsBinFullFx);
     CopyFileToDirectory("./src/Cake/bin/" + parameters.Configuration + "/netcoreapp2.0/Cake.xml", parameters.Paths.Directories.ArtifactsBinNetCore);
@@ -312,7 +316,7 @@ Task("Create-NuGet-Packages")
         });
     }
 
-    // Cake - Symbols - .NET 4.6
+    // Cake - Symbols - .NET 4.6.1
     NuGetPack("./nuspec/Cake.symbols.nuspec", new NuGetPackSettings {
         Version = parameters.Version.SemVersion,
         ReleaseNotes = parameters.ReleaseNotes.Notes.ToArray(),
@@ -325,7 +329,7 @@ Task("Create-NuGet-Packages")
     var netFxFullArtifactPath = MakeAbsolute(parameters.Paths.Directories.ArtifactsBinFullFx).FullPath;
     var netFxFullArtifactPathLength = netFxFullArtifactPath.Length+1;
 
-    // Cake - .NET 4.6
+    // Cake - .NET 4.6.1
     NuGetPack("./nuspec/Cake.nuspec", new NuGetPackSettings {
         Version = parameters.Version.SemVersion,
         ReleaseNotes = parameters.ReleaseNotes.Notes.ToArray(),

--- a/build.cake
+++ b/build.cake
@@ -10,7 +10,7 @@
 #tool "nuget:https://api.nuget.org/v3/index.json?package=coveralls.io&version=1.4.2"
 #tool "nuget:https://api.nuget.org/v3/index.json?package=OpenCover&version=4.6.519"
 #tool "nuget:https://api.nuget.org/v3/index.json?package=ReportGenerator&version=4.0.4"
-#tool "nuget:https://api.nuget.org/v3/index.json?package=nuget.commandline&version=5.2.0"
+#tool "nuget:https://api.nuget.org/v3/index.json?package=nuget.commandline&version=5.3.0"
 
 // Install .NET Core Global tools.
 #tool "dotnet:https://api.nuget.org/v3/index.json?package=GitVersion.Tool&version=5.0.1"

--- a/nuspec/Cake.CoreCLR.nuspec
+++ b/nuspec/Cake.CoreCLR.nuspec
@@ -8,7 +8,7 @@
     <summary>Cake (C# Make) is a build automation system with a C# DSL to do things like compiling code, copy files/folders, running unit tests, compress files and build NuGet packages.</summary>
     <license type="expression">MIT</license>
     <projectUrl>https://cakebuild.net</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/cake-build/graphics/master/png/cake-medium.png</iconUrl>
+    <icon>cake-medium.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <repository type="git" url="https://github.com/cake-build/cake"/>
     <copyright>Copyright (c) .NET Foundation and contributors</copyright>

--- a/nuspec/Cake.CoreCLR.symbols.nuspec
+++ b/nuspec/Cake.CoreCLR.symbols.nuspec
@@ -8,7 +8,7 @@
     <summary>Cake (C# Make) is a build automation system with a C# DSL to do things like compiling code, copy files/folders, running unit tests, compress files and build NuGet packages.</summary>
     <license type="expression">MIT</license>
     <projectUrl>https://cakebuild.net</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/cake-build/graphics/master/png/cake-medium.png</iconUrl>
+    <icon>cake-medium.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <repository type="git" url="https://github.com/cake-build/cake"/>
     <copyright>Copyright (c) .NET Foundation and contributors</copyright>
@@ -19,5 +19,6 @@
     <file src="Cake.pdb" target="lib/netcoreapp2.0" />
     <file src="Cake.xml" target="lib/netcoreapp2.0" />
     <file src="LICENSE" />
+    <file src="cake-medium.png" />
   </files>
 </package>

--- a/nuspec/Cake.nuspec
+++ b/nuspec/Cake.nuspec
@@ -8,7 +8,7 @@
     <summary>Cake (C# Make) is a build automation system with a C# DSL to do things like compiling code, copy files/folders, running unit tests, compress files and build NuGet packages.</summary>
     <license type="expression">MIT</license>
     <projectUrl>https://cakebuild.net</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/cake-build/graphics/master/png/cake-medium.png</iconUrl>
+    <icon>cake-medium.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <repository type="git" url="https://github.com/cake-build/cake"/>
     <copyright>Copyright (c) .NET Foundation and contributors</copyright>

--- a/nuspec/Cake.symbols.nuspec
+++ b/nuspec/Cake.symbols.nuspec
@@ -8,16 +8,17 @@
     <summary>Cake (C# Make) is a build automation system with a C# DSL to do things like compiling code, copy files/folders, running unit tests, compress files and build NuGet packages.</summary>
     <license type="expression">MIT</license>
     <projectUrl>https://cakebuild.net</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/cake-build/graphics/master/png/cake-medium.png</iconUrl>
+    <icon>cake-medium.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <repository type="git" url="https://github.com/cake-build/cake"/>
     <copyright>Copyright (c) .NET Foundation and contributors</copyright>
     <tags>Cake Script Build</tags>
   </metadata>
   <files>
-    <file src="Cake.exe" target="lib/net46" />
-    <file src="Cake.pdb" target="lib/net46" />
-    <file src="Cake.xml" target="lib/net46" />
+    <file src="Cake.exe" target="lib/net461" />
+    <file src="Cake.pdb" target="lib/net461" />
+    <file src="Cake.xml" target="lib/net461" />
     <file src="LICENSE" />
+    <file src="cake-medium.png" />
   </files>
 </package>


### PR DESCRIPTION
* Update NuGet CommandLine to version 5.3.0
* Include icon in package
* Switch from iconUrl to icon element
* Correct Cake symbols framework moniker
* Fixes #2643

