### PR TITLE
GH2825: Add HandleExitCode to ToolSettings

### DIFF
--- a/src/Cake.Core.Tests/Unit/Tooling/ToolTests.cs
+++ b/src/Cake.Core.Tests/Unit/Tooling/ToolTests.cs
@@ -144,6 +144,21 @@ namespace Cake.Core.Tests.Unit.Tooling
                 // Then
                 AssertEx.IsCakeException(result, "UnitTest");
             }
+
+            [Fact]
+            public void Should_Not_Throw_On_Invalid_ExitCode_When_HandleExitCode_Returns_True()
+            {
+                // Given
+                var fixture = new DummyToolFixture();
+                fixture.Settings.HandleExitCode = _ => true;
+                fixture.GivenProcessExitsWithCode(10);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.IsNotType<Exception>(result);
+            }
         }
     }
 }

--- a/src/Cake.Core/Tooling/Tool.cs
+++ b/src/Cake.Core/Tooling/Tool.cs
@@ -97,7 +97,11 @@ namespace Cake.Core.Tooling
             // Post action specified?
             postAction?.Invoke(process);
 
-            ProcessExitCode(process.GetExitCode());
+            var exitCode = process.GetExitCode();
+            if (!settings.HandleExitCode?.Invoke(exitCode) ?? true)
+            {
+                ProcessExitCode(process.GetExitCode());
+            }
         }
 
         /// <summary>

--- a/src/Cake.Core/Tooling/ToolSettings.cs
+++ b/src/Cake.Core/Tooling/ToolSettings.cs
@@ -73,5 +73,41 @@ namespace Cake.Core.Tooling
         /// </code>
         /// </example>
         public IDictionary<string, string> EnvironmentVariables { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Gets or sets whether the exit code from the tool process causes an exception to be thrown.
+        /// <para>
+        /// If the delegate is null (the default) or returns false, then an exception is thrown upon a non-zero exit code.
+        /// </para>
+        /// <para>
+        /// If the delegate returns true then no exception is thrown.
+        /// </para>
+        /// <para>
+        /// This can be useful when the exit code should be ignored, or if there is a desire to apply logic that is conditional
+        /// on the exit code value.
+        /// </para>
+        /// </summary>
+        /// <example>
+        /// Don't throw exceptions if DotNetCoreTest returns non-zero:
+        /// <code>
+        /// DotNetCoreTest("MyProject.csproj", new DotNetCoreTestSettings {
+        ///     HandleExitCode = _=&gt; true
+        /// });
+        /// </code>
+        /// </example>
+        /// <example>
+        /// Use custom logic for exit code:
+        /// <code>
+        /// DotNetCoreTest("MyProject.csproj", new DotNetCoreTestSettings {
+        ///     HandleExitCode = exitCode =&gt; exitCode switch {
+        ///         0 =&gt; throw new CakeException("ZERO"),
+        ///         1 =&gt; true, // treat 1 and 2 as handled "ok".
+        ///         2 =&gt; true,
+        ///         _ =&gt; false // everything else will throw via default implementation
+        ///     };
+        /// });
+        /// </code>
+        /// </example>
+        public Func<int, bool> HandleExitCode { get; set; }
     }
 }


### PR DESCRIPTION
- When true, then ProcessExitCode method is not called
