### PR TITLE
GH-2839: Add support for PublishReadyToRunShowWarnings property in DotNetCorePublish

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Publish/DotNetCorePublisherTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Publish/DotNetCorePublisherTests.cs
@@ -233,6 +233,20 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Publish
                 // Then
                 Assert.Equal("publish -p:PublishReadyToRun=true", result.Args);
             }
+
+            [Fact]
+            public void Should_Add_PublishReadyToRunShowWarnings()
+            {
+                // Given
+                var fixture = new DotNetCorePublisherFixture();
+                fixture.Settings.PublishReadyToRunShowWarnings = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("publish -p:PublishReadyToRunShowWarnings=true", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/Publish/DotNetCorePublishSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Publish/DotNetCorePublishSettings.cs
@@ -130,6 +130,14 @@ namespace Cake.Common.Tools.DotNetCore.Publish
         public bool? PublishReadyToRun { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to show warnings emitted by ReadyToRun (R2R) compilation.
+        /// </summary>
+        /// <remarks>
+        /// Requires .NET Core 3.x or newer. Tiered compilation is enabled by default in .NET Core 3.
+        /// </remarks>
+        public bool? PublishReadyToRunShowWarnings { get; set; }
+
+        /// <summary>
         /// Gets or sets the specified NuGet package sources to use during the restore.
         /// </summary>
         /// <remarks>

--- a/src/Cake.Common/Tools/DotNetCore/Publish/DotNetCorePublisher.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Publish/DotNetCorePublisher.cs
@@ -204,6 +204,19 @@ namespace Cake.Common.Tools.DotNetCore.Publish
                 }
             }
 
+            // Publish ReadyToRunShowWarnings
+            if (settings.PublishReadyToRunShowWarnings.HasValue)
+            {
+                if (settings.PublishReadyToRunShowWarnings.Value)
+                {
+                    builder.Append("-p:PublishReadyToRunShowWarnings=true");
+                }
+                else
+                {
+                    builder.Append("-p:PublishReadyToRunShowWarnings=false");
+                }
+            }
+
             // Sources
             if (settings.Sources != null)
             {


### PR DESCRIPTION
Resolves #2839

```csharp
DotNetCorePublish("./src/MyApp/MyApp.csproj", new DotNetCorePublishSettings
{
    // ...
    PublishReadyToRun = true,
    PublishReadyToRunShowWarnings = true, // <<<
});
```
