### PR TITLE
GH2671: Add support for removing -NonInteractive in NuGet Install command

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/NuGet/Install/NuGetInstallerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NuGet/Install/NuGetInstallerTests.cs
@@ -215,6 +215,20 @@ namespace Cake.Common.Tests.Unit.Tools.NuGet.Install
                              "-NonInteractive", result.Args);
             }
 
+            [Fact]
+            public void Should_Remove_NonInteractive_From_Arguments_If_False()
+            {
+                // Given
+                var fixture = new NuGetInstallerFixture();
+                fixture.Settings.NonInteractive = false;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("install \"Cake\"", result.Args);
+            }
+
             [Theory]
             [InlineData(NuGetVerbosity.Detailed, "install \"Cake\" -Verbosity detailed -NonInteractive")]
             [InlineData(NuGetVerbosity.Normal, "install \"Cake\" -Verbosity normal -NonInteractive")]

--- a/src/Cake.Common/Tools/NuGet/Install/NuGetInstaller.cs
+++ b/src/Cake.Common/Tools/NuGet/Install/NuGetInstaller.cs
@@ -161,7 +161,11 @@ namespace Cake.Common.Tools.NuGet.Install
                 builder.AppendQuoted(settings.ConfigFile.MakeAbsolute(_environment).FullPath);
             }
 
-            builder.Append("-NonInteractive");
+            // NonInteractive?
+            if (settings.NonInteractive)
+            {
+                builder.Append("-NonInteractive");
+            }
 
             return builder;
         }

--- a/src/Cake.Common/Tools/NuGet/Install/NugetInstallSettings.cs
+++ b/src/Cake.Common/Tools/NuGet/Install/NugetInstallSettings.cs
@@ -101,5 +101,16 @@ namespace Cake.Common.Tools.NuGet.Install
         /// </summary>
         /// <value>The list of packages sources to use as fallbacks for this command.</value>
         public ICollection<string> FallbackSource { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not NuGet suppresses prompts for user input or confirmations.
+        /// </summary>
+        /// <remarks>
+        /// This setting is passed by NuGet.exe to any extensions such as authorization providers
+        /// </remarks>
+        /// <value>
+        /// <c>false</c> to allow NuGet to show prompts for user input or confirmations; otherwise, <c>true</c>.
+        /// </value>
+        public bool NonInteractive { get; set; } = true;
     }
 }


### PR DESCRIPTION
Tackling issue #2671.

Brief summary of changes:

Added a property to define whether NonInteractive is passed or not to NuGet Install command.

The implementation is similar to the one already being used in NuGet Restore (with test included).