### PR TITLE
GH2675: Add InspectCode.x86.exe tool management

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/InspectCode/InspectCodeFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/InspectCode/InspectCodeFixture.cs
@@ -9,8 +9,8 @@ namespace Cake.Common.Tests.Fixtures.Tools.InspectCode
 {
     internal abstract class InspectCodeFixture : ToolFixture<InspectCodeSettings>
     {
-        protected InspectCodeFixture()
-            : base("inspectcode.exe")
+        protected InspectCodeFixture(bool useX86)
+            : base(useX86 ? "inspectcode.x86.exe" : "inspectcode.exe")
         {
         }
     }

--- a/src/Cake.Common.Tests/Fixtures/Tools/InspectCode/InspectCodeRunFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/InspectCode/InspectCodeRunFixture.cs
@@ -17,7 +17,7 @@ namespace Cake.Common.Tests.Fixtures.Tools.InspectCode
         public ICakeLog Log { get; set; }
         public FilePath Solution { get; set; }
 
-        public InspectCodeRunFixture()
+        public InspectCodeRunFixture(bool useX86 = false) : base(useX86)
         {
             Solution = new FilePath("./Test.sln");
 

--- a/src/Cake.Common.Tests/Fixtures/Tools/InspectCode/InspectCodeRunFromConfigFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/InspectCode/InspectCodeRunFromConfigFixture.cs
@@ -14,7 +14,7 @@ namespace Cake.Common.Tests.Fixtures.Tools.InspectCode
         public ICakeLog Log { get; set; }
         public FilePath Config { get; set; }
 
-        public InspectCodeRunFromConfigFixture()
+        public InspectCodeRunFromConfigFixture(bool useX86 = false) : base(useX86)
         {
             Log = Substitute.For<ICakeLog>();
         }

--- a/src/Cake.Common.Tests/Unit/Tools/InspectCode/InspectCodeRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/InspectCode/InspectCodeRunnerTests.cs
@@ -45,6 +45,19 @@ namespace Cake.Common.Tests.Unit.Tools.InspectCode
             }
 
             [Fact]
+            public void Should_Find_Inspect_Code_Runner_X86()
+            {
+                // Given
+                var fixture = new InspectCodeRunFixture(true);
+                fixture.Settings.UseX86Tool = true;
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/Working/tools/inspectcode.x86.exe", result.Path.FullPath);
+            }
+
+            [Fact]
             public void Should_Use_Provided_Solution_In_Process_Arguments()
             {
                 // Given

--- a/src/Cake.Common/Tools/InspectCode/InspectCodeRunner.cs
+++ b/src/Cake.Common/Tools/InspectCode/InspectCodeRunner.cs
@@ -212,10 +212,17 @@ namespace Cake.Common.Tools.InspectCode
         /// <summary>
         /// Gets the possible names of the tool executable.
         /// </summary>
+        /// <param name="settings">The settings.</param>
         /// <returns>The tool executable name.</returns>
-        protected override IEnumerable<string> GetToolExecutableNames()
+        protected override IEnumerable<string> GetToolExecutableNames(InspectCodeSettings settings)
         {
-            return new[] { "inspectcode.exe" };
+            return new[] { settings != null && settings.UseX86Tool ? "inspectcode.x86.exe" : "inspectcode.exe" };
         }
+
+        /// <summary>
+        /// Gets the possible names of the tool executable.
+        /// </summary>
+        /// <returns>The tool executable name.</returns>
+        protected override IEnumerable<string> GetToolExecutableNames() => GetToolExecutableNames(null);
     }
 }

--- a/src/Cake.Common/Tools/InspectCode/InspectCodeSettings.cs
+++ b/src/Cake.Common/Tools/InspectCode/InspectCodeSettings.cs
@@ -99,5 +99,10 @@ namespace Cake.Common.Tools.InspectCode
         /// Gets or sets a value indicating whether to throw an exception on finding violations
         /// </summary>
         public bool ThrowExceptionOnFindingViolations { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use x86 tool.
+        /// </summary>
+        public bool UseX86Tool { get; set; }
     }
 }


### PR DESCRIPTION
- This PR should handle issue #2675 
- The Resharper InspectCode tool embeds another tool `InspectCode.x86.exe` that needs to be used if you want to also analyze the C++ project that you may have in your Visual Studio solution. Note. that this tool `InspectCode.x86.exe` has the same arguments as `InspectCode.exe`