### PR TITLE
(GH-3077) Downgrade to Spectre.Console v0.36.0 due to bug in v0.37.0 with OSX ANSI

### DIFF
--- a/src/Cake.Cli/Cake.Cli.csproj
+++ b/src/Cake.Cli/Cake.Cli.csproj
@@ -20,6 +20,6 @@
 
     <ItemGroup>
       <PackageReference Include="Autofac" Version="6.1.0" />
-      <PackageReference Include="Spectre.Console" Version="0.37.0" />
+      <PackageReference Include="Spectre.Console" Version="0.36.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
After Cake v1.0 RTM is released, we'll upgrade to a future version of Spectre.Console that fixes it

Resolves #3077