### PR TITLE
(GH-3024) Expose remaining root registry keys to Cake scripts

### DIFF
--- a/src/Cake.Core/IO/IRegistry.cs
+++ b/src/Cake.Core/IO/IRegistry.cs
@@ -10,11 +10,51 @@ namespace Cake.Core.IO
     public interface IRegistry
     {
         /// <summary>
+        /// Gets a registry key representing HKEY_CURRENT_USER.
+        /// </summary>
+        /// <value>
+        /// A registry key representing HKEY_CURRENT_USER.
+        /// </value>
+        IRegistryKey CurrentUser { get; }
+
+        /// <summary>
         /// Gets a registry key representing HKEY_LOCAL_MACHINE.
         /// </summary>
         /// <value>
         /// A registry key representing HKEY_LOCAL_MACHINE.
         /// </value>
         IRegistryKey LocalMachine { get; }
+
+        /// <summary>
+        /// Gets a registry key representing HKEY_CLASSES_ROOT.
+        /// </summary>
+        /// <value>
+        /// A registry key representing HKEY_CLASSES_ROOT.
+        /// </value>
+        IRegistryKey ClassesRoot { get; }
+
+        /// <summary>
+        /// Gets a registry key representing HKEY_USERS.
+        /// </summary>
+        /// <value>
+        /// A registry key representing HKEY_USERS.
+        /// </value>
+        IRegistryKey Users { get; }
+
+        /// <summary>
+        /// Gets a registry key representing HKEY_PERFORMANCE_DATA.
+        /// </summary>
+        /// <value>
+        /// A registry key representing HKEY_PERFORMANCE_DATA.
+        /// </value>
+        IRegistryKey PerformanceData { get; }
+
+        /// <summary>
+        /// Gets a registry key representing HKEY_CURRENT_CONFIG.
+        /// </summary>
+        /// <value>
+        /// A registry key representing HKEY_CURRENT_CONFIG.
+        /// </value>
+        IRegistryKey CurrentConfig { get; }
     }
 }

--- a/src/Cake.Core/IO/WindowsRegistry.cs
+++ b/src/Cake.Core/IO/WindowsRegistry.cs
@@ -10,6 +10,21 @@ namespace Cake.Core.IO
     public sealed class WindowsRegistry : IRegistry
     {
         /// <inheritdoc/>
+        public IRegistryKey CurrentUser => new WindowsRegistryKey(Microsoft.Win32.Registry.CurrentUser);
+
+        /// <inheritdoc/>
         public IRegistryKey LocalMachine => new WindowsRegistryKey(Microsoft.Win32.Registry.LocalMachine);
+
+        /// <inheritdoc/>
+        public IRegistryKey ClassesRoot => new WindowsRegistryKey(Microsoft.Win32.Registry.ClassesRoot);
+
+        /// <inheritdoc/>
+        public IRegistryKey Users => new WindowsRegistryKey(Microsoft.Win32.Registry.Users);
+
+        /// <inheritdoc/>
+        public IRegistryKey PerformanceData => new WindowsRegistryKey(Microsoft.Win32.Registry.PerformanceData);
+
+        /// <inheritdoc/>
+        public IRegistryKey CurrentConfig => new WindowsRegistryKey(Microsoft.Win32.Registry.CurrentConfig);
     }
 }


### PR DESCRIPTION
Update `IRegistry` to expose the remaining standard root registry keys:

- `IRegistry.CurrentUser`
- `IRegistry.ClassesRoot`
- `IRegistry.Users`
- `IRegistry.PerformanceData`
- `IRegistry.CurrentConfig`

---

Closes #3024