### PR TITLE
GH-2703: Added hideskipped option support for OpenCover

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/OpenCover/OpenCoverTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/OpenCover/OpenCoverTests.cs
@@ -345,6 +345,27 @@ namespace Cake.Common.Tests.Unit.Tools.OpenCover
             }
 
             [Fact]
+            public void Should_Append_HideSkipped()
+            {
+                // Given
+                var fixture = new OpenCoverFixture();
+                fixture.Settings.HideSkippedOption = OpenCoverHideSkippedOption.File
+                                                     | OpenCoverHideSkippedOption.MissingPdb
+                                                     | OpenCoverHideSkippedOption.Filter
+                                                     | OpenCoverHideSkippedOption.All
+                                                     | OpenCoverHideSkippedOption.Attribute;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-target:\"/Working/tools/Test.exe\" " +
+                             "-targetargs:\"-argument\" " +
+                             "-register:user -output:\"/Working/result.xml\" " +
+                             "-hideskipped:All", result.Args);
+            }
+
+            [Fact]
             public void Should_Append_MergeByHash()
             {
                 // Given

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverHideSkippedOption.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverHideSkippedOption.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Tools.OpenCover
+{
+    using System;
+
+    /// <summary>
+    /// Represents the hide skipped option for OpenCover.
+    /// </summary>
+    [Flags]
+    public enum OpenCoverHideSkippedOption
+    {
+        /// <summary>
+        /// Removes no information from output file.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Removes information from output files that relates to classes/modules that have been skipped (filtered) due to use of the -excludebyfile -switch.
+        /// </summary>
+        File = 1,
+
+        /// <summary>
+        /// Removes information from output files that relates to classes/modules that have been skipped (filtered) due to use of the -filter -switch.
+        /// </summary>
+        Filter = 2,
+
+        /// <summary>
+        /// Removes information from output files that relates to classes/modules that have been skipped (filtered) due to use of the -excludebyattribute -switch.
+        /// </summary>
+        Attribute = 4,
+
+        /// <summary>
+        /// Removes missing Pdb information from output file.
+        /// </summary>
+        MissingPdb = 8,
+
+        /// <summary>
+        /// Removes all information from output file.
+        /// </summary>
+        All = File | Filter | Attribute | MissingPdb
+    }
+}

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverHideSkippedOptionExtensions.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverHideSkippedOptionExtensions.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Tools.OpenCover
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Extensions class for <see cref="OpenCoverHideSkippedOption"/>.
+    /// </summary>
+    public static class OpenCoverHideSkippedOptionExtensions
+    {
+        /// <summary>
+        /// Get flags.
+        /// </summary>
+        /// <param name="openCoverHideSkippedOption">
+        /// The input.
+        /// </param>
+        /// <returns>
+        /// The <see cref="IEnumerable"/>.
+        /// </returns>
+        public static IEnumerable<OpenCoverHideSkippedOption> GetFlags(this OpenCoverHideSkippedOption openCoverHideSkippedOption)
+        {
+            foreach (OpenCoverHideSkippedOption value in Enum.GetValues(openCoverHideSkippedOption.GetType()))
+            {
+                if (openCoverHideSkippedOption.HasFlag(value))
+                {
+                    yield return value;
+                }
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverRunner.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverRunner.cs
@@ -16,6 +16,7 @@ namespace Cake.Common.Tools.OpenCover
     /// </summary>
     public sealed class OpenCoverRunner : Tool<OpenCoverSettings>
     {
+        private const string HideSkippedConstant = "-hideskipped";
         private readonly ICakeEnvironment _environment;
 
         /// <summary>
@@ -163,6 +164,20 @@ namespace Cake.Common.Tools.OpenCover
             if (settings.LogLevel != OpenCoverLogLevel.Info)
             {
                 builder.AppendSwitch("-log", ":", settings.LogLevel.ToString());
+            }
+
+            // HideSkipped Option
+            if (settings.HideSkippedOption != OpenCoverHideSkippedOption.None)
+            {
+                if (settings.HideSkippedOption == OpenCoverHideSkippedOption.All)
+                {
+                    builder.AppendSwitch(HideSkippedConstant, ":", "All");
+                }
+                else
+                {
+                    var hideSkippedOptions = string.Join(";", settings.HideSkippedOption.GetFlags());
+                    builder.AppendSwitch(HideSkippedConstant, ":", hideSkippedOptions);
+                }
             }
 
             // Merge by hash

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverSettings.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverSettings.cs
@@ -77,6 +77,11 @@ namespace Cake.Common.Tools.OpenCover
         public OpenCoverLogLevel LogLevel { get; set; }
 
         /// <summary>
+        /// Gets or sets the hide skipped option of OpenCover.
+        /// </summary>
+        public OpenCoverHideSkippedOption HideSkippedOption { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to merge the coverage results for an assembly
         /// regardless of where it was loaded assuming it has the same file-hash in each location.
         /// </summary>
@@ -115,6 +120,7 @@ namespace Cake.Common.Tools.OpenCover
             _excludedFileFilters = new HashSet<string>(StringComparer.Ordinal);
             Register = "user";
             LogLevel = OpenCoverLogLevel.Info;
+            HideSkippedOption = OpenCoverHideSkippedOption.None;
             _excludeDirectories = new HashSet<DirectoryPath>();
             _searchDirectories = new HashSet<DirectoryPath>();
         }


### PR DESCRIPTION
- Added hideskipped support for OpenCover.
- Added unit tests.
- Added extension method to fetch all valid flag values.