### PR TITLE
GH-2755: Add DirectoryHashCalculator

### DIFF
--- a/src/Cake.Common.Tests/Unit/Security/DirectoryHashCalculatorTests.cs
+++ b/src/Cake.Common.Tests/Unit/Security/DirectoryHashCalculatorTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Cake.Common.Security;
 using Cake.Core;
 using Cake.Core.IO;
@@ -10,27 +11,27 @@ using Xunit;
 
 namespace Cake.Common.Tests.Unit.Security
 {
-    public sealed class FileHashCalculatorTests
+    public sealed class DirectoryHashCalculatorTests
     {
         public sealed class TheCalculateMethod
         {
             [Fact]
-            public void Should_Throw_If_File_Path_Is_Null()
+            public void Should_Throw_If_Directory_Path_Is_Null()
             {
                 // Given
                 var hashAlgorithmBuilder = Substitute.For<IHashAlgorithmBuilder>();
-                var fileSystem = Substitute.For<IFileSystem>();
-                var calculator = new FileHashCalculator(fileSystem, hashAlgorithmBuilder);
+                var cakeContext = Substitute.For<ICakeContext>();
+                var calculator = new DirectoryHashCalculator(cakeContext, hashAlgorithmBuilder);
 
                 // When
-                var result = Record.Exception(() => calculator.Calculate(null, HashAlgorithm.MD5));
+                var result = Record.Exception(() => calculator.Calculate(null, null, HashAlgorithm.MD5));
 
                 // Then
-                AssertEx.IsArgumentNullException(result, "filePath");
+                AssertEx.IsArgumentNullException(result, "directoryPath");
             }
 
             [Fact]
-            public void Should_Throw_If_File_Does_Not_Exist()
+            public void Should_Throw_If_Directory_Does_Not_Exist()
             {
                 // Given
                 var hashAlgorithmBuilder = Substitute.For<IHashAlgorithmBuilder>();
@@ -38,14 +39,16 @@ namespace Cake.Common.Tests.Unit.Security
                 var file = Substitute.For<IFile>();
                 file.Exists.Returns(false);
                 fileSystem.GetFile(Arg.Any<FilePath>()).Returns(file);
+                var cakeContext = Substitute.For<ICakeContext>();
+                cakeContext.FileSystem.Returns(fileSystem);
 
-                var calculator = new FileHashCalculator(fileSystem, hashAlgorithmBuilder);
+                var calculator = new DirectoryHashCalculator(cakeContext, hashAlgorithmBuilder);
 
                 // When
-                var result = Record.Exception(() => calculator.Calculate("./non-existent-path", HashAlgorithm.MD5));
+                var result = Record.Exception(() => calculator.Calculate("./non-existent-path", new List<string> { "./**/*.cs" }, HashAlgorithm.MD5));
 
                 // Then
-                AssertEx.IsExceptionWithMessage<CakeException>(result, "File 'non-existent-path' does not exist.");
+                AssertEx.IsExceptionWithMessage<CakeException>(result, "Directory 'non-existent-path' does not exist.");
             }
         }
     }

--- a/src/Cake.Common.Tests/Unit/Security/HashAlgorithmBuilderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Security/HashAlgorithmBuilderTests.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Security;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Security
+{
+    public sealed class HashAlgorithmBuilderTests
+    {
+        public sealed class TheCreateHashAlgorithmMethod
+        {
+            [Fact]
+            public void Should_Return_MD5_Algorithm_Instance_If_Input_Is_Cake_HashAlgorithm_Enum_MD5()
+            {
+                // Given
+                var hashAlgorithmbuilder = new HashAlgorithmBuilder();
+
+                // When
+                var result = hashAlgorithmbuilder.CreateHashAlgorithm(HashAlgorithm.MD5);
+
+                // Then
+                Assert.IsAssignableFrom<System.Security.Cryptography.MD5>(result);
+            }
+
+            [Fact]
+            public void Should_Return_SHA256_Algorithm_Instance_If_Input_Is_Cake_HashAlgorithm_Enum_SHA256()
+            {
+                // Given
+                var hashAlgorithmbuilder = new HashAlgorithmBuilder();
+
+                // When
+                var result = hashAlgorithmbuilder.CreateHashAlgorithm(HashAlgorithm.SHA256);
+
+                // Then
+                Assert.IsAssignableFrom<System.Security.Cryptography.SHA256>(result);
+            }
+
+            [Fact]
+            public void Should_Return_SHA512_Algorithm_Instance_If_Input_Is_Cake_HashAlgorithm_Enum_SHA512()
+            {
+                // Given
+                var hashAlgorithmbuilder = new HashAlgorithmBuilder();
+
+                // When
+                var result = hashAlgorithmbuilder.CreateHashAlgorithm(HashAlgorithm.SHA512);
+
+                // Then
+                Assert.IsAssignableFrom<System.Security.Cryptography.SHA512>(result);
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Security/DirectoryHash.cs
+++ b/src/Cake.Common/Security/DirectoryHash.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Cake.Core.IO;
+
+namespace Cake.Common.Security
+{
+    /// <summary>
+    /// Represents a calculated directory hash.
+    /// </summary>
+    public sealed class DirectoryHash
+    {
+        private readonly byte[] _hash;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DirectoryHash"/> class.
+        /// </summary>
+        /// <param name="directoryPath">The directory path.</param>
+        /// <param name="hash">The computed hash.</param>
+        /// <param name="hashAlgorithm">The algorithm used.</param>
+        /// <param name="fileHashList">List of all computed <see cref="FileHash"/>.</param>
+        public DirectoryHash(
+            DirectoryPath directoryPath,
+            byte[] hash,
+            HashAlgorithm hashAlgorithm,
+            IEnumerable<FileHash> fileHashList)
+        {
+            if (directoryPath == null)
+            {
+                throw new ArgumentNullException(nameof(directoryPath));
+            }
+
+            if (hash == null)
+            {
+                throw new ArgumentNullException(nameof(hash));
+            }
+
+            if (fileHashList == null)
+            {
+                throw new ArgumentNullException(nameof(fileHashList));
+            }
+
+            Path = directoryPath;
+            _hash = (byte[])hash.Clone();
+            Algorithm = hashAlgorithm;
+            FileHashList.AddRange(fileHashList);
+        }
+
+        /// <summary>
+        /// Gets the algorithm used for the hash computation.
+        /// </summary>
+        public HashAlgorithm Algorithm { get; }
+
+        /// <summary>
+        /// Gets the <see cref="DirectoryPath"/> for the directory.
+        /// </summary>
+        public DirectoryPath Path { get; }
+
+        /// <summary>
+        /// Gets the list of <see cref="FileHash"/> for all files of the directory.
+        /// </summary>
+        public List<FileHash> FileHashList { get; } = new List<FileHash>();
+
+        /// <summary>
+        /// Gets the raw computed hash.
+        /// </summary>
+        public byte[] ComputedHash => (byte[])_hash.Clone();
+
+        /// <summary>
+        /// Convert the directory hash to a hexadecimal string.
+        /// </summary>
+        /// <returns>A hexadecimal string representing the computed hash.</returns>
+        public string ToHex()
+        {
+            // Each byte becomes two characters. Prepare the StringBuilder accordingly.
+            var builder = new StringBuilder(_hash.Length * 2);
+
+            foreach (var b in _hash)
+            {
+                builder.AppendFormat("{0:x2}", b);
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/src/Cake.Common/Security/DirectoryHashCalculator.cs
+++ b/src/Cake.Common/Security/DirectoryHashCalculator.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using Cake.Common.IO;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Security
+{
+    /// <summary>
+    /// Class for calculating a hash for a directory.
+    /// </summary>
+    public class DirectoryHashCalculator
+    {
+        private readonly ICakeContext _context;
+        private readonly IHashAlgorithmBuilder _hashAlgorithmBuilder;
+        private readonly FileHashCalculator _fileHashCalculator;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DirectoryHashCalculator"/> class.
+        /// </summary>
+        /// <param name="context">The cake context.</param>
+        /// <param name="hashAlgorithmBuilder">The hash algorithm builder.</param>
+        public DirectoryHashCalculator(ICakeContext context, IHashAlgorithmBuilder hashAlgorithmBuilder)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (hashAlgorithmBuilder == null)
+            {
+                throw new ArgumentNullException(nameof(hashAlgorithmBuilder));
+            }
+
+            _context = context;
+            _hashAlgorithmBuilder = hashAlgorithmBuilder;
+            _fileHashCalculator = new FileHashCalculator(_context.FileSystem, _hashAlgorithmBuilder);
+        }
+
+        /// <summary>
+        /// Calculates the hash for a given directory.
+        /// </summary>
+        /// <param name="directoryPath">The directory path.</param>
+        /// <param name="pattern">The glob pattern to match.</param>
+        /// <param name="hashAlgorithm">The hash algorithm to use.</param>
+        /// <returns>A <see cref="DirectoryHash"/> instance representing the calculated hash.</returns>
+        /// <example>
+        /// <code>
+        /// Information(
+        ///     "Cake It calculates the hashes from all cs files in all subdirectories using a MD5 hash: {0}",
+        ///     CalculateDirectoryHash("C:\directoryToHash", "./**/*.cs", HashAlgorithm.MD5).ToHex());
+        /// </code>
+        /// </example>
+        public DirectoryHash Calculate(
+            DirectoryPath directoryPath,
+            IEnumerable<string> pattern,
+            HashAlgorithm hashAlgorithm)
+        {
+            if (directoryPath == null)
+            {
+                throw new ArgumentNullException(nameof(directoryPath));
+            }
+
+            if (pattern == null)
+            {
+                throw new ArgumentNullException(nameof(pattern));
+            }
+
+            using (var incrementalDirectoryHash = _hashAlgorithmBuilder.CreateHashAlgorithm(hashAlgorithm))
+            {
+                var fileHashList = new List<FileHash>();
+                var files = GetDirectoryFiles(directoryPath, pattern).OrderBy(file => file.FullPath);
+                if (files.Any())
+                {
+                    var lastFile = files.LastOrDefault();
+                    foreach (var file in GetDirectoryFiles(directoryPath, pattern))
+                    {
+                        var fileContentAndNameHash = CalculateFileContentAndNameHash(file, directoryPath, hashAlgorithm);
+                        fileHashList.Add(fileContentAndNameHash);
+                        if (file == lastFile)
+                        {
+                            incrementalDirectoryHash.TransformFinalBlock(
+                                fileContentAndNameHash.ComputedHash, 0,
+                                fileContentAndNameHash.ComputedHash.Length);
+                        }
+                        else
+                        {
+                            incrementalDirectoryHash.TransformBlock(
+                                fileContentAndNameHash.ComputedHash, 0,
+                                fileContentAndNameHash.ComputedHash.Length,
+                                fileContentAndNameHash.ComputedHash, 0);
+                        }
+                    }
+
+                    var directoryHash = incrementalDirectoryHash.Hash;
+                    return new DirectoryHash(directoryPath, directoryHash, hashAlgorithm, fileHashList);
+                }
+
+                // No files found.
+                return null;
+            }
+        }
+
+        private FilePathCollection GetDirectoryFiles(
+            DirectoryPath directoryPath,
+            IEnumerable<string> pattern)
+        {
+            var directory = new Directory(directoryPath);
+
+            if (!directory.Exists)
+            {
+                const string format = "Directory '{0}' does not exist.";
+                var message = string.Format(CultureInfo.InvariantCulture, format, directoryPath.FullPath);
+                throw new CakeException(message);
+            }
+
+            var filePathCollection = new FilePathCollection();
+            var fullGlobs = pattern.Select(x => directoryPath + x).ToArray();
+
+            foreach (var glob in fullGlobs)
+            {
+                foreach (var file in _context.GetFiles(glob))
+                {
+                    filePathCollection.Add(file);
+                }
+            }
+
+            return filePathCollection;
+        }
+
+        private FileHash CalculateFileContentAndNameHash(
+            FilePath filePath,
+            DirectoryPath directoryPath,
+            HashAlgorithm hashAlgorithm)
+        {
+            if (filePath == null)
+            {
+                throw new ArgumentNullException(nameof(filePath));
+            }
+
+            if (directoryPath == null)
+            {
+                throw new ArgumentNullException(nameof(directoryPath));
+            }
+
+            using (var incrementalFileHash = _hashAlgorithmBuilder.CreateHashAlgorithm(hashAlgorithm))
+            {
+                // Calculate file content hash
+                var fileContentHash = _fileHashCalculator.Calculate(filePath, hashAlgorithm);
+
+                // Combine file content hash
+                incrementalFileHash.TransformBlock(
+                    fileContentHash.ComputedHash, 0,
+                    fileContentHash.ComputedHash.Length,
+                    fileContentHash.ComputedHash, 0);
+
+                // combine filename hash
+                var relativeFilePath = filePath.GetRelativePath(directoryPath);
+                var fileFullNameArray = Encoding.ASCII.GetBytes(filePath.GetFilename().FullPath);
+                using (var hashAlgorithmInstance = _hashAlgorithmBuilder.CreateHashAlgorithm(hashAlgorithm))
+                {
+                    var filenameHash = hashAlgorithmInstance.ComputeHash(fileFullNameArray);
+                    incrementalFileHash.TransformFinalBlock(
+                        filenameHash, 0,
+                        filenameHash.Length);
+                }
+                var fileContentAndNameHash = incrementalFileHash.Hash;
+
+                return new FileHash(filePath, fileContentAndNameHash, hashAlgorithm);
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Security/HashAlgorithmBuilder.cs
+++ b/src/Cake.Common/Security/HashAlgorithmBuilder.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Security.Cryptography;
+
+namespace Cake.Common.Security
+{
+    /// <summary>
+    /// Creates a <see cref="System.Security.Cryptography.HashAlgorithm"/> instance by
+    /// <see cref="HashAlgorithm"/>.
+    /// </summary>
+    public sealed class HashAlgorithmBuilder : IHashAlgorithmBuilder
+    {
+        /// <summary>
+        /// Return a instance of <see cref="System.Security.Cryptography.HashAlgorithm"/> by
+        /// <see cref="HashAlgorithm"/> enum value.
+        /// </summary>
+        /// <param name="hashAlgorithm">Algorithm enum value.</param>
+        /// <returns>A <see cref="System.Security.Cryptography.HashAlgorithm"/> instance.</returns>
+        public System.Security.Cryptography.HashAlgorithm CreateHashAlgorithm(HashAlgorithm hashAlgorithm)
+        {
+            switch (hashAlgorithm)
+            {
+                case HashAlgorithm.MD5:
+                    return MD5.Create();
+
+                case HashAlgorithm.SHA256:
+                    return SHA256.Create();
+
+                case HashAlgorithm.SHA512:
+                    return SHA512.Create();
+            }
+
+            throw new NotSupportedException(hashAlgorithm.ToString());
+        }
+    }
+}

--- a/src/Cake.Common/Security/IHashAlgorithmBuilder.cs
+++ b/src/Cake.Common/Security/IHashAlgorithmBuilder.cs
@@ -1,0 +1,17 @@
+﻿namespace Cake.Common.Security
+{
+    /// <summary>
+    /// Creates a <see cref="System.Security.Cryptography.HashAlgorithm"/> instance by
+    /// <see cref="HashAlgorithm"/>.
+    /// </summary>
+    public interface IHashAlgorithmBuilder
+    {
+        /// <summary>
+        /// Return a instance of <see cref="System.Security.Cryptography.HashAlgorithm"/> by
+        /// <see cref="HashAlgorithm"/> enum value.
+        /// </summary>
+        /// <param name="hashAlgorithm">Algorithm enum value.</param>
+        /// <returns>A <see cref="System.Security.Cryptography.HashAlgorithm"/> instance.</returns>
+        System.Security.Cryptography.HashAlgorithm CreateHashAlgorithm(HashAlgorithm hashAlgorithm);
+    }
+}

--- a/src/Cake.Common/Security/SecurityAliases.cs
+++ b/src/Cake.Common/Security/SecurityAliases.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using Cake.Core;
 using Cake.Core.Annotations;
 using Cake.Core.IO;
@@ -57,8 +58,57 @@ namespace Cake.Common.Security
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var fileHashCalculator = new FileHashCalculator(context.FileSystem);
+            var fileHashCalculator = new FileHashCalculator(context.FileSystem, new HashAlgorithmBuilder());
             return fileHashCalculator.Calculate(filePath, hashAlgorithm);
+        }
+
+        /// <summary>
+        /// Calculates the hash for a given directory using the default (SHA256) algorithm.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="directoryPath">The file path.</param>
+        /// <param name="globs">The glob pattern to match.</param>
+        /// <returns>A <see cref="DirectoryHash"/> instance representing the calculated hash.</returns>
+        /// <example>
+        /// <code>
+        /// Information(
+        ///     "Cake It calculates the hashes from all cs files in all subdirectories using a SHA256 hash: {0}",
+        ///     CalculateDirectoryHash("C:\directoryToHash", "./**/*.cs").ToHex());
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static DirectoryHash CalculateDirectoryHash(this ICakeContext context,
+            IEnumerable<string> globs, DirectoryPath directoryPath)
+        {
+            return CalculateDirectoryHash(context, directoryPath, globs, HashAlgorithm.SHA256);
+        }
+
+        /// <summary>
+        /// Calculates the hash for a given directory.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="directoryPath">The file path.</param>
+        /// <param name="globs">The glob pattern to match.</param>
+        /// <param name="hashAlgorithm">The hash algorithm to use.</param>
+        /// <returns>A <see cref="DirectoryHash"/> instance representing the calculated hash.</returns>
+        /// <example>
+        /// <code>
+        /// Information(
+        ///     "Cake It calculates the hashes from all cs files in all subdirectories using a MD5 hash: {0}",
+        ///     CalculateDirectoryHash("C:\directoryToHash", "./**/*.cs", HashAlgorithm.MD5).ToHex());
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static DirectoryHash CalculateDirectoryHash(this ICakeContext context,
+            DirectoryPath directoryPath, IEnumerable<string> globs, HashAlgorithm hashAlgorithm)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var directoryHashCalculator = new DirectoryHashCalculator(context, new HashAlgorithmBuilder());
+            return directoryHashCalculator.Calculate(directoryPath, globs, hashAlgorithm);
         }
     }
 }


### PR DESCRIPTION
- Add DirectoryHash represents a calculated directory hash.
- Add DirectoryHashCalculator for calculating a hash for a directory.
- Add HashAlgorithmBuilder for a common usage of creating a instance of the hash algorithm.

- Overload the ctor of FileHashCalculator with IHashAlgorithmBuilder as additional parameter.

Fixes #2755
