### PR TITLE
Update links to Gitter to point to GitHub discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,8 @@
 <!--
 BEFORE YOU SUBMIT AN ISSUE:
 
-DO NOT CREATE AN ISSUE FOR A QUESTION - questions are better served in chat, and can be later raised as an issue if required.
--  chat - https://gitter.im/cake-build/cake
+DO NOT CREATE AN ISSUE FOR A QUESTION - questions are better served in discussions, and can be later raised as an issue if required.
+-  discussions - https://github.com/cake-build/cake/discussions
 
 DELETE EVERYTHING IN THIS COMMENT BLOCK
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,9 +64,9 @@ Any new code should also have reasonable unit test coverage.
 ## Contributing process
 ### Get buyoff or find open community issues or features
 
- * Through GitHub, or through the [Gitter chat](https://gitter.im/cake-build/cake) (preferred),
+ * Through GitHub, or through the [GitHub discussions](https://github.com/cake-build/cake/discussions) (preferred),
    you talk about a feature you would like to see (or a bug), and why it should be in Cake.
-   * If approved through the Gitter chat, ensure an accompanying GitHub issue is created with
+   * If approved through the GitHub discussions, ensure an accompanying GitHub issue is created with
      information and a link back to the discussion.
  * Once you get a nod from one of the [Cake Team](https://github.com/cake-build?tab=members), you can start on the feature.
  * Alternatively, if a feature is on the issues list with the

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Make sure you've read the [contribution guidelines](https://cakebuild.net/docs/c
 
 [![Follow @cakebuildnet](https://img.shields.io/badge/Twitter-Follow%20%40cakebuildnet-blue.svg)](https://twitter.com/intent/follow?screen_name=cakebuildnet)
 
-[![Join the chat at https://gitter.im/cake-build/cake](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/cake-build/cake?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat at https://github.com/cake-build/cake/discussions](https://img.shields.io/badge/discussions-join%20chat-brightgreen)](https://github.com/cake-build/cake/discussions?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## License
 


### PR DESCRIPTION
[Now that GH discussions is the preferred communication channel moving forward](https://gitter.im/cake-build/cake?at=5fa5656bb86f640704354b3d).

---

Badge in the PR:

[![Join the chat at https://github.com/cake-build/cake/discussions](https://img.shields.io/badge/discussions-join%20chat-brightgreen)](https://github.com/cake-build/cake/discussions?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)