### PR TITLE
GH2887: Enforce bash scrips LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
 * text=auto
+*.sh text eol=lf
 
 ###############################################################################
 # Set default behavior for command prompt diff.


### PR DESCRIPTION
* fixes #2887

If already cloned repo endings can be fixed after this is merged by executing (as attributes are cached)
1. `git rm --cached -r .`
2.  `git reset --hard`