### PR TITLE
Add IsRunningOn for macOS and Linux 

### DIFF
--- a/src/Cake.Common.Tests/Unit/EnvironmentAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/EnvironmentAliasesTests.cs
@@ -226,5 +226,65 @@ namespace Cake.Common.Tests.Unit
                 Assert.Equal(expected, result);
             }
         }
+
+        public sealed class TheIsRunningOnLinuxMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Context_Is_Null()
+            {
+                // Given, When
+                var result = Record.Exception(() => EnvironmentAliases.IsRunningOnLinux(null));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "context");
+            }
+
+            [Theory]
+            [InlineData(PlatformFamily.Linux, true)]
+            [InlineData(PlatformFamily.OSX, false)]
+            [InlineData(PlatformFamily.Windows, false)]
+            public void Should_Return_Correct_Value(PlatformFamily family, bool expected)
+            {
+                // Given
+                var context = Substitute.For<ICakeContext>();
+                context.Environment.Returns(new FakeEnvironment(family));
+
+                // When
+                var result = EnvironmentAliases.IsRunningOnLinux(context);
+
+                // Then
+                Assert.Equal(expected, result);
+            }
+        }
+
+        public sealed class TheIsRunningOnMacMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Context_Is_Null()
+            {
+                // Given, When
+                var result = Record.Exception(() => EnvironmentAliases.IsRunningOnMacOs(null));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "context");
+            }
+
+            [Theory]
+            [InlineData(PlatformFamily.Linux, false)]
+            [InlineData(PlatformFamily.OSX, true)]
+            [InlineData(PlatformFamily.Windows, false)]
+            public void Should_Return_Correct_Value(PlatformFamily family, bool expected)
+            {
+                // Given
+                var context = Substitute.For<ICakeContext>();
+                context.Environment.Returns(new FakeEnvironment(family));
+
+                // When
+                var result = EnvironmentAliases.IsRunningOnMacOs(context);
+
+                // Then
+                Assert.Equal(expected, result);
+            }
+        }
     }
 }

--- a/src/Cake.Common/EnviromentAliases.cs
+++ b/src/Cake.Common/EnviromentAliases.cs
@@ -186,6 +186,58 @@ namespace Cake.Common
             return context.Environment.Platform.IsUnix();
         }
 
+        /// <summary>
+        /// Determines whether the build script running on a macOS based system.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// if (IsRunningOnMacOs())
+        /// {
+        ///     Information("macOS!");
+        /// }
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <returns>
+        ///   <c>true</c> if the build script running on a macOS based system; otherwise <c>false</c>.
+        /// </returns>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Platform")]
+        public static bool IsRunningOnMacOs(this ICakeContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            return context.Environment.Platform.IsOSX();
+        }
+
+        /// <summary>
+        /// Determines whether the build script running on a Linux based system.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// if (IsRunningOnLinux())
+        /// {
+        ///     Information("Linux!");
+        /// }
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <returns>
+        ///   <c>true</c> if the build script running on a Linux based system; otherwise <c>false</c>.
+        /// </returns>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Platform")]
+        public static bool IsRunningOnLinux(this ICakeContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            return context.Environment.Platform.IsLinux();
+        }
+
         private static T Convert<T>(string value)
         {
             var converter = TypeDescriptor.GetConverter(typeof(T));

--- a/src/Cake.Core/Extensions/CakePlatformExtensions.cs
+++ b/src/Cake.Core/Extensions/CakePlatformExtensions.cs
@@ -26,5 +26,33 @@ namespace Cake.Core
             }
             return EnvironmentHelper.IsUnix(platform.Family);
         }
+
+        /// <summary>
+        /// Determines whether the specified platform is a macOS platform.
+        /// </summary>
+        /// <param name="platform">The platform.</param>
+        /// <returns><c>true</c> if the platform is a macOS platform; otherwise <c>false</c>.</returns>
+        public static bool IsOSX(this ICakePlatform platform)
+        {
+            if (platform == null)
+            {
+                throw new ArgumentNullException(nameof(platform));
+            }
+            return EnvironmentHelper.IsOSX(platform.Family);
+        }
+
+        /// <summary>
+        /// Determines whether the specified platform is a Linux platform.
+        /// </summary>
+        /// <param name="platform">The platform.</param>
+        /// <returns><c>true</c> if the platform is a Linux platform; otherwise <c>false</c>.</returns>
+        public static bool IsLinux(this ICakePlatform platform)
+        {
+            if (platform == null)
+            {
+                throw new ArgumentNullException(nameof(platform));
+            }
+            return EnvironmentHelper.IsLinux(platform.Family);
+        }
     }
 }

--- a/src/Cake.Core/Polyfill/EnvironmentHelper.cs
+++ b/src/Cake.Core/Polyfill/EnvironmentHelper.cs
@@ -111,6 +111,16 @@ namespace Cake.Core.Polyfill
                    || family == PlatformFamily.OSX;
         }
 
+        public static bool IsOSX(PlatformFamily family)
+        {
+            return family == PlatformFamily.OSX;
+        }
+
+        public static bool IsLinux(PlatformFamily family)
+        {
+            return family == PlatformFamily.Linux;
+        }
+
         public static Runtime GetRuntime()
         {
             if (IsCoreClr())


### PR DESCRIPTION
This is very helpful for when things run on just macOS or just Linux. The Unix variant is nice for the basic Windows/not-Windows, but in some cases, the build script needs to know if Xcode should be used or some other mac-specific tool.

This actually was supposedly "added" in #741, but it never actually was?

Did I miss something? If this was excluded for a specific reason, then feel free to close.

I am also looking at the code, and not sure if this fits exactly since the Windows variant is basically !Unix, however, I can iterate on this PR based on any feedback.