### PR TITLE
changed the register-property in OpenCover/OpenCoverSettings.cs from string

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/OpenCover/OpenCoverTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/OpenCover/OpenCoverTests.cs
@@ -8,6 +8,10 @@ using Cake.Common.Tools.OpenCover;
 using Cake.Common.Tools.XUnit;
 using Cake.Core.IO;
 using Cake.Testing;
+
+using System;
+using System.IO;
+
 using Xunit;
 
 namespace Cake.Common.Tests.Unit.Tools.OpenCover
@@ -229,7 +233,7 @@ namespace Cake.Common.Tests.Unit.Tools.OpenCover
             {
                 // Given
                 var fixture = new OpenCoverFixture();
-                fixture.Settings.Register = "Path32";
+                fixture.Settings.Register = new OpenCoverRegisterOption("Path32");
 
                 // When
                 var result = fixture.Run();
@@ -238,6 +242,56 @@ namespace Cake.Common.Tests.Unit.Tools.OpenCover
                 Assert.Equal("-target:\"/Working/tools/Test.exe\" " +
                              "-targetargs:\"-argument\" " +
                              "-register:Path32 -output:\"/Working/result.xml\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Use_No_Register()
+            {
+                // Given
+                var fixture = new OpenCoverFixture();
+                fixture.Settings.Register = null;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-target:\"/Working/tools/Test.exe\" " +
+                             "-targetargs:\"-argument\" " +
+                             "-output:\"/Working/result.xml\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Use_Admin_Register()
+            {
+                // Given
+                var fixture = new OpenCoverFixture();
+                fixture.Settings.Register = OpenCoverRegisterOption.Admin;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-target:\"/Working/tools/Test.exe\" " +
+                             "-targetargs:\"-argument\" " +
+                             "-register -output:\"/Working/result.xml\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_break_when_old_string_registrations_are_used()
+            {
+                // Given
+                var fixture = new OpenCoverFixture();
+#pragma warning disable CS0618 // Type or member is obsolete
+                fixture.Settings.Register = "Path64";
+#pragma warning restore CS0618 // Type or member is obsolete
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-target:\"/Working/tools/Test.exe\" " +
+                             "-targetargs:\"-argument\" " +
+                             "-register:Path64 -output:\"/Working/result.xml\"", result.Args);
             }
 
             [Fact]

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverRegisterOption.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverRegisterOption.cs
@@ -1,0 +1,82 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core.IO;
+
+using System;
+
+namespace Cake.Common.Tools.OpenCover
+{
+    /// <summary>
+    /// Represents the register-options:
+    ///  - empty for admin-registry-access
+    ///  - "user" for user-registry-access
+    ///  - path for non-registry-dll dll
+    /// </summary>
+    public class OpenCoverRegisterOption
+    {
+        private string value;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenCoverRegisterOption"/> class.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        public OpenCoverRegisterOption(string value)
+        {
+            this.value = value;
+        }
+
+        /// <summary>
+        /// Converts to string.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String" /> that represents this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return string.Empty;
+            }
+
+            return $":{value}";
+        }
+
+        /// <summary>
+        /// Gets the register-option representing the "user"-mode.
+        /// (this will translate to -register:user)
+        /// this
+        /// </summary>
+        public static OpenCoverRegisterOption User => new OpenCoverRegisterOption("user");
+
+        /// <summary>
+        /// Gets the register-option representing the "admin"-mode.
+        /// (this will translate to -register)
+        /// this
+        /// </summary>
+        public static OpenCoverRegisterOption Admin => new OpenCoverRegisterOption(string.Empty);
+
+        /// <summary>
+        /// Gets a register-option pointing to a dll.
+        /// (this will translate to -register:[path-to-dll])
+        /// </summary>
+        /// <param name="path">The path.</param>
+        /// <returns>The <see cref="OpenCoverRegisterOption"/></returns>
+        public static OpenCoverRegisterOption Dll(FilePath path)
+        {
+            return new OpenCoverRegisterOption(path.FullPath);
+        }
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="System.String"/> to <see cref="OpenCoverRegisterOption"/>.
+        /// (Since the switch from pure string to <see cref="OpenCoverRegisterOption"/> is a breaking change)
+        /// </summary>
+        /// <param name="option">The option.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+        [Obsolete("use new OpenCoverRegisterOption() instead.")]
+        public static implicit operator OpenCoverRegisterOption(string option) => new OpenCoverRegisterOption(option);
+    }
+}

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverRunner.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverRunner.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
@@ -141,7 +142,10 @@ namespace Cake.Common.Tools.OpenCover
                 builder.Append("-mergeoutput");
             }
 
-            builder.AppendSwitch("-register", ":", settings.Register);
+            if (settings.Register != null)
+            {
+                builder.AppendSwitch("-register", string.Empty, settings.Register.ToString());
+            }
 
             if (settings.ReturnTargetCodeOffset != null)
             {

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverSettings.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverSettings.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+
 using Cake.Core.IO;
 using Cake.Core.Tooling;
 
@@ -49,7 +50,7 @@ namespace Cake.Common.Tools.OpenCover
         /// <summary>
         /// Gets or sets the register option
         /// </summary>
-        public string Register { get; set; }
+        public OpenCoverRegisterOption Register { get; set; }
 
         /// <summary>
         /// Gets or sets the Return target code offset to be used
@@ -113,7 +114,7 @@ namespace Cake.Common.Tools.OpenCover
             _filters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             _excludedAttributeFilters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             _excludedFileFilters = new HashSet<string>(StringComparer.Ordinal);
-            Register = "user";
+            Register = OpenCoverRegisterOption.User;
             LogLevel = OpenCoverLogLevel.Info;
             _excludeDirectories = new HashSet<DirectoryPath>();
             _searchDirectories = new HashSet<DirectoryPath>();

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverSettingsExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Core.IO;
+
 using System;
 
 namespace Cake.Common.Tools.OpenCover
@@ -57,6 +59,67 @@ namespace Cake.Common.Tools.OpenCover
                 throw new ArgumentNullException(nameof(settings));
             }
             settings.ExcludedFileFilters.Add(filter);
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the register-option to "none"
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The same <see cref="OpenCoverSettings"/> instance so that multiple calls can be chained.</returns>
+        public static OpenCoverSettings WithoutRegister(this OpenCoverSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            settings.Register = null;
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the register-option to admin-registry-access
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The same <see cref="OpenCoverSettings"/> instance so that multiple calls can be chained.</returns>
+        public static OpenCoverSettings WithRegisterAdmin(this OpenCoverSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            settings.Register = OpenCoverRegisterOption.Admin;
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the register-option to user-registry-access
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The same <see cref="OpenCoverSettings"/> instance so that multiple calls can be chained.</returns>
+        public static OpenCoverSettings WithRegisterUser(this OpenCoverSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            settings.Register = OpenCoverRegisterOption.User;
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the register-option to dll-registration (i.e no registry-access)
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="path">The path</param>
+        /// <returns>The same <see cref="OpenCoverSettings"/> instance so that multiple calls can be chained.</returns>
+        public static OpenCoverSettings WithRegisterDll(this OpenCoverSettings settings, FilePath path)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            settings.Register = OpenCoverRegisterOption.Dll(path);
             return settings;
         }
     }


### PR DESCRIPTION
…to a custom OpenCoverRegisterOption to make it clearer what the actual options are. 

As suggested in #2788 this commit implements an `OpenCoverRegisterOption` with predifined static accessors:
* `OpenCoverRegisterOption.User` 
* `OpenCoverRegisterOption.Admin` 
* `OpenCoverRegisterOption.Dll(FilePath)` 

additionally I introduced extensions to `OpenCoverSettings`:

* `WithoutRegister()` this will set the register property to `null` an thereby omitting register alltogether
* `WithRegisterAdmin()` this will set the register property to `OpenCoverRegisterOption.Admin`
* `WithRegisterUser()` this will set the register property to `OpenCoverRegisterOption.User`
* `WithRegisterDll(FilePath)` this will set the register property to `OpenCoverRegisterOption.Dll(FilePath)`

To avoid breaking changes I have implemented an implicit cast from string to the new OpenCoverRegisterOption. So all cake file using the "old" syntax will continue to work without problems.

