### PR TITLE
GH-2966: Update AnsiDetector to support the TERM env. variable on Windows

### DIFF
--- a/src/Cake.Core/Diagnostics/Console/AnsiDetector.cs
+++ b/src/Cake.Core/Diagnostics/Console/AnsiDetector.cs
@@ -55,6 +55,16 @@ namespace Cake.Core.Diagnostics
                 return true;
             }
 
+            // Check if the terminal is of type ANSI/VT100/xterm compatible.
+            var term = environment.GetEnvironmentVariable("TERM");
+            if (!string.IsNullOrWhiteSpace(term))
+            {
+                if (_regexes.Any(regex => regex.IsMatch(term)))
+                {
+                    return true;
+                }
+            }
+
             // Running on Windows?
             if (environment.Platform.Family == PlatformFamily.Windows)
             {
@@ -66,16 +76,6 @@ namespace Cake.Core.Diagnostics
                 }
 
                 return Windows.SupportsAnsi();
-            }
-
-            // Check if the terminal is of type ANSI/VT100/xterm compatible.
-            var term = environment.GetEnvironmentVariable("TERM");
-            if (!string.IsNullOrWhiteSpace(term))
-            {
-                if (_regexes.Any(regex => regex.IsMatch(term)))
-                {
-                    return true;
-                }
             }
 
             return false;


### PR DESCRIPTION
When I was working on #2968 and #2969 I noticed that the `TERM` environment variable that would allow forcing Cake to enable ANSI is not checked when running on Windows.

This PR is just changing the order of the conditions so that the check for the `TERM` variable is done before checking if running on Windows.

---

Relates to #2966