### PR TITLE
Make identity of BuildProblem in TeamCityProvider optional

### DIFF
--- a/src/Cake.Common/Build/TeamCity/ITeamCityProvider.cs
+++ b/src/Cake.Common/Build/TeamCity/ITeamCityProvider.cs
@@ -75,7 +75,7 @@ namespace Cake.Common.Build.TeamCity
         /// </summary>
         /// <param name="description">A human-readable plain text describing the build problem. By default, the description appears in the build status text and in the list of build's problems. The text is limited to 4000 symbols, and will be truncated if the limit is exceeded.</param>
         /// <param name="identity">A unique problem ID (optional). Different problems must have different identity, same problems - same identity, which should not change throughout builds if the same problem, for example, the same compilation error occurs. It must be a valid Java ID up to 60 characters. If omitted, the identity is calculated based on the description text.</param>
-        void BuildProblem(string description, string identity);
+        void BuildProblem(string description, string identity = null);
 
         /// <summary>
         /// Tell TeamCity to import data of a given type.

--- a/src/Cake.Common/Build/TeamCity/ITeamCityProvider.cs
+++ b/src/Cake.Common/Build/TeamCity/ITeamCityProvider.cs
@@ -73,8 +73,8 @@ namespace Cake.Common.Build.TeamCity
         /// <summary>
         /// Report a build problem to TeamCity.
         /// </summary>
-        /// <param name="description">Description of build problem.</param>
-        /// <param name="identity">Build identity.</param>
+        /// <param name="description">A human-readable plain text describing the build problem. By default, the description appears in the build status text and in the list of build's problems. The text is limited to 4000 symbols, and will be truncated if the limit is exceeded.</param>
+        /// <param name="identity">A unique problem ID (optional). Different problems must have different identity, same problems - same identity, which should not change throughout builds if the same problem, for example, the same compilation error occurs. It must be a valid Java ID up to 60 characters. If omitted, the identity is calculated based on the description text.</param>
         void BuildProblem(string description, string identity);
 
         /// <summary>

--- a/src/Cake.Common/Build/TeamCity/TeamCityProvider.cs
+++ b/src/Cake.Common/Build/TeamCity/TeamCityProvider.cs
@@ -252,7 +252,7 @@ namespace Cake.Common.Build.TeamCity
         /// </summary>
         /// <param name="description">A human-readable plain text describing the build problem. By default, the description appears in the build status text and in the list of build's problems. The text is limited to 4000 symbols, and will be truncated if the limit is exceeded.</param>
         /// <param name="identity">A unique problem ID (optional). Different problems must have different identity, same problems - same identity, which should not change throughout builds if the same problem, for example, the same compilation error occurs. It must be a valid Java ID up to 60 characters. If omitted, the identity is calculated based on the description text.</param>
-        public void BuildProblem(string description, string identity)
+        public void BuildProblem(string description, string identity = null)
         {
             var tokens = new Dictionary<string, string> { { "description", description } };
             if (!string.IsNullOrEmpty(identity))

--- a/src/Cake.Common/Build/TeamCity/TeamCityProvider.cs
+++ b/src/Cake.Common/Build/TeamCity/TeamCityProvider.cs
@@ -250,8 +250,8 @@ namespace Cake.Common.Build.TeamCity
         /// <summary>
         /// Report a build problem to TeamCity.
         /// </summary>
-        /// <param name="description">Description of build problem.</param>
-        /// <param name="identity">Build identity.</param>
+        /// <param name="description">A human-readable plain text describing the build problem. By default, the description appears in the build status text and in the list of build's problems. The text is limited to 4000 symbols, and will be truncated if the limit is exceeded.</param>
+        /// <param name="identity">A unique problem ID (optional). Different problems must have different identity, same problems - same identity, which should not change throughout builds if the same problem, for example, the same compilation error occurs. It must be a valid Java ID up to 60 characters. If omitted, the identity is calculated based on the description text.</param>
         public void BuildProblem(string description, string identity)
         {
             var tokens = new Dictionary<string, string> { { "description", description } };


### PR DESCRIPTION
Resolves #2811.

- Make `identity` of `BuildProblem` in `TeamCityProvider` optional
- Improve description of the arguments with more details copied from TeamCity's documentation

The current tests [already provide coverage for identity being `null`](https://github.com/cake-build/cake/blob/e4ccdab3183bae78915f587171bd4a9387fc0300/src/Cake.Common.Tests/Unit/Build/TeamCity/TeamCityProviderTests.cs#L137).

---

![image](https://user-images.githubusercontent.com/177608/85247569-96cc1180-b424-11ea-9e26-931f93cd9437.png)

![image](https://user-images.githubusercontent.com/177608/85247995-f4ad2900-b425-11ea-9ad4-96882e2838cc.png)
