### PR TITLE
GH2961: SetApplicationName based tfm

### DIFF
--- a/src/Cake/Program.cs
+++ b/src/Cake/Program.cs
@@ -43,6 +43,22 @@ namespace Cake
             var app = new CommandApp<DefaultCommand>(registrar);
             app.Configure(config =>
             {
+#pragma warning disable SA1114 // Parameter list should follow declaration
+#pragma warning disable SA1009 // Closing parenthesis should be spaced correctly
+#pragma warning disable SA1111 // Closing parenthesis should be on line of last parameter
+                config.SetApplicationName(
+#if NETCOREAPP2_0
+
+                    "dotnet Cake.dll"
+#elif NETFRAMEWORK
+                    "Cake.exe"
+#else
+                    "dotnet cake"
+#endif
+                );
+#pragma warning restore SA1111 // Closing parenthesis should be on line of last parameter
+#pragma warning restore SA1009 // Closing parenthesis should be spaced correctly
+#pragma warning restore SA1114 // Parameter list should follow declaration
                 config.ValidateExamples();
 
                 if (_propagateExceptions)


### PR DESCRIPTION
* fixes #2961

This will adjust application name in help based on target framework moniker, examples after adjustment:

**net461**

```
USAGE:
    Cake.exe [SCRIPT] [OPTIONS]

EXAMPLES:
    Cake.exe
    Cake.exe build.cake --verbosity quiet
    Cake.exe build.cake --showtree
```


**net5.0**

```
USAGE:
    dotnet cake [SCRIPT] [OPTIONS]

EXAMPLES:
    dotnet cake
    dotnet cake build.cake --verbosity quiet
    dotnet cake build.cake --showtree
```


**netcoreapp2.0**

```
USAGE:
    dotnet Cake.dll [SCRIPT] [OPTIONS]

EXAMPLES:
    dotnet Cake.dll
    dotnet Cake.dll build.cake --verbosity quiet
    dotnet Cake.dll build.cake --showtree
```

**netcoreapp2.1**

```
USAGE:
    dotnet cake [SCRIPT] [OPTIONS]

EXAMPLES:
    dotnet cake
    dotnet cake build.cake --verbosity quiet
    dotnet cake build.cake --showtree
```

**netcoreapp3.0**

```
USAGE:
    dotnet cake [SCRIPT] [OPTIONS]

EXAMPLES:
    dotnet cake
    dotnet cake build.cake --verbosity quiet
    dotnet cake build.cake --showtree
```
