### PR TITLE
GH2533: Add new RawValue parameter to skip attribute value quoting

### DIFF
--- a/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoCreatorTests.cs
+++ b/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoCreatorTests.cs
@@ -333,6 +333,21 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
             }
 
             [Fact]
+            public void Should_Add_CustomAttributes_If_Set_With_Raw_Value()
+            {
+                // Given
+                var fixture = new AssemblyInfoFixture();
+                fixture.Settings.CustomAttributes = new Collection<AssemblyInfoCustomAttribute> { new AssemblyInfoCustomAttribute { Name = "TestAttribute", NameSpace = "Test.NameSpace", Value = "RawTestValue", UseRawValue = true } };
+
+                // When
+                var result = fixture.CreateAndReturnContent();
+
+                // Then
+                Assert.Contains("using Test.NameSpace;", result);
+                Assert.Contains("[assembly: TestAttribute(RawTestValue)]", result);
+            }
+
+            [Fact]
             public void Should_Add_CustomAttributes_If_Set()
             {
                 // Given

--- a/src/Cake.Common/Solution/Project/Properties/AssemblyInfoCreatorData.cs
+++ b/src/Cake.Common/Solution/Project/Properties/AssemblyInfoCreatorData.cs
@@ -72,7 +72,7 @@ namespace Cake.Common.Solution.Project.Properties
             {
                 foreach (var item in settings.CustomAttributes.Where(item => item != null))
                 {
-                    AddCustomAttribute(item.Name, item.NameSpace, item.Value);
+                    AddCustomAttribute(item.Name, item.NameSpace, item.Value, item.UseRawValue);
                 }
             }
             if (settings.MetaDataAttributes != null)
@@ -100,14 +100,14 @@ namespace Cake.Common.Solution.Project.Properties
             }
         }
 
-        private void AddCustomAttribute(string name, string @namespace, object value)
+        private void AddCustomAttribute(string name, string @namespace, object value, bool isRawValue)
         {
-            var attributeValue = AttributeValueToString(value);
+            var attributeValue = AttributeValueToString(value, isRawValue);
 
             AddAttributeCore(CustomAttributes, name, @namespace, attributeValue);
         }
 
-        private string AttributeValueToString(object value)
+        private string AttributeValueToString(object value, bool isRawValue)
         {
             switch (value)
             {
@@ -123,7 +123,9 @@ namespace Cake.Common.Solution.Project.Properties
                 {
                     return stringValue == string.Empty
                         ? string.Empty
-                        : string.Concat("\"", value, "\"");
+                        : isRawValue
+                            ? stringValue
+                            : string.Concat("\"", stringValue.Replace("\"", "\\\""), "\"");
                 }
                 default:
                 {

--- a/src/Cake.Common/Solution/Project/Properties/AssemblyInfoCustomAttribute.cs
+++ b/src/Cake.Common/Solution/Project/Properties/AssemblyInfoCustomAttribute.cs
@@ -26,5 +26,13 @@ namespace Cake.Common.Solution.Project.Properties
         /// </summary>
         /// <value>The value for the attribute.</value>
         public object Value { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the value is raw or should be quoted in the created attribute.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if should be treated as raw; otherwise, <c>false</c>.
+        /// </value>
+        public bool UseRawValue { get; set; }
     }
 }


### PR DESCRIPTION
This PR should solve #2533 in a more generic way. Rather than hardcoding for `SecurityRules` this adds opt-in behaviour to skip attribute quoting.

I'm not 100% sure on the whole "raw" naming, but I couldn't think of anything better. Other option would be to more explicit and use something like `NoQuote`.
