### PR TITLE
GH3069: Remove use of UseWorkingDirectory in default template

### DIFF
--- a/src/Cake.Frosting.Template/templates/cakefrosting/build/Program.cs
+++ b/src/Cake.Frosting.Template/templates/cakefrosting/build/Program.cs
@@ -9,7 +9,6 @@ public static class Program
     {
         return new CakeHost()
             .UseContext<BuildContext>()
-            .UseWorkingDirectory("..")
             .Run(args);
     }
 }


### PR DESCRIPTION
Remove call to `UseWorkingDirectory` in Frosting default template, since we should not promote its usage as it can lead to some known issues.

Fixes #3069