### PR TITLE
GH-2983: Add SetOuputVariable in AzurePipelinesCommands

### DIFF
--- a/src/Cake.Common.Tests/Unit/Build/AzurePipelines/AzurePipelinesCommandTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/AzurePipelines/AzurePipelinesCommandTests.cs
@@ -256,6 +256,20 @@ namespace Cake.Common.Tests.Unit.Build.AzurePipelines
             }
 
             [Fact]
+            public void Should_Set_Output_Variable()
+            {
+                // Given
+                var fixture = new AzurePipelinesFixture();
+                var service = fixture.CreateAzurePipelinesService();
+
+                // When
+                service.Commands.SetOutputVariable("Output Variable", "Output Value");
+
+                // Then
+                Assert.Contains(fixture.Writer.Entries, m => m == "##vso[task.setvariable variable=Output Variable;isOutput=true;]Output Value");
+            }
+
+            [Fact]
             public void Should_Upload_Task_Summary()
             {
                 // Given

--- a/src/Cake.Common/Build/AzurePipelines/AzurePipelinesCommands.cs
+++ b/src/Cake.Common/Build/AzurePipelines/AzurePipelinesCommands.cs
@@ -138,6 +138,16 @@ namespace Cake.Common.Build.AzurePipelines
         }
 
         /// <inheritdoc/>
+        public void SetOutputVariable(string name, string value)
+        {
+            WriteLoggingCommand("task.setvariable", new Dictionary<string, string>
+            {
+                ["variable"] = name,
+                ["isOutput"] = "true"
+            }, value);
+        }
+
+        /// <inheritdoc/>
         public void SetSecretVariable(string name, string value)
         {
             WriteLoggingCommand("task.setvariable", new Dictionary<string, string>

--- a/src/Cake.Common/Build/AzurePipelines/IAzurePipelinesCommands.cs
+++ b/src/Cake.Common/Build/AzurePipelines/IAzurePipelinesCommands.cs
@@ -94,6 +94,16 @@ namespace Cake.Common.Build.AzurePipelines
         void SetVariable(string name, string value);
 
         /// <summary>
+        /// Sets a output variable in the variable service of the task context.
+        /// </summary>
+        /// <remarks>
+        /// The variable is exposed to following tasks as an environment variable.
+        /// </remarks>
+        /// <param name="name">The variable name.</param>
+        /// <param name="value">The variable value.</param>
+        void SetOutputVariable(string name, string value);
+
+        /// <summary>
         /// Sets a secret variable in the variable service of the task context.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
There is currently no way to set a output variable in Azure DevOps, this PR adds that.

Fixes #2983