### PR TITLE
GH-2975: Prevents the addition of ANSI color if NO_COLOR env. variable is present

### DIFF
--- a/src/Cake.Core/Diagnostics/Console/AnsiDetector.cs
+++ b/src/Cake.Core/Diagnostics/Console/AnsiDetector.cs
@@ -42,6 +42,13 @@ namespace Cake.Core.Diagnostics
 
         public static bool SupportsAnsi(ICakeEnvironment environment)
         {
+            // Prevents the addition of ANSI color if NO_COLOR env. variable is present
+            // https://no-color.org
+            if (!string.IsNullOrWhiteSpace(environment.GetEnvironmentVariable("NO_COLOR")))
+            {
+                return false;
+            }
+
             // Github action doesn't setup a correct PTY but supports ANSI.
             if (!string.IsNullOrWhiteSpace(environment.GetEnvironmentVariable("GITHUB_ACTION")))
             {


### PR DESCRIPTION
Honors `NO_COLOR` environment variable to opt-out of ANSI color.

---

(Partially) closes ... #2975