### PR TITLE
GH2745: Change file share access to Read for XmlPeekAliases

### DIFF
--- a/src/Cake.Common/Xml/XmlPeekAliases.cs
+++ b/src/Cake.Common/Xml/XmlPeekAliases.cs
@@ -92,7 +92,7 @@ namespace Cake.Common.Xml
                 throw new FileNotFoundException("Source File not found.", file.Path.FullPath);
             }
 
-            using (var fileStream = file.Open(FileMode.Open, FileAccess.Read, FileShare.None))
+            using (var fileStream = file.Open(FileMode.Open, FileAccess.Read, FileShare.Read))
             using (var xmlReader = XmlReader.Create(fileStream, GetXmlReaderSettings(settings)))
             {
                 var xmlValue = XmlPeek(xmlReader, xpath, settings);


### PR DESCRIPTION
A small change in file-sharing access to avoid the error: "The process cannot access the file because it is being used by another process."

Related to #2745

Please review,
Thank you in advance
