### PR TITLE
GH2911: Update Specre.CLI to 0.45.0

### DIFF
--- a/src/Cake/Cake.csproj
+++ b/src/Cake/Cake.csproj
@@ -32,6 +32,6 @@
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0-rc.1.20451.14" />
     <PackageReference Include="System.Reflection.Metadata" Version="5.0.0-rc.1.20451.14" />
     <PackageReference Include="Autofac" Version="5.2.0" />
-    <PackageReference Include="Spectre.Cli" Version="0.44.0" />
+    <PackageReference Include="Spectre.Cli" Version="0.45.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* fixes #2911
