### PR TITLE
GH-3144: TeamCityPullRequestInfo without GIT_BRANCH

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Build/TeamCityInfoFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/TeamCityInfoFixture.cs
@@ -61,7 +61,7 @@ namespace Cake.Common.Tests.Fixtures.Build
 
         public TeamCityPullRequestInfo CreatePullRequestInfo()
         {
-            return new TeamCityPullRequestInfo(Environment);
+            return new TeamCityPullRequestInfo(Environment, CreateBuildInfo());
         }
 
         public TeamCityEnvironmentInfo CreateEnvironmentInfo()

--- a/src/Cake.Common.Tests/Unit/Build/TeamCity/Data/TeamCityPullRequestInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/TeamCity/Data/TeamCityPullRequestInfoTests.cs
@@ -18,11 +18,14 @@ namespace Cake.Common.Tests.Unit.Build.TeamCity.Data
             [InlineData("refs/pull/1/merge", true)]
             [InlineData("refs/changes/1/head", true)]
             [InlineData("refs/heads/master", false)]
+            [InlineData("", true)]
             public void Should_Return_Correct_Value(string value, bool expected)
             {
                 // Given
                 var fixture = new TeamCityInfoFixture();
                 fixture.SetGitBranch(value);
+                fixture.SetBuildPropertiesContent(Properties.Resources.TeamCity_Build_Properties_Xml);
+                fixture.SetConfigPropertiesContent(Properties.Resources.TeamCity_Config_Properties_Xml);
                 var info = fixture.CreatePullRequestInfo();
 
                 // When
@@ -41,11 +44,14 @@ namespace Cake.Common.Tests.Unit.Build.TeamCity.Data
             [InlineData("refs/changes/3/merge", 3)]
             [InlineData("refs/merge-requests/4/merge", 4)]
             [InlineData("refs/heads/master", null)]
+            [InlineData("", 5)]
             public void Should_Return_Correct_Value(string value, int? expected)
             {
                 // Given
                 var fixture = new TeamCityInfoFixture();
                 fixture.SetGitBranch(value);
+                fixture.SetBuildPropertiesContent(Properties.Resources.TeamCity_Build_Properties_Xml);
+                fixture.SetConfigPropertiesContent(Properties.Resources.TeamCity_Config_Properties_Xml);
                 var info = fixture.CreatePullRequestInfo();
 
                 // When

--- a/src/Cake.Common/Build/TeamCity/Data/TeamCityEnvironmentInfo.cs
+++ b/src/Cake.Common/Build/TeamCity/Data/TeamCityEnvironmentInfo.cs
@@ -156,7 +156,7 @@ namespace Cake.Common.Build.TeamCity.Data
         {
             Project = new TeamCityProjectInfo(environment);
             Build = new TeamCityBuildInfo(environment, fileSystem);
-            PullRequest = new TeamCityPullRequestInfo(environment);
+            PullRequest = new TeamCityPullRequestInfo(environment, Build);
         }
     }
 }

--- a/src/Cake.Common/Build/TeamCity/Data/TeamCityPullRequestInfo.cs
+++ b/src/Cake.Common/Build/TeamCity/Data/TeamCityPullRequestInfo.cs
@@ -11,8 +11,12 @@ namespace Cake.Common.Build.TeamCity.Data
     /// </summary>
     public class TeamCityPullRequestInfo : TeamCityInfo
     {
-        private static bool InferIsPullRequest(string gitReferenceName)
+        private readonly TeamCityBuildInfo _buildInfo;
+
+        private bool InferIsPullRequest()
         {
+            var gitReferenceName = GetBranchRef();
+
             if (string.IsNullOrEmpty(gitReferenceName))
             {
                 return false;
@@ -37,8 +41,10 @@ namespace Cake.Common.Build.TeamCity.Data
             return false;
         }
 
-        private static int? GetPullRequestNumber(string gitReferenceName)
+        private int? GetPullRequestNumber()
         {
+            var gitReferenceName = GetBranchRef();
+
             if (string.IsNullOrEmpty(gitReferenceName))
             {
                 return null;
@@ -54,6 +60,18 @@ namespace Cake.Common.Build.TeamCity.Data
             return null;
         }
 
+        private string GetBranchRef()
+        {
+            var gitBranch = GetEnvironmentString("Git_Branch");
+
+            if (string.IsNullOrWhiteSpace(gitBranch))
+            {
+                gitBranch = _buildInfo.VcsBranchName;
+            }
+
+            return gitBranch;
+        }
+
         /// <summary>
         /// Gets a value indicating whether the current build was started by a pull request.
         /// </summary>
@@ -63,7 +81,7 @@ namespace Cake.Common.Build.TeamCity.Data
         /// <remarks>
         /// <c>env.Git_Branch</c> is a required parameter in TeamCity for this to work.
         /// </remarks>
-        public bool IsPullRequest => InferIsPullRequest(GetEnvironmentString("Git_Branch"));
+        public bool IsPullRequest => InferIsPullRequest();
 
         /// <summary>
         /// Gets the pull request number.
@@ -74,15 +92,17 @@ namespace Cake.Common.Build.TeamCity.Data
         /// <remarks>
         /// <c>env.Git_Branch</c> is a required parameter in TeamCity for this to work.
         /// </remarks>
-        public int? Number => IsPullRequest ? GetPullRequestNumber(GetEnvironmentString("Git_Branch")) : null;
+        public int? Number => IsPullRequest ? GetPullRequestNumber() : null;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TeamCityPullRequestInfo"/> class.
         /// </summary>
         /// <param name="environment">The environment.</param>
-        public TeamCityPullRequestInfo(ICakeEnvironment environment)
+        /// <param name="buildInfo">The TeamCity build info.</param>
+        public TeamCityPullRequestInfo(ICakeEnvironment environment, TeamCityBuildInfo buildInfo)
             : base(environment)
         {
+            _buildInfo = buildInfo;
         }
     }
 }


### PR DESCRIPTION
This PR extends #3113 and adds a fix for #3144 to use the configuration property `vcsroot.branch` if the `GIT_BRANCH` environment variable does not exist.

I have raised this as a seperate pull request so if there is any issue/contention with the change it doesn't hold up the original PR.
This has all commits in #3113 with 1 additional commit added [3e28e0aeca739f2b7927d5a1f6409224026b687d](https://github.com/cake-build/cake/pull/3145/commits/3e28e0aeca739f2b7927d5a1f6409224026b687d)

Fixes #2967
Fixes #3144