### PR TITLE
(GH-2657) Rename TFBuildRepositoryInfo.Branch to TFBuildRepositoryInfo.SourceBranchName

### DIFF
--- a/src/Cake.Common.Tests/Unit/Build/TFBuild/Data/TFBuildRepositoryInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TFBuild/Data/TFBuildRepositoryInfoTests.cs
@@ -19,7 +19,25 @@ namespace Cake.Common.Tests.Unit.Build.TFBuild.Data
                 var info = new TFBuildInfoFixture().CreateRepositoryInfo();
 
                 // When
+#pragma warning disable 618
                 var result = info.Branch;
+#pragma warning restore 618
+
+                // Then
+                Assert.Equal("develop", result);
+            }
+        }
+
+        public sealed class TheSourceBranchNameProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TFBuildInfoFixture().CreateRepositoryInfo();
+
+                // When
+                var result = info.SourceBranchName;
 
                 // Then
                 Assert.Equal("develop", result);

--- a/src/Cake.Common/Build/TFBuild/Data/TFBuildRepositoryInfo.cs
+++ b/src/Cake.Common/Build/TFBuild/Data/TFBuildRepositoryInfo.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Cake.Core;
 
 namespace Cake.Common.Build.TFBuild.Data
@@ -34,7 +35,16 @@ namespace Cake.Common.Build.TFBuild.Data
         /// <value>
         /// The SCM branch name
         /// </value>
-        public string Branch => GetEnvironmentString("BUILD_SOURCEBRANCHNAME");
+        public string SourceBranchName => GetEnvironmentString("BUILD_SOURCEBRANCHNAME");
+
+        /// <summary>
+        /// Gets name of the branch the build was queued for.
+        /// </summary>
+        /// <value>
+        /// The SCM branch name
+        /// </value>
+        [Obsolete("Please use TFBuildRepositoryInfo.SourceBranchName instead")]
+        public string Branch => SourceBranchName;
 
         /// <summary>
         /// Gets the latest version control change that is included in this build.


### PR DESCRIPTION
Rename `TFBuildRepositoryInfo.Branch` to `TFBuildRepositoryInfo.SourceBranchName` and mark `TFBuildRepositoryInfo.Branch` as obsolete.

Fixes #2657