### PR TITLE
(GH-2956) Remove build.config from Frosting template

### DIFF
--- a/src/Cake.Frosting.Template/Cake.Frosting.Template.csproj
+++ b/src/Cake.Frosting.Template/Cake.Frosting.Template.csproj
@@ -17,9 +17,9 @@
 
   <ItemGroup>
     <Content Include="templates\**\*" Exclude="templates\**\bin\**;templates\**\obj\**" />
-    <Content Include="../../build.config" Link="templates/cakefrosting/build.config" PackagePath="/content/templates/cakefrosting/build.config" />
     <Content Include="build.ps1" Link="templates/cakefrosting/build.ps1"  PackagePath="/content/templates/cakefrosting/build.ps1" />
     <Content Include="build.sh" Link="templates/cakefrosting/build.sh" PackagePath="/content/templates/cakefrosting/build.sh" />
+    <Content Include="global.json" Link="templates/cakefrosting/global.json"  PackagePath="/content/templates/cakefrosting/global.json" />
     <Compile Remove="**\*" />
   </ItemGroup>
 

--- a/src/Cake.Frosting.Template/build.ps1
+++ b/src/Cake.Frosting.Template/build.ps1
@@ -1,27 +1,8 @@
 #!/usr/bin/env pwsh
 $DotNetInstallerUri = 'https://dot.net/v1/dotnet-install.ps1';
-$DotNetUnixInstallerUri = 'https://dot.net/v1/dotnet-install.sh'
-$DotNetChannel = 'LTS'
 $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
-
-[string] $DotNetVersion= ''
-foreach($line in Get-Content (Join-Path $PSScriptRoot 'build.config'))
-{
-  if ($line -like 'DOTNET_VERSION=*') {
-      $DotNetVersion =$line.SubString(15)
-  }
-}
-
-
-if ([string]::IsNullOrEmpty($DotNetVersion)) {
-    'Failed to parse .NET Core SDK Version'
-    exit 1
-}
-
-$DotNetInstallerUri = "https://dot.net/v1/dotnet-install.ps1";
 
 # Make sure tools folder exists
-$PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 $ToolPath = Join-Path $PSScriptRoot "tools"
 if (!(Test-Path $ToolPath)) {
     Write-Verbose "Creating tools directory..."
@@ -42,25 +23,17 @@ Function Remove-PathVariable([string]$VariableToRemove)
   [Environment]::SetEnvironmentVariable("PATH", [System.String]::Join(';', $newItems), "Process")
 }
 
-# Get .NET Core CLI path if installed.
-$FoundDotNetCliVersion = $null;
-if (Get-Command dotnet -ErrorAction SilentlyContinue) {
-    $FoundDotNetCliVersion = dotnet --version;
+$InstallPath = Join-Path $PSScriptRoot ".dotnet"
+if (!(Test-Path $InstallPath)) {
+    mkdir -Force $InstallPath | Out-Null;
 }
+(New-Object System.Net.WebClient).DownloadFile($DotNetInstallerUri, "$InstallPath\dotnet-install.ps1");
+& $InstallPath\dotnet-install.ps1 -JSonFile global.json -InstallDir $InstallPath;
 
-if($FoundDotNetCliVersion -ne $DotNetVersion) {
-    $InstallPath = Join-Path $PSScriptRoot ".dotnet"
-    if (!(Test-Path $InstallPath)) {
-        mkdir -Force $InstallPath | Out-Null;
-    }
-    (New-Object System.Net.WebClient).DownloadFile($DotNetInstallerUri, "$InstallPath\dotnet-install.ps1");
-    & $InstallPath\dotnet-install.ps1 -Version $DotNetVersion -InstallDir $InstallPath;
-
-    Remove-PathVariable "$InstallPath"
-    $env:PATH = "$InstallPath;$env:PATH"
-    $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-    $env:DOTNET_CLI_TELEMETRY_OPTOUT=1
-}
+Remove-PathVariable "$InstallPath"
+$env:PATH = "$InstallPath;$env:PATH"
+$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+$env:DOTNET_CLI_TELEMETRY_OPTOUT=1
 
 ###########################################################################
 # RUN BUILD SCRIPT

--- a/src/Cake.Frosting.Template/build.sh
+++ b/src/Cake.Frosting.Template/build.sh
@@ -1,12 +1,6 @@
 #!/usr/bin/env bash
-# Define varibles
+# Define variables
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source $SCRIPT_DIR/build.config
-
-if [ "$DOTNET_VERSION" = "" ]; then
-    echo "An error occured while parsing .NET Core SDK version."
-    exit 1
-fi
 
 ###########################################################################
 # INSTALL .NET CORE CLI
@@ -17,18 +11,14 @@ export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER=0
 export DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=2
 
-DOTNET_INSTALLED_VERSION=$(dotnet --version 2>&1)
-
-if [ "$DOTNET_VERSION" != "$DOTNET_INSTALLED_VERSION" ]; then
-    echo "Installing .NET CLI..."
-    if [ ! -d "$SCRIPT_DIR/.dotnet" ]; then
-      mkdir "$SCRIPT_DIR/.dotnet"
-    fi
-    curl -Lsfo "$SCRIPT_DIR/.dotnet/dotnet-install.sh" https://dot.net/v1/dotnet-install.sh
-    bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version $DOTNET_VERSION --install-dir .dotnet --no-path
-    export PATH="$SCRIPT_DIR/.dotnet":$PATH
-    export DOTNET_ROOT="$SCRIPT_DIR/.dotnet"
+echo "Installing .NET CLI..."
+if [ ! -d "$SCRIPT_DIR/.dotnet" ]; then
+  mkdir "$SCRIPT_DIR/.dotnet"
 fi
+curl -Lsfo "$SCRIPT_DIR/.dotnet/dotnet-install.sh" https://dot.net/v1/dotnet-install.sh
+bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --jsonfile "$SCRIPT_DIR/global.json"  --install-dir .dotnet --no-path
+export PATH="$SCRIPT_DIR/.dotnet":$PATH
+export DOTNET_ROOT="$SCRIPT_DIR/.dotnet"
 
 ###########################################################################
 # RUN BUILD SCRIPT

--- a/src/Cake.Frosting.Template/global.json
+++ b/src/Cake.Frosting.Template/global.json
@@ -1,0 +1,9 @@
+{
+    "projects": [
+        "src"
+    ],
+    "sdk": {
+        "version": "5.0.100",
+        "rollForward": "latestFeature"
+    }
+}


### PR DESCRIPTION
Removes `build.config` from Frosting template. Cake version from the `build.config` file was not used and .NET SDK version is now used from `global.json` file which has been added to the template. One side effect of this approach is that we always download the .NET install script on Windows, but this is something which we already did on Linux/macOS.

Also cleaned up some stuff which was in the bootstrapper script, but not used.

Fixes #2956 