### PR TITLE
GH2099: Cache compiled script on disk

### DIFF
--- a/src/Cake/Commands/DefaultCommandSettings.cs
+++ b/src/Cake/Commands/DefaultCommandSettings.cs
@@ -59,5 +59,9 @@ namespace Cake.Commands
         [CommandOption("--info")]
         [Description("Displays additional information about Cake.")]
         public bool ShowInfo { get; set; }
+
+        [CommandOption("--" + Infrastructure.Constants.Cache.InvalidateScriptCache)]
+        [Description("Forces the script to be recompiled if caching is enabled.")]
+        public bool Recompile { get; set; }
     }
 }

--- a/src/Cake/Infrastructure/CakeConfigurationExtensions.cs
+++ b/src/Cake/Infrastructure/CakeConfigurationExtensions.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core;
+using Cake.Core.Configuration;
+using Cake.Core.IO;
+
+namespace Cake.Infrastructure
+{
+    /// <summary>
+    /// Contains extension methods for <see cref="ICakeConfiguration"/>.
+    /// </summary>
+    internal static class CakeConfigurationExtensions
+    {
+        /// <summary>
+        /// Gets the script cache directory path.
+        /// </summary>
+        /// <param name="configuration">The Cake configuration.</param>
+        /// <param name="defaultRoot">The default root path.</param>
+        /// <param name="environment">The environment.</param>
+        /// <returns>The script cache directory path.</returns>
+        public static DirectoryPath GetScriptCachePath(this ICakeConfiguration configuration, DirectoryPath defaultRoot, ICakeEnvironment environment)
+        {
+            var cachePath = configuration.GetValue(Constants.Paths.Cache);
+            if (!string.IsNullOrWhiteSpace(cachePath))
+            {
+                return new DirectoryPath(cachePath).MakeAbsolute(environment);
+            }
+            var toolPath = configuration.GetToolPath(defaultRoot, environment);
+            return toolPath.Combine("cache").Collapse();
+        }
+    }
+}

--- a/src/Cake/Infrastructure/Constants.cs
+++ b/src/Cake/Infrastructure/Constants.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Infrastructure
+{
+    internal static class Constants
+    {
+        public static class Settings
+        {
+            public const string EnableScriptCache = "Settings_EnableScriptCache";
+        }
+
+        public static class Paths
+        {
+            public const string Cache = "Paths_Cache";
+        }
+
+        public static class Cache
+        {
+            public const string InvalidateScriptCache = "invalidate-script-cache";
+        }
+    }
+}

--- a/src/Cake/Infrastructure/IScriptHostSettings.cs
+++ b/src/Cake/Infrastructure/IScriptHostSettings.cs
@@ -2,10 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Core.IO;
+
 namespace Cake.Infrastructure
 {
     public interface IScriptHostSettings
     {
         bool Debug { get; }
+
+        FilePath Script { get; }
     }
 }

--- a/src/Cake/Infrastructure/Utilities/FastHash.cs
+++ b/src/Cake/Infrastructure/Utilities/FastHash.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Cake.Infrastructure.Utilities
+{
+    /// <summary>
+    /// Optimized hash generator. Using SHA512 since it is FIPS compliant.
+    /// </summary>
+    internal static class FastHash
+    {
+        /// <summary>
+        /// Generates a hash of the passed byte arrays.
+        /// </summary>
+        /// <param name="input">The binary data to hash.</param>
+        /// <returns>The hash value.</returns>
+        public static string GenerateHash(byte[] input)
+        {
+            using (var sha512 = SHA512.Create())
+            {
+                sha512.TransformBlock(input, 0, input.Length, input, 0);
+
+                // Just finalize with empty bytes so we don't have to iterate over the enumerable multiple times
+                sha512.TransformFinalBlock(Encoding.UTF8.GetBytes(string.Empty), 0, 0);
+                // Convert to hex string; This method is supposedly faster than the usual StringBuilder approach
+                return ConvertBits(sha512.Hash);
+            }
+        }
+
+        /// <summary>
+        /// Generates a hash of the passed byte arrays.
+        /// </summary>
+        /// <param name="inputs">The binary data to hash.</param>
+        /// <returns>The hash value.</returns>
+        public static string GenerateHash(IEnumerable<byte[]> inputs)
+        {
+            using (var sha512 = SHA512.Create())
+            {
+                foreach (var input in inputs)
+                {
+                    sha512.TransformBlock(input, 0, input.Length, input, 0);
+                }
+
+                // Just finalize with empty bytes so we don't have to iterate over the enumerable multiple times
+                sha512.TransformFinalBlock(Encoding.UTF8.GetBytes(string.Empty), 0, 0);
+                // Convert to hex string; This method is supposedly faster than the usual StringBuilder approach
+                return ConvertBits(sha512.Hash);
+            }
+        }
+
+        private static string ConvertBits(byte[] hash)
+        {
+#if NETCOREAPP3_1
+            return BitConverter.ToString(hash)
+                    // without dashes
+                    .Replace("-", string.Empty);
+#else
+            return Convert.ToHexString(hash);
+#endif
+        }
+    }
+}

--- a/tests/integration/Cake/ScriptCache.cake
+++ b/tests/integration/Cake/ScriptCache.cake
@@ -1,0 +1,136 @@
+#load "./../../../utilities/xunit.cake"
+#load "./../../../utilities/paths.cake"
+using System.Diagnostics;
+
+public class ScriptCacheData
+{
+    public FilePath ScriptPath { get; }
+    public FilePath ScriptCacheAssemblyPath { get; }
+    public FilePath ScriptCacheHashPath { get; }
+    public (TimeSpan Elapsed, string Hash) CompileResult { get; set; }
+    public (TimeSpan Elapsed, string Hash) ExecuteResult { get; set; }
+    public (TimeSpan Elapsed, string Hash) ReCompileResult { get; set; }
+    public CakeSettings Settings { get; }
+    private Action<FilePath, CakeSettings> CakeExecuteScript { get; }
+    private Func<FilePath, FileHash> CalculateFileHash { get; }
+
+    public TimeSpan Time(Action action)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            action();
+        }
+        finally
+        {
+            stopwatch.Stop();
+        }
+        return stopwatch.Elapsed;
+    }
+
+    public (TimeSpan Elapsed, string Hash) TimeCakeExecuteScript() => TimeCakeExecuteScript(args => args);
+
+    public (TimeSpan Elapsed, string Hash) TimeCakeExecuteScript(Func<ProcessArgumentBuilder, ProcessArgumentBuilder> argumentCustomization) =>
+        (
+            Time(
+            () => {
+                Settings.ArgumentCustomization = argumentCustomization;
+                CakeExecuteScript(
+                    ScriptPath,
+                    Settings);
+            }),
+            CalculateFileHash(ScriptCacheAssemblyPath).ToHex()
+        );
+
+    public ScriptCacheData(
+        DirectoryPath scriptDirectoryPath,
+        Action<FilePath, CakeSettings> cakeExecuteScript,
+        Func<FilePath, FileHash> calculateFileHash
+        )
+    {
+        ScriptPath = scriptDirectoryPath.CombineWithFilePath("build.cake");
+        var cacheDirectoryPath = scriptDirectoryPath.Combine("tools").Combine("cache");
+        ScriptCacheAssemblyPath = cacheDirectoryPath.CombineWithFilePath("build.cake.dll");
+        ScriptCacheHashPath = cacheDirectoryPath.CombineWithFilePath("build.cake.hash");
+        Settings = new CakeSettings {
+                        EnvironmentVariables = new Dictionary<string, string> {
+                            { "CAKE_SETTINGS_ENABLESCRIPTCACHE", "true" }
+                        },
+                        Verbosity = Verbosity.Quiet
+                    };
+        CakeExecuteScript = cakeExecuteScript;
+        CalculateFileHash = calculateFileHash;
+    }
+}
+
+Setup(context =>
+    new ScriptCacheData(
+                    Paths.Temp
+                        .Combine("./Cake/ScriptCache"),
+                    context.CakeExecuteScript,
+                    context.CalculateFileHash
+    ));
+
+Task("Cake.ScriptCache.Setup")
+    .Does(() =>
+{
+    var sourcePath = Paths.Resources.Combine("./Cake/ScriptCache");
+    var targetPath = Paths.Temp.Combine("./Cake/ScriptCache");
+    EnsureDirectoryExists(targetPath.Combine("../").Collapse());
+    if (DirectoryExists(targetPath))
+    {
+        DeleteDirectory(
+            targetPath,
+                new DeleteDirectorySettings {
+                Recursive = true,
+                Force = true
+            });
+    }
+    CopyDirectory(sourcePath, targetPath);
+});
+
+Task("Cake.ScriptCache.Compile")
+    .IsDependentOn("Cake.ScriptCache.Setup")
+    .Does<ScriptCacheData>((context, data) =>
+{
+    // Given / When
+    data.CompileResult = data.TimeCakeExecuteScript();
+
+    // Then
+    Assert.True(FileExists(data.ScriptCacheAssemblyPath), $"Script Cache Assembly Path {data.ScriptCacheAssemblyPath} missing.");
+    Assert.True(FileExists(data.ScriptCacheAssemblyPath), $"Script Cache Hash Path {data.ScriptCacheHashPath} missing.");
+});
+
+var scriptCacheExecute =  Task("Cake.ScriptCache.Execute");
+for(var index = 1; index <= 5; index++)
+{
+    scriptCacheExecute.IsDependentOn(
+        Task($"Cake.ScriptCache.Execute.{index}")
+            .Does<ScriptCacheData>((context, data) =>
+        {
+            // Given / When
+            data.ExecuteResult = data.TimeCakeExecuteScript();
+
+            // Then
+            Assert.True(data.CompileResult.Elapsed > data.ExecuteResult.Elapsed, $"Compile time {data.CompileResult.Elapsed} should be greater than execute time  {data.ExecuteResult.Elapsed}.");
+            Assert.Equal(data.CompileResult.Hash, data.ExecuteResult.Hash);
+        })
+    );
+}
+
+Task("Cake.ScriptCache.ReCompile")
+    .IsDependentOn("Cake.ScriptCache.Execute")
+    .Does<ScriptCacheData>((context, data) => {
+        // Given / When
+        data.ReCompileResult = data.TimeCakeExecuteScript(args => args.Append("--invalidate-script-cache"));
+
+        // Then
+        Assert.True(data.ReCompileResult.Elapsed> data.ExecuteResult.Elapsed, $"ReCompileTime time {data.ReCompileResult.Elapsed} should be greater than execute time  {data.ExecuteResult.Elapsed}.");
+        Assert.NotEqual(data.CompileResult.Hash , data.ReCompileResult.Hash);
+    });
+
+Task("Cake.ScriptCache")
+    .IsDependentOn("Cake.ScriptCache.Setup")
+    .IsDependentOn("Cake.ScriptCache.Compile")
+    .IsDependentOn("Cake.ScriptCache.Execute")
+    .IsDependentOn("Cake.ScriptCache.ReCompile");

--- a/tests/integration/build.cake
+++ b/tests/integration/build.cake
@@ -6,6 +6,7 @@
 // Tests
 #load "setup.cake"
 #load "teardown.cake"
+#load "./Cake/ScriptCache.cake"
 #load "./Cake.Common/ArgumentAliases.cake"
 #load "./Cake.Common/Build/BuildSystemAliases.cake"
 #load "./Cake.Common/EnvironmentAliases.cake"
@@ -54,6 +55,9 @@ var target = Argument<string>("target", "Run-All-Tests");
 // TARGETS
 //////////////////////////////////////////////////
 
+Task("Cake")
+    .IsDependentOn("Cake.ScriptCache");
+
 Task("Cake.Core")
     .IsDependentOn("Cake.Core.Diagnostics")
     .IsDependentOn("Cake.Core.IO.Path")
@@ -100,6 +104,7 @@ Task("Cake.Chocolatey")
 
 Task("Run-All-Tests")
     .IsDependentOn("Setup-Tests")
+    .IsDependentOn("Cake")
     .IsDependentOn("Cake.Core")
     .IsDependentOn("Cake.Common")
     .IsDependentOn("Cake.DotNetTool.Module")

--- a/tests/integration/resources/Cake/ScriptCache/build.cake
+++ b/tests/integration/resources/Cake/ScriptCache/build.cake
@@ -1,0 +1,1 @@
+Information("Hello from compiled script!");


### PR DESCRIPTION
This pull request is what started RFC-02.  At the time I was not able to submit a pull request for the changes.

**Differences from RFC-02**

1. The cache argument was removed.  A new section was added to the cake.config file [Cache] with 2 possible properties Enabled and Path.  Enabled defaults to false and Path defaults cache under the tools folder.
2. I originally used a time stamp to determine if the cache was valid or not.  This worked for the way I was using Cake but would not work for all cases.  I have changed this to use a hash like pull request 2584 used.  I did change it to use SHA1CryptoServiceProvider instead of MD5 since MD5 is not FIPS compliant.

I have been using several versions of Cake with this  applied and have had no issues.

@mholo65 posted this in the RFC Comments
"Caching compilation is not alone enough. We must also cache registered tools resolved via #tool directive. Addins (and their dependencies) must also be loaded into app domain / load context in same order as the first time when resolved via #addin directive."

For the way this is implemented I feel just caching the compilation is enough.  I need all of the lines of the script in order to do the hash for determining if anything has changed.  The tools and addins are still being found like usual.  The main changes were made in RoslynScriptSession and in there it just determines if it needs to compile the script or run the cached DLL. 

