### PR TITLE
Add Additional Information to TeamCityBuildInfo

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Build/TeamCityFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/TeamCityFixture.cs
@@ -5,7 +5,7 @@
 using Cake.Common.Build.TeamCity;
 using Cake.Common.Tests.Fakes;
 using Cake.Core;
-using Cake.Testing;
+using Cake.Core.IO;
 using NSubstitute;
 
 namespace Cake.Common.Tests.Fixtures.Build
@@ -13,6 +13,7 @@ namespace Cake.Common.Tests.Fixtures.Build
     internal sealed class TeamCityFixture
     {
         public ICakeEnvironment Environment { get; set; }
+        public IFileSystem FileSystem { get; set; }
         public FakeBuildSystemServiceMessageWriter Writer { get; set; }
 
         public TeamCityFixture()
@@ -20,6 +21,7 @@ namespace Cake.Common.Tests.Fixtures.Build
             Environment = Substitute.For<ICakeEnvironment>();
             Environment.WorkingDirectory.Returns("C:\\build\\CAKE-CAKE-JOB1");
             Environment.GetEnvironmentVariable("TEAMCITY_VERSION").Returns((string)null);
+            FileSystem = Substitute.For<IFileSystem>();
             Writer = new FakeBuildSystemServiceMessageWriter();
         }
 
@@ -30,7 +32,7 @@ namespace Cake.Common.Tests.Fixtures.Build
 
         public TeamCityProvider CreateTeamCityService()
         {
-            return new TeamCityProvider(Environment, Writer);
+            return new TeamCityProvider(Environment, FileSystem, Writer);
         }
     }
 }

--- a/src/Cake.Common.Tests/Fixtures/Build/TeamCityInfoFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/TeamCityInfoFixture.cs
@@ -23,20 +23,25 @@ namespace Cake.Common.Tests.Fixtures.Build
             ((FakeEnvironment)Environment).SetEnvironmentVariable("TEAMCITY_BUILDCONF_NAME", @"Cake Build");
             ((FakeEnvironment)Environment).SetEnvironmentVariable("BUILD_NUMBER", "10-Foo");
             ((FakeEnvironment)Environment).SetEnvironmentVariable("TEAMCITY_PROJECT_NAME", "Cake");
-            ((FakeEnvironment)Environment).SetEnvironmentVariable("TEAMCITY_BUILD_PROPERTIES_FILE", "/Working/file.properties");
+            ((FakeEnvironment)Environment).SetEnvironmentVariable("TEAMCITY_BUILD_PROPERTIES_FILE", "/Working/teamcity.build.properties");
             ((FakeEnvironment)Environment).SetEnvironmentVariable("Git_Branch", "refs/pull-requests/7/from");
             ((FakeEnvironment)Environment).SetEnvironmentVariable("BUILD_START_DATE", "20200822");
             ((FakeEnvironment)Environment).SetEnvironmentVariable("BUILD_START_TIME", "123456");
         }
 
-        public void SetPropertiesFileContent(string xml)
+        public void SetBuildPropertiesContent(string xml)
         {
-            ((FakeFileSystem)FileSystem).GetFile("/Working/file.properties.xml").SetContent(xml);
+            ((FakeFileSystem)FileSystem).GetFile("/Working/teamcity.build.properties.xml").SetContent(xml);
         }
 
-        public void SetBuildConfigurationFileContent(string xml)
+        public void SetConfigPropertiesContent(string xml)
         {
-            ((FakeFileSystem)FileSystem).GetFile("/Working/file.build.configuration.xml").SetContent(xml);
+            ((FakeFileSystem)FileSystem).GetFile("/Working/teamcity.config.configuration.xml").SetContent(xml);
+        }
+
+        public void SetRunnerPropertiesContent(string xml)
+        {
+            ((FakeFileSystem)FileSystem).GetFile("/Working/teamcity.runner.configuration.xml").SetContent(xml);
         }
 
         public void SetGitBranch(string branch)

--- a/src/Cake.Common.Tests/Fixtures/Build/TeamCityInfoFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/TeamCityInfoFixture.cs
@@ -24,6 +24,8 @@ namespace Cake.Common.Tests.Fixtures.Build
 
             Environment.GetEnvironmentVariable("TEAMCITY_PROJECT_NAME").Returns("Cake");
 
+            Environment.GetEnvironmentVariable("TEAMCITY_BUILD_PROPERTIES_FILE").Returns("path/to/file");
+
             Environment.GetEnvironmentVariable("Git_Branch").Returns("refs/pull-requests/7/from");
         }
 

--- a/src/Cake.Common.Tests/Properties/Resources.Designer.cs
+++ b/src/Cake.Common.Tests/Properties/Resources.Designer.cs
@@ -682,16 +682,15 @@ namespace Cake.Common.Tests.Properties {
         ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;no&quot;?&gt;
         ///&lt;!DOCTYPE properties SYSTEM &quot;http://java.sun.com/dtd/properties.dtd&quot;&gt;
         ///&lt;properties&gt;
-        ///&lt;comment&gt;TeamCity configuration parameters for build with id 812869&lt;/comment&gt;
-        ///&lt;entry key=&quot;build.counter&quot;&gt;414&lt;/entry&gt;
-        ///&lt;entry key=&quot;build.number&quot;&gt;3246&lt;/entry&gt;
-        ///&lt;entry key=&quot;teamcity.build.branch&quot;&gt;branchName&lt;/entry&gt;
-        ///&lt;entry key=&quot;teamcity.build.branch.is_default&quot;&gt;true&lt;/entry&gt;
+        ///&lt;comment&gt;TeamCity build properties without &apos;system.&apos; prefix&lt;/comment&gt;
+        ///&lt;entry key=&quot;teamcity.build.properties.file&quot;&gt;/Working/teamcity.build.configuration&lt;/entry&gt;
+        ///&lt;entry key=&quot;teamcity.configuration.properties.file&quot;&gt;/Working/teamcity.config.configuration&lt;/entry&gt;
+        ///&lt;entry key=&quot;teamcity.runner.properties.file&quot;&gt;/Working/teamcity.runner.configuration&lt;/entry&gt;
         ///&lt;/properties&gt;.
         /// </summary>
-        public static string TeamCity_Build_Configuration_Xml {
+        public static string TeamCity_Build_Properties_Xml {
             get {
-                return ResourceManager.GetString("TeamCity_Build_Configuration_Xml", resourceCulture);
+                return ResourceManager.GetString("TeamCity_Build_Properties_Xml", resourceCulture);
             }
         }
         
@@ -699,13 +698,31 @@ namespace Cake.Common.Tests.Properties {
         ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;no&quot;?&gt;
         ///&lt;!DOCTYPE properties SYSTEM &quot;http://java.sun.com/dtd/properties.dtd&quot;&gt;
         ///&lt;properties&gt;
-        ///&lt;comment&gt;TeamCity build properties without &apos;system.&apos; prefix&lt;/comment&gt;
-        ///&lt;entry key=&quot;teamcity.configuration.properties.file&quot;&gt;/Working/file.build.configuration&lt;/entry&gt;
+        ///&lt;comment&gt;TeamCity configuration parameters for build with id 812869&lt;/comment&gt;
+        ///&lt;entry key=&quot;build.counter&quot;&gt;414&lt;/entry&gt;
+        ///&lt;entry key=&quot;build.number&quot;&gt;3246&lt;/entry&gt;
+        ///&lt;entry key=&quot;teamcity.build.branch&quot;&gt;pull/5&lt;/entry&gt;
+        ///&lt;entry key=&quot;teamcity.build.branch.is_default&quot;&gt;true&lt;/entry&gt;
+        ///&lt;entry key=&quot;teamcity.build.vcs.branch.MyVcsRootName&quot;&gt;refs/pull/5/merge&lt;/entry&gt;
         ///&lt;/properties&gt;.
         /// </summary>
-        public static string TeamCity_Properties_Xml {
+        public static string TeamCity_Config_Properties_Xml {
             get {
-                return ResourceManager.GetString("TeamCity_Properties_Xml", resourceCulture);
+                return ResourceManager.GetString("TeamCity_Config_Properties_Xml", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;no&quot;?&gt;
+        ///&lt;!DOCTYPE properties SYSTEM &quot;http://java.sun.com/dtd/properties.dtd&quot;&gt;
+        ///&lt;properties&gt;
+        ///&lt;comment&gt;TeamCity configuration parameters for build with id 812869&lt;/comment&gt;
+        ///&lt;entry key=&quot;command.executable&quot;&gt;run.cmd&lt;/entry&gt;
+        ///&lt;/properties&gt;.
+        /// </summary>
+        public static string TeamCity_Runner_Properties_Xml {
+            get {
+                return ResourceManager.GetString("TeamCity_Runner_Properties_Xml", resourceCulture);
             }
         }
         

--- a/src/Cake.Common.Tests/Properties/Resources.Designer.cs
+++ b/src/Cake.Common.Tests/Properties/Resources.Designer.cs
@@ -679,6 +679,37 @@ namespace Cake.Common.Tests.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;no&quot;?&gt;
+        ///&lt;!DOCTYPE properties SYSTEM &quot;http://java.sun.com/dtd/properties.dtd&quot;&gt;
+        ///&lt;properties&gt;
+        ///&lt;comment&gt;TeamCity configuration parameters for build with id 812869&lt;/comment&gt;
+        ///&lt;entry key=&quot;build.counter&quot;&gt;414&lt;/entry&gt;
+        ///&lt;entry key=&quot;build.number&quot;&gt;3246&lt;/entry&gt;
+        ///&lt;entry key=&quot;teamcity.build.branch&quot;&gt;branchName&lt;/entry&gt;
+        ///&lt;entry key=&quot;teamcity.build.branch.is_default&quot;&gt;true&lt;/entry&gt;
+        ///&lt;/properties&gt;.
+        /// </summary>
+        public static string TeamCity_Build_Configuration_Xml {
+            get {
+                return ResourceManager.GetString("TeamCity_Build_Configuration_Xml", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; standalone=&quot;no&quot;?&gt;
+        ///&lt;!DOCTYPE properties SYSTEM &quot;http://java.sun.com/dtd/properties.dtd&quot;&gt;
+        ///&lt;properties&gt;
+        ///&lt;comment&gt;TeamCity build properties without &apos;system.&apos; prefix&lt;/comment&gt;
+        ///&lt;entry key=&quot;teamcity.configuration.properties.file&quot;&gt;/Working/file.build.configuration&lt;/entry&gt;
+        ///&lt;/properties&gt;.
+        /// </summary>
+        public static string TeamCity_Properties_Xml {
+            get {
+                return ResourceManager.GetString("TeamCity_Properties_Xml", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to using System.Reflection;
         ///using System.Runtime.CompilerServices;
         ///

--- a/src/Cake.Common.Tests/Properties/Resources.resx
+++ b/src/Cake.Common.Tests/Properties/Resources.resx
@@ -1372,4 +1372,23 @@ Line #3]]&gt;&lt;/releaseNotes&gt;
   &lt;/files&gt;
 &lt;/package&gt;</value>
   </data>
+  <data name="TeamCity_Build_Configuration_Xml" xml:space="preserve">
+    <value>&lt;?xml version="1.0" encoding="utf-8" standalone="no"?&gt;
+&lt;!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd"&gt;
+&lt;properties&gt;
+&lt;comment&gt;TeamCity configuration parameters for build with id 812869&lt;/comment&gt;
+&lt;entry key="build.counter"&gt;414&lt;/entry&gt;
+&lt;entry key="build.number"&gt;3246&lt;/entry&gt;
+&lt;entry key="teamcity.build.branch"&gt;branchName&lt;/entry&gt;
+&lt;entry key="teamcity.build.branch.is_default"&gt;true&lt;/entry&gt;
+&lt;/properties&gt;</value>
+  </data>
+  <data name="TeamCity_Properties_Xml" xml:space="preserve">
+    <value>&lt;?xml version="1.0" encoding="utf-8" standalone="no"?&gt;
+&lt;!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd"&gt;
+&lt;properties&gt;
+&lt;comment&gt;TeamCity build properties without 'system.' prefix&lt;/comment&gt;
+&lt;entry key="teamcity.configuration.properties.file"&gt;/Working/file.build.configuration&lt;/entry&gt;
+&lt;/properties&gt;</value>
+  </data>
 </root>

--- a/src/Cake.Common.Tests/Properties/Resources.resx
+++ b/src/Cake.Common.Tests/Properties/Resources.resx
@@ -1372,23 +1372,34 @@ Line #3]]&gt;&lt;/releaseNotes&gt;
   &lt;/files&gt;
 &lt;/package&gt;</value>
   </data>
-  <data name="TeamCity_Build_Configuration_Xml" xml:space="preserve">
+  <data name="TeamCity_Config_Properties_Xml" xml:space="preserve">
     <value>&lt;?xml version="1.0" encoding="utf-8" standalone="no"?&gt;
 &lt;!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd"&gt;
 &lt;properties&gt;
 &lt;comment&gt;TeamCity configuration parameters for build with id 812869&lt;/comment&gt;
 &lt;entry key="build.counter"&gt;414&lt;/entry&gt;
 &lt;entry key="build.number"&gt;3246&lt;/entry&gt;
-&lt;entry key="teamcity.build.branch"&gt;branchName&lt;/entry&gt;
+&lt;entry key="teamcity.build.branch"&gt;pull/5&lt;/entry&gt;
 &lt;entry key="teamcity.build.branch.is_default"&gt;true&lt;/entry&gt;
+&lt;entry key="teamcity.build.vcs.branch.MyVcsRootName"&gt;refs/pull/5/merge&lt;/entry&gt;
 &lt;/properties&gt;</value>
   </data>
-  <data name="TeamCity_Properties_Xml" xml:space="preserve">
+  <data name="TeamCity_Build_Properties_Xml" xml:space="preserve">
     <value>&lt;?xml version="1.0" encoding="utf-8" standalone="no"?&gt;
 &lt;!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd"&gt;
 &lt;properties&gt;
 &lt;comment&gt;TeamCity build properties without 'system.' prefix&lt;/comment&gt;
-&lt;entry key="teamcity.configuration.properties.file"&gt;/Working/file.build.configuration&lt;/entry&gt;
+&lt;entry key="teamcity.build.properties.file"&gt;/Working/teamcity.build.configuration&lt;/entry&gt;
+&lt;entry key="teamcity.configuration.properties.file"&gt;/Working/teamcity.config.configuration&lt;/entry&gt;
+&lt;entry key="teamcity.runner.properties.file"&gt;/Working/teamcity.runner.configuration&lt;/entry&gt;
+&lt;/properties&gt;</value>
+  </data>
+  <data name="TeamCity_Runner_Properties_Xml" xml:space="preserve">
+    <value>&lt;?xml version="1.0" encoding="utf-8" standalone="no"?&gt;
+&lt;!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd"&gt;
+&lt;properties&gt;
+&lt;comment&gt;TeamCity configuration parameters for build with id 812869&lt;/comment&gt;
+&lt;entry key="command.executable"&gt;run.cmd&lt;/entry&gt;
 &lt;/properties&gt;</value>
   </data>
 </root>

--- a/src/Cake.Common.Tests/Unit/Build/TeamCity/Data/TeamCityBuildInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TeamCity/Data/TeamCityBuildInfoTests.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Common.Tests.Fixtures.Build;
 using System;
 using System.Globalization;
+using Cake.Common.Tests.Fixtures.Build;
 using Xunit;
 
 namespace Cake.Common.Tests.Unit.Build.TeamCity.Data
@@ -125,65 +125,142 @@ namespace Cake.Common.Tests.Unit.Build.TeamCity.Data
             {
                 // Given
                 var fixture = new TeamCityInfoFixture();
-                fixture.SetPropertiesFileContent(Properties.Resources.TeamCity_Properties_Xml);
-                fixture.SetBuildConfigurationFileContent(Properties.Resources.TeamCity_Build_Configuration_Xml);
+                fixture.SetBuildPropertiesContent(Properties.Resources.TeamCity_Build_Properties_Xml);
+                fixture.SetConfigPropertiesContent(Properties.Resources.TeamCity_Config_Properties_Xml);
                 var info = fixture.CreateBuildInfo();
 
                 // When
                 var result = info.BranchName;
 
                 // Then
-                Assert.Equal("branchName", result);
+                Assert.Equal("pull/5", result);
             }
         }
 
-        public sealed class ThePropertiesProperty
+        public sealed class TheVcsBranchProperty
         {
             [Fact]
-            public void Should_Return_Empty_When_File_Not_Created()
+            public void Should_Return_Empty_When_No_Properties()
             {
                 // Given
-                var fixture = new TeamCityInfoFixture();
-                var info = fixture.CreateBuildInfo();
+                var info = new TeamCityInfoFixture().CreateBuildInfo();
 
                 // When
-                var result = info.Properties;
+                var result = info.VcsBranchName;
 
                 // Then
-                Assert.Empty(result);
+                Assert.Equal(string.Empty, result);
             }
 
             [Fact]
-            public void Should_Return_Empty_When_Build_Properties_File_Not_Created()
+            public void Should_Return_Value_From_Properties()
             {
                 // Given
                 var fixture = new TeamCityInfoFixture();
-                fixture.SetPropertiesFileContent(Properties.Resources.TeamCity_Properties_Xml);
+                fixture.SetBuildPropertiesContent(Properties.Resources.TeamCity_Build_Properties_Xml);
+                fixture.SetConfigPropertiesContent(Properties.Resources.TeamCity_Config_Properties_Xml);
                 var info = fixture.CreateBuildInfo();
 
                 // When
-                var result = info.Properties;
+                var result = info.VcsBranchName;
 
                 // Then
-                Assert.Empty(result);
+                Assert.Equal("refs/pull/5/merge", result);
+            }
+        }
+
+        public sealed class ThePropertiesProperties
+        {
+            [Fact]
+            public void Should_Return_Empty_ForAll_When_File_Not_Created()
+            {
+                // Given
+                var fixture = new TeamCityInfoFixture();
+                var info = fixture.CreateBuildInfo();
+
+                // When
+                var buildProperties = info.BuildProperties;
+                var configProperties = info.ConfigProperties;
+                var runnerProperties = info.RunnerProperties;
+
+                // Then
+                Assert.Empty(buildProperties);
+                Assert.Empty(configProperties);
+                Assert.Empty(runnerProperties);
             }
 
             [Fact]
-            public void Should_Return_Values_When_Files_Exist()
+            public void Should_Return_Empty_When_Config_Properties_File_Not_Created()
             {
                 // Given
                 var fixture = new TeamCityInfoFixture();
-                fixture.SetPropertiesFileContent(Properties.Resources.TeamCity_Properties_Xml);
-                fixture.SetBuildConfigurationFileContent(Properties.Resources.TeamCity_Build_Configuration_Xml);
+                fixture.SetBuildPropertiesContent(Properties.Resources.TeamCity_Build_Properties_Xml);
                 var info = fixture.CreateBuildInfo();
 
                 // When
-                var result = info.Properties;
+                var buildProperties = info.BuildProperties;
+                var configProperties = info.ConfigProperties;
 
                 // Then
-                Assert.NotEmpty(result);
-                Assert.Equal(4, result.Count);
-                Assert.Equal("3246", result["build.number"]);
+                Assert.NotEmpty(buildProperties);
+                Assert.Empty(configProperties);
+            }
+
+            [Fact]
+            public void Should_Return_Config_Values_When_Files_Exist()
+            {
+                // Given
+                var fixture = new TeamCityInfoFixture();
+                fixture.SetBuildPropertiesContent(Properties.Resources.TeamCity_Build_Properties_Xml);
+                fixture.SetConfigPropertiesContent(Properties.Resources.TeamCity_Config_Properties_Xml);
+                var info = fixture.CreateBuildInfo();
+
+                // When
+                var buildProperties = info.BuildProperties;
+                var configProperties = info.ConfigProperties;
+
+                // Then
+                Assert.NotEmpty(buildProperties);
+                Assert.NotEmpty(configProperties);
+                Assert.Equal(5, configProperties.Count);
+                Assert.Equal("3246", configProperties["build.number"]);
+            }
+
+            [Fact]
+            public void Should_Return_Empty_When_Runner_Properties_File_Not_Created()
+            {
+                // Given
+                var fixture = new TeamCityInfoFixture();
+                fixture.SetBuildPropertiesContent(Properties.Resources.TeamCity_Build_Properties_Xml);
+                var info = fixture.CreateBuildInfo();
+
+                // When
+                var buildProperties = info.BuildProperties;
+                var runnerProperties = info.RunnerProperties;
+
+                // Then
+                Assert.NotEmpty(buildProperties);
+                Assert.Empty(runnerProperties);
+            }
+
+            [Fact]
+            public void Should_Return_Runner_Values_When_Files_Exist()
+            {
+                // Given
+                var fixture = new TeamCityInfoFixture();
+                fixture.SetBuildPropertiesContent(Properties.Resources.TeamCity_Build_Properties_Xml);
+                fixture.SetRunnerPropertiesContent(Properties.Resources.TeamCity_Runner_Properties_Xml);
+                var info = fixture.CreateBuildInfo();
+
+                // When
+                var buildProperties = info.BuildProperties;
+                var runnerProperties = info.RunnerProperties;
+
+                // Then
+                Assert.NotEmpty(buildProperties);
+                Assert.NotEmpty(runnerProperties);
+                Assert.Single(runnerProperties);
+                Assert.Equal("run.cmd", runnerProperties["command.executable"]);
             }
         }
     }

--- a/src/Cake.Common.Tests/Unit/Build/TeamCity/Data/TeamCityBuildInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TeamCity/Data/TeamCityBuildInfoTests.cs
@@ -105,5 +105,21 @@ namespace Cake.Common.Tests.Unit.Build.TeamCity.Data
                 Assert.Equal(null, result);
             }
         }
+
+        public sealed class ThePropertiesProperty
+        {
+            [Fact]
+            public void Should_Return_Empty_When_Path_Unknown()
+            {
+                // Given
+                var info = new TeamCityInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.Properties;
+
+                // Then
+                Assert.Empty(result);
+            }
+        }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Build/TeamCity/Data/TeamCityBuildInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TeamCity/Data/TeamCityBuildInfoTests.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Common.Tests.Fixtures.Build;
 using System;
 using System.Globalization;
-using Cake.Common.Tests.Fixtures.Build;
-using NSubstitute;
 using Xunit;
 
 namespace Cake.Common.Tests.Unit.Build.TeamCity.Data
@@ -69,8 +68,8 @@ namespace Cake.Common.Tests.Unit.Build.TeamCity.Data
                 var startTime = now.ToString("HHmmss", CultureInfo.InvariantCulture);
 
                 var fixture = new TeamCityInfoFixture();
-                fixture.Environment.GetEnvironmentVariable("BUILD_START_DATE").Returns(startDate);
-                fixture.Environment.GetEnvironmentVariable("BUILD_START_TIME").Returns(startTime);
+                fixture.SetBuildStartDate(startDate);
+                fixture.SetBuildStartTime(startTime);
 
                 var info = fixture.CreateBuildInfo();
 
@@ -93,8 +92,8 @@ namespace Cake.Common.Tests.Unit.Build.TeamCity.Data
             {
                 // Given
                 var fixture = new TeamCityInfoFixture();
-                fixture.Environment.GetEnvironmentVariable("BUILD_START_DATE").Returns(startDate);
-                fixture.Environment.GetEnvironmentVariable("BUILD_START_TIME").Returns(startTime);
+                fixture.SetBuildStartDate(startDate);
+                fixture.SetBuildStartTime(startTime);
 
                 var info = fixture.CreateBuildInfo();
 
@@ -109,7 +108,7 @@ namespace Cake.Common.Tests.Unit.Build.TeamCity.Data
         public sealed class TheBranchProperty
         {
             [Fact]
-            public void Should_Return_Correct_Value()
+            public void Should_Return_Empty_When_No_Properties()
             {
                 // Given
                 var info = new TeamCityInfoFixture().CreateBuildInfo();
@@ -120,21 +119,71 @@ namespace Cake.Common.Tests.Unit.Build.TeamCity.Data
                 // Then
                 Assert.Equal(string.Empty, result);
             }
+
+            [Fact]
+            public void Should_Return_Value_From_Properties()
+            {
+                // Given
+                var fixture = new TeamCityInfoFixture();
+                fixture.SetPropertiesFileContent(Properties.Resources.TeamCity_Properties_Xml);
+                fixture.SetBuildConfigurationFileContent(Properties.Resources.TeamCity_Build_Configuration_Xml);
+                var info = fixture.CreateBuildInfo();
+
+                // When
+                var result = info.BranchName;
+
+                // Then
+                Assert.Equal("branchName", result);
+            }
         }
 
         public sealed class ThePropertiesProperty
         {
             [Fact]
-            public void Should_Return_Empty_When_Path_Unknown()
+            public void Should_Return_Empty_When_File_Not_Created()
             {
                 // Given
-                var info = new TeamCityInfoFixture().CreateBuildInfo();
+                var fixture = new TeamCityInfoFixture();
+                var info = fixture.CreateBuildInfo();
 
                 // When
                 var result = info.Properties;
 
                 // Then
                 Assert.Empty(result);
+            }
+
+            [Fact]
+            public void Should_Return_Empty_When_Build_Properties_File_Not_Created()
+            {
+                // Given
+                var fixture = new TeamCityInfoFixture();
+                fixture.SetPropertiesFileContent(Properties.Resources.TeamCity_Properties_Xml);
+                var info = fixture.CreateBuildInfo();
+
+                // When
+                var result = info.Properties;
+
+                // Then
+                Assert.Empty(result);
+            }
+
+            [Fact]
+            public void Should_Return_Values_When_Files_Exist()
+            {
+                // Given
+                var fixture = new TeamCityInfoFixture();
+                fixture.SetPropertiesFileContent(Properties.Resources.TeamCity_Properties_Xml);
+                fixture.SetBuildConfigurationFileContent(Properties.Resources.TeamCity_Build_Configuration_Xml);
+                var info = fixture.CreateBuildInfo();
+
+                // When
+                var result = info.Properties;
+
+                // Then
+                Assert.NotEmpty(result);
+                Assert.Equal(4, result.Count);
+                Assert.Equal("3246", result["build.number"]);
             }
         }
     }

--- a/src/Cake.Common.Tests/Unit/Build/TeamCity/Data/TeamCityBuildInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TeamCity/Data/TeamCityBuildInfoTests.cs
@@ -106,6 +106,22 @@ namespace Cake.Common.Tests.Unit.Build.TeamCity.Data
             }
         }
 
+        public sealed class TheBranchProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new TeamCityInfoFixture().CreateBuildInfo();
+
+                // When
+                var result = info.BranchName;
+
+                // Then
+                Assert.Equal(string.Empty, result);
+            }
+        }
+
         public sealed class ThePropertiesProperty
         {
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Build/TeamCity/Data/TeamCityPullRequestInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TeamCity/Data/TeamCityPullRequestInfoTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Cake.Common.Tests.Fixtures.Build;
-using NSubstitute;
 using Xunit;
 
 namespace Cake.Common.Tests.Unit.Build.TeamCity.Data
@@ -23,7 +22,7 @@ namespace Cake.Common.Tests.Unit.Build.TeamCity.Data
             {
                 // Given
                 var fixture = new TeamCityInfoFixture();
-                fixture.Environment.GetEnvironmentVariable("Git_Branch").Returns(value);
+                fixture.SetGitBranch(value);
                 var info = fixture.CreatePullRequestInfo();
 
                 // When
@@ -46,7 +45,7 @@ namespace Cake.Common.Tests.Unit.Build.TeamCity.Data
             {
                 // Given
                 var fixture = new TeamCityInfoFixture();
-                fixture.Environment.GetEnvironmentVariable("Git_Branch").Returns(value);
+                fixture.SetGitBranch(value);
                 var info = fixture.CreatePullRequestInfo();
 
                 // When

--- a/src/Cake.Common.Tests/Unit/Build/TeamCity/TeamCityProviderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TeamCity/TeamCityProviderTests.cs
@@ -6,7 +6,6 @@ using System;
 using Cake.Common.Build.TeamCity;
 using Cake.Common.Tests.Fixtures.Build;
 using Cake.Core.IO;
-using Cake.Testing.Extensions;
 using Xunit;
 
 namespace Cake.Common.Tests.Unit.Build.TeamCity
@@ -19,10 +18,23 @@ namespace Cake.Common.Tests.Unit.Build.TeamCity
             public void Should_Throw_If_Environment_Is_Null()
             {
                 // Given, When
-                var result = Record.Exception(() => new TeamCityProvider(null, null));
+                var result = Record.Exception(() => new TeamCityProvider(null, null, null));
 
                 // Then
                 AssertEx.IsArgumentNullException(result, "environment");
+            }
+
+            [Fact]
+            public void Should_Throw_If_FileSystem_Is_Null()
+            {
+                // Given
+                var fixture = new TeamCityFixture();
+
+                // When
+                var result = Record.Exception(() => new TeamCityProvider(fixture.Environment, null, null));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "fileSystem");
             }
 
             [Fact]
@@ -32,7 +44,7 @@ namespace Cake.Common.Tests.Unit.Build.TeamCity
                 var fixture = new TeamCityFixture();
 
                 // When
-                var result = Record.Exception(() => new TeamCityProvider(fixture.Environment, null));
+                var result = Record.Exception(() => new TeamCityProvider(fixture.Environment, fixture.FileSystem, null));
 
                 // Then
                 AssertEx.IsArgumentNullException(result, "writer");

--- a/src/Cake.Common/Build/BuildSystemAliases.cs
+++ b/src/Cake.Common/Build/BuildSystemAliases.cs
@@ -48,7 +48,7 @@ namespace Cake.Common.Build
             }
 
             var appVeyorProvider = new AppVeyorProvider(context.Environment, context.ProcessRunner, context.Log);
-            var teamCityProvider = new TeamCityProvider(context.Environment, new BuildSystemServiceMessageWriter());
+            var teamCityProvider = new TeamCityProvider(context.Environment, context.FileSystem, new BuildSystemServiceMessageWriter());
             var myGetProvider = new MyGetProvider(context.Environment, new BuildSystemServiceMessageWriter());
             var bambooProvider = new BambooProvider(context.Environment);
             var continuaCIProvider = new ContinuaCIProvider(context.Environment, new BuildSystemServiceMessageWriter());

--- a/src/Cake.Common/Build/TeamCity/Data/TeamCityBuildInfo.cs
+++ b/src/Cake.Common/Build/TeamCity/Data/TeamCityBuildInfo.cs
@@ -70,6 +70,14 @@ namespace Cake.Common.Build.TeamCity.Data
         }
 
         /// <summary>
+        /// Gets the branch display name.
+        /// </summary>
+        /// <value>
+        /// The  branch display name.
+        /// </value>
+        public string BranchName => Properties.ContainsKey("teamcity.build.branch") ? Properties["teamcity.build.branch"] : string.Empty;
+
+        /// <summary>
         /// Gets the TeamCity properties.
         /// </summary>
         /// <value>

--- a/src/Cake.Common/Build/TeamCity/Data/TeamCityEnvironmentInfo.cs
+++ b/src/Cake.Common/Build/TeamCity/Data/TeamCityEnvironmentInfo.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Cake.Core;
+using Cake.Core.IO;
 
 namespace Cake.Common.Build.TeamCity.Data
 {
@@ -149,11 +150,12 @@ namespace Cake.Common.Build.TeamCity.Data
         /// Initializes a new instance of the <see cref="TeamCityEnvironmentInfo"/> class.
         /// </summary>
         /// <param name="environment">The environment.</param>
-        public TeamCityEnvironmentInfo(ICakeEnvironment environment)
+        /// <param name="fileSystem">The file system.</param>
+        public TeamCityEnvironmentInfo(ICakeEnvironment environment, IFileSystem fileSystem)
             : base(environment)
         {
             Project = new TeamCityProjectInfo(environment);
-            Build = new TeamCityBuildInfo(environment);
+            Build = new TeamCityBuildInfo(environment, fileSystem);
             PullRequest = new TeamCityPullRequestInfo(environment);
         }
     }

--- a/src/Cake.Common/Build/TeamCity/TeamCityProvider.cs
+++ b/src/Cake.Common/Build/TeamCity/TeamCityProvider.cs
@@ -24,6 +24,7 @@ namespace Cake.Common.Build.TeamCity
         private static readonly Dictionary<string, string> _sanitizationTokens;
 
         private readonly ICakeEnvironment _environment;
+        private readonly IFileSystem _fileSystem;
         private readonly IBuildSystemServiceMessageWriter _writer;
 
         /// <inheritdoc/>
@@ -49,13 +50,15 @@ namespace Cake.Common.Build.TeamCity
         /// Initializes a new instance of the <see cref="TeamCityProvider"/> class.
         /// </summary>
         /// <param name="environment">The cake environment.</param>
+        /// <param name="fileSystem">The cake file system.</param>
         /// <param name="writer">The build system service message writer.</param>
-        public TeamCityProvider(ICakeEnvironment environment, IBuildSystemServiceMessageWriter writer)
+        public TeamCityProvider(ICakeEnvironment environment, IFileSystem fileSystem, IBuildSystemServiceMessageWriter writer)
         {
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
+            _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
             _writer = writer ?? throw new ArgumentNullException(nameof(writer));
 
-            Environment = new TeamCityEnvironmentInfo(environment);
+            Environment = new TeamCityEnvironmentInfo(environment, fileSystem);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Adding support in the `TeamCityBuildInfo` to load the properties XML files as a key/value data store.
Files loaded as a Lazy to prevent IO when properties are not required & to also then cache the results if subsequent queries are to properties are required.

Also exposing the teamcity branch name.

NOTE: no test of loading the XML files have been added as i am unsure about the rules/convention for this sort of test for cake.

Fixes #2967