### PR TITLE
GH2595: Installs prerelease package versions when explicitly specified

### DIFF
--- a/src/Cake.NuGet/Install/NuGetPackageInstaller.cs
+++ b/src/Cake.NuGet/Install/NuGetPackageInstaller.cs
@@ -133,8 +133,8 @@ namespace Cake.NuGet.Install
 
             if (packageIdentity.Version.IsPrerelease && !package.IsPrerelease())
             {
-                // TODO: Is this allowed? If not, log and return
-                return Array.Empty<IFile>();
+                // If a prerelease version is explicitly specified, we should install that with or without prerelease flag.
+                _log.Debug("Prerelease version string explicitly specified. Installing prerelease package version.");
             }
 
             var pathResolver = new PackagePathResolver(packageRoot);


### PR DESCRIPTION
Got hit by this one today and based on the conversation in #2595, seems like the consensus is that we should honour explicitly specified prerelease versions, even without a `prerelease` flag. From what I can test, behaviour is otherwise unchanged.

---

fixes #2595
