### PR TITLE
GH2941: Return empty process argument builder when values is null

### DIFF
--- a/src/Cake.Core.Tests/Unit/IO/ProcessArgumentBuilderTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/ProcessArgumentBuilderTests.cs
@@ -23,7 +23,33 @@ namespace Cake.Core.Tests.Unit.IO
                 builder.Clear();
 
                 // Then
-                Assert.Empty(builder.Render());
+                Assert.Empty(builder);
+            }
+        }
+
+        public sealed class TheFromStringsMethod
+        {
+            [Fact]
+            public void Should_Return_Empty_Builder_When_Values_Is_Null()
+            {
+                // Given, When
+                var builder = ProcessArgumentBuilder.FromStrings(null);
+
+                // Then
+                Assert.Empty(builder);
+            }
+        }
+
+        public sealed class TheFromStringsQuotedMethod
+        {
+            [Fact]
+            public void Should_Return_Empty_Builder_When_Values_Is_Null()
+            {
+                // Given, When
+                var builder = ProcessArgumentBuilder.FromStringsQuoted(null);
+
+                // Then
+                Assert.Empty(builder);
             }
         }
 

--- a/src/Cake.Core/IO/ProcessArgumentBuilder.cs
+++ b/src/Cake.Core/IO/ProcessArgumentBuilder.cs
@@ -143,9 +143,12 @@ namespace Cake.Core.IO
         public static ProcessArgumentBuilder FromStrings(IEnumerable<string> values)
         {
             var builder = new ProcessArgumentBuilder();
-            foreach (var value in values)
+            if (values != null)
             {
-                builder.Append(new TextArgument(value));
+                foreach (var value in values)
+                {
+                    builder.Append(new TextArgument(value));
+                }
             }
             return builder;
         }
@@ -158,9 +161,12 @@ namespace Cake.Core.IO
         public static ProcessArgumentBuilder FromStringsQuoted(IEnumerable<string> values)
         {
             var builder = new ProcessArgumentBuilder();
-            foreach (var value in values)
+            if (values != null)
             {
-                builder.AppendQuoted(new TextArgument(value));
+                foreach (var value in values)
+                {
+                    builder.AppendQuoted(new TextArgument(value));
+                }
             }
             return builder;
         }


### PR DESCRIPTION
Fixes #2941.