### PR TITLE
GH2735: Improve documentation to make clear that project can be passed to MsBuild alias

### DIFF
--- a/src/Cake.Common/Tools/MSBuild/MSBuildAliases.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildAliases.cs
@@ -20,10 +20,10 @@ namespace Cake.Common.Tools.MSBuild
     public static class MSBuildAliases
     {
         /// <summary>
-        /// Builds the specified solution using MSBuild.
+        /// Builds the specified solution or MsBuild project file using MSBuild.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="solution">The solution.</param>
+        /// <param name="solution">The solution or MsBuild project file to build.</param>
         /// <example>
         /// <code>
         /// MSBuild("./src/Cake.sln");
@@ -36,10 +36,10 @@ namespace Cake.Common.Tools.MSBuild
         }
 
         /// <summary>
-        /// Builds the specified solution using MSBuild.
+        /// Builds the specified solution or MsBuild project file using MSBuild.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="solution">The solution to build.</param>
+        /// <param name="solution">The solution or MsBuild project file to build.</param>
         /// <param name="configurator">The settings configurator.</param>
         /// <example>
         /// <code>
@@ -71,10 +71,10 @@ namespace Cake.Common.Tools.MSBuild
         }
 
         /// <summary>
-        /// Builds the specified solution using MSBuild.
+        /// Builds the specified solution or MsBuild project file using MSBuild.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="solution">The solution to build.</param>
+        /// <param name="solution">The solution or MsBuild project file to build.</param>
         /// <param name="settings">The settings.</param>
         /// <example>
         /// <code>

--- a/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
@@ -41,14 +41,14 @@ namespace Cake.Common.Tools.MSBuild
         /// <summary>
         /// Runs MSBuild with the specified settings.
         /// </summary>
-        /// <param name="solution">The solution to build.</param>
+        /// <param name="solution">The solution or MsBuild project file to build.</param>
         /// <param name="settings">The settings.</param>
         public void Run(FilePath solution, MSBuildSettings settings)
         {
             Run(settings, GetArguments(solution, settings));
         }
 
-        private ProcessArgumentBuilder GetArguments(FilePath solution, MSBuildSettings settings)
+        private ProcessArgumentBuilder GetArguments(FilePath projectFile, MSBuildSettings settings)
         {
             var builder = new ProcessArgumentBuilder();
 
@@ -95,7 +95,7 @@ namespace Cake.Common.Tools.MSBuild
             if (settings.PlatformTarget.HasValue)
             {
                 var platform = settings.PlatformTarget.Value;
-                bool isSolution = string.Equals(solution.GetExtension(), ".sln", StringComparison.OrdinalIgnoreCase);
+                bool isSolution = string.Equals(projectFile.GetExtension(), ".sln", StringComparison.OrdinalIgnoreCase);
                 builder.Append(string.Concat("/p:Platform=", GetPlatformName(platform, isSolution)));
             }
 
@@ -211,7 +211,7 @@ namespace Cake.Common.Tools.MSBuild
             }
 
             // Add the solution as the last parameter.
-            builder.AppendQuoted(solution.MakeAbsolute(_environment).FullPath);
+            builder.AppendQuoted(projectFile.MakeAbsolute(_environment).FullPath);
 
             return builder;
         }


### PR DESCRIPTION
Improve documentation to make clear that project can be passed to MsBuild alias. Also change naming of the argument to make this more clear and be in line with [underlying tools documentation](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2019).

Fixes #2735