### PR TITLE
GH2814: Don't create prerelease GH release

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -571,7 +571,7 @@ Task("Create-Release-Notes")
     GitReleaseManagerCreate(parameters.GitHub.Token, "cake-build", "cake", new GitReleaseManagerCreateSettings {
         Milestone         = parameters.Version.Milestone,
         Name              = parameters.Version.Milestone,
-        Prerelease        = true,
+        Prerelease        = false,
         TargetCommitish   = "main"
     });
 });


### PR DESCRIPTION
This causes problems when creating PR's into the Homebrew repository
and also when displaying releases within the GitHub UI.  There is no
real benefit to marking them as prerelease, so lets just not do it.

Fixes #2814 