### PR TITLE
GH-2852: Use the default background color when writing to the Console

### DIFF
--- a/src/Cake.Core.Tests/Unit/Diagnostics/CakeBuildLogTests.cs
+++ b/src/Cake.Core.Tests/Unit/Diagnostics/CakeBuildLogTests.cs
@@ -102,10 +102,10 @@ namespace Cake.Core.Tests.Unit.Diagnostics
                 }
 
                 [Theory]
-                [InlineData(LogLevel.Warning, "\u001b[40m\u001b[33;1mHello, \u001b[0m\u001b[40m\u001b[33;1mWorld\u001b[0m")]
-                [InlineData(LogLevel.Information, "\u001b[40m\u001b[37;1mHello, \u001b[0m\u001b[44m\u001b[37;1mWorld\u001b[0m")]
-                [InlineData(LogLevel.Verbose, "\u001b[40m\u001b[37mHello, \u001b[0m\u001b[40m\u001b[37;1mWorld\u001b[0m")]
-                [InlineData(LogLevel.Debug, "\u001b[40m\u001b[30;1mHello, \u001b[0m\u001b[40m\u001b[37mWorld\u001b[0m")]
+                [InlineData(LogLevel.Warning, "\u001b[33;1mHello, \u001b[0m\u001b[33;1mWorld\u001b[0m")]
+                [InlineData(LogLevel.Information, "\u001b[37;1mHello, \u001b[0m\u001b[44m\u001b[37;1mWorld\u001b[0m")]
+                [InlineData(LogLevel.Verbose, "\u001b[37mHello, \u001b[0m\u001b[37;1mWorld\u001b[0m")]
+                [InlineData(LogLevel.Debug, "\u001b[30;1mHello, \u001b[0m\u001b[37mWorld\u001b[0m")]
                 public void Should_Colorize_Tokens_Correctly(LogLevel level, string expected)
                 {
                     // Given
@@ -266,7 +266,7 @@ namespace Cake.Core.Tests.Unit.Diagnostics
 
                 [Theory]
                 [InlineData(false, "#[Black|DarkGray]Executing: if ($LASTEXITCODE -gt 0) { throw \"script failed with exit code $LASTEXITCODE\" }[/]")]
-                [InlineData(true, "\u001b[40m\u001b[30;1mExecuting: if ($LASTEXITCODE -gt 0) { throw \"script failed with exit code $LASTEXITCODE\" }\u001b[0m")]
+                [InlineData(true, "\u001b[30;1mExecuting: if ($LASTEXITCODE -gt 0) { throw \"script failed with exit code $LASTEXITCODE\" }\u001b[0m")]
                 public void Should_Output_Escaped_Tokens_Correctly(bool ansi, string expected)
                 {
                     // Given

--- a/src/Cake.Core/Constants.cs
+++ b/src/Cake.Core/Constants.cs
@@ -8,6 +8,8 @@ namespace Cake.Core
 {
     internal static class Constants
     {
+        public const ConsoleColor DefaultConsoleColor = (ConsoleColor)(-1);
+
         public static readonly Version LatestBreakingChange = new Version(0, 26, 0);
         public static readonly Version LatestPotentialBreakingChange = new Version(1, 0, 0);
 

--- a/src/Cake.Core/Diagnostics/Console/AnsiConsoleRenderer.cs
+++ b/src/Cake.Core/Diagnostics/Console/AnsiConsoleRenderer.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using Cake.Core.Diagnostics.Console;
 using Cake.Core.Diagnostics.Formatting;
 
 namespace Cake.Core.Diagnostics
@@ -24,7 +25,8 @@ namespace Cake.Core.Diagnostics
 
             _ansiLookup = new Dictionary<ConsoleColor, string>
             {
-                { ConsoleColor.DarkGray, $"\u001b[30;1m" }, // Bright black
+                { ConsoleColorEx.Default, string.Empty },   // Default
+                { ConsoleColor.DarkGray, "\u001b[30;1m" },  // Bright black
                 { ConsoleColor.Red, "\u001b[31;1m" },       // Bright red
                 { ConsoleColor.Green, "\u001b[32;1m" },     // Bright green
                 { ConsoleColor.Yellow, "\u001b[33;1m" },    // Bright yellow
@@ -44,6 +46,7 @@ namespace Cake.Core.Diagnostics
 
             _ansiBackgroundLookup = new Dictionary<ConsoleColor, string>
             {
+                { ConsoleColorEx.Default, string.Empty },   // Default
                 { ConsoleColor.DarkGray, "\u001b[40;1m" },  // Bright black
                 { ConsoleColor.Red, "\u001b[41;1m" },       // Bright red
                 { ConsoleColor.Green, "\u001b[42;1m" },     // Bright green

--- a/src/Cake.Core/Diagnostics/Console/AnsiConsoleRenderer.cs
+++ b/src/Cake.Core/Diagnostics/Console/AnsiConsoleRenderer.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using Cake.Core.Diagnostics.Console;
 using Cake.Core.Diagnostics.Formatting;
 
 namespace Cake.Core.Diagnostics
@@ -25,7 +24,7 @@ namespace Cake.Core.Diagnostics
 
             _ansiLookup = new Dictionary<ConsoleColor, string>
             {
-                { ConsoleColorEx.Default, string.Empty },   // Default
+                { Constants.DefaultConsoleColor, string.Empty }, // Default
                 { ConsoleColor.DarkGray, "\u001b[30;1m" },  // Bright black
                 { ConsoleColor.Red, "\u001b[31;1m" },       // Bright red
                 { ConsoleColor.Green, "\u001b[32;1m" },     // Bright green
@@ -46,7 +45,7 @@ namespace Cake.Core.Diagnostics
 
             _ansiBackgroundLookup = new Dictionary<ConsoleColor, string>
             {
-                { ConsoleColorEx.Default, string.Empty },   // Default
+                { Constants.DefaultConsoleColor, string.Empty }, // Default
                 { ConsoleColor.DarkGray, "\u001b[40;1m" },  // Bright black
                 { ConsoleColor.Red, "\u001b[41;1m" },       // Bright red
                 { ConsoleColor.Green, "\u001b[42;1m" },     // Bright green

--- a/src/Cake.Core/Diagnostics/Console/ConsoleColorEx.cs
+++ b/src/Cake.Core/Diagnostics/Console/ConsoleColorEx.cs
@@ -1,9 +1,0 @@
-﻿using System;
-
-namespace Cake.Core.Diagnostics.Console
-{
-    internal static class ConsoleColorEx
-    {
-        public const ConsoleColor Default = (ConsoleColor)(-1);
-    }
-}

--- a/src/Cake.Core/Diagnostics/Console/ConsoleColorEx.cs
+++ b/src/Cake.Core/Diagnostics/Console/ConsoleColorEx.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Cake.Core.Diagnostics.Console
+{
+    internal static class ConsoleColorEx
+    {
+        public const ConsoleColor Default = (ConsoleColor)(-1);
+    }
+}

--- a/src/Cake.Core/Diagnostics/Console/ConsolePalette.cs
+++ b/src/Cake.Core/Diagnostics/Console/ConsolePalette.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using Cake.Core.Diagnostics.Console;
 
 namespace Cake.Core.Diagnostics
 {
@@ -29,7 +28,7 @@ namespace Cake.Core.Diagnostics
             var background = console.BackgroundColor;
             if ((int)background < 0 || console.SupportAnsiEscapeCodes)
             {
-                background = ConsoleColorEx.Default;
+                background = Constants.DefaultConsoleColor;
             }
 
             return new Dictionary<LogLevel, ConsolePalette>

--- a/src/Cake.Core/Diagnostics/Console/ConsolePalette.cs
+++ b/src/Cake.Core/Diagnostics/Console/ConsolePalette.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using Cake.Core.Diagnostics.Console;
 
 namespace Cake.Core.Diagnostics
 {
@@ -26,9 +27,9 @@ namespace Cake.Core.Diagnostics
         public static IDictionary<LogLevel, ConsolePalette> CreateLookup(IConsole console)
         {
             var background = console.BackgroundColor;
-            if ((int)background < 0)
+            if ((int)background < 0 || console.SupportAnsiEscapeCodes)
             {
-                background = ConsoleColor.Black;
+                background = ConsoleColorEx.Default;
             }
 
             return new Dictionary<LogLevel, ConsolePalette>

--- a/src/Cake.Core/Diagnostics/Console/ConsoleRenderer.cs
+++ b/src/Cake.Core/Diagnostics/Console/ConsoleRenderer.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using Cake.Core.Diagnostics.Console;
 using Cake.Core.Diagnostics.Formatting;
 
 namespace Cake.Core.Diagnostics
@@ -62,13 +63,27 @@ namespace Cake.Core.Diagnostics
         {
             if (colorize && token is PropertyToken)
             {
-                _console.BackgroundColor = palette.ArgumentBackground;
-                _console.ForegroundColor = palette.ArgumentForeground;
+                if (palette.ArgumentBackground != ConsoleColorEx.Default)
+                {
+                    _console.BackgroundColor = palette.ArgumentBackground;
+                }
+
+                if (palette.ArgumentForeground != ConsoleColorEx.Default)
+                {
+                    _console.ForegroundColor = palette.ArgumentForeground;
+                }
             }
             else
             {
-                _console.BackgroundColor = palette.Background;
-                _console.ForegroundColor = palette.Foreground;
+                if (palette.Background != ConsoleColorEx.Default)
+                {
+                    _console.BackgroundColor = palette.Background;
+                }
+
+                if (palette.Foreground != ConsoleColorEx.Default)
+                {
+                    _console.ForegroundColor = palette.Foreground;
+                }
             }
         }
     }

--- a/src/Cake.Core/Diagnostics/Console/ConsoleRenderer.cs
+++ b/src/Cake.Core/Diagnostics/Console/ConsoleRenderer.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using Cake.Core.Diagnostics.Console;
 using Cake.Core.Diagnostics.Formatting;
 
 namespace Cake.Core.Diagnostics
@@ -63,24 +62,24 @@ namespace Cake.Core.Diagnostics
         {
             if (colorize && token is PropertyToken)
             {
-                if (palette.ArgumentBackground != ConsoleColorEx.Default)
+                if (palette.ArgumentBackground != Constants.DefaultConsoleColor)
                 {
                     _console.BackgroundColor = palette.ArgumentBackground;
                 }
 
-                if (palette.ArgumentForeground != ConsoleColorEx.Default)
+                if (palette.ArgumentForeground != Constants.DefaultConsoleColor)
                 {
                     _console.ForegroundColor = palette.ArgumentForeground;
                 }
             }
             else
             {
-                if (palette.Background != ConsoleColorEx.Default)
+                if (palette.Background != Constants.DefaultConsoleColor)
                 {
                     _console.BackgroundColor = palette.Background;
                 }
 
-                if (palette.Foreground != ConsoleColorEx.Default)
+                if (palette.Foreground != Constants.DefaultConsoleColor)
                 {
                     _console.ForegroundColor = palette.Foreground;
                 }


### PR DESCRIPTION
Quick fix to remove the black background color when writing messages to the console, and use the default background color instead.

It seems to work well for any dark background. For white backgrounds (e.g. TeamCity) it will require a different color palette as some messages are written using white foreground color.

/cc @patriksvensson as per chat via e-mail

---

- Closes #2852
- Relates to #2976 and #2966
