### PR TITLE
GH2859: Identify .NET 5 as CoreCLR

### DIFF
--- a/src/Cake.Core/Polyfill/EnvironmentHelper.cs
+++ b/src/Cake.Core/Polyfill/EnvironmentHelper.cs
@@ -92,7 +92,8 @@ namespace Cake.Core.Polyfill
 #if NETCORE
             if (_isCoreClr == null)
             {
-                _isCoreClr = RuntimeInformation.FrameworkDescription.StartsWith(".NET Core");
+                _isCoreClr = RuntimeInformation.FrameworkDescription.StartsWith(".NET Core")
+                                || RuntimeInformation.FrameworkDescription.StartsWith(".NET 5");
             }
             return _isCoreClr.Value;
 #else

--- a/src/Cake.Core/Polyfill/Runtime.cs
+++ b/src/Cake.Core/Polyfill/Runtime.cs
@@ -11,7 +11,7 @@
         Clr,
 
         /// <summary>
-        /// .NET Core 2.
+        /// .NET Core / .NET 5.
         /// </summary>
         CoreClr
     }


### PR DESCRIPTION
* fixes #2859