### PR TITLE
Add dotnet test --blame Flag to DotNetCoreTestSettings

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Test/DotNetCoreTesterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Test/DotNetCoreTesterTests.cs
@@ -140,12 +140,13 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Test
                 fixture.Settings.ResultsDirectory = "./tests/";
                 fixture.Settings.VSTestReportPath = "./tests/TestResults.xml";
                 fixture.Settings.Runtime = "win-x64";
+                fixture.Settings.Blame = true;
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("test --settings \"/Working/demo.runsettings\" --filter \"Priority = 1\" --test-adapter-path \"/Working/custom-test-adapter\" --logger \"trx;LogFileName=/Working/logfile.trx\" --logger \"html;LogFileName=/Working/logfile.html\" --output \"/Working/artifacts\" --framework dnxcore50 --configuration Release --collect \"XPlat Code Coverage\" --diag \"/Working/artifacts/logging/diagnostics.txt\" --no-build --no-restore --nologo --results-directory \"/Working/tests\" --logger trx;LogFileName=\"/Working/tests/TestResults.xml\" --runtime win-x64", result.Args);
+                Assert.Equal("test --settings \"/Working/demo.runsettings\" --filter \"Priority = 1\" --test-adapter-path \"/Working/custom-test-adapter\" --logger \"trx;LogFileName=/Working/logfile.trx\" --logger \"html;LogFileName=/Working/logfile.html\" --output \"/Working/artifacts\" --framework dnxcore50 --configuration Release --collect \"XPlat Code Coverage\" --diag \"/Working/artifacts/logging/diagnostics.txt\" --no-build --no-restore --nologo --results-directory \"/Working/tests\" --logger trx;LogFileName=\"/Working/tests/TestResults.xml\" --runtime win-x64 --blame", result.Args);
             }
 
             [Fact]

--- a/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTestSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTestSettings.cs
@@ -103,5 +103,11 @@ namespace Cake.Common.Tools.DotNetCore.Test
         /// Gets or sets the target runtime to test for. This setting is only available from .NET Core 3.x upward.
         /// </summary>
         public string Runtime { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run the tests in blame mode. This option is helpful in isolating a problematic test causing the test host to crash.
+        /// Outputs a 'Sequence.xml' file in the current directory that captures the order of execution of test before the crash.
+        /// </summary>
+        public bool Blame { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTester.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTester.cs
@@ -173,6 +173,12 @@ namespace Cake.Common.Tools.DotNetCore.Test
                 builder.Append(settings.Runtime);
             }
 
+            // Blame
+            if (settings.Blame)
+            {
+                builder.Append("--blame");
+            }
+
             if (!arguments.IsNullOrEmpty())
             {
                 builder.Append("--");


### PR DESCRIPTION
Added `--blame` flag to `dotnet test` command

Fixes #2932

Please review
Thank you in advance
