### PR TITLE
GH-3081: Add netcoreapp3.1 target to Cake

### DIFF
--- a/src/Cake/Cake.csproj
+++ b/src/Cake/Cake.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>Cake</AssemblyName>
     <OutputType>Exe</OutputType>
     <PlatformTarget>AnyCpu</PlatformTarget>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(PackAsTool)' != 'true'">
@@ -16,7 +16,7 @@
   <PropertyGroup Condition=" '$(PackAsTool)' == 'true'">
     <PackageId>Cake.Tool</PackageId>
     <ToolCommandName>dotnet-cake</ToolCommandName>
-    <PackageDescription>The Cake .NET Core Global Tool.</PackageDescription>
+    <PackageDescription>The Cake .NET Tool.</PackageDescription>
   </PropertyGroup>
 
   <!-- Project references -->


### PR DESCRIPTION
Tests already target `netcoreapp3.1` so changes needed there.

---

Closes #3081
