### PR TITLE
GH2928: Push Cake.Frosting and Cake.Frosting.Template to NuGet

### DIFF
--- a/build/parameters.cake
+++ b/build/parameters.cake
@@ -104,7 +104,18 @@ public class BuildParameters
         Packages = BuildPackages.GetPackages(
             Paths.Directories.NuGetRoot,
             Version.SemVersion,
-            new [] { "Cake", "Cake.Core", "Cake.Common", "Cake.Testing", "Cake.Testing.Xunit", "Cake.CoreCLR", "Cake.NuGet", "Cake.Tool" },
+            new [] { 
+                "Cake",
+                "Cake.Core",
+                "Cake.Common",
+                "Cake.Testing",
+                "Cake.Testing.Xunit",
+                "Cake.CoreCLR",
+                "Cake.NuGet",
+                "Cake.Tool",
+                "Cake.Frosting",
+                "Cake.Frosting.Template"
+                },
             new [] { "cake.portable" });
 
         var releaseNotes = string.Join("\n", ReleaseNotes.Notes.ToArray()).Replace("\"", "\"\"");


### PR DESCRIPTION
* fixes #2928