### PR TITLE
GH2541: fix unit test

### DIFF
--- a/src/Cake.Common.Tests/Unit/EnvironmentAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/EnvironmentAliasesTests.cs
@@ -162,7 +162,8 @@ namespace Cake.Common.Tests.Unit
 
                 // Then
                 Assert.NotNull(ex);
-                Assert.Contains("not a valid value", ex.Message);
+                Assert.NotNull(ex.InnerException);
+                Assert.IsType<FormatException>(ex.InnerException);
             }
         }
 


### PR DESCRIPTION
fix fail unit test on no-english #2541

In russin test fail:
```
Cake.Common.Tests.Unit.EnvironmentAliasesTests+TheEnvironmentVariableMethod.Should_Throw_If_Value_Does_Not_Convert
   Source: EnvironmentAliasesTests.cs line 152
   Duration: 27 ms

  Message: 
    Assert.Contains() Failure
    Not found: not a valid value
    In value:  abc не является допустимым значением для 'Int32'.
  Stack Trace: 
    Assert.Contains(String expectedSubstring, String actualString) line 22
    TheEnvironmentVariableMethod.Should_Throw_If_Value_Does_Not_Convert() line 172
```

## Cause of the problem:
.Net localizes all standart exception message (in .net standart library). 
see message "In value:  abc не является допустимым значением для 'Int32'."

## Solution:
Not check message. Exeption have InnerExeption.

![image](https://user-images.githubusercontent.com/780901/67723971-10774100-f9f7-11e9-828b-b9d993c796f9.png)


## Alternative solution:
Set InvariantCulture culture before test (will use not localized message).
```
Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
```
