### PR TITLE
(GH-2822) Change order for tool names

### DIFF
--- a/src/Cake.Common/Tools/ReportGenerator/ReportGeneratorRunner.cs
+++ b/src/Cake.Common/Tools/ReportGenerator/ReportGeneratorRunner.cs
@@ -126,7 +126,7 @@ namespace Cake.Common.Tools.ReportGenerator
         /// <returns>The tool executable name.</returns>
         protected override IEnumerable<string> GetToolExecutableNames()
         {
-            return new[] { "ReportGenerator.exe", "reportgenerator" };
+            return new[] { "reportgenerator", "ReportGenerator.exe" };
         }
 
         private void AppendQuoted(ProcessArgumentBuilder builder, string key, string value)


### PR DESCRIPTION
When attempting to run the change that was made on my Mac, the Cake
Tool resolver still returns ReportGenerator.exe, since there is one of
these nested within the folder structure for the gloal tool.  So even
though we"want" the shim to be found, it isn't.

Workaround this by chaning the order for the tool names.  Since the
since shouldn't exist on a Windows machine, it shouldn't have any
adverse affects.

Fixes #2822