### PR TITLE
Added options to skip analysis

### DIFF
--- a/src/Cake.Common/Tools/DupFinder/DupFinderRunner.cs
+++ b/src/Cake.Common/Tools/DupFinder/DupFinderRunner.cs
@@ -62,10 +62,13 @@ namespace Cake.Common.Tools.DupFinder
 
             Run(settings, GetArgument(settings, filePaths));
 
-            if (settings.OutputFile != null)
+            if (settings.DoNotAnalyseOutput ||
+                settings.OutputFile == null)
             {
-                AnalyzeResultsFile(settings.OutputFile, settings.ThrowExceptionOnFindingDuplicates);
+                return;
             }
+
+            AnalyzeResultsFile(settings.OutputFile, settings.ThrowExceptionOnFindingDuplicates);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DupFinder/DupFinderSettings.cs
+++ b/src/Cake.Common/Tools/DupFinder/DupFinderSettings.cs
@@ -101,5 +101,11 @@ namespace Cake.Common.Tools.DupFinder
         /// Gets or sets a value indicating whether to throw an exception on finding duplicates
         /// </summary>
         public bool ThrowExceptionOnFindingDuplicates { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to skip analysis of the file
+        /// that was output by the command line tool or not.
+        /// </summary>
+        public bool DoNotAnalyseOutput { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/InspectCode/InspectCodeRunner.cs
+++ b/src/Cake.Common/Tools/InspectCode/InspectCodeRunner.cs
@@ -61,10 +61,13 @@ namespace Cake.Common.Tools.InspectCode
 
             Run(settings, GetArguments(settings, solution));
 
-            if (settings.OutputFile != null)
+            if (settings.DoNotAnalyseOutput ||
+                settings.OutputFile == null)
             {
-                AnalyseResultsFile(settings.OutputFile, settings.ThrowExceptionOnFindingViolations);
+                return;
             }
+
+            AnalyseResultsFile(settings.OutputFile, settings.ThrowExceptionOnFindingViolations);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/InspectCode/InspectCodeSettings.cs
+++ b/src/Cake.Common/Tools/InspectCode/InspectCodeSettings.cs
@@ -114,5 +114,11 @@ namespace Cake.Common.Tools.InspectCode
         /// Gets or sets the minimal severity of issues to report.
         /// </summary>
         public InspectCodeSeverity? Severity { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to skip analysis of the file
+        /// that was output by the command line tool or not.
+        /// </summary>
+        public bool DoNotAnalyseOutput { get; set; }
     }
 }


### PR DESCRIPTION
I've added an option to skip the analysis part after the command line tool is done.

In our situation we will do not need logging of the errors at that moment of time, we do the analysis of the result at a later stage. That's why we needed an possibility to skip it.