### PR TITLE
GH1616 : Better error message for interdependent tasks

### DIFF
--- a/src/Cake.Core.Tests/Unit/Graph/CakeGraphTests.cs
+++ b/src/Cake.Core.Tests/Unit/Graph/CakeGraphTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Linq;
 using Cake.Core.Graph;
 using Xunit;
@@ -152,7 +153,7 @@ namespace Cake.Core.Tests.Unit.Graph
 
                 // Then
                 Assert.IsType<CakeException>(result);
-                Assert.Equal("Unidirectional edges in graph are not allowed.", result?.Message);
+                Assert.Equal($"Unidirectional edges in graph are not allowed.{Environment.NewLine}\"start\" and \"end\" cannot depend on each other.", result?.Message);
             }
 
             [Fact]
@@ -167,7 +168,7 @@ namespace Cake.Core.Tests.Unit.Graph
 
                 // Then
                 Assert.IsType<CakeException>(result);
-                Assert.Equal("Unidirectional edges in graph are not allowed.", result?.Message);
+                Assert.Equal($"Unidirectional edges in graph are not allowed.{Environment.NewLine}\"start\" and \"end\" cannot depend on each other.", result?.Message);
             }
         }
 

--- a/src/Cake.Core/Graph/CakeGraph.cs
+++ b/src/Cake.Core/Graph/CakeGraph.cs
@@ -67,7 +67,8 @@ namespace Cake.Core.Graph
             if (_edges.Any(x => x.Start.Equals(end, StringComparison.OrdinalIgnoreCase)
                 && x.End.Equals(start, StringComparison.OrdinalIgnoreCase)))
             {
-                throw new CakeException("Unidirectional edges in graph are not allowed.");
+                var firstBadEdge = _edges.First(x => x.Start.Equals(end, StringComparison.OrdinalIgnoreCase) && x.End.Equals(start, StringComparison.OrdinalIgnoreCase));
+                throw new CakeException($"Unidirectional edges in graph are not allowed.{Environment.NewLine}\"{firstBadEdge.Start}\" and \"{firstBadEdge.End}\" cannot depend on each other.");
             }
             if (_edges.Any(x => x.Start.Equals(start, StringComparison.OrdinalIgnoreCase)
                 && x.End.Equals(end, StringComparison.OrdinalIgnoreCase)))


### PR DESCRIPTION
- Error message was changed.
- Fixes https://github.com/cake-build/cake/issues/1616
- Added information was put on another line to maintain backwards compatibility with old message. 
