### PR TITLE
GH1571: Adding integration tests for DotNetCoreAliases VSTest, Tool, etc.

### DIFF
--- a/tests/integration/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cake
+++ b/tests/integration/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cake
@@ -55,8 +55,33 @@ Task("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreTest")
     DotNetCoreTest(project.FullPath);
 });
 
+Task("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreVSTest")
+    .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreBuild")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNetCore");
+    var assembly = path.CombineWithFilePath("hwapp.tests/bin/Debug/netcoreapp3.0/hwapp.tests.dll");
+
+    // When
+    DotNetCoreVSTest(assembly.FullPath);
+});
+
+Task("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreTool")
+    .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreBuild")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNetCore");
+    var project = path.CombineWithFilePath("hwapp.tests/hwapp.tests.csproj");
+
+    // When
+    DotNetCoreTool("--info");
+});
+
 Task("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreRun")
     .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreTest")
+    .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreVSTest")
     .Does(() =>
 {
     // Given
@@ -85,6 +110,48 @@ Task("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCorePack")
     // Then
     Assert.True(System.IO.File.Exists(nuget.FullPath), "Path:" + nuget.FullPath);
     Assert.True(System.IO.File.Exists(nugetSymbols.FullPath), "Path:" + nugetSymbols.FullPath);
+});
+
+Task("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreNuGetPush")
+    .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCorePack")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNetCore");
+    var outputPath = path.Combine("DotNetCorePack");
+    var nugetServerPath = path.Combine("DotNetCorePush");
+    var nugetSource = outputPath.CombineWithFilePath("hwapp.1.0.0.nupkg");
+    var nugetDestination = nugetServerPath.CombineWithFilePath("hwapp.1.0.0.nupkg");
+    
+    EnsureDirectoryExist(outputPath);
+    EnsureDirectoryExist(nugetServerPath);
+    Assert.True(System.IO.File.Exists(nugetSource.FullPath), "Path:" + nugetSource.FullPath);
+
+    // When
+    DotNetCoreNuGetPush(nugetSource.FullPath, new DotNetCoreNuGetPushSettings { Source = nugetServerPath.FullPath });
+
+    // Then
+    Assert.True(System.IO.File.Exists(nugetDestination.FullPath), "Path:" + nugetDestination.FullPath);
+});
+
+
+Task("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreNuGetDelete")
+    .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreNuGetPush")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNetCore");
+    var nugetServerPath = path.Combine("DotNetCorePush");
+    var nugetDestination = nugetServerPath.CombineWithFilePath("hwapp.1.0.0.nupkg");
+    
+    EnsureDirectoryExist(nugetServerPath);
+    Assert.True(System.IO.File.Exists(nugetDestination.FullPath), "Path:" + nugetDestination.FullPath);
+
+    // When
+    DotNetCoreNuGetDelete("hwapp", "1.0.0", new DotNetCoreNuGetDeleteSettings { Source = nugetServerPath.FullPath, NonInteractive = true });
+
+    // Then
+    Assert.False(System.IO.File.Exists(nugetDestination.FullPath), "Path:" + nugetDestination.FullPath);
 });
 
 Task("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCorePublish")
@@ -128,6 +195,39 @@ Task("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreExecute")
     DotNetCoreExecute(assembly);
 });
 
+Task("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreClean")
+    .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreBuild")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNetCore");
+    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
+    var assembly = path.CombineWithFilePath("hwapp/bin/Debug/netcoreapp3.0/hwapp.dll");
+    Assert.True(System.IO.File.Exists(assembly.FullPath));
+
+    // When
+    DotNetCoreClean(project.FullPath);
+
+    // Then
+    Assert.False(System.IO.File.Exists(assembly.FullPath));
+});
+
+Task("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreMSBuild")
+    .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreClean")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNetCore");
+    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
+    var assembly = path.CombineWithFilePath("hwapp/bin/Debug/netcoreapp3.0/hwapp.dll");
+
+    // When
+    DotNetCoreMSBuild(project.FullPath);
+
+    // Then
+    Assert.True(System.IO.File.Exists(assembly.FullPath));
+});
+
 Task("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreTest.Fail")
     .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreTest")
     .Does(() =>
@@ -152,10 +252,16 @@ Task("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreBuildServerShutdo
     .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreRestore")
     .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreBuild")
     .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreTest")
+    .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreVSTest")
+    .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreTool")
     .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreRun")
     .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCorePack")
+    .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreNuGetPush")
+    .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreNuGetDelete")
     .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCorePublish")
     .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreExecute")
+    .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreClean")
+    .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreMSBuild")
     .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreTest.Fail")
     .Does(() =>
 {

--- a/tests/integration/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cake
+++ b/tests/integration/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cake
@@ -71,10 +71,6 @@ Task("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreTool")
     .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreBuild")
     .Does(() =>
 {
-    // Given
-    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNetCore");
-    var project = path.CombineWithFilePath("hwapp.tests/hwapp.tests.csproj");
-
     // When
     DotNetCoreTool("--info");
 });
@@ -133,7 +129,6 @@ Task("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreNuGetPush")
     // Then
     Assert.True(System.IO.File.Exists(nugetDestination.FullPath), "Path:" + nugetDestination.FullPath);
 });
-
 
 Task("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreNuGetDelete")
     .IsDependentOn("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreNuGetPush")

--- a/tests/integration/resources/Cake.Common/Tools/DotNetCore/hwapp.tests/VSTests.cs
+++ b/tests/integration/resources/Cake.Common/Tools/DotNetCore/hwapp.tests/VSTests.cs
@@ -1,0 +1,53 @@
+﻿using HWApp.Common;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace hwapp.tests
+{
+    public sealed class GreeterVSTests
+    {
+        [TestClass]
+        public sealed class TheGreaterMethod
+        {
+            [TestMethod]
+            public void Should_Not_Fail_Test()
+            {
+                Assert.AreNotEqual("true", Environment.GetEnvironmentVariable("hwapp_fail_test"));
+            }
+
+            [TestMethod]
+            public void Should_Greet_World()
+            {
+                // Given
+                var name = "World";
+                var expect = "Hello World!";
+
+                // When
+                var result = Greeter.GetGreeting(name);
+
+                // Then
+                Assert.AreEqual(expect, result);
+            }
+
+            [TestMethod]
+            public void Should_Throw_On_Null_Name()
+            {
+                // Given
+                string name = null;
+
+                // When
+                try
+                {
+                    Greeter.GetGreeting(name);
+                }
+                catch (Exception result)
+                {
+                    // Then
+                    Assert.IsNotNull(result);
+                    Assert.IsInstanceOfType(result, typeof(ArgumentNullException));
+                    Assert.AreEqual($"Value cannot be null. (Parameter 'name')", result.Message);
+                }
+            }
+        }
+    }
+}

--- a/tests/integration/resources/Cake.Common/Tools/DotNetCore/hwapp.tests/hwapp.tests.csproj
+++ b/tests/integration/resources/Cake.Common/Tools/DotNetCore/hwapp.tests/hwapp.tests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />


### PR DESCRIPTION
Adding integration tests for DotNetCoreAliases VSTest, Tool, NuGetPush, NuGetDelete, Clean, and MSBuild.

This change is to address #1571 