### PR TITLE
(GH-3072) Fix [IsDependeeOf] attribute

### DIFF
--- a/src/Cake.Frosting.Example/Program.cs
+++ b/src/Cake.Frosting.Example/Program.cs
@@ -37,6 +37,16 @@ public sealed class HelloTask : FrostingTask<BuildContext>
     }
 }
 
+[TaskName("Dependee")]
+[IsDependeeOf(typeof(WorldTask))]
+public sealed class DependeeTask : FrostingTask<BuildContext>
+{
+    public override void Run(BuildContext context)
+    {
+        context.Log.Information("Dependee of World");
+    }
+}
+
 [TaskName("World")]
 [IsDependentOn(typeof(HelloTask))]
 public sealed class WorldTask : AsyncFrostingTask<BuildContext>

--- a/src/Cake.Frosting.Tests/CakeHostTests.cs
+++ b/src/Cake.Frosting.Tests/CakeHostTests.cs
@@ -166,6 +166,26 @@ namespace Cake.Frosting.Tests
         }
 
         [Fact]
+        public void Should_Execute_Dependee_Task()
+        {
+            // Given
+            var fixture = new CakeHostFixture();
+            fixture.RegisterTask<CleanTask>();
+            fixture.RegisterTask<DependeeTask>();
+            fixture.Strategy = Substitute.For<IExecutionStrategy>();
+
+            // When
+            fixture.Run("--target", nameof(CleanTask));
+
+            // Then
+            Received.InOrder(() =>
+            {
+                fixture.Strategy.ExecuteAsync(Arg.Is<CakeTask>(t => t.Name == nameof(DependeeTask)), Arg.Any<ICakeContext>());
+                fixture.Strategy.ExecuteAsync(Arg.Is<CakeTask>(t => t.Name == nameof(CleanTask)), Arg.Any<ICakeContext>());
+            });
+        }
+
+        [Fact]
         public void Should_Execute_Tasks_In_Correct_Order()
         {
             // Given

--- a/src/Cake.Frosting.Tests/Tasks/DependeeTask.cs
+++ b/src/Cake.Frosting.Tests/Tasks/DependeeTask.cs
@@ -1,0 +1,9 @@
+﻿using Cake.Core;
+
+namespace Cake.Frosting.Tests
+{
+    [IsDependeeOf(typeof(CleanTask))]
+    public sealed class DependeeTask : FrostingTask<ICakeContext>
+    {
+    }
+}

--- a/src/Cake.Frosting/Internal/Extensions/TaskNameHelper.cs
+++ b/src/Cake.Frosting/Internal/Extensions/TaskNameHelper.cs
@@ -17,5 +17,15 @@ namespace Cake.Frosting.Internal
 
             return dependency.Task.GetTaskName();
         }
+
+        public static string GetTaskName(this IReverseTaskDependency dependency)
+        {
+            if (dependency is null)
+            {
+                throw new ArgumentNullException(nameof(dependency));
+            }
+
+            return dependency.Task.GetTaskName();
+        }
     }
 }

--- a/src/Cake.Frosting/Internal/FrostingEngine.cs
+++ b/src/Cake.Frosting/Internal/FrostingEngine.cs
@@ -164,7 +164,7 @@ namespace Cake.Frosting.Internal
                     // Add reverse dependencies
                     foreach (var dependee in task.GetReverseDependencies())
                     {
-                        var dependeeName = dependee.GetType().GetTaskName();
+                        var dependeeName = dependee.GetTaskName();
                         if (!typeof(IFrostingTask).IsAssignableFrom(dependee.Task))
                         {
                             throw new FrostingException($"The reverse dependency '{dependeeName}' is not a valid task.");


### PR DESCRIPTION
Fixes #3072

- Fix the `FrostingEngine.ConfigureTasks()`
- Add a `.GetTaskName()` helper for `IReverseTaskDependency`
- Add unit test for `IsDependeeOf`
- Add `DependeeTask` to `Example` project