### PR TITLE
GH-2966: Enable AnsiConsoleRenderer when running on Azure Pipelines

### DIFF
--- a/src/Cake.Core.Tests/Unit/Diagnostics/AnsiDetectorTests.cs
+++ b/src/Cake.Core.Tests/Unit/Diagnostics/AnsiDetectorTests.cs
@@ -1,0 +1,53 @@
+﻿using Cake.Core.Diagnostics;
+using Cake.Testing;
+using Xunit;
+
+namespace Cake.Core.Tests.Unit.Diagnostics
+{
+    public sealed class AnsiDetectorTests
+    {
+        public sealed class The_SupportsAnsi_Method
+        {
+            public sealed class UsingTeamCity
+            {
+                [Theory]
+                [InlineData("2020.2")]
+                [InlineData("2020.1.5")]
+                [InlineData("2017.1")]
+                [InlineData("10.0.5")]
+                [InlineData("10.0")]
+                [InlineData("9.1.7")]
+                public void Should_Return_True_When_Running_TeamCity_9_1_or_2017_Or_Higher(string teamCityVersion)
+                {
+                    // Given
+                    var fakeEnvironment = FakeEnvironment.CreateUnixEnvironment();
+
+                    // When
+                    fakeEnvironment.SetEnvironmentVariable("TEAMCITY_VERSION", teamCityVersion);
+
+                    // Then
+                    Assert.True(AnsiDetector.SupportsAnsi(fakeEnvironment));
+                }
+
+                [Theory]
+                [InlineData("9.0.5")]
+                [InlineData("9.0.1")]
+                [InlineData("8.1.5")]
+                [InlineData("7.1.5")]
+                [InlineData("7.0.1")]
+                [InlineData("6.0")]
+                public void Should_Return_False_When_Running_TeamCity_9_0_Or_Lower(string teamCityVersion)
+                {
+                    // Given
+                    var fakeEnvironment = FakeEnvironment.CreateUnixEnvironment();
+
+                    // When
+                    fakeEnvironment.SetEnvironmentVariable("TEAMCITY_VERSION", teamCityVersion);
+
+                    // Then
+                    Assert.False(AnsiDetector.SupportsAnsi(fakeEnvironment));
+                }
+            }
+        }
+    }
+}

--- a/src/Cake.Core/Diagnostics/Console/AnsiDetector.cs
+++ b/src/Cake.Core/Diagnostics/Console/AnsiDetector.cs
@@ -55,6 +55,13 @@ namespace Cake.Core.Diagnostics
                 return true;
             }
 
+            // Azure Pipelines doesn't set the TERM environment variable but supports ANSI
+            // https://github.com/microsoft/azure-pipelines-agent/issues/1569
+            if (!string.IsNullOrWhiteSpace(environment.GetEnvironmentVariable("TF_BUILD")))
+            {
+                return true;
+            }
+
             // Running on Windows?
             if (environment.Platform.Family == PlatformFamily.Windows)
             {

--- a/src/Cake.Core/Diagnostics/Console/AnsiDetector.cs
+++ b/src/Cake.Core/Diagnostics/Console/AnsiDetector.cs
@@ -17,6 +17,7 @@ namespace Cake.Core.Diagnostics
     internal static class AnsiDetector
     {
         private static readonly Regex[] _regexes;
+        private static readonly Regex _teamCityVersionWithAnsiSupportRegEx;
 
         static AnsiDetector()
         {
@@ -38,6 +39,11 @@ namespace Cake.Core.Diagnostics
                 new Regex("konsole"), // Konsole
                 new Regex("bvterm"), // Bitvise SSH Client
             };
+
+            // TeamCity old version numbers look like 9.1.2, 9.1.6, 10.0.5, etc.
+            // TeamCity current version numbers look like 2017.1, 2019.2.1, 2020.2, etc.
+            // https://confluence.jetbrains.com/display/TW/Previous+Releases+Downloads
+            _teamCityVersionWithAnsiSupportRegEx = new Regex(@"^(\d{2,4}\.|9\.([1-9]\d*))");
         }
 
         public static bool SupportsAnsi(ICakeEnvironment environment)
@@ -58,6 +64,14 @@ namespace Cake.Core.Diagnostics
             // Azure Pipelines doesn't set the TERM environment variable but supports ANSI
             // https://github.com/microsoft/azure-pipelines-agent/issues/1569
             if (!string.IsNullOrWhiteSpace(environment.GetEnvironmentVariable("TF_BUILD")))
+            {
+                return true;
+            }
+
+            // TeamCity doesn't set the TERM environment variable but supports ANSI since 9.1
+            // https://blog.jetbrains.com/teamcity/2015/07/teamcity-9-1-release-truly-historical-and-very-personal-builds/
+            var teamCityVersion = environment.GetEnvironmentVariable("TEAMCITY_VERSION");
+            if (!string.IsNullOrWhiteSpace(teamCityVersion) && _teamCityVersionWithAnsiSupportRegEx.IsMatch(teamCityVersion))
             {
                 return true;
             }

--- a/src/Cake.Core/Diagnostics/Console/AnsiDetector.cs
+++ b/src/Cake.Core/Diagnostics/Console/AnsiDetector.cs
@@ -62,6 +62,16 @@ namespace Cake.Core.Diagnostics
                 return true;
             }
 
+            // Check if the terminal is of type ANSI/VT100/xterm compatible.
+            var term = environment.GetEnvironmentVariable("TERM");
+            if (!string.IsNullOrWhiteSpace(term))
+            {
+                if (_regexes.Any(regex => regex.IsMatch(term)))
+                {
+                    return true;
+                }
+            }
+
             // Running on Windows?
             if (environment.Platform.Family == PlatformFamily.Windows)
             {
@@ -73,16 +83,6 @@ namespace Cake.Core.Diagnostics
                 }
 
                 return Windows.SupportsAnsi();
-            }
-
-            // Check if the terminal is of type ANSI/VT100/xterm compatible.
-            var term = environment.GetEnvironmentVariable("TERM");
-            if (!string.IsNullOrWhiteSpace(term))
-            {
-                if (_regexes.Any(regex => regex.IsMatch(term)))
-                {
-                    return true;
-                }
             }
 
             return false;


### PR DESCRIPTION
Update the `AnsiDetector` to enable the `AnsiConsoleRenderer` when Cake is running on Azure Pipelines

![image](https://user-images.githubusercontent.com/177608/101235572-e1bea600-369f-11eb-93b4-aeff80a7ab99.png)

---

Partially closes ... #2966 (one more PR to follow)
