### PR TITLE
GH-2695: Update Microsoft.CodeAnalysis.CSharp.Scripting to 3.5.0-beta2-final

### DIFF
--- a/src/Cake/Cake.csproj
+++ b/src/Cake/Cake.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <!-- Global packages -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.5.0-beta2-final" />
     <PackageReference Include="Autofac" Version="4.9.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* Addresses issue with Mono 6.8+
* Fixes #2695