### PR TITLE
Prefer tools with platform affinity

### DIFF
--- a/src/Cake.Common/EnviromentAliases.cs
+++ b/src/Cake.Common/EnviromentAliases.cs
@@ -157,7 +157,11 @@ namespace Cake.Common
         [CakeAliasCategory("Platform")]
         public static bool IsRunningOnWindows(this ICakeContext context)
         {
-            return !IsRunningOnUnix(context);
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            return context.Environment.Platform.IsWindows();
         }
 
         /// <summary>

--- a/src/Cake.Core.Tests/Fixtures/ToolResolutionStrategyFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/ToolResolutionStrategyFixture.cs
@@ -18,9 +18,9 @@ namespace Cake.Core.Tests.Fixtures
         public FakeConfiguration Configuration { get; set; }
         public IToolRepository Repository { get; set; }
 
-        public ToolResolutionStrategyFixture()
+        public ToolResolutionStrategyFixture(FakeEnvironment environment = null)
         {
-            Environment = FakeEnvironment.CreateUnixEnvironment();
+            Environment = environment ?? FakeEnvironment.CreateUnixEnvironment();
             FileSystem = new FakeFileSystem(Environment);
             Globber = new Globber(FileSystem, Environment);
             Configuration = new FakeConfiguration();

--- a/src/Cake.Core.Tests/Unit/Tooling/ToolResolutionStrategyTests.cs
+++ b/src/Cake.Core.Tests/Unit/Tooling/ToolResolutionStrategyTests.cs
@@ -9,6 +9,7 @@ using Cake.Core.IO;
 using Cake.Core.Tests.Fixtures;
 using Cake.Core.Tooling;
 using Cake.Testing;
+using Cake.Testing.Xunit;
 using NSubstitute;
 using Xunit;
 
@@ -136,7 +137,7 @@ namespace Cake.Core.Tests.Unit.Tooling
             }
 
             [Fact]
-            public void Should_Prefer_To_Resolve_Tool_From_Repository_If_Possible()
+            public void Should_Prefer_Tool_From_Repository()
             {
                 // Given
                 var fixture = new ToolResolutionStrategyFixture();
@@ -153,7 +154,7 @@ namespace Cake.Core.Tests.Unit.Tooling
             }
 
             [Fact]
-            public void Should_Resolve_Tool_From_Tools_Directory_If_Not_Present_In_Repository()
+            public void Should_Return_Tool_From_Tools_Directory_If_Not_Present_In_Repository()
             {
                 // Given
                 var fixture = new ToolResolutionStrategyFixture();
@@ -169,7 +170,7 @@ namespace Cake.Core.Tests.Unit.Tooling
             }
 
             [Fact]
-            public void Should_Resolve_Tool_From_Tools_Directory_Specified_In_Configuration_If_Not_Present_In_Repository()
+            public void Should_Return_Tool_From_Tools_Directory_Specified_In_Configuration_If_Not_Present_In_Repository()
             {
                 // Given
                 var fixture = new ToolResolutionStrategyFixture();
@@ -186,7 +187,7 @@ namespace Cake.Core.Tests.Unit.Tooling
             }
 
             [Fact]
-            public void Should_Resolve_Tool_From_Environment_Variable_If_Not_Present_In_Tools_Directory()
+            public void Should_Return_Tool_From_Environment_Variable_If_Not_Present_In_Tools_Directory()
             {
                 // Given
                 var fixture = new ToolResolutionStrategyFixture();
@@ -214,7 +215,7 @@ namespace Cake.Core.Tests.Unit.Tooling
             }
 
             [Fact]
-            public void Should_Resolve_Tool_From_Environment_Variable_Gracefully_Proceed_If_FileSystem_Throw_Exception()
+            public void Should_Return_Tool_From_Environment_Variable_Gracefully_Proceed_If_FileSystem_Throw_Exception()
             {
                 // Given
                 var fixture = new ToolResolutionStrategyFixture();
@@ -244,7 +245,7 @@ namespace Cake.Core.Tests.Unit.Tooling
             }
 
             [Fact]
-            public void Should_Prefer_To_Resolve_ToolExeNames_From_Repository_If_Possible()
+            public void Should_Prefer_ToolExeNames_From_Repository()
             {
                 // Given
                 var fixture = new ToolResolutionStrategyFixture();
@@ -260,8 +261,44 @@ namespace Cake.Core.Tests.Unit.Tooling
                 Assert.Equal("/Working/dotnet-tool.exe", result.FullPath);
             }
 
+            [Theory]
+            [InlineData("tool.bat")]
+            [InlineData("tool.cmd")]
+            [InlineData("tool.exe")]
+            public void Should_Prefer_ToolExeNames_With_Unix_Platform_Affinity_When_Unix_Environment(string windowsTool)
+            {
+                // Given
+                var fixture = new ToolResolutionStrategyFixture();
+                fixture.Repository.Register($"./{windowsTool}");
+                fixture.Repository.Register("./tool");
+
+                // When
+                var result = fixture.Resolve(new[] { windowsTool, "tool" });
+
+                // Then
+                Assert.Equal("/Working/tool", result.FullPath);
+            }
+
+            [WindowsTheory]
+            [InlineData("tool.bat")]
+            [InlineData("tool.cmd")]
+            [InlineData("tool.exe")]
+            public void Should_Prefer_ToolExeNames_With_Windows_Platform_Affinity_When_Windows_Environment(string windowsTool)
+            {
+                // Given
+                var fixture = new ToolResolutionStrategyFixture(FakeEnvironment.CreateWindowsEnvironment());
+                fixture.Repository.Register("./tool");
+                fixture.Repository.Register($"./{windowsTool}");
+
+                // When
+                var result = fixture.Resolve(new[] { "tool", windowsTool });
+
+                // Then
+                Assert.Equal($"C:/Working/{windowsTool}", result.FullPath);
+            }
+
             [Fact]
-            public void Should_Resolve_ToolExeNames_From_Tools_Directory_If_Not_Present_In_Repository()
+            public void Should_Return_ToolExeNames_From_Tools_Directory_If_Not_Present_In_Repository()
             {
                 // Given
                 var fixture = new ToolResolutionStrategyFixture();
@@ -277,7 +314,7 @@ namespace Cake.Core.Tests.Unit.Tooling
             }
 
             [Fact]
-            public void Should_Resolve_ToolExeNames_From_Tools_Directory_Specified_In_Configuration_If_Not_Present_In_Repository()
+            public void Should_Return_ToolExeNames_From_Tools_Directory_Specified_In_Configuration_If_Not_Present_In_Repository()
             {
                 // Given
                 var fixture = new ToolResolutionStrategyFixture();
@@ -294,7 +331,7 @@ namespace Cake.Core.Tests.Unit.Tooling
             }
 
             [Fact]
-            public void Should_Resolve_ToolExeNames_From_Environment_Variable_If_Not_Present_In_Tools_Directory()
+            public void Should_Return_ToolExeNames_From_Environment_Variable_If_Not_Present_In_Tools_Directory()
             {
                 // Given
                 var fixture = new ToolResolutionStrategyFixture();

--- a/src/Cake.Core/Extensions/CakePlatformExtensions.cs
+++ b/src/Cake.Core/Extensions/CakePlatformExtensions.cs
@@ -14,6 +14,20 @@ namespace Cake.Core
     public static class CakePlatformExtensions
     {
         /// <summary>
+        /// Determines whether the specified platform is a Windows platform.
+        /// </summary>
+        /// <param name="platform">The platform.</param>
+        /// <returns><c>true</c> if the platform is a Windows platform; otherwise <c>false</c>.</returns>
+        public static bool IsWindows(this ICakePlatform platform)
+        {
+            if (platform == null)
+            {
+                throw new ArgumentNullException(nameof(platform));
+            }
+            return EnvironmentHelper.IsWindows(platform.Family);
+        }
+
+        /// <summary>
         /// Determines whether the specified platform is a Unix platform.
         /// </summary>
         /// <param name="platform">The platform.</param>

--- a/src/Cake.Core/Polyfill/EnvironmentHelper.cs
+++ b/src/Cake.Core/Polyfill/EnvironmentHelper.cs
@@ -101,6 +101,11 @@ namespace Cake.Core.Polyfill
 #endif
         }
 
+        public static bool IsWindows(PlatformFamily family)
+        {
+            return family == PlatformFamily.Windows;
+        }
+
         public static bool IsUnix()
         {
             return IsUnix(GetPlatformFamily());

--- a/tests/integration/Cake.Common/Tools/Cake/CakeAliases.cake
+++ b/tests/integration/Cake.Common/Tools/Cake/CakeAliases.cake
@@ -29,9 +29,7 @@ Task("Cake.Common.Tools.Cake.CakeAliases.CakeExecuteScript.Settings.NotOk")
     // Given
     var path = Paths.Resources.Combine("./Cake.Common/Tools/Cake");
     var file = path.CombineWithFilePath("./test.cake");
-    var expect = Context.Environment.Runtime.IsCoreClr
-                    ? ".NET Core CLI: Process returned an error (exit code 1)."
-                    : "Cake: Process returned an error (exit code 1).";
+    var expect = "Process returned an error (exit code 1).";
 
     // When
     var exception = Record.Exception(
@@ -41,7 +39,7 @@ Task("Cake.Common.Tools.Cake.CakeAliases.CakeExecuteScript.Settings.NotOk")
     // Then
     Assert.NotNull(exception);
     Assert.IsType<CakeException>(exception);
-    Assert.Equal(expect, exception.Message);
+    Assert.EndsWith(expect, exception.Message);
 });
 
 Task("Cake.Common.Tools.Cake.CakeAliases.CakeExecuteExpression")
@@ -68,9 +66,7 @@ Task("Cake.Common.Tools.Cake.CakeAliases.CakeExecuteExpression.Settings.NotOk")
 {
     // Given
     var script = "System.Environment.Exit((Argument<string>(\"ok\", \"no\")==\"yes\") ? 0 : 1);";
-    var expect = Context.Environment.Runtime.IsCoreClr
-                    ? ".NET Core CLI: Process returned an error (exit code 1)."
-                    : "Cake: Process returned an error (exit code 1).";
+    var expect = "Process returned an error (exit code 1).";
 
     // When
     var exception = Record.Exception(
@@ -80,7 +76,7 @@ Task("Cake.Common.Tools.Cake.CakeAliases.CakeExecuteExpression.Settings.NotOk")
     // Then
     Assert.NotNull(exception);
     Assert.IsType<CakeException>(exception);
-    Assert.Equal(expect, exception.Message);
+    Assert.EndsWith(expect, exception.Message);
 });
 
 Task("Cake.Common.Tools.Cake.CakeAliases")


### PR DESCRIPTION
Initial idea to fix #3066 - sort tool exe names by "platform affinity"; using executable extension to identify Windows specific tools.

Specifically, tool exe names ending with `bat`, `cmd` or `exe` extensions are assumed to be Windows tools. If the detected runtime platform is also Windows then such tools will be prioritized, otherwise they will be deprioritized. In both cases their relative order will be preserved.

With this fix, tool authors won't have to deal with environmental specific hacks like https://github.com/MihaMarkic/Cake.Docker/pull/84.