### PR TITLE
Better handling for GitVersion failure cases

### DIFF
--- a/src/Cake.Common/Tools/GitVersion/GitVersionRunner.cs
+++ b/src/Cake.Common/Tools/GitVersion/GitVersionRunner.cs
@@ -51,6 +51,8 @@ namespace Cake.Common.Tools.GitVersion
                 throw new ArgumentNullException(nameof(settings));
             }
 
+            Run(settings, GetArguments(settings));
+
             if (settings.OutputType != GitVersionOutput.BuildServer)
             {
                 var jsonString = string.Empty;
@@ -65,8 +67,6 @@ namespace Cake.Common.Tools.GitVersion
                     return (jsonSerializer.ReadObject(jsonStream) as GitVersionInternal)?.GitVersion;
                 }
             }
-
-            Run(settings, GetArguments(settings));
 
             return new GitVersion();
         }


### PR DESCRIPTION
GitVersion was failing for our builds this week, but the reason was a mystery until we were able to dig into the GitVersion log file on a failed build. What made this really difficult is the actual error was masked by the GitVersionRunner.

The error according to Cake was `Expecting state 'Element'.. Encountered 'Text'  with name '', namespace ''.` This is accurate because the `DataContactJsonSerializer` is failing to deserialise what is actually an error message from `gitversion.exe`. However, it is ultimately misleading since the actual error message is masked by this exception.

We changed our process to call GitVersion twice:

1. Run GitVersion with `OutputType = GitVersionOutput.BuildServer` so it logs to stdout, including any error messages
2. Run GitVersion with `OutputType = GitVersionOutput.Json` to get the deserialised version information

This PR proposes a similar approach, but within the GitVersionRunner itself so others fall into the pit of success. It appears the intent of the code was to run GitVersion twice, but the deserialization exception prevents the intended behaviour.

Hope this helps!

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over CONTRIBUTING - https://github.com/cake-build/cake/blob/develop/CONTRIBUTING.md. We provide VERY defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - You are not submitting a pull request from your MASTER branch.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
