### PR TITLE
GH2861: Restore pre 1.0 error logging

### DIFF
--- a/src/Cake/Commands/DefaultCommand.cs
+++ b/src/Cake/Commands/DefaultCommand.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Features.Bootstrapping;
 using Cake.Features.Building;
@@ -34,40 +36,70 @@ namespace Cake.Commands
 
         public override int Execute(CommandContext context, DefaultCommandSettings settings)
         {
-            // Set log verbosity.
-            _log.Verbosity = settings.Verbosity;
-
-            if (settings.ShowVersion)
+            try
             {
-                return _version.Run();
-            }
-            else if (settings.ShowInfo)
-            {
-                return _info.Run();
-            }
+                // Set log verbosity.
+                _log.Verbosity = settings.Verbosity;
 
-            // Get the build host type.
-            var host = GetBuildHostKind(settings);
-
-            // Run the bootstrapper?
-            if (!settings.SkipBootstrap || settings.Bootstrap)
-            {
-                int bootstrapperResult = PerformBootstrapping(context, settings, host);
-                if (bootstrapperResult != 0 || settings.Bootstrap)
+                if (settings.ShowVersion)
                 {
-                    return bootstrapperResult;
+                    return _version.Run();
+                }
+                else if (settings.ShowInfo)
+                {
+                    return _info.Run();
+                }
+
+                // Get the build host type.
+                var host = GetBuildHostKind(settings);
+
+                // Run the bootstrapper?
+                if (!settings.SkipBootstrap || settings.Bootstrap)
+                {
+                    int bootstrapperResult = PerformBootstrapping(context, settings, host);
+                    if (bootstrapperResult != 0 || settings.Bootstrap)
+                    {
+                        return bootstrapperResult;
+                    }
+                }
+
+                // Run the build feature.
+                return _builder.Run(context.Remaining, new BuildFeatureSettings(host)
+                {
+                    Script = settings.Script,
+                    Verbosity = settings.Verbosity,
+                    Exclusive = settings.Exclusive,
+                    Debug = settings.Debug,
+                    NoBootstrapping = settings.SkipBootstrap,
+                });
+            }
+            catch (Exception ex)
+            {
+                return LogException(_log, ex);
+            }
+        }
+
+        private static int LogException<T>(ICakeLog log, T ex) where T : Exception
+        {
+            log = log ?? new CakeBuildLog(
+                new CakeConsole(new CakeEnvironment(new CakePlatform(), new CakeRuntime())));
+
+            if (log.Verbosity == Verbosity.Diagnostic)
+            {
+                log.Error("Error: {0}", ex);
+            }
+            else
+            {
+                log.Error("Error: {0}", ex.Message);
+                if (ex is AggregateException aex)
+                {
+                    foreach (var exception in aex.Flatten().InnerExceptions)
+                    {
+                        log.Error("\t{0}", exception.Message);
+                    }
                 }
             }
-
-            // Run the build feature.
-            return _builder.Run(context.Remaining, new BuildFeatureSettings(host)
-            {
-                Script = settings.Script,
-                Verbosity = settings.Verbosity,
-                Exclusive = settings.Exclusive,
-                Debug = settings.Debug,
-                NoBootstrapping = settings.SkipBootstrap,
-            });
+            return 1;
         }
 
         private BuildHostKind GetBuildHostKind(DefaultCommandSettings settings)


### PR DESCRIPTION
Adds back support for aggregate exception and that diagnostic verbosity will print a full stack trace.

* fixes #2861