### PR TITLE
GH2895: Custom contexts inherit CakeContextAdapter instead of ICakeContext directly

### DIFF
--- a/src/Cake.Common/Tools/DotCover/DotCoverContext.cs
+++ b/src/Cake.Common/Tools/DotCover/DotCoverContext.cs
@@ -10,38 +10,20 @@ using Cake.Core.Tooling;
 
 namespace Cake.Common.Tools.DotCover
 {
-    internal sealed class DotCoverContext : ICakeContext
+    internal sealed class DotCoverContext : CakeContextAdapter
     {
-        private readonly ICakeContext _context;
         private readonly DotCoverProcessRunner _runner;
 
-        public IFileSystem FileSystem => _context.FileSystem;
+        public override ICakeLog Log { get; }
 
-        public ICakeEnvironment Environment => _context.Environment;
-
-        public IGlobber Globber => _context.Globber;
-
-        public ICakeLog Log { get; }
-
-        public ICakeArguments Arguments => _context.Arguments;
-
-        public IProcessRunner ProcessRunner => _runner;
-
-        public IRegistry Registry => _context.Registry;
-
-        public IToolLocator Tools => _context.Tools;
-
-        public ICakeDataResolver Data => _context.Data;
+        public override IProcessRunner ProcessRunner => _runner;
 
         public FilePath FilePath => _runner.FilePath;
 
         public ProcessSettings Settings => _runner.ProcessSettings;
 
-        public ICakeConfiguration Configuration => _context.Configuration;
-
-        public DotCoverContext(ICakeContext context)
+        public DotCoverContext(ICakeContext context) : base(context)
         {
-            _context = context;
             Log = new NullLog();
             _runner = new DotCoverProcessRunner();
         }

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverContext.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverContext.cs
@@ -10,38 +10,20 @@ using Cake.Core.Tooling;
 
 namespace Cake.Common.Tools.OpenCover
 {
-    internal sealed class OpenCoverContext : ICakeContext
+    internal sealed class OpenCoverContext : CakeContextAdapter
     {
-        private readonly ICakeContext _context;
         private readonly OpenCoverProcessRunner _runner;
 
-        public IFileSystem FileSystem => _context.FileSystem;
+        public override ICakeLog Log { get; }
 
-        public ICakeEnvironment Environment => _context.Environment;
-
-        public IGlobber Globber => _context.Globber;
-
-        public ICakeLog Log { get; }
-
-        public ICakeArguments Arguments => _context.Arguments;
-
-        public IProcessRunner ProcessRunner => _runner;
-
-        public IRegistry Registry => _context.Registry;
-
-        public IToolLocator Tools => _context.Tools;
-
-        public ICakeDataResolver Data => _context.Data;
+        public override IProcessRunner ProcessRunner => _runner;
 
         public FilePath FilePath => _runner.FilePath;
 
         public ProcessSettings Settings => _runner.ProcessSettings;
 
-        public ICakeConfiguration Configuration => _context.Configuration;
-
-        public OpenCoverContext(ICakeContext context)
+        public OpenCoverContext(ICakeContext context) : base(context)
         {
-            _context = context;
             Log = new NullLog();
             _runner = new OpenCoverProcessRunner();
         }

--- a/src/Cake.Common/Tools/SpecFlow/SpecFlowContext.cs
+++ b/src/Cake.Common/Tools/SpecFlow/SpecFlowContext.cs
@@ -10,38 +10,20 @@ using Cake.Core.Tooling;
 
 namespace Cake.Common.Tools.SpecFlow
 {
-    internal sealed class SpecFlowContext : ICakeContext
+    internal sealed class SpecFlowContext : CakeContextAdapter
     {
-        private readonly ICakeContext _context;
         private readonly SpecFlowProcessRunner _runner;
 
-        public IFileSystem FileSystem => _context.FileSystem;
+        public override ICakeLog Log { get; }
 
-        public ICakeEnvironment Environment => _context.Environment;
-
-        public IGlobber Globber => _context.Globber;
-
-        public ICakeLog Log { get; }
-
-        public ICakeArguments Arguments => _context.Arguments;
-
-        public IProcessRunner ProcessRunner => _runner;
-
-        public IRegistry Registry => _context.Registry;
-
-        public IToolLocator Tools => _context.Tools;
-
-        public ICakeDataResolver Data => _context.Data;
+        public override IProcessRunner ProcessRunner => _runner;
 
         public FilePath FilePath => _runner.FilePath;
 
         public ProcessSettings Settings => _runner.ProcessSettings;
 
-        public ICakeConfiguration Configuration => _context.Configuration;
-
-        public SpecFlowContext(ICakeContext context)
+        public SpecFlowContext(ICakeContext context) : base(context)
         {
-            _context = context;
             Log = new NullLog();
             _runner = new SpecFlowProcessRunner();
         }

--- a/src/Cake.Core/CakeContextAdapter.cs
+++ b/src/Cake.Core/CakeContextAdapter.cs
@@ -37,7 +37,7 @@ namespace Cake.Core
         /// <value>
         /// The file system.
         /// </value>
-        public IFileSystem FileSystem => _context.FileSystem;
+        public virtual IFileSystem FileSystem => _context.FileSystem;
 
         /// <summary>
         /// Gets the environment.
@@ -45,7 +45,7 @@ namespace Cake.Core
         /// <value>
         /// The environment.
         /// </value>
-        public ICakeEnvironment Environment => _context.Environment;
+        public virtual ICakeEnvironment Environment => _context.Environment;
 
         /// <summary>
         /// Gets the globber.
@@ -53,7 +53,7 @@ namespace Cake.Core
         /// <value>
         /// The globber.
         /// </value>
-        public IGlobber Globber => _context.Globber;
+        public virtual IGlobber Globber => _context.Globber;
 
         /// <summary>
         /// Gets the log.
@@ -61,7 +61,7 @@ namespace Cake.Core
         /// <value>
         /// The log.
         /// </value>
-        public ICakeLog Log => _context.Log;
+        public virtual ICakeLog Log => _context.Log;
 
         /// <summary>
         /// Gets the arguments.
@@ -69,7 +69,7 @@ namespace Cake.Core
         /// <value>
         /// The arguments.
         /// </value>
-        public ICakeArguments Arguments => _context.Arguments;
+        public virtual ICakeArguments Arguments => _context.Arguments;
 
         /// <summary>
         /// Gets the process runner.
@@ -77,7 +77,7 @@ namespace Cake.Core
         /// <value>
         /// The process runner.
         /// </value>
-        public IProcessRunner ProcessRunner => _context.ProcessRunner;
+        public virtual IProcessRunner ProcessRunner => _context.ProcessRunner;
 
         /// <summary>
         /// Gets the registry.
@@ -85,7 +85,7 @@ namespace Cake.Core
         /// <value>
         /// The registry.
         /// </value>
-        public IRegistry Registry => _context.Registry;
+        public virtual IRegistry Registry => _context.Registry;
 
         /// <summary>
         /// Gets the tool locator.
@@ -93,16 +93,16 @@ namespace Cake.Core
         /// <value>
         /// The tool locator.
         /// </value>
-        public IToolLocator Tools => _context.Tools;
+        public virtual IToolLocator Tools => _context.Tools;
 
         /// <summary>
         /// Gets the data context resolver.
         /// </summary>
-        public ICakeDataResolver Data => _context.Data;
+        public virtual ICakeDataResolver Data => _context.Data;
 
         /// <summary>
         /// Gets the cake configuration.
         /// </summary>
-        public ICakeConfiguration Configuration => _context.Configuration;
+        public virtual ICakeConfiguration Configuration => _context.Configuration;
     }
 }


### PR DESCRIPTION
- [x] Make CakeContextAdapter overrideable to allow custom behavior
- [x] src/Cake.Common/Tools/DotCover/DotCoverContext.cs
- [x] src/Cake.Common/Tools/OpenCover/OpenCoverContext.cs
- [x] src/Cake.Common/Tools/SpecFlow/SpecFlowContext.cs
* fixes #2895
