### PR TITLE
GH2696: Update Cake support for GitReleaseManager

### DIFF
--- a/GitReleaseManager.yaml
+++ b/GitReleaseManager.yaml
@@ -10,3 +10,20 @@ issue-labels-alias:
     - name:    Documentation
       header:  Documentation
       plural:  Documentation
+create:
+  include-sha-section: true
+  sha-section-heading: "SHA256 Hashes of the release artifacts"
+  sha-section-line-format: "- `{1}\t{0}`"
+close:
+  use-issue-comments: true
+  issue-comment: |-
+    :tada: This issue has been resolved in version {milestone} :tada:
+
+    The release is available on:
+
+    - [GitHub Release](https://github.com/{owner}/{repository}/releases/tag/{milestone})
+    - [NuGet Package](https://www.nuget.org/packages/Cake/{milestone})
+    - [Chocolatey Package](https://chocolatey.org/packages/cake.portable/{milestone})
+    - [.Net Global Tool](https://www.nuget.org/packages/Cake.Tool/{milestone})
+    
+    Your **[GitReleaseManager](https://github.com/GitTools/GitReleaseManager)** bot :package::rocket:

--- a/build.cake
+++ b/build.cake
@@ -15,7 +15,7 @@
 // Install .NET Core Global tools.
 #tool "dotnet:https://api.nuget.org/v3/index.json?package=GitVersion.Tool&version=5.1.2"
 #tool "dotnet:https://api.nuget.org/v3/index.json?package=SignClient&version=1.0.82"
-#tool "dotnet:https://api.nuget.org/v3/index.json?package=GitReleaseManager.Tool&version=0.9.0"
+#tool "dotnet:https://api.nuget.org/v3/index.json?package=GitReleaseManager.Tool&version=0.10.2"
 
 // Load other scripts.
 #load "./build/parameters.cake"
@@ -579,9 +579,9 @@ Task("Publish-GitHub-Release")
     .WithCriteria<BuildParameters>((context, parameters) => parameters.ShouldPublish)
     .Does<BuildParameters>((context, parameters) =>
 {
-    GitReleaseManagerAddAssets(parameters.GitHub.UserName, parameters.GitHub.Password, "cake-build", "cake", parameters.Version.Milestone, parameters.Paths.Files.ZipArtifactPathDesktop.ToString());
-    GitReleaseManagerAddAssets(parameters.GitHub.UserName, parameters.GitHub.Password, "cake-build", "cake", parameters.Version.Milestone, parameters.Paths.Files.ZipArtifactPathCoreClr.ToString());
-    GitReleaseManagerClose(parameters.GitHub.UserName, parameters.GitHub.Password, "cake-build", "cake", parameters.Version.Milestone);
+    GitReleaseManagerAddAssets(parameters.GitHub.Token, "cake-build", "cake", parameters.Version.Milestone, parameters.Paths.Files.ZipArtifactPathDesktop.ToString());
+    GitReleaseManagerAddAssets(parameters.GitHub.Token, "cake-build", "cake", parameters.Version.Milestone, parameters.Paths.Files.ZipArtifactPathCoreClr.ToString());
+    GitReleaseManagerClose(parameters.GitHub.Token, "cake-build", "cake", parameters.Version.Milestone);
 })
 .OnError<BuildParameters>((exception, parameters) =>
 {
@@ -592,7 +592,7 @@ Task("Publish-GitHub-Release")
 Task("Create-Release-Notes")
     .Does<BuildParameters>((context, parameters) =>
 {
-    GitReleaseManagerCreate(parameters.GitHub.UserName, parameters.GitHub.Password, "cake-build", "cake", new GitReleaseManagerCreateSettings {
+    GitReleaseManagerCreate(parameters.GitHub.Token, "cake-build", "cake", new GitReleaseManagerCreateSettings {
         Milestone         = parameters.Version.Milestone,
         Name              = parameters.Version.Milestone,
         Prerelease        = true,

--- a/build/credentials.cake
+++ b/build/credentials.cake
@@ -1,19 +1,16 @@
 public class BuildCredentials
 {
-    public string UserName { get; private set; }
-    public string Password { get; private set; }
+    public string Token { get; private set; }
 
-    public BuildCredentials(string userName, string password)
+    public BuildCredentials(string token)
     {
-        UserName = userName;
-        Password = password;
+        Token = token;
     }
 
     public static BuildCredentials GetGitHubCredentials(ICakeContext context)
     {
         return new BuildCredentials(
-            context.EnvironmentVariable("CAKE_GITHUB_USERNAME"),
-            context.EnvironmentVariable("CAKE_GITHUB_PASSWORD"));
+            context.EnvironmentVariable("CAKE_GITHUB_TOKEN"));
     }
 }
 

--- a/src/Cake.Common.Tests/Fixtures/Tools/GitReleaseManager/GitReleaseManagerDiscarderFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/GitReleaseManager/GitReleaseManagerDiscarderFixture.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.GitReleaseManager.Discard;
+
+namespace Cake.Common.Tests.Fixtures.Tools.GitReleaseManager
+{
+    internal sealed class GitReleaseManagerDiscarderFixture : GitReleaseManagerFixture<GitReleaseManagerDiscardSettings>
+    {
+        public string Token { get; set; }
+        public string Owner { get; set; }
+        public string Repository { get; set; }
+
+        public string Milestone { get; set; }
+
+        public GitReleaseManagerDiscarderFixture()
+        {
+            Token = "token";
+            Owner = "repoOwner";
+            Repository = "repo";
+            Milestone = "0.1.0";
+        }
+
+        protected override void RunTool()
+        {
+            var tool = new GitReleaseManagerDiscarder(FileSystem, Environment, ProcessRunner, Tools);
+
+            tool.Discard(Token, Owner, Repository, Milestone, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Fixtures/Tools/GitReleaseManager/GitReleaseManagerMilestoneOpenerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/GitReleaseManager/GitReleaseManagerMilestoneOpenerFixture.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.GitReleaseManager.Open;
+
+namespace Cake.Common.Tests.Fixtures.Tools.GitReleaseManager
+{
+    internal sealed class GitReleaseManagerMilestoneOpenerFixture : GitReleaseManagerFixture<GitReleaseManagerOpenMilestoneSettings>
+    {
+        public string Token { get; set; }
+        public string Owner { get; set; }
+        public string Repository { get; set; }
+        public string Milestone { get; set; }
+
+        public GitReleaseManagerMilestoneOpenerFixture()
+        {
+            Token = "token";
+            Owner = "repoOwner";
+            Repository = "repo";
+            Milestone = "0.1.0";
+        }
+
+        protected override void RunTool()
+        {
+            var tool = new GitReleaseManagerMilestoneOpener(FileSystem, Environment, ProcessRunner, Tools);
+
+            tool.Open(Token, Owner, Repository, Milestone, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/AddAssets/GitReleaseManagerAssetsAdderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/AddAssets/GitReleaseManagerAssetsAdderTests.cs
@@ -481,6 +481,111 @@ namespace Cake.Common.Tests.Unit.Tools.GitReleaseManager.AddAssets
                              "-a \"/temp/asset1.txt\" " +
                              "-l \"/temp/log.txt\"", result.Args);
             }
+
+            [Fact]
+            public void Should_Add_Debug_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerAssetsAdderFixture();
+                fixture.Settings.Debug = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("addasset -u \"bob\" -p \"password\" " +
+                             "-o \"repoOwner\" -r \"repo\" -t \"0.1.0\" " +
+                             "-a \"/temp/asset1.txt\" " +
+                             "--debug", result.Args);
+            }
+
+            [Fact]
+            public void Should_All_Debug_To_Arguments_If_Set_When_Using_Token()
+            {
+                // Given
+                var fixture = new GitReleaseManagerAssetsAdderFixture();
+                fixture.UseToken();
+                fixture.Settings.Debug = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("addasset --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" -t \"0.1.0\" " +
+                             "-a \"/temp/asset1.txt\" " +
+                             "--debug", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Verbose_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerAssetsAdderFixture();
+                fixture.Settings.Verbose = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("addasset -u \"bob\" -p \"password\" " +
+                             "-o \"repoOwner\" -r \"repo\" -t \"0.1.0\" " +
+                             "-a \"/temp/asset1.txt\" " +
+                             "--verbose", result.Args);
+            }
+
+            [Fact]
+            public void Should_All_Verbose_To_Arguments_If_Set_When_Using_Token()
+            {
+                // Given
+                var fixture = new GitReleaseManagerAssetsAdderFixture();
+                fixture.UseToken();
+                fixture.Settings.Verbose = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("addasset --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" -t \"0.1.0\" " +
+                             "-a \"/temp/asset1.txt\" " +
+                             "--verbose", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_NoLogo_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerAssetsAdderFixture();
+                fixture.Settings.NoLogo = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("addasset -u \"bob\" -p \"password\" " +
+                             "-o \"repoOwner\" -r \"repo\" -t \"0.1.0\" " +
+                             "-a \"/temp/asset1.txt\" " +
+                             "--no-logo", result.Args);
+            }
+
+            [Fact]
+            public void Should_All_NoLogo_To_Arguments_If_Set_When_Using_Token()
+            {
+                // Given
+                var fixture = new GitReleaseManagerAssetsAdderFixture();
+                fixture.UseToken();
+                fixture.Settings.NoLogo = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("addasset --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" -t \"0.1.0\" " +
+                             "-a \"/temp/asset1.txt\" " +
+                             "--no-logo", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/Close/GitReleaseManagerMilestoneCloserTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/Close/GitReleaseManagerMilestoneCloserTests.cs
@@ -448,6 +448,105 @@ namespace Cake.Common.Tests.Unit.Tools.GitReleaseManager.Close
                              "-o \"repoOwner\" -r \"repo\" -m \"0.1.0\" " +
                              "-l \"/temp/log.txt\"", result.Args);
             }
+
+            [Fact]
+            public void Should_Add_Debug_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneCloserFixture();
+                fixture.Settings.Debug = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("close -u \"bob\" -p \"password\" " +
+                             "-o \"repoOwner\" -r \"repo\" -m \"0.1.0\" " +
+                             "--debug", result.Args);
+            }
+
+            [Fact]
+            public void Should_All_Debug_To_Arguments_If_Set_When_Using_Token()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneCloserFixture();
+                fixture.UseToken();
+                fixture.Settings.Debug = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("close --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" -m \"0.1.0\" " +
+                             "--debug", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Verbose_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneCloserFixture();
+                fixture.Settings.Verbose = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("close -u \"bob\" -p \"password\" " +
+                             "-o \"repoOwner\" -r \"repo\" -m \"0.1.0\" " +
+                             "--verbose", result.Args);
+            }
+
+            [Fact]
+            public void Should_All_Verbose_To_Arguments_If_Set_When_Using_Token()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneCloserFixture();
+                fixture.UseToken();
+                fixture.Settings.Verbose = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("close --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" -m \"0.1.0\" " +
+                             "--verbose", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_NoLogo_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneCloserFixture();
+                fixture.Settings.NoLogo = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("close -u \"bob\" -p \"password\" " +
+                             "-o \"repoOwner\" -r \"repo\" -m \"0.1.0\" " +
+                             "--no-logo", result.Args);
+            }
+
+            [Fact]
+            public void Should_All_NoLogo_To_Arguments_If_Set_When_Using_Token()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneCloserFixture();
+                fixture.UseToken();
+                fixture.Settings.NoLogo = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("close --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" -m \"0.1.0\" " +
+                             "--no-logo", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/Create/GitReleaseManagerCreatorTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/Create/GitReleaseManagerCreatorTests.cs
@@ -605,6 +605,105 @@ namespace Cake.Common.Tests.Unit.Tools.GitReleaseManager.Create
                              "-o \"repoOwner\" -r \"repo\" " +
                              "-l \"/temp/log.txt\"", result.Args);
             }
+
+            [Fact]
+            public void Should_Add_Debug_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+                fixture.Settings.Debug = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create -u \"bob\" -p \"password\" " +
+                             "-o \"repoOwner\" -r \"repo\" " +
+                             "--debug", result.Args);
+            }
+
+            [Fact]
+            public void Should_All_Debug_To_Arguments_If_Set_When_Using_Token()
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+                fixture.UseToken();
+                fixture.Settings.Debug = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" " +
+                             "--debug", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Verbose_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+                fixture.Settings.Verbose = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create -u \"bob\" -p \"password\" " +
+                             "-o \"repoOwner\" -r \"repo\" " +
+                             "--verbose", result.Args);
+            }
+
+            [Fact]
+            public void Should_All_Verbose_To_Arguments_If_Set_When_Using_Token()
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+                fixture.UseToken();
+                fixture.Settings.Verbose = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" " +
+                             "--verbose", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_NoLogo_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+                fixture.Settings.NoLogo = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create -u \"bob\" -p \"password\" " +
+                             "-o \"repoOwner\" -r \"repo\" " +
+                             "--no-logo", result.Args);
+            }
+
+            [Fact]
+            public void Should_All_NoLogo_To_Arguments_If_Set_When_Using_Token()
+            {
+                // Given
+                var fixture = new GitReleaseManagerCreatorFixture();
+                fixture.UseToken();
+                fixture.Settings.NoLogo = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("create --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" " +
+                             "--no-logo", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/Discard/GitReleaseManagerDiscarderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/Discard/GitReleaseManagerDiscarderTests.cs
@@ -1,0 +1,269 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tests.Fixtures.Tools.GitReleaseManager;
+using Cake.Testing;
+using Cake.Testing.Xunit;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.GitReleaseManager.Discard
+{
+    public sealed class GitReleaseManagerDiscarderTests
+    {
+        public sealed class TheDiscardMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Token_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerDiscarderFixture();
+                fixture.Token = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "token");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Owner_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerDiscarderFixture();
+                fixture.Owner = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "owner");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Repository_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerDiscarderFixture();
+                fixture.Repository = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "repository");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerDiscarderFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_GitReleaseManager_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new GitReleaseManagerDiscarderFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, "GitReleaseManager: Could not locate executable.");
+            }
+
+            [Theory]
+            [InlineData("/bin/tools/GitReleaseManager/GitReleaseManager.exe", "/bin/tools/GitReleaseManager/GitReleaseManager.exe")]
+            [InlineData("./tools/GitReleaseManager/GitReleaseManager.exe", "/Working/tools/GitReleaseManager/GitReleaseManager.exe")]
+            public void Should_Use_GitReleaseManager_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new GitReleaseManagerDiscarderFixture();
+                fixture.Settings.ToolPath = toolPath;
+                fixture.GivenSettingsToolPathExist();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Path.FullPath);
+            }
+
+            [WindowsTheory]
+            [InlineData("C:/GitReleaseManager/GitReleaseManager.exe", "C:/GitReleaseManager/GitReleaseManager.exe")]
+            public void Should_Use_GitReleaseManager_Executable_From_Tool_Path_If_Provided_On_Windows(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new GitReleaseManagerDiscarderFixture();
+                fixture.Settings.ToolPath = toolPath;
+                fixture.GivenSettingsToolPathExist();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Path.FullPath);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new GitReleaseManagerDiscarderFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, "GitReleaseManager: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new GitReleaseManagerDiscarderFixture();
+                fixture.GivenProcessExitsWithCode(1);
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, "GitReleaseManager: Process returned an error (exit code 1).");
+            }
+
+            [Fact]
+            public void Should_Find_GitReleaseManager_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new GitReleaseManagerDiscarderFixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/Working/tools/GitReleaseManager.exe", result.Path.FullPath);
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new GitReleaseManagerDiscarderFixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("discard --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" -m \"0.1.0\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Milestone_To_Arguments_If_True()
+            {
+                // Given
+                var fixture = new GitReleaseManagerDiscarderFixture();
+                fixture.Milestone = "1.0.0";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("discard --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" -m \"1.0.0\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_TargetDirectory_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerDiscarderFixture();
+                fixture.Settings.TargetDirectory = @"/temp";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("discard --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" -m \"0.1.0\" -d \"/temp\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_LogFilePath_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerDiscarderFixture();
+                fixture.Settings.LogFilePath = @"/temp/log.txt";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("discard --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" -m \"0.1.0\" " +
+                             "-l \"/temp/log.txt\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Debug_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerDiscarderFixture();
+                fixture.Settings.Debug = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("discard --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" -m \"0.1.0\" " +
+                             "--debug", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Verbose_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerDiscarderFixture();
+                fixture.Settings.Verbose = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("discard --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" -m \"0.1.0\" " +
+                             "--verbose", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_NoLogo_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerDiscarderFixture();
+                fixture.Settings.NoLogo = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("discard --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" -m \"0.1.0\" " +
+                             "--no-logo", result.Args);
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/Export/GitReleaseManagerExporterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/Export/GitReleaseManagerExporterTests.cs
@@ -483,6 +483,105 @@ namespace Cake.Common.Tests.Unit.Tools.GitReleaseManager.Export
                              "-o \"repoOwner\" -r \"repo\" -f \"/temp\" " +
                              "-l \"/temp/log.txt\"", result.Args);
             }
+
+            [Fact]
+            public void Should_Add_Debug_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerExporterFixture();
+                fixture.Settings.Debug = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("export -u \"bob\" -p \"password\" " +
+                             "-o \"repoOwner\" -r \"repo\" -f \"/temp\" " +
+                             "--debug", result.Args);
+            }
+
+            [Fact]
+            public void Should_All_Debug_To_Arguments_If_Set_When_Using_Token()
+            {
+                // Given
+                var fixture = new GitReleaseManagerExporterFixture();
+                fixture.UseToken();
+                fixture.Settings.Debug = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("export --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" -f \"/temp\" " +
+                             "--debug", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Verbose_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerExporterFixture();
+                fixture.Settings.Verbose = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("export -u \"bob\" -p \"password\" " +
+                             "-o \"repoOwner\" -r \"repo\" -f \"/temp\" " +
+                             "--verbose", result.Args);
+            }
+
+            [Fact]
+            public void Should_All_Verbose_To_Arguments_If_Set_When_Using_Token()
+            {
+                // Given
+                var fixture = new GitReleaseManagerExporterFixture();
+                fixture.UseToken();
+                fixture.Settings.Verbose = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("export --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" -f \"/temp\" " +
+                             "--verbose", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_NoLogo_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerExporterFixture();
+                fixture.Settings.NoLogo = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("export -u \"bob\" -p \"password\" " +
+                             "-o \"repoOwner\" -r \"repo\" -f \"/temp\" " +
+                             "--no-logo", result.Args);
+            }
+
+            [Fact]
+            public void Should_All_NoLogo_To_Arguments_If_Set_When_Using_Token()
+            {
+                // Given
+                var fixture = new GitReleaseManagerExporterFixture();
+                fixture.UseToken();
+                fixture.Settings.NoLogo = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("export --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" -f \"/temp\" " +
+                             "--no-logo", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/Label/GitReleaseManagerLabellerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/Label/GitReleaseManagerLabellerTests.cs
@@ -417,6 +417,105 @@ namespace Cake.Common.Tests.Unit.Tools.GitReleaseManager.Label
                              "-o \"repoOwner\" -r \"repo\" " +
                              "-l \"/temp/log.txt\"", result.Args);
             }
+
+            [Fact]
+            public void Should_Add_Debug_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerLabellerFixture();
+                fixture.Settings.Debug = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("label -u \"bob\" -p \"password\" " +
+                             "-o \"repoOwner\" -r \"repo\" " +
+                             "--debug", result.Args);
+            }
+
+            [Fact]
+            public void Should_All_Debug_To_Arguments_If_Set_When_Using_Token()
+            {
+                // Given
+                var fixture = new GitReleaseManagerLabellerFixture();
+                fixture.UseToken();
+                fixture.Settings.Debug = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("label --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" " +
+                             "--debug", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Verbose_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerLabellerFixture();
+                fixture.Settings.Verbose = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("label -u \"bob\" -p \"password\" " +
+                             "-o \"repoOwner\" -r \"repo\" " +
+                             "--verbose", result.Args);
+            }
+
+            [Fact]
+            public void Should_All_Verbose_To_Arguments_If_Set_When_Using_Token()
+            {
+                // Given
+                var fixture = new GitReleaseManagerLabellerFixture();
+                fixture.UseToken();
+                fixture.Settings.Verbose = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("label --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" " +
+                             "--verbose", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_NoLogo_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerLabellerFixture();
+                fixture.Settings.NoLogo = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("label -u \"bob\" -p \"password\" " +
+                             "-o \"repoOwner\" -r \"repo\" " +
+                             "--no-logo", result.Args);
+            }
+
+            [Fact]
+            public void Should_All_NoLogo_To_Arguments_If_Set_When_Using_Token()
+            {
+                // Given
+                var fixture = new GitReleaseManagerLabellerFixture();
+                fixture.UseToken();
+                fixture.Settings.NoLogo = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("label --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" " +
+                             "--no-logo", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/Open/GitReleaseManagerMilestoneOpenerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/Open/GitReleaseManagerMilestoneOpenerTests.cs
@@ -1,0 +1,269 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tests.Fixtures.Tools.GitReleaseManager;
+using Cake.Testing;
+using Cake.Testing.Xunit;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.GitReleaseManager.Open
+{
+    public sealed class GitReleaseManagerMilestoneOpenerTests
+    {
+        public sealed class TheOpenMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Token_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneOpenerFixture();
+                fixture.Token = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "token");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Owner_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneOpenerFixture();
+                fixture.Owner = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "owner");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Repository_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneOpenerFixture();
+                fixture.Repository = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "repository");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Milestone_Is_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneOpenerFixture();
+                fixture.Milestone = string.Empty;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "milestone");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneOpenerFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_GitReleaseManager_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneOpenerFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, "GitReleaseManager: Could not locate executable.");
+            }
+
+            [Theory]
+            [InlineData("/bin/tools/GitReleaseManager/GitReleaseManager.exe", "/bin/tools/GitReleaseManager/GitReleaseManager.exe")]
+            [InlineData("./tools/GitReleaseManager/GitReleaseManager.exe", "/Working/tools/GitReleaseManager/GitReleaseManager.exe")]
+            public void Should_Use_GitReleaseManager_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneOpenerFixture();
+                fixture.Settings.ToolPath = toolPath;
+                fixture.GivenSettingsToolPathExist();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Path.FullPath);
+            }
+
+            [WindowsTheory]
+            [InlineData("C:/GitReleaseManager/GitReleaseManager.exe", "C:/GitReleaseManager/GitReleaseManager.exe")]
+            public void Should_Use_GitReleaseManager_Executable_From_Tool_Path_If_Provided_On_Windows(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneOpenerFixture();
+                fixture.Settings.ToolPath = toolPath;
+                fixture.GivenSettingsToolPathExist();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Path.FullPath);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneOpenerFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, "GitReleaseManager: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneOpenerFixture();
+                fixture.GivenProcessExitsWithCode(1);
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, "GitReleaseManager: Process returned an error (exit code 1).");
+            }
+
+            [Fact]
+            public void Should_Find_GitReleaseManager_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneOpenerFixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/Working/tools/GitReleaseManager.exe", result.Path.FullPath);
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneOpenerFixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("open --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" -m \"0.1.0\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_TargetDirectory_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneOpenerFixture();
+                fixture.Settings.TargetDirectory = @"/temp";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("open --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" -m \"0.1.0\" " +
+                             "-d \"/temp\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_LogFilePath_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneOpenerFixture();
+                fixture.Settings.LogFilePath = @"/temp/log.txt";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("open --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" -m \"0.1.0\" " +
+                             "-l \"/temp/log.txt\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Debug_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneOpenerFixture();
+                fixture.Settings.Debug = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("open --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" -m \"0.1.0\" " +
+                             "--debug", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Verbose_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneOpenerFixture();
+                fixture.Settings.Verbose = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("open --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" -m \"0.1.0\" " +
+                             "--verbose", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_NoLogo_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerMilestoneOpenerFixture();
+                fixture.Settings.NoLogo = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("open --token \"token\" " +
+                             "-o \"repoOwner\" -r \"repo\" -m \"0.1.0\" " +
+                             "--no-logo", result.Args);
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/Publish/GitReleaseManagerPublisherTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/GitReleaseManager/Publish/GitReleaseManagerPublisherTests.cs
@@ -454,6 +454,105 @@ namespace Cake.Common.Tests.Unit.Tools.GitReleaseManager.Publish
                              "\"repoOwner\" -r \"repo\" -t \"0.1.0\" " +
                              "-l \"/temp/log.txt\"", result.Args);
             }
+
+            [Fact]
+            public void Should_Add_Debug_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerPublisherFixture();
+                fixture.Settings.Debug = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("publish -u \"bob\" -p \"password\" -o " +
+                             "\"repoOwner\" -r \"repo\" -t \"0.1.0\" " +
+                             "--debug", result.Args);
+            }
+
+            [Fact]
+            public void Should_All_Debug_To_Arguments_If_Set_When_Using_Token()
+            {
+                // Given
+                var fixture = new GitReleaseManagerPublisherFixture();
+                fixture.UseToken();
+                fixture.Settings.Debug = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("publish --token \"token\" -o " +
+                             "\"repoOwner\" -r \"repo\" -t \"0.1.0\" " +
+                             "--debug", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Verbose_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerPublisherFixture();
+                fixture.Settings.Verbose = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("publish -u \"bob\" -p \"password\" -o " +
+                             "\"repoOwner\" -r \"repo\" -t \"0.1.0\" " +
+                             "--verbose", result.Args);
+            }
+
+            [Fact]
+            public void Should_All_Verbose_To_Arguments_If_Set_When_Using_Token()
+            {
+                // Given
+                var fixture = new GitReleaseManagerPublisherFixture();
+                fixture.UseToken();
+                fixture.Settings.Verbose = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("publish --token \"token\" -o " +
+                             "\"repoOwner\" -r \"repo\" -t \"0.1.0\" " +
+                             "--verbose", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_NoLogo_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitReleaseManagerPublisherFixture();
+                fixture.Settings.NoLogo = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("publish -u \"bob\" -p \"password\" -o " +
+                             "\"repoOwner\" -r \"repo\" -t \"0.1.0\" " +
+                             "--no-logo", result.Args);
+            }
+
+            [Fact]
+            public void Should_All_NoLogo_To_Arguments_If_Set_When_Using_Token()
+            {
+                // Given
+                var fixture = new GitReleaseManagerPublisherFixture();
+                fixture.UseToken();
+                fixture.Settings.NoLogo = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("publish --token \"token\" -o " +
+                             "\"repoOwner\" -r \"repo\" -t \"0.1.0\" " +
+                             "--no-logo", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common/Tools/GitReleaseManager/AddAssets/GitReleaseManagerAddAssetsSettings.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/AddAssets/GitReleaseManagerAddAssetsSettings.cs
@@ -2,24 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Core.IO;
-using Cake.Core.Tooling;
-
 namespace Cake.Common.Tools.GitReleaseManager.AddAssets
 {
     /// <summary>
     /// Contains settings used by <see cref="GitReleaseManagerAssetsAdder"/>.
     /// </summary>
-    public sealed class GitReleaseManagerAddAssetsSettings : ToolSettings
+    public sealed class GitReleaseManagerAddAssetsSettings : GitReleaseManagerSettings
     {
-        /// <summary>
-        /// Gets or sets the path on which GitReleaseManager should be executed.
-        /// </summary>
-        public DirectoryPath TargetDirectory { get; set; }
-
-        /// <summary>
-        /// Gets or sets the path to the GitReleaseManager log file.
-        /// </summary>
-        public FilePath LogFilePath { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/GitReleaseManager/AddAssets/GitReleaseManagerAssetsAdder.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/AddAssets/GitReleaseManagerAssetsAdder.cs
@@ -14,8 +14,6 @@ namespace Cake.Common.Tools.GitReleaseManager.AddAssets
     /// </summary>
     public sealed class GitReleaseManagerAssetsAdder : GitReleaseManagerTool<GitReleaseManagerAddAssetsSettings>
     {
-        private readonly ICakeEnvironment _environment;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="GitReleaseManagerAssetsAdder"/> class.
         /// </summary>
@@ -29,7 +27,6 @@ namespace Cake.Common.Tools.GitReleaseManager.AddAssets
             IProcessRunner processRunner,
             IToolLocator tools) : base(fileSystem, environment, processRunner, tools)
         {
-            _environment = environment;
         }
 
         /// <summary>
@@ -138,7 +135,9 @@ namespace Cake.Common.Tools.GitReleaseManager.AddAssets
             builder.Append("-p");
             builder.AppendQuotedSecret(password);
 
-            ParseCommonArguments(builder, owner, repository, tagName, assets, settings);
+            ParseCommonArguments(builder, owner, repository, tagName, assets);
+
+            AddBaseArguments(settings, builder);
 
             return builder;
         }
@@ -152,12 +151,14 @@ namespace Cake.Common.Tools.GitReleaseManager.AddAssets
             builder.Append("--token");
             builder.AppendQuoted(token);
 
-            ParseCommonArguments(builder, owner, repository, tagName, assets, settings);
+            ParseCommonArguments(builder, owner, repository, tagName, assets);
+
+            AddBaseArguments(settings, builder);
 
             return builder;
         }
 
-        private void ParseCommonArguments(ProcessArgumentBuilder builder, string owner, string repository, string tagName, string assets, GitReleaseManagerAddAssetsSettings settings)
+        private void ParseCommonArguments(ProcessArgumentBuilder builder, string owner, string repository, string tagName, string assets)
         {
             builder.Append("-o");
             builder.AppendQuoted(owner);
@@ -170,20 +171,6 @@ namespace Cake.Common.Tools.GitReleaseManager.AddAssets
 
             builder.Append("-a");
             builder.AppendQuoted(assets);
-
-            // Target Directory
-            if (settings.TargetDirectory != null)
-            {
-                builder.Append("-d");
-                builder.AppendQuoted(settings.TargetDirectory.MakeAbsolute(_environment).FullPath);
-            }
-
-            // Log File Path
-            if (settings.LogFilePath != null)
-            {
-                builder.Append("-l");
-                builder.AppendQuoted(settings.LogFilePath.MakeAbsolute(_environment).FullPath);
-            }
         }
     }
 }

--- a/src/Cake.Common/Tools/GitReleaseManager/AddAssets/GitReleaseManagerAssetsAdder.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/AddAssets/GitReleaseManagerAssetsAdder.cs
@@ -149,7 +149,7 @@ namespace Cake.Common.Tools.GitReleaseManager.AddAssets
             builder.Append("addasset");
 
             builder.Append("--token");
-            builder.AppendQuoted(token);
+            builder.AppendQuotedSecret(token);
 
             ParseCommonArguments(builder, owner, repository, tagName, assets);
 

--- a/src/Cake.Common/Tools/GitReleaseManager/Close/GitReleaseManagerCloseMilestoneSettings.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Close/GitReleaseManagerCloseMilestoneSettings.cs
@@ -2,24 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Core.IO;
-using Cake.Core.Tooling;
-
 namespace Cake.Common.Tools.GitReleaseManager.Close
 {
     /// <summary>
     /// Contains settings used by <see cref="GitReleaseManagerMilestoneCloser"/>.
     /// </summary>
-    public sealed class GitReleaseManagerCloseMilestoneSettings : ToolSettings
+    public sealed class GitReleaseManagerCloseMilestoneSettings : GitReleaseManagerSettings
     {
-        /// <summary>
-        /// Gets or sets the path on which GitReleaseManager should be executed.
-        /// </summary>
-        public DirectoryPath TargetDirectory { get; set; }
-
-        /// <summary>
-        /// Gets or sets the path to the GitReleaseManager log file.
-        /// </summary>
-        public FilePath LogFilePath { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/GitReleaseManager/Close/GitReleaseManagerMilestoneCloser.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Close/GitReleaseManagerMilestoneCloser.cs
@@ -137,7 +137,7 @@ namespace Cake.Common.Tools.GitReleaseManager.Close
             builder.Append("close");
 
             builder.Append("--token");
-            builder.AppendQuoted(token);
+            builder.AppendQuotedSecret(token);
 
             ParseCommonArguments(builder, owner, repository, milestone);
 

--- a/src/Cake.Common/Tools/GitReleaseManager/Close/GitReleaseManagerMilestoneCloser.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Close/GitReleaseManagerMilestoneCloser.cs
@@ -30,7 +30,7 @@ namespace Cake.Common.Tools.GitReleaseManager.Close
         }
 
         /// <summary>
-        /// Creates a Release using the specified settings.
+        /// Closes a milestone using the specified settings.
         /// </summary>
         /// <param name="userName">The user name.</param>
         /// <param name="password">The password.</param>
@@ -74,7 +74,7 @@ namespace Cake.Common.Tools.GitReleaseManager.Close
         }
 
         /// <summary>
-        /// Creates a Release using the specified settings.
+        /// Closes a milestone using the specified settings.
         /// </summary>
         /// <param name="token">The token.</param>
         /// <param name="owner">The owner.</param>

--- a/src/Cake.Common/Tools/GitReleaseManager/Close/GitReleaseManagerMilestoneCloser.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Close/GitReleaseManagerMilestoneCloser.cs
@@ -14,8 +14,6 @@ namespace Cake.Common.Tools.GitReleaseManager.Close
     /// </summary>
     public sealed class GitReleaseManagerMilestoneCloser : GitReleaseManagerTool<GitReleaseManagerCloseMilestoneSettings>
     {
-        private readonly ICakeEnvironment _environment;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="GitReleaseManagerMilestoneCloser"/> class.
         /// </summary>
@@ -29,7 +27,6 @@ namespace Cake.Common.Tools.GitReleaseManager.Close
             IProcessRunner processRunner,
             IToolLocator tools) : base(fileSystem, environment, processRunner, tools)
         {
-            _environment = environment;
         }
 
         /// <summary>
@@ -126,7 +123,9 @@ namespace Cake.Common.Tools.GitReleaseManager.Close
             builder.Append("-p");
             builder.AppendQuotedSecret(password);
 
-            ParseCommonArguments(builder, owner, repository, milestone, settings);
+            ParseCommonArguments(builder, owner, repository, milestone);
+
+            AddBaseArguments(settings, builder);
 
             return builder;
         }
@@ -140,12 +139,14 @@ namespace Cake.Common.Tools.GitReleaseManager.Close
             builder.Append("--token");
             builder.AppendQuoted(token);
 
-            ParseCommonArguments(builder, owner, repository, milestone, settings);
+            ParseCommonArguments(builder, owner, repository, milestone);
+
+            AddBaseArguments(settings, builder);
 
             return builder;
         }
 
-        private void ParseCommonArguments(ProcessArgumentBuilder builder, string owner, string repository, string milestone, GitReleaseManagerCloseMilestoneSettings settings)
+        private void ParseCommonArguments(ProcessArgumentBuilder builder, string owner, string repository, string milestone)
         {
             builder.Append("-o");
             builder.AppendQuoted(owner);
@@ -155,20 +156,6 @@ namespace Cake.Common.Tools.GitReleaseManager.Close
 
             builder.Append("-m");
             builder.AppendQuoted(milestone);
-
-            // Target Directory
-            if (settings.TargetDirectory != null)
-            {
-                builder.Append("-d");
-                builder.AppendQuoted(settings.TargetDirectory.MakeAbsolute(_environment).FullPath);
-            }
-
-            // Log File Path
-            if (settings.LogFilePath != null)
-            {
-                builder.Append("-l");
-                builder.AppendQuoted(settings.LogFilePath.MakeAbsolute(_environment).FullPath);
-            }
         }
     }
 }

--- a/src/Cake.Common/Tools/GitReleaseManager/Create/GitReleaseManagerCreateSettings.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Create/GitReleaseManagerCreateSettings.cs
@@ -3,14 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using Cake.Core.IO;
-using Cake.Core.Tooling;
 
 namespace Cake.Common.Tools.GitReleaseManager.Create
 {
     /// <summary>
     /// Contains settings used by <see cref="GitReleaseManagerCreator"/>.
     /// </summary>
-    public sealed class GitReleaseManagerCreateSettings : ToolSettings
+    public sealed class GitReleaseManagerCreateSettings : GitReleaseManagerSettings
     {
         /// <summary>
         /// Gets or sets the milestone to be used when creating the release.
@@ -41,15 +40,5 @@ namespace Cake.Common.Tools.GitReleaseManager.Create
         /// Gets or sets the commit to tag. Can be a branch or SHA. Defaults to repository's default branch..
         /// </summary>
         public string TargetCommitish { get; set; }
-
-        /// <summary>
-        /// Gets or sets the path on which GitReleaseManager should be executed.
-        /// </summary>
-        public DirectoryPath TargetDirectory { get; set; }
-
-        /// <summary>
-        /// Gets or sets the path to the GitReleaseManager log file.
-        /// </summary>
-        public FilePath LogFilePath { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/GitReleaseManager/Create/GitReleaseManagerCreator.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Create/GitReleaseManagerCreator.cs
@@ -128,7 +128,7 @@ namespace Cake.Common.Tools.GitReleaseManager.Create
             builder.Append("create");
 
             builder.Append("--token");
-            builder.AppendQuoted(token);
+            builder.AppendQuotedSecret(token);
 
             ParseCommonArguments(builder, owner, repository, settings);
 

--- a/src/Cake.Common/Tools/GitReleaseManager/Create/GitReleaseManagerCreator.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Create/GitReleaseManagerCreator.cs
@@ -116,6 +116,8 @@ namespace Cake.Common.Tools.GitReleaseManager.Create
 
             ParseCommonArguments(builder, owner, repository, settings);
 
+            AddBaseArguments(settings, builder);
+
             return builder;
         }
 
@@ -129,6 +131,8 @@ namespace Cake.Common.Tools.GitReleaseManager.Create
             builder.AppendQuoted(token);
 
             ParseCommonArguments(builder, owner, repository, settings);
+
+            AddBaseArguments(settings, builder);
 
             return builder;
         }
@@ -180,20 +184,6 @@ namespace Cake.Common.Tools.GitReleaseManager.Create
             {
                 builder.Append("-c");
                 builder.AppendQuoted(settings.TargetCommitish);
-            }
-
-            // Target Directory
-            if (settings.TargetDirectory != null)
-            {
-                builder.Append("-d");
-                builder.AppendQuoted(settings.TargetDirectory.MakeAbsolute(_environment).FullPath);
-            }
-
-            // Log File Path
-            if (settings.LogFilePath != null)
-            {
-                builder.Append("-l");
-                builder.AppendQuoted(settings.LogFilePath.MakeAbsolute(_environment).FullPath);
             }
         }
     }

--- a/src/Cake.Common/Tools/GitReleaseManager/Create/GitReleaseManagerCreator.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Create/GitReleaseManagerCreator.cs
@@ -33,7 +33,7 @@ namespace Cake.Common.Tools.GitReleaseManager.Create
         }
 
         /// <summary>
-        /// Creates a Release using the specified and settings.
+        /// Creates a Release using the specified settings.
         /// </summary>
         /// <param name="userName">The user name.</param>
         /// <param name="password">The password.</param>
@@ -70,8 +70,8 @@ namespace Cake.Common.Tools.GitReleaseManager.Create
             Run(settings, GetArguments(userName, password, owner, repository, settings));
         }
 
-                /// <summary>
-        /// Creates a Release using the specified and settings.
+        /// <summary>
+        /// Creates a Release using the specified settings.
         /// </summary>
         /// <param name="token">The token.</param>
         /// <param name="owner">The owner.</param>

--- a/src/Cake.Common/Tools/GitReleaseManager/Discard/GitReleaseManagerDiscardSettings.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Discard/GitReleaseManagerDiscardSettings.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Tools.GitReleaseManager.Discard
+{
+    /// <summary>
+    /// Contains settings used by <see cref="GitReleaseManagerDiscarder"/>.
+    /// </summary>
+    public sealed class GitReleaseManagerDiscardSettings : GitReleaseManagerSettings
+    {
+    }
+}

--- a/src/Cake.Common/Tools/GitReleaseManager/Discard/GitReleaseManagerDiscarder.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Discard/GitReleaseManagerDiscarder.cs
@@ -74,7 +74,7 @@ namespace Cake.Common.Tools.GitReleaseManager.Discard
             builder.Append("discard");
 
             builder.Append("--token");
-            builder.AppendQuoted(token);
+            builder.AppendQuotedSecret(token);
 
             builder.Append("-o");
             builder.AppendQuoted(owner);

--- a/src/Cake.Common/Tools/GitReleaseManager/Discard/GitReleaseManagerDiscarder.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Discard/GitReleaseManagerDiscarder.cs
@@ -1,0 +1,93 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.GitReleaseManager.Discard
+{
+    /// <summary>
+    /// The GitReleaseManager Release Discarder used to discard releases.
+    /// </summary>
+    public sealed class GitReleaseManagerDiscarder : GitReleaseManagerTool<GitReleaseManagerDiscardSettings>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GitReleaseManagerDiscarder"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="tools">The tool locator.</param>
+        public GitReleaseManagerDiscarder(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IToolLocator tools) : base(fileSystem, environment, processRunner, tools)
+        {
+        }
+
+        /// <summary>
+        /// Discards a Release using the specified settings.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="owner">The owner.</param>
+        /// <param name="repository">The repository.</param>
+        /// <param name="milestone">The milestone.</param>
+        /// <param name="settings">The settings.</param>
+        public void Discard(string token, string owner, string repository, string milestone, GitReleaseManagerDiscardSettings settings)
+        {
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            if (string.IsNullOrWhiteSpace(owner))
+            {
+                throw new ArgumentNullException(nameof(owner));
+            }
+
+            if (string.IsNullOrWhiteSpace(repository))
+            {
+                throw new ArgumentNullException(nameof(repository));
+            }
+
+            if (string.IsNullOrWhiteSpace(milestone))
+            {
+                throw new ArgumentNullException(nameof(milestone));
+            }
+
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            Run(settings, GetArguments(token, owner, repository, milestone, settings));
+        }
+
+        private ProcessArgumentBuilder GetArguments(string token, string owner, string repository, string milestone, GitReleaseManagerDiscardSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("discard");
+
+            builder.Append("--token");
+            builder.AppendQuoted(token);
+
+            builder.Append("-o");
+            builder.AppendQuoted(owner);
+
+            builder.Append("-r");
+            builder.AppendQuoted(repository);
+
+            builder.Append("-m");
+            builder.AppendQuoted(milestone);
+
+            AddBaseArguments(settings, builder);
+
+            return builder;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/GitReleaseManager/Export/GitReleaseManagerExportSettings.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Export/GitReleaseManagerExportSettings.cs
@@ -2,29 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Core.IO;
-using Cake.Core.Tooling;
-
 namespace Cake.Common.Tools.GitReleaseManager.Export
 {
     /// <summary>
     /// Contains settings used by <see cref="GitReleaseManagerExporter"/>.
     /// </summary>
-    public sealed class GitReleaseManagerExportSettings : ToolSettings
+    public sealed class GitReleaseManagerExportSettings : GitReleaseManagerSettings
     {
         /// <summary>
         /// Gets or sets the tag name to be used when exporting the release notes.
         /// </summary>
         public string TagName { get; set; }
-
-        /// <summary>
-        /// Gets or sets the path on which GitReleaseManager should be executed.
-        /// </summary>
-        public DirectoryPath TargetDirectory { get; set; }
-
-        /// <summary>
-        /// Gets or sets the path to the GitReleaseManager log file.
-        /// </summary>
-        public FilePath LogFilePath { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/GitReleaseManager/Export/GitReleaseManagerExporter.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Export/GitReleaseManagerExporter.cs
@@ -128,6 +128,8 @@ namespace Cake.Common.Tools.GitReleaseManager.Export
 
             ParseCommonArguments(builder, owner, repository, fileOutputPath, settings);
 
+            AddBaseArguments(settings, builder);
+
             return builder;
         }
 
@@ -141,6 +143,8 @@ namespace Cake.Common.Tools.GitReleaseManager.Export
             builder.AppendQuoted(token);
 
             ParseCommonArguments(builder, owner, repository, fileOutputPath, settings);
+
+            AddBaseArguments(settings, builder);
 
             return builder;
         }
@@ -160,20 +164,6 @@ namespace Cake.Common.Tools.GitReleaseManager.Export
             {
                 builder.Append("-t");
                 builder.AppendQuoted(settings.TagName);
-            }
-
-            // Target Directory
-            if (settings.TargetDirectory != null)
-            {
-                builder.Append("-d");
-                builder.AppendQuoted(settings.TargetDirectory.MakeAbsolute(_environment).FullPath);
-            }
-
-            // Log File Path
-            if (settings.LogFilePath != null)
-            {
-                builder.Append("-l");
-                builder.AppendQuoted(settings.LogFilePath.MakeAbsolute(_environment).FullPath);
             }
         }
     }

--- a/src/Cake.Common/Tools/GitReleaseManager/Export/GitReleaseManagerExporter.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Export/GitReleaseManagerExporter.cs
@@ -140,7 +140,7 @@ namespace Cake.Common.Tools.GitReleaseManager.Export
             builder.Append("export");
 
             builder.Append("--token");
-            builder.AppendQuoted(token);
+            builder.AppendQuotedSecret(token);
 
             ParseCommonArguments(builder, owner, repository, fileOutputPath, settings);
 

--- a/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerAliases.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerAliases.cs
@@ -6,8 +6,10 @@ using System;
 using Cake.Common.Tools.GitReleaseManager.AddAssets;
 using Cake.Common.Tools.GitReleaseManager.Close;
 using Cake.Common.Tools.GitReleaseManager.Create;
+using Cake.Common.Tools.GitReleaseManager.Discard;
 using Cake.Common.Tools.GitReleaseManager.Export;
 using Cake.Common.Tools.GitReleaseManager.Label;
+using Cake.Common.Tools.GitReleaseManager.Open;
 using Cake.Common.Tools.GitReleaseManager.Publish;
 using Cake.Core;
 using Cake.Core.Annotations;
@@ -50,7 +52,7 @@ namespace Cake.Common.Tools.GitReleaseManager
             GitReleaseManagerCreate(context, userName, password, owner, repository, new GitReleaseManagerCreateSettings());
         }
 
-                /// <summary>
+        /// <summary>
         /// Creates a Package Release.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -708,6 +710,118 @@ namespace Cake.Common.Tools.GitReleaseManager
 
             var labeller = new GitReleaseManagerLabeller(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             labeller.Label(token, owner, repository, settings);
+        }
+
+        /// <summary>
+        /// Opens the milestone associated with a release.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="token">The token.</param>
+        /// <param name="owner">The owner.</param>
+        /// <param name="repository">The repository.</param>
+        /// <param name="milestone">The milestone.</param>
+        /// <example>
+        /// <code>
+        /// GitReleaseManagerOpen("token", "owner", "repo", "0.1.0");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Open")]
+        [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.Open")]
+        public static void GitReleaseManagerOpen(this ICakeContext context, string token, string owner, string repository, string milestone)
+        {
+            GitReleaseManagerOpen(context, token, owner, repository, milestone, new GitReleaseManagerOpenMilestoneSettings());
+        }
+
+        /// <summary>
+        /// Opens the milestone associated with a release using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="token">The token.</param>
+        /// <param name="owner">The owner.</param>
+        /// <param name="repository">The repository.</param>
+        /// <param name="milestone">The milestone.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// GitReleaseManagerOpen("token", "owner", "repo", "0.1.0", new GitReleaseManagerOpenMilestoneSettings {
+        ///     TargetDirectory   = "c:/repo",
+        ///     LogFilePath       = "c:/temp/grm.log"
+        /// });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Open")]
+        [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.Open")]
+        public static void GitReleaseManagerOpen(this ICakeContext context, string token, string owner, string repository, string milestone, GitReleaseManagerOpenMilestoneSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var milestoneOpener = new GitReleaseManagerMilestoneOpener(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            milestoneOpener.Open(token, owner, repository, milestone, settings);
+        }
+
+        /// <summary>
+        /// Discards a Release.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="token">The token.</param>
+        /// <param name="owner">The owner.</param>
+        /// <param name="repository">The repository.</param>
+        /// <param name="milestone">The milestone.</param>
+        /// <example>
+        /// <code>
+        /// GitReleaseManagerDiscard("token", "owner", "repo", "0.1.0");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Discard")]
+        [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.Discard")]
+        public static void GitReleaseManagerDiscard(this ICakeContext context, string token, string owner, string repository, string milestone)
+        {
+            GitReleaseManagerDiscard(context, token, owner, repository, milestone, new GitReleaseManagerDiscardSettings());
+        }
+
+        /// <summary>
+        /// Discards a Release using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="token">The token.</param>
+        /// <param name="owner">The owner.</param>
+        /// <param name="repository">The repository.</param>
+        /// <param name="milestone">The milestone.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// GitReleaseManagerDiscard("token", "owner", "repo", "0.1.0", new GitReleaseManagerDiscardSettings {
+        ///     TargetDirectory   = "c:/repo",
+        ///     LogFilePath       = "c:/temp/grm.log"
+        /// });
+        /// </code>
+        /// </example>
+        /// <example>
+        /// <code>
+        /// GitReleaseManagerDiscard("token", "owner", "repo", "0.1.0", new GitReleaseManagerDiscardSettings {
+        ///     TargetDirectory   = "c:/repo",
+        ///     LogFilePath       = "c:/temp/grm.log"
+        /// });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Discard")]
+        [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.Discard")]
+        public static void GitReleaseManagerDiscard(this ICakeContext context, string token, string owner, string repository, string milestone, GitReleaseManagerDiscardSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var discarder = new GitReleaseManagerDiscarder(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            discarder.Discard(token, owner, repository, milestone, settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerAliases.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerAliases.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -117,7 +117,7 @@ namespace Cake.Common.Tools.GitReleaseManager
             creator.Create(userName, password, owner, repository, settings);
         }
 
-/// <summary>
+        /// <summary>
         /// Creates a Package Release using the specified settings.
         /// </summary>
         /// <param name="context">The context.</param>

--- a/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerAliases.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerAliases.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -44,6 +44,7 @@ namespace Cake.Common.Tools.GitReleaseManager
         [CakeMethodAlias]
         [CakeAliasCategory("Create")]
         [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.Create")]
+        [Obsolete("Use the overload that accepts a token instead.")]
         public static void GitReleaseManagerCreate(this ICakeContext context, string userName, string password, string owner, string repository)
         {
             GitReleaseManagerCreate(context, userName, password, owner, repository, new GitReleaseManagerCreateSettings());
@@ -106,6 +107,7 @@ namespace Cake.Common.Tools.GitReleaseManager
         [CakeMethodAlias]
         [CakeAliasCategory("Create")]
         [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.Create")]
+        [Obsolete("Use the overload that accepts a token instead.")]
         public static void GitReleaseManagerCreate(this ICakeContext context, string userName, string password, string owner, string repository, GitReleaseManagerCreateSettings settings)
         {
             if (context == null)
@@ -182,6 +184,7 @@ namespace Cake.Common.Tools.GitReleaseManager
         [CakeMethodAlias]
         [CakeAliasCategory("AddAssets")]
         [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.AddAssets")]
+        [Obsolete("Use the overload that accepts a token instead.")]
         public static void GitReleaseManagerAddAssets(this ICakeContext context, string userName, string password, string owner, string repository, string tagName, string assets)
         {
             GitReleaseManagerAddAssets(context, userName, password, owner, repository, tagName, assets, new GitReleaseManagerAddAssetsSettings());
@@ -231,6 +234,7 @@ namespace Cake.Common.Tools.GitReleaseManager
         [CakeMethodAlias]
         [CakeAliasCategory("AddAssets")]
         [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.AddAssets")]
+        [Obsolete("Use the overload that accepts a token instead.")]
         public static void GitReleaseManagerAddAssets(this ICakeContext context, string userName, string password, string owner, string repository, string tagName, string assets, GitReleaseManagerAddAssetsSettings settings)
         {
             if (context == null)
@@ -291,6 +295,7 @@ namespace Cake.Common.Tools.GitReleaseManager
         [CakeMethodAlias]
         [CakeAliasCategory("Close")]
         [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.Close")]
+        [Obsolete("Use the overload that accepts a token instead.")]
         public static void GitReleaseManagerClose(this ICakeContext context, string userName, string password, string owner, string repository, string milestone)
         {
             GitReleaseManagerClose(context, userName, password, owner, repository, milestone, new GitReleaseManagerCloseMilestoneSettings());
@@ -338,6 +343,7 @@ namespace Cake.Common.Tools.GitReleaseManager
         [CakeMethodAlias]
         [CakeAliasCategory("Close")]
         [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.Close")]
+        [Obsolete("Use the overload that accepts a token instead.")]
         public static void GitReleaseManagerClose(this ICakeContext context, string userName, string password, string owner, string repository, string milestone, GitReleaseManagerCloseMilestoneSettings settings)
         {
             if (context == null)
@@ -397,6 +403,7 @@ namespace Cake.Common.Tools.GitReleaseManager
         [CakeMethodAlias]
         [CakeAliasCategory("Publish")]
         [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.Publish")]
+        [Obsolete("Use the overload that accepts a token instead.")]
         public static void GitReleaseManagerPublish(this ICakeContext context, string userName, string password, string owner, string repository, string tagName)
         {
             GitReleaseManagerPublish(context, userName, password, owner, repository, tagName, new GitReleaseManagerPublishSettings());
@@ -444,6 +451,7 @@ namespace Cake.Common.Tools.GitReleaseManager
         [CakeMethodAlias]
         [CakeAliasCategory("Publish")]
         [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.Publish")]
+        [Obsolete("Use the overload that accepts a token instead.")]
         public static void GitReleaseManagerPublish(this ICakeContext context, string userName, string password, string owner, string repository, string tagName, GitReleaseManagerPublishSettings settings)
         {
             if (context == null)
@@ -504,6 +512,7 @@ namespace Cake.Common.Tools.GitReleaseManager
         [CakeMethodAlias]
         [CakeAliasCategory("Export")]
         [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.Export")]
+        [Obsolete("Use the overload that accepts a token instead.")]
         public static void GitReleaseManagerExport(this ICakeContext context, string userName, string password, string owner, string repository, FilePath fileOutputPath)
         {
             GitReleaseManagerExport(context, userName, password, owner, repository, fileOutputPath, new GitReleaseManagerExportSettings());
@@ -553,6 +562,7 @@ namespace Cake.Common.Tools.GitReleaseManager
         [CakeMethodAlias]
         [CakeAliasCategory("Export")]
         [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.Export")]
+        [Obsolete("Use the overload that accepts a token instead.")]
         public static void GitReleaseManagerExport(this ICakeContext context, string userName, string password, string owner, string repository, FilePath fileOutputPath, GitReleaseManagerExportSettings settings)
         {
             if (context == null)
@@ -613,6 +623,7 @@ namespace Cake.Common.Tools.GitReleaseManager
         [CakeMethodAlias]
         [CakeAliasCategory("Label")]
         [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.Label")]
+        [Obsolete("Use the overload that accepts a token instead.")]
         public static void GitReleaseManagerLabel(this ICakeContext context, string userName, string password, string owner, string repository)
         {
             GitReleaseManagerLabel(context, userName, password, owner, repository, new GitReleaseManagerLabelSettings());
@@ -658,6 +669,7 @@ namespace Cake.Common.Tools.GitReleaseManager
         [CakeMethodAlias]
         [CakeAliasCategory("Label")]
         [CakeNamespaceImport("Cake.Common.Tools.GitReleaseManager.Label")]
+        [Obsolete("Use the overload that accepts a token instead.")]
         public static void GitReleaseManagerLabel(this ICakeContext context, string userName, string password, string owner, string repository, GitReleaseManagerLabelSettings settings)
         {
             if (context == null)

--- a/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerSettings.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerSettings.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.GitReleaseManager
+{
+    /// <summary>
+    /// Contains settings used by <see cref="GitReleaseManagerSettings"/>
+    /// </summary>
+    public class GitReleaseManagerSettings : ToolSettings
+    {
+        /// <summary>
+        /// Gets or sets the path on which GitReleaseManager should be executed.
+        /// </summary>
+        public DirectoryPath TargetDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the GitReleaseManager log file.
+        /// </summary>
+        public FilePath LogFilePath { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerSettings.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerSettings.cs
@@ -21,5 +21,20 @@ namespace Cake.Common.Tools.GitReleaseManager
         /// Gets or sets the path to the GitReleaseManager log file.
         /// </summary>
         public FilePath LogFilePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not to use debug level logging.
+        /// </summary>
+        public bool Debug { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not to use verbose level logging.
+        /// </summary>
+        public bool Verbose { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not to show the GitReleaseManager logo during execution.
+        /// </summary>
+        public bool NoLogo { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerTool.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/GitReleaseManagerTool.cs
@@ -16,6 +16,8 @@ namespace Cake.Common.Tools.GitReleaseManager
     public abstract class GitReleaseManagerTool<TSettings> : Tool<TSettings>
         where TSettings : ToolSettings
     {
+        private readonly ICakeEnvironment _environment;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="GitReleaseManagerTool{TSettings}"/> class.
         /// </summary>
@@ -29,6 +31,7 @@ namespace Cake.Common.Tools.GitReleaseManager
             IProcessRunner processRunner,
             IToolLocator tools) : base(fileSystem, environment, processRunner, tools)
         {
+            _environment = environment;
         }
 
         /// <summary>
@@ -47,6 +50,49 @@ namespace Cake.Common.Tools.GitReleaseManager
         protected sealed override IEnumerable<string> GetToolExecutableNames()
         {
             return new[] { "GitReleaseManager.exe", "gitreleasemanager.exe", "grm.exe", "dotnet-gitreleasemanager", "dotnet-gitreleasemanager.exe" };
+        }
+
+        /// <summary>
+        /// Adds common arguments to the process builder.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="builder">The process argument builder.</param>
+        /// <returns>The process argument builder.</returns>
+        protected ProcessArgumentBuilder AddBaseArguments(GitReleaseManagerSettings settings, ProcessArgumentBuilder builder)
+        {
+            // Target Directory
+            if (settings.TargetDirectory != null)
+            {
+                builder.Append("-d");
+                builder.AppendQuoted(settings.TargetDirectory.MakeAbsolute(_environment).FullPath);
+            }
+
+            // Log File Path
+            if (settings.LogFilePath != null)
+            {
+                builder.Append("-l");
+                builder.AppendQuoted(settings.LogFilePath.MakeAbsolute(_environment).FullPath);
+            }
+
+            // Debug
+            if (settings.Debug)
+            {
+                builder.Append("--debug");
+            }
+
+            // Verbose
+            if (settings.Verbose)
+            {
+                builder.Append("--verbose");
+            }
+
+            // NoLogo
+            if (settings.NoLogo)
+            {
+                builder.Append("--no-logo");
+            }
+
+            return builder;
         }
     }
 }

--- a/src/Cake.Common/Tools/GitReleaseManager/Label/GitReleaseManagerLabelSettings.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Label/GitReleaseManagerLabelSettings.cs
@@ -2,24 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Core.IO;
-using Cake.Core.Tooling;
-
 namespace Cake.Common.Tools.GitReleaseManager.Label
 {
     /// <summary>
     /// Contains settings used by <see cref="GitReleaseManagerLabeller"/>.
     /// </summary>
-    public class GitReleaseManagerLabelSettings : ToolSettings
+    public class GitReleaseManagerLabelSettings : GitReleaseManagerSettings
     {
-        /// <summary>
-        /// Gets or sets the path on which GitReleaseManager should be executed.
-        /// </summary>
-        public DirectoryPath TargetDirectory { get; set; }
-
-        /// <summary>
-        /// Gets or sets the path to the GitReleaseManager log file.
-        /// </summary>
-        public FilePath LogFilePath { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/GitReleaseManager/Label/GitReleaseManagerLabeller.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Label/GitReleaseManagerLabeller.cs
@@ -125,7 +125,7 @@ namespace Cake.Common.Tools.GitReleaseManager.Label
             builder.Append("label");
 
             builder.Append("--token");
-            builder.AppendQuoted(token);
+            builder.AppendQuotedSecret(token);
 
             ParseCommonArguments(builder, owner, repository);
 

--- a/src/Cake.Common/Tools/GitReleaseManager/Label/GitReleaseManagerLabeller.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Label/GitReleaseManagerLabeller.cs
@@ -14,8 +14,6 @@ namespace Cake.Common.Tools.GitReleaseManager.Label
     /// </summary>
     public sealed class GitReleaseManagerLabeller : GitReleaseManagerTool<GitReleaseManagerLabelSettings>
     {
-        private readonly ICakeEnvironment _environment;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="GitReleaseManagerLabeller"/> class.
         /// </summary>
@@ -29,7 +27,6 @@ namespace Cake.Common.Tools.GitReleaseManager.Label
             IProcessRunner processRunner,
             IToolLocator tools) : base(fileSystem, environment, processRunner, tools)
         {
-            _environment = environment;
         }
 
         /// <summary>
@@ -114,7 +111,9 @@ namespace Cake.Common.Tools.GitReleaseManager.Label
             builder.Append("-p");
             builder.AppendQuotedSecret(password);
 
-            ParseCommonArguments(builder, owner, repository, settings);
+            ParseCommonArguments(builder, owner, repository);
+
+            AddBaseArguments(settings, builder);
 
             return builder;
         }
@@ -128,31 +127,20 @@ namespace Cake.Common.Tools.GitReleaseManager.Label
             builder.Append("--token");
             builder.AppendQuoted(token);
 
-            ParseCommonArguments(builder, owner, repository, settings);
+            ParseCommonArguments(builder, owner, repository);
+
+            AddBaseArguments(settings, builder);
+
             return builder;
         }
 
-        private void ParseCommonArguments(ProcessArgumentBuilder builder, string owner, string repository, GitReleaseManagerLabelSettings settings)
+        private void ParseCommonArguments(ProcessArgumentBuilder builder, string owner, string repository)
         {
             builder.Append("-o");
             builder.AppendQuoted(owner);
 
             builder.Append("-r");
             builder.AppendQuoted(repository);
-
-            // Target Directory
-            if (settings.TargetDirectory != null)
-            {
-                builder.Append("-d");
-                builder.AppendQuoted(settings.TargetDirectory.MakeAbsolute(_environment).FullPath);
-            }
-
-            // Log File Path
-            if (settings.LogFilePath != null)
-            {
-                builder.Append("-l");
-                builder.AppendQuoted(settings.LogFilePath.MakeAbsolute(_environment).FullPath);
-            }
         }
     }
 }

--- a/src/Cake.Common/Tools/GitReleaseManager/Label/GitReleaseManagerLabeller.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Label/GitReleaseManagerLabeller.cs
@@ -70,7 +70,7 @@ namespace Cake.Common.Tools.GitReleaseManager.Label
             Run(settings, GetArguments(userName, password, owner, repository, settings));
         }
 
-/// <summary>
+        /// <summary>
         /// Deletes and creates labels using the specified and settings.
         /// </summary>
         /// <param name="token">The token.</param>

--- a/src/Cake.Common/Tools/GitReleaseManager/Open/GitReleaseManagerMilestoneOpener.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Open/GitReleaseManagerMilestoneOpener.cs
@@ -74,7 +74,7 @@ namespace Cake.Common.Tools.GitReleaseManager.Open
             builder.Append("open");
 
             builder.Append("--token");
-            builder.AppendQuoted(token);
+            builder.AppendQuotedSecret(token);
 
             builder.Append("-o");
             builder.AppendQuoted(owner);

--- a/src/Cake.Common/Tools/GitReleaseManager/Open/GitReleaseManagerMilestoneOpener.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Open/GitReleaseManagerMilestoneOpener.cs
@@ -1,0 +1,93 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.GitReleaseManager.Open
+{
+    /// <summary>
+    /// The GitReleaseManager Milestone Opener used to open milestones.
+    /// </summary>
+    public sealed class GitReleaseManagerMilestoneOpener : GitReleaseManagerTool<GitReleaseManagerOpenMilestoneSettings>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GitReleaseManagerMilestoneOpener"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="tools">The tool locator.</param>
+        public GitReleaseManagerMilestoneOpener(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IToolLocator tools) : base(fileSystem, environment, processRunner, tools)
+        {
+        }
+
+        /// <summary>
+        /// Creates a Release using the specified settings.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="owner">The owner.</param>
+        /// <param name="repository">The repository.</param>
+        /// <param name="milestone">The milestone.</param>
+        /// <param name="settings">The settings.</param>
+        public void Open(string token, string owner, string repository, string milestone, GitReleaseManagerOpenMilestoneSettings settings)
+        {
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            if (string.IsNullOrWhiteSpace(owner))
+            {
+                throw new ArgumentNullException(nameof(owner));
+            }
+
+            if (string.IsNullOrWhiteSpace(repository))
+            {
+                throw new ArgumentNullException(nameof(repository));
+            }
+
+            if (string.IsNullOrWhiteSpace(milestone))
+            {
+                throw new ArgumentNullException(nameof(milestone));
+            }
+
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            Run(settings, GetArguments(token, owner, repository, milestone, settings));
+        }
+
+        private ProcessArgumentBuilder GetArguments(string token, string owner, string repository, string milestone, GitReleaseManagerOpenMilestoneSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("open");
+
+            builder.Append("--token");
+            builder.AppendQuoted(token);
+
+            builder.Append("-o");
+            builder.AppendQuoted(owner);
+
+            builder.Append("-r");
+            builder.AppendQuoted(repository);
+
+            builder.Append("-m");
+            builder.AppendQuoted(milestone);
+
+            AddBaseArguments(settings, builder);
+
+            return builder;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/GitReleaseManager/Open/GitReleaseManagerOpenMilestoneSettings.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Open/GitReleaseManagerOpenMilestoneSettings.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Tools.GitReleaseManager.Open
+{
+    /// <summary>
+    /// Contains settings used by <see cref="GitReleaseManagerMilestoneOpener"/>.
+    /// </summary>
+    public sealed class GitReleaseManagerOpenMilestoneSettings : GitReleaseManagerSettings
+    {
+    }
+}

--- a/src/Cake.Common/Tools/GitReleaseManager/Publish/GitReleaseManagerPublishSettings.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Publish/GitReleaseManagerPublishSettings.cs
@@ -2,24 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Core.IO;
-using Cake.Core.Tooling;
-
 namespace Cake.Common.Tools.GitReleaseManager.Publish
 {
     /// <summary>
     /// Contains settings used by <see cref="GitReleaseManagerPublisher"/>.
     /// </summary>
-    public sealed class GitReleaseManagerPublishSettings : ToolSettings
+    public sealed class GitReleaseManagerPublishSettings : GitReleaseManagerSettings
     {
-        /// <summary>
-        /// Gets or sets the path on which GitReleaseManager should be executed.
-        /// </summary>
-        public DirectoryPath TargetDirectory { get; set; }
-
-        /// <summary>
-        /// Gets or sets the path to the GitReleaseManager log file.
-        /// </summary>
-        public FilePath LogFilePath { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/GitReleaseManager/Publish/GitReleaseManagerPublisher.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Publish/GitReleaseManagerPublisher.cs
@@ -14,8 +14,6 @@ namespace Cake.Common.Tools.GitReleaseManager.Publish
     /// </summary>
     public sealed class GitReleaseManagerPublisher : GitReleaseManagerTool<GitReleaseManagerPublishSettings>
     {
-        private readonly ICakeEnvironment _environment;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="GitReleaseManagerPublisher"/> class.
         /// </summary>
@@ -29,7 +27,6 @@ namespace Cake.Common.Tools.GitReleaseManager.Publish
             IProcessRunner processRunner,
             IToolLocator tools) : base(fileSystem, environment, processRunner, tools)
         {
-            _environment = environment;
         }
 
         /// <summary>
@@ -126,7 +123,9 @@ namespace Cake.Common.Tools.GitReleaseManager.Publish
             builder.Append("-p");
             builder.AppendQuotedSecret(password);
 
-            ParseCommonArguments(builder, owner, repository, tagName, settings);
+            ParseCommonArguments(builder, owner, repository, tagName);
+
+            AddBaseArguments(settings, builder);
 
             return builder;
         }
@@ -140,12 +139,14 @@ namespace Cake.Common.Tools.GitReleaseManager.Publish
             builder.Append("--token");
             builder.AppendQuoted(token);
 
-            ParseCommonArguments(builder, owner, repository, tagName, settings);
+            ParseCommonArguments(builder, owner, repository, tagName);
+
+            AddBaseArguments(settings, builder);
 
             return builder;
         }
 
-        private void ParseCommonArguments(ProcessArgumentBuilder builder, string owner, string repository, string tagName, GitReleaseManagerPublishSettings settings)
+        private void ParseCommonArguments(ProcessArgumentBuilder builder, string owner, string repository, string tagName)
         {
             builder.Append("-o");
             builder.AppendQuoted(owner);
@@ -155,20 +156,6 @@ namespace Cake.Common.Tools.GitReleaseManager.Publish
 
             builder.Append("-t");
             builder.AppendQuoted(tagName);
-
-            // Target Directory
-            if (settings.TargetDirectory != null)
-            {
-                builder.Append("-d");
-                builder.AppendQuoted(settings.TargetDirectory.MakeAbsolute(_environment).FullPath);
-            }
-
-            // Log File Path
-            if (settings.LogFilePath != null)
-            {
-                builder.Append("-l");
-                builder.AppendQuoted(settings.LogFilePath.MakeAbsolute(_environment).FullPath);
-            }
         }
     }
 }

--- a/src/Cake.Common/Tools/GitReleaseManager/Publish/GitReleaseManagerPublisher.cs
+++ b/src/Cake.Common/Tools/GitReleaseManager/Publish/GitReleaseManagerPublisher.cs
@@ -137,7 +137,7 @@ namespace Cake.Common.Tools.GitReleaseManager.Publish
             builder.Append("publish");
 
             builder.Append("--token");
-            builder.AppendQuoted(token);
+            builder.AppendQuotedSecret(token);
 
             ParseCommonArguments(builder, owner, repository, tagName);
 


### PR DESCRIPTION
Fixes #2696 

If/when this is merged, we will need to make sure to switch to the `CAKE_GITHUB_TOKEN` environment variable.