### PR TITLE
InspectCode: Add support for /verbosity and /severity arguments

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/InspectCode/InspectCodeRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/InspectCode/InspectCodeRunnerTests.cs
@@ -303,6 +303,20 @@ namespace Cake.Common.Tests.Unit.Tools.InspectCode
                 Assert.Equal("\"/profile=/Working/profile.DotSettings\" " +
                              "\"/Working/Test.sln\"", result.Args);
             }
+
+            [Fact]
+            public void Should_Set_Verbosity()
+            {
+                // Given
+                var fixture = new InspectCodeRunFixture();
+                fixture.Settings.Verbosity = InspectCodeVerbosity.Error;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("\"/verbosity=ERROR\" \"/Working/Test.sln\"", result.Args);
+            }
         }
 
         public sealed class TheRunFromConfigMethod

--- a/src/Cake.Common.Tests/Unit/Tools/InspectCode/InspectCodeRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/InspectCode/InspectCodeRunnerTests.cs
@@ -317,6 +317,20 @@ namespace Cake.Common.Tests.Unit.Tools.InspectCode
                 // Then
                 Assert.Equal("\"/verbosity=ERROR\" \"/Working/Test.sln\"", result.Args);
             }
+
+            [Fact]
+            public void Should_Set_Severity()
+            {
+                // Given
+                var fixture = new InspectCodeRunFixture();
+                fixture.Settings.Severity = InspectCodeSeverity.Hint;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("\"/severity=HINT\" \"/Working/Test.sln\"", result.Args);
+            }
         }
 
         public sealed class TheRunFromConfigMethod

--- a/src/Cake.Common/Tools/InspectCode/InspectCodeRunner.cs
+++ b/src/Cake.Common/Tools/InspectCode/InspectCodeRunner.cs
@@ -200,6 +200,11 @@ namespace Cake.Common.Tools.InspectCode
                 builder.AppendQuoted(string.Format(CultureInfo.InvariantCulture, "/verbosity={0}", settings.Verbosity.ToString().ToUpper(CultureInfo.InvariantCulture)));
             }
 
+            if (settings.Severity != null)
+            {
+                builder.AppendQuoted(string.Format(CultureInfo.InvariantCulture, "/severity={0}", settings.Severity.ToString().ToUpper(CultureInfo.InvariantCulture)));
+            }
+
             builder.AppendQuoted(solution.MakeAbsolute(_environment).FullPath);
 
             return builder;

--- a/src/Cake.Common/Tools/InspectCode/InspectCodeRunner.cs
+++ b/src/Cake.Common/Tools/InspectCode/InspectCodeRunner.cs
@@ -195,6 +195,11 @@ namespace Cake.Common.Tools.InspectCode
                 builder.AppendQuoted(string.Format(CultureInfo.InvariantCulture, "/profile={0}", settings.Profile.MakeAbsolute(_environment).FullPath));
             }
 
+            if (settings.Verbosity != null)
+            {
+                builder.AppendQuoted(string.Format(CultureInfo.InvariantCulture, "/verbosity={0}", settings.Verbosity.ToString().ToUpper(CultureInfo.InvariantCulture)));
+            }
+
             builder.AppendQuoted(solution.MakeAbsolute(_environment).FullPath);
 
             return builder;

--- a/src/Cake.Common/Tools/InspectCode/InspectCodeSettings.cs
+++ b/src/Cake.Common/Tools/InspectCode/InspectCodeSettings.cs
@@ -104,5 +104,10 @@ namespace Cake.Common.Tools.InspectCode
         /// Gets or sets a value indicating whether to use x86 tool.
         /// </summary>
         public bool UseX86Tool { get; set; }
+
+        /// <summary>
+        /// Gets or sets the verbosity level of the log messages.
+        /// </summary>
+        public InspectCodeVerbosity? Verbosity { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/InspectCode/InspectCodeSettings.cs
+++ b/src/Cake.Common/Tools/InspectCode/InspectCodeSettings.cs
@@ -109,5 +109,10 @@ namespace Cake.Common.Tools.InspectCode
         /// Gets or sets the verbosity level of the log messages.
         /// </summary>
         public InspectCodeVerbosity? Verbosity { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimal severity of issues to report.
+        /// </summary>
+        public InspectCodeSeverity? Severity { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/InspectCode/InspectCodeSeverity.cs
+++ b/src/Cake.Common/Tools/InspectCode/InspectCodeSeverity.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Tools.InspectCode
+{
+    /// <summary>
+    /// Represents InspectCode's minimal severity report.
+    /// </summary>
+    public enum InspectCodeSeverity
+    {
+        /// <summary>
+        /// Severity: INFO.
+        /// </summary>
+        Info = 1,
+
+        /// <summary>
+        /// Severity: HINT.
+        /// </summary>
+        Hint = 2,
+
+        /// <summary>
+        /// Severity: SUGGESTION.
+        /// </summary>
+        Suggestion = 3,
+
+        /// <summary>
+        /// Severity: WARNING.
+        /// </summary>
+        Warning = 4,
+
+        /// <summary>
+        /// Severity: ERROR.
+        /// </summary>
+        Error = 5
+    }
+}

--- a/src/Cake.Common/Tools/InspectCode/InspectCodeVerbosity.cs
+++ b/src/Cake.Common/Tools/InspectCode/InspectCodeVerbosity.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Tools.InspectCode
+{
+    /// <summary>
+    /// Represents InspectCode's logging verbosity.
+    /// </summary>
+    public enum InspectCodeVerbosity
+    {
+        /// <summary>
+        /// Verbosity: OFF.
+        /// </summary>
+        Off = 1,
+
+        /// <summary>
+        /// Verbosity: FATAL.
+        /// </summary>
+        Fatal = 2,
+
+        /// <summary>
+        /// Verbosity: ERROR.
+        /// </summary>
+        Error = 3,
+
+        /// <summary>
+        /// Verbosity: WARN.
+        /// </summary>
+        Warn = 4,
+
+        /// <summary>
+        /// Verbosity: INFO.
+        /// </summary>
+        Info = 5,
+
+        /// <summary>
+        /// Verbosity: VERBOSE.
+        /// </summary>
+        Verbose = 6,
+
+        /// <summary>
+        /// Verbosity: TRACE.
+        /// </summary>
+        Trace = 7
+    }
+}


### PR DESCRIPTION
💡 It fixes the issue https://github.com/cake-build/cake/issues/2328.

This PR adds the support of the arguments /verbosity and /severity for the tool InspectCode.
