### PR TITLE
Remove check for file extension when loading scripts

### DIFF
--- a/src/Cake.Core/Scripting/Processors/Loading/FileLoadDirectiveProvider.cs
+++ b/src/Cake.Core/Scripting/Processors/Loading/FileLoadDirectiveProvider.cs
@@ -56,11 +56,6 @@ namespace Cake.Core.Scripting.Processors.Loading
 
             var files = _globber
                 .GetFiles(path.FullPath)
-                .Where(file =>
-                {
-                    var extension = file.GetExtension();
-                    return extension != null && extension.Equals(".cake", StringComparison.OrdinalIgnoreCase);
-                })
                 .ToArray();
             if (files.Length == 0)
             {


### PR DESCRIPTION
In upgrading all my projects to the latest version of Cake I noticed the PR that added file globbing also introduced a regression where the file extension for loaded scripts must now be `.cake`. I have several scripts used in the Cake build which are also used directly as scriptcs scripts and they have a `.csx` extension.

I see no reason for the extension check at all, if you wants `*.cake` files then glob for them in your file path.

I'm not sure the proposed change is *trivial*, but it is extremely simple so I thought it was better than just filing an issue.