### PR TITLE
GH2752: Fix precedence of VS2019 MSTest.exe to be higher than VS2017.

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSTest/MSTestRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSTest/MSTestRunnerTests.cs
@@ -114,6 +114,24 @@ namespace Cake.Common.Tests.Unit.Tools.MSTest
             Assert.Equal(existingToolPath, result.Path.FullPath);
         }
 
+        [Theory]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2019/Enterprise/Common7/IDE/mstest.exe", "/ProgramFilesX86/Microsoft Visual Studio/2017/Enterprise/Common7/IDE/mstest.exe")]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2019/Professional/Common7/IDE/mstest.exe", "/ProgramFilesX86/Microsoft Visual Studio/2017/Enterprise/Common7/IDE/mstest.exe")]
+        public void Should_Use_Highest_Available_Version_Tool_Path(string prioritizedPath, string lesserPath)
+        {
+            // Given
+            var fixture = new MSTestRunnerFixture();
+            fixture.GivenDefaultToolDoNotExist();
+            fixture.FileSystem.CreateFile(lesserPath);
+            fixture.FileSystem.CreateFile(prioritizedPath);
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            Assert.Equal(prioritizedPath, result.Path.FullPath);
+        }
+
         [Fact]
         public void Should_Set_Working_Directory()
         {

--- a/src/Cake.Common/Tools/MSTest/MSTestRunner.cs
+++ b/src/Cake.Common/Tools/MSTest/MSTestRunner.cs
@@ -114,7 +114,7 @@ namespace Cake.Common.Tools.MSTest
         /// <returns>The default tool path.</returns>
         protected override IEnumerable<FilePath> GetAlternativeToolPaths(MSTestSettings settings)
         {
-            foreach (var yearAndEdition in new[] { "2017/Enterprise", "2017/Professional", "2017/Community", "2019/Enterprise", "2019/Professional", "2019/Community" })
+            foreach (var yearAndEdition in new[] { "2019/Enterprise", "2019/Professional", "2019/Community", "2017/Enterprise", "2017/Professional", "2017/Community" })
             {
                 var path = GetYearAndEditionToolPath(yearAndEdition);
                 if (_fileSystem.Exist(path))


### PR DESCRIPTION
This re-orders the "Year and Edition" folder path segments of VS2019 to appear
first in the list as the newest VS version, which allows any alternative tool path
resolution to resolve latest first.  This follows the patterns established where the
resolution has historically resolved VS2015 over VS2013, and so on.

This also adds tests to explicitly exercise this evaluation.  If additional coverage is desired, I can add that, but I think that's probably superfluous at this point.  As always, any feedback or change requests are welcome 👍