### PR TITLE
GH-2966: Enable AnsiConsoleRenderer when running on TeamCity 9.1 and later

### DIFF
--- a/src/Cake.Core.Tests/Unit/Diagnostics/AnsiDetectorTests.cs
+++ b/src/Cake.Core.Tests/Unit/Diagnostics/AnsiDetectorTests.cs
@@ -1,0 +1,53 @@
+﻿using Cake.Core.Diagnostics;
+using Cake.Testing;
+using Xunit;
+
+namespace Cake.Core.Tests.Unit.Diagnostics
+{
+    public sealed class AnsiDetectorTests
+    {
+        public sealed class The_SupportsAnsi_Method
+        {
+            public sealed class UsingTeamCity
+            {
+                [Theory]
+                [InlineData("2020.2")]
+                [InlineData("2020.1.5")]
+                [InlineData("2017.1")]
+                [InlineData("10.0.5")]
+                [InlineData("10.0")]
+                [InlineData("9.1.7")]
+                public void Should_Return_True_When_Running_TeamCity_9_1_or_2017_Or_Higher(string teamCityVersion)
+                {
+                    // Given
+                    var fakeEnvironment = FakeEnvironment.CreateUnixEnvironment();
+
+                    // When
+                    fakeEnvironment.SetEnvironmentVariable("TEAMCITY_VERSION", teamCityVersion);
+
+                    // Then
+                    Assert.True(AnsiDetector.SupportsAnsi(fakeEnvironment));
+                }
+
+                [Theory]
+                [InlineData("9.0.5")]
+                [InlineData("9.0.1")]
+                [InlineData("8.1.5")]
+                [InlineData("7.1.5")]
+                [InlineData("7.0.1")]
+                [InlineData("6.0")]
+                public void Should_Return_False_When_Running_TeamCity_9_0_Or_Lower(string teamCityVersion)
+                {
+                    // Given
+                    var fakeEnvironment = FakeEnvironment.CreateUnixEnvironment();
+
+                    // When
+                    fakeEnvironment.SetEnvironmentVariable("TEAMCITY_VERSION", teamCityVersion);
+
+                    // Then
+                    Assert.False(AnsiDetector.SupportsAnsi(fakeEnvironment));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Update the `AnsiDetector` to enable the `AnsiConsoleRenderer` when Cake is running on modern versions of TeamCity (i.e. 9.1+)

The colors don't looks amazing with the default theme given Cake is setting the dark background color. We may want to change as to not set the background color or perhaps introduce separate color palettes for the different CI systems.

![image](https://user-images.githubusercontent.com/177608/101235624-4d087800-36a0-11eb-8aad-178c169f2bd9.png)

---

Partially closes ... #2966
