### PR TITLE
GH-3018: Restore original Console Mode (if any) after running external processes

### DIFF
--- a/src/Cake.Core/IO/ConsoleMode.cs
+++ b/src/Cake.Core/IO/ConsoleMode.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Cake.Core.IO
+{
+    internal sealed class ConsoleMode
+    {
+#pragma warning disable SA1310 // Field names should not contain underscore
+        private const int STD_OUTPUT_HANDLE = -11;
+#pragma warning restore SA1310 // Field names should not contain underscore
+
+        private readonly uint? _previousConsoleMode;
+
+        public static ConsoleMode None { get; } = new ConsoleMode();
+
+        public static ConsoleMode GetCurrent(ICakeEnvironment environment)
+        {
+            // We only need to reset the Console Mode on Windows
+            if (environment.Platform.Family != PlatformFamily.Windows)
+            {
+                return None;
+            }
+
+            var @out = GetStdHandle(STD_OUTPUT_HANDLE);
+            if (!GetConsoleMode(@out, out var currentConsoleMode))
+            {
+                return None;
+            }
+
+            return new ConsoleMode(currentConsoleMode);
+        }
+
+        private ConsoleMode()
+        {
+        }
+
+        public ConsoleMode(uint consoleMode)
+        {
+            _previousConsoleMode = consoleMode;
+        }
+
+        public void Reset()
+        {
+            if (!_previousConsoleMode.HasValue)
+            {
+                // We're not running on Windows or the GetConsoleMode call in GetCurrent failed
+                return;
+            }
+
+            var @out = GetStdHandle(STD_OUTPUT_HANDLE);
+            if (GetConsoleMode(@out, out var currentConsoleMode) && currentConsoleMode != _previousConsoleMode)
+            {
+                SetConsoleMode(@out, _previousConsoleMode.Value);
+            }
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern IntPtr GetStdHandle(int nStdHandle);
+
+        [DllImport("kernel32.dll")]
+        private static extern bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);
+
+        [DllImport("kernel32.dll")]
+        private static extern bool SetConsoleMode(IntPtr hConsoleHandle, uint dwMode);
+    }
+}


### PR DESCRIPTION
As described in https://github.com/cake-build/cake/issues/3018, external processes spawned by Cake have the ability to modify the current console mode, affecting the console output written by Cake itself, as is the case of SQLCMD disabling ANSI escape codes support.

This PR updates the `ProcessRunner` to take a snapshot of the current console mode (if any i.e. When running on Windows and with a console handle available) and restores it back to its original value in case the process that was executed changed the console mode.

---

Closes https://github.com/cake-build/cake/issues/3018
