### PR TITLE
Added options to skip the analysis of the output file

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DupFinder/DupFinderRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DupFinder/DupFinderRunnerTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Linq;
 using Cake.Common.Tests.Fixtures.Tools.DupFinder;
 using Cake.Core;
 using Cake.Core.IO;
@@ -54,7 +55,7 @@ namespace Cake.Common.Tests.Unit.Tools.DupFinder
 
                 // Then
                 Assert.IsType<CakeException>(result);
-                Assert.Equal("DupFinder: Process was not started.", result?.Message);
+                Assert.Equal("DupFinder: Process was not started.", result.Message);
             }
 
             [Fact]
@@ -69,7 +70,7 @@ namespace Cake.Common.Tests.Unit.Tools.DupFinder
 
                 // Then
                 Assert.IsType<CakeException>(result);
-                Assert.Equal("DupFinder: Process returned an error (exit code 1).", result?.Message);
+                Assert.Equal("DupFinder: Process returned an error (exit code 1).", result.Message);
             }
 
             [Fact]
@@ -331,6 +332,51 @@ namespace Cake.Common.Tests.Unit.Tools.DupFinder
 
                 // Then
                 Assert.Equal("/show-text \"/Working/Test.sln\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Analyze_Output()
+            {
+                var log = new FakeLog();
+
+                // Given
+                var fixture = new DupFinderRunnerFixture
+                {
+                    Log = log
+                };
+                fixture.Settings.OutputFile = new FilePath("build/duplicates.xml");
+
+                // When
+                fixture.Run();
+
+                // Then
+                var logContainsInspectionResults =
+                    log.Entries.Any(p => p.Message.StartsWith("Duplicate Located with a cost of"));
+
+                Assert.True(logContainsInspectionResults);
+            }
+
+            [Fact]
+            public void Should_Not_Analyze_Output()
+            {
+                var log = new FakeLog();
+
+                // Given
+                var fixture = new DupFinderRunnerFixture
+                {
+                    Log = log
+                };
+                fixture.Settings.OutputFile = new FilePath("build/duplicates.xml");
+                fixture.Settings.DoNotAnalyseOutput = true;
+
+                // When
+                fixture.Run();
+
+                // Then
+                var logContainsInspectionResults =
+                    log.Entries.Any(p => p.Message.StartsWith("Duplicate Located with a cost of"));
+
+                Assert.False(logContainsInspectionResults);
             }
         }
 

--- a/src/Cake.Common.Tests/Unit/Tools/DupFinder/DupFinderRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DupFinder/DupFinderRunnerTests.cs
@@ -367,7 +367,7 @@ namespace Cake.Common.Tests.Unit.Tools.DupFinder
                     Log = log
                 };
                 fixture.Settings.OutputFile = new FilePath("build/duplicates.xml");
-                fixture.Settings.DoNotAnalyseOutput = true;
+                fixture.Settings.SkipOutputAnalysis = true;
 
                 // When
                 fixture.Run();

--- a/src/Cake.Common.Tests/Unit/Tools/InspectCode/InspectCodeRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/InspectCode/InspectCodeRunnerTests.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Cake.Common.Tests.Fixtures.Tools.InspectCode;
 using Cake.Common.Tools.InspectCode;
 using Cake.Core;
@@ -330,6 +331,51 @@ namespace Cake.Common.Tests.Unit.Tools.InspectCode
 
                 // Then
                 Assert.Equal("\"/severity=HINT\" \"/Working/Test.sln\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Analyze_Output()
+            {
+                var log = new FakeLog();
+
+                // Given
+                var fixture = new InspectCodeRunFixture
+                {
+                    Log = log
+                };
+                fixture.Settings.OutputFile = new FilePath("build/violations.xml");
+
+                // When
+                fixture.Run();
+
+                // Then
+                var logContainsInspectionResults =
+                    log.Entries.Any(p => p.Message.StartsWith("Code Inspection Error(s) Located."));
+
+                Assert.True(logContainsInspectionResults);
+            }
+
+            [Fact]
+            public void Should_Not_Analyze_Output()
+            {
+                var log = new FakeLog();
+
+                // Given
+                var fixture = new InspectCodeRunFixture
+                {
+                    Log = log
+                };
+                fixture.Settings.OutputFile = new FilePath("build/violations.xml");
+                fixture.Settings.DoNotAnalyseOutput = true;
+
+                // When
+                fixture.Run();
+
+                // Then
+                var logContainsInspectionResults =
+                    log.Entries.Any(p => p.Message.StartsWith("Code Inspection Error(s) Located."));
+
+                Assert.False(logContainsInspectionResults);
             }
         }
 

--- a/src/Cake.Common.Tests/Unit/Tools/InspectCode/InspectCodeRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/InspectCode/InspectCodeRunnerTests.cs
@@ -366,7 +366,7 @@ namespace Cake.Common.Tests.Unit.Tools.InspectCode
                     Log = log
                 };
                 fixture.Settings.OutputFile = new FilePath("build/violations.xml");
-                fixture.Settings.DoNotAnalyseOutput = true;
+                fixture.Settings.SkipOutputAnalysis = true;
 
                 // When
                 fixture.Run();

--- a/src/Cake.Common/Tools/DupFinder/DupFinderRunner.cs
+++ b/src/Cake.Common/Tools/DupFinder/DupFinderRunner.cs
@@ -62,10 +62,13 @@ namespace Cake.Common.Tools.DupFinder
 
             Run(settings, GetArgument(settings, filePaths));
 
-            if (settings.OutputFile != null)
+            if (settings.DoNotAnalyseOutput ||
+                settings.OutputFile == null)
             {
-                AnalyzeResultsFile(settings.OutputFile, settings.ThrowExceptionOnFindingDuplicates);
+                return;
             }
+
+            AnalyzeResultsFile(settings.OutputFile, settings.ThrowExceptionOnFindingDuplicates);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DupFinder/DupFinderRunner.cs
+++ b/src/Cake.Common/Tools/DupFinder/DupFinderRunner.cs
@@ -62,7 +62,7 @@ namespace Cake.Common.Tools.DupFinder
 
             Run(settings, GetArgument(settings, filePaths));
 
-            if (settings.DoNotAnalyseOutput ||
+            if (settings.SkipOutputAnalysis ||
                 settings.OutputFile == null)
             {
                 return;

--- a/src/Cake.Common/Tools/DupFinder/DupFinderSettings.cs
+++ b/src/Cake.Common/Tools/DupFinder/DupFinderSettings.cs
@@ -106,6 +106,6 @@ namespace Cake.Common.Tools.DupFinder
         /// Gets or sets a value indicating whether to skip analysis of the file
         /// that was output by the command line tool or not.
         /// </summary>
-        public bool DoNotAnalyseOutput { get; set; }
+        public bool SkipOutputAnalysis { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DupFinder/DupFinderSettings.cs
+++ b/src/Cake.Common/Tools/DupFinder/DupFinderSettings.cs
@@ -101,5 +101,11 @@ namespace Cake.Common.Tools.DupFinder
         /// Gets or sets a value indicating whether to throw an exception on finding duplicates
         /// </summary>
         public bool ThrowExceptionOnFindingDuplicates { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to skip analysis of the file
+        /// that was output by the command line tool or not.
+        /// </summary>
+        public bool DoNotAnalyseOutput { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/InspectCode/InspectCodeRunner.cs
+++ b/src/Cake.Common/Tools/InspectCode/InspectCodeRunner.cs
@@ -61,10 +61,13 @@ namespace Cake.Common.Tools.InspectCode
 
             Run(settings, GetArguments(settings, solution));
 
-            if (settings.OutputFile != null)
+            if (settings.DoNotAnalyseOutput ||
+                settings.OutputFile == null)
             {
-                AnalyseResultsFile(settings.OutputFile, settings.ThrowExceptionOnFindingViolations);
+                return;
             }
+
+            AnalyseResultsFile(settings.OutputFile, settings.ThrowExceptionOnFindingViolations);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/InspectCode/InspectCodeRunner.cs
+++ b/src/Cake.Common/Tools/InspectCode/InspectCodeRunner.cs
@@ -61,7 +61,7 @@ namespace Cake.Common.Tools.InspectCode
 
             Run(settings, GetArguments(settings, solution));
 
-            if (settings.DoNotAnalyseOutput ||
+            if (settings.SkipOutputAnalysis ||
                 settings.OutputFile == null)
             {
                 return;

--- a/src/Cake.Common/Tools/InspectCode/InspectCodeSettings.cs
+++ b/src/Cake.Common/Tools/InspectCode/InspectCodeSettings.cs
@@ -119,6 +119,6 @@ namespace Cake.Common.Tools.InspectCode
         /// Gets or sets a value indicating whether to skip analysis of the file
         /// that was output by the command line tool or not.
         /// </summary>
-        public bool DoNotAnalyseOutput { get; set; }
+        public bool SkipOutputAnalysis { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/InspectCode/InspectCodeSettings.cs
+++ b/src/Cake.Common/Tools/InspectCode/InspectCodeSettings.cs
@@ -114,5 +114,11 @@ namespace Cake.Common.Tools.InspectCode
         /// Gets or sets the minimal severity of issues to report.
         /// </summary>
         public InspectCodeSeverity? Severity { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to skip analysis of the file
+        /// that was output by the command line tool or not.
+        /// </summary>
+        public bool DoNotAnalyseOutput { get; set; }
     }
 }


### PR DESCRIPTION
Resolves #2768 

I've added an option to skip the built-in analysis part that is performed after the JetBrains command line tool is done. In our case we use another tool to do the analysis using a custom logic. That's why we do not want to output the "issues" directly.