### PR TITLE
GH2077: Adds alternate tool path support to vstest.console.exe  for VS2017 + 2019

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/VSTest/VSTestRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/VSTest/VSTestRunnerTests.cs
@@ -95,6 +95,12 @@ namespace Cake.Common.Tests.Unit.Tools.VSTest
         [InlineData("/ProgramFilesX86/Microsoft Visual Studio 14.0/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
         [InlineData("/ProgramFilesX86/Microsoft Visual Studio 12.0/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
         [InlineData("/ProgramFilesX86/Microsoft Visual Studio 11.0/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2017/Enterprise/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2017/Professional/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2017/Community/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2019/Enterprise/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2019/Professional/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2019/Community/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
         public void Should_Use_Available_Tool_Path(string existingToolPath)
         {
             // Given

--- a/src/Cake.Common/Tools/VSTest/VSTestRunner.cs
+++ b/src/Cake.Common/Tools/VSTest/VSTestRunner.cs
@@ -147,9 +147,18 @@ namespace Cake.Common.Tools.VSTest
         /// <returns>The default tool path.</returns>
         protected override IEnumerable<FilePath> GetAlternativeToolPaths(VSTestSettings settings)
         {
+            foreach (var yearAndEdition in new[] { "2019/Enterprise", "2019/Professional", "2019/Community", "2017/Enterprise", "2017/Professional", "2017/Community" })
+            {
+                var path = GetYearAndEditionToolPath(yearAndEdition);
+                if (_fileSystem.Exist(path))
+                {
+                    yield return path;
+                }
+            }
+
             foreach (var version in new[] { "15.0", "14.0", "12.0", "11.0" })
             {
-                var path = GetToolPath(version);
+                var path = GetVersionNumberToolPath(version);
                 if (_fileSystem.Exist(path))
                 {
                     yield return path;
@@ -157,7 +166,14 @@ namespace Cake.Common.Tools.VSTest
             }
         }
 
-        private FilePath GetToolPath(string version)
+        private FilePath GetYearAndEditionToolPath(string yearAndEdition)
+        {
+            var programFiles = _environment.GetSpecialPath(SpecialPath.ProgramFilesX86);
+            var root = programFiles.Combine(string.Concat("Microsoft Visual Studio/", yearAndEdition, "/Common7/IDE/CommonExtensions/Microsoft/TestWindow"));
+            return root.CombineWithFilePath(VSTestConsoleExecutableName);
+        }
+
+        private FilePath GetVersionNumberToolPath(string version)
         {
             var programFiles = _environment.GetSpecialPath(SpecialPath.ProgramFilesX86);
             var root = programFiles.Combine(string.Concat("Microsoft Visual Studio ", version, "/Common7/IDE/CommonExtensions/Microsoft/TestWindow"));


### PR DESCRIPTION
This addresses the outstanding issue identified in GH-2077.
While acknowledging that the better-supported solution was introduced with GH-2152, this gives the Cake implementation a more complete solution, especially for users that are constrained to the Visual Studio provided executable (i.e., build server, non-homogenized environments, etc.)

This introduces the "year and edition" path querying that is implemented in the `MSTestRunner`.

The one thing worth mentioning is that I am pretty sure the inclusion of `"15.0"` in the block below isn't quite right - the `2017/` paths added in this PR most likely covers the VS2017 ("15.0") case, but given the logic employed, the implementation is most likely fully backward-compatible, and I saw no pragmatic reason to alter the existing implementation.
```csharp
foreach (var version in new[] { "15.0",
```

Let me know if there's anything you'd like added or changed 👍 Thanks!