### PR TITLE
GH2818: Bump next version in GitVersion.yml

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,3 +1,4 @@
+next-version: 1.0.0
 branches:
   master:
     regex: main


### PR DESCRIPTION
Based on current git history, the next version number for Cake should
be 0.39.0, however, the plan is to ship 1.0.0 as the next version.  By
putting this into the GitVersion.yml file, we force GitVersion to use
1.0.0 as the next base version number.

Fixes #2818 