### PR TITLE
GH-3143: Don't try to parse empty solution file lines

### DIFF
--- a/src/Cake.Common.Tests/Properties/Resources.Designer.cs
+++ b/src/Cake.Common.Tests/Properties/Resources.Designer.cs
@@ -660,6 +660,23 @@ namespace Cake.Common.Tests.Properties {
                 return ResourceManager.GetString("Solution_WithProjectsAndFolders", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Microsoft Visual Studio Solution File, Format Version 12.00
+        ///# Visual Studio 14
+        ///VisualStudioVersion = 14.0.25123.0
+        ///MinimumVisualStudioVersion = 10.0.40219.1
+        ///Project(&quot;{2150E333-8FDC-42A3-9474-1A3956D46DE8}&quot;) = &quot;src&quot;, &quot;src&quot;, &quot;{2400A22B-695E-4BDF-93CB-8757F5FB3FB7}&quot;
+        ///EndProject
+        ///Project(&quot;{2150E333-8FDC-42A3-9474-1A3956D46DE8}&quot;) = &quot;test&quot;, &quot;test&quot;, &quot;{69930DD1-1688-4407-B4AB-B9E2C0BFB284}&quot;
+        ///EndProject
+        ///Project(&quot;{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}&quot;) = &quot;dummy&quot;, &quot;src\dummy\dummy.csproj&quot;, &quot;{ADCB37DA-2469-462F-99 [rest of string was truncated]&quot;;.
+        /// </summary>
+        public static string Solution_WithProjectsAndFoldersAndMissingLine {
+            get {
+                return ResourceManager.GetString("Solution_WithProjectsAndFoldersAndMissingLine", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to using System.Reflection;

--- a/src/Cake.Common.Tests/Properties/Resources.resx
+++ b/src/Cake.Common.Tests/Properties/Resources.resx
@@ -901,6 +901,50 @@ Global
 	EndGlobalSection
 EndGlobal</value>
   </data>
+  <data name="Solution_WithProjectsAndFoldersAndMissingLine" xml:space="preserve">
+    <value>Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{2400A22B-695E-4BDF-93CB-8757F5FB3FB7}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{69930DD1-1688-4407-B4AB-B9E2C0BFB284}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dummy", "src\dummy\dummy.csproj", "{ADCB37DA-2469-462F-99F6-9D4FB7691A3B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dummy.Tests", "test\dummy.Tests\dummy.Tests.csproj", "{5D553DC6-36AB-4823-85BD-A33F57C81381}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "executable", "executable\executable.csproj", "{CF305C72-F3E0-44AA-9474-6F12C5276F9F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{ADCB37DA-2469-462F-99F6-9D4FB7691A3B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ADCB37DA-2469-462F-99F6-9D4FB7691A3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ADCB37DA-2469-462F-99F6-9D4FB7691A3B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ADCB37DA-2469-462F-99F6-9D4FB7691A3B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5D553DC6-36AB-4823-85BD-A33F57C81381}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5D553DC6-36AB-4823-85BD-A33F57C81381}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5D553DC6-36AB-4823-85BD-A33F57C81381}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5D553DC6-36AB-4823-85BD-A33F57C81381}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CF305C72-F3E0-44AA-9474-6F12C5276F9F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF305C72-F3E0-44AA-9474-6F12C5276F9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF305C72-F3E0-44AA-9474-6F12C5276F9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF305C72-F3E0-44AA-9474-6F12C5276F9F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+
+		{ADCB37DA-2469-462F-99F6-9D4FB7691A3B} = {2400A22B-695E-4BDF-93CB-8757F5FB3FB7}
+		{5D553DC6-36AB-4823-85BD-A33F57C81381} = {69930DD1-1688-4407-B4AB-B9E2C0BFB284}
+	EndGlobalSection
+EndGlobal</value>
+  </data>
   <data name="Nuspec_Metadata_PackWithTargetFrameworkDependencies" xml:space="preserve">
     <value>&lt;?xml version="1.0" encoding="utf-8"?&gt;
 &lt;package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;

--- a/src/Cake.Common.Tests/Unit/Solution/SolutionParserTests.cs
+++ b/src/Cake.Common.Tests/Unit/Solution/SolutionParserTests.cs
@@ -111,6 +111,25 @@ namespace Cake.Common.Tests.Unit.Solution
                 Assert.Contains(dummyProject, srcFolder.Items);
                 Assert.Equal(srcFolder, dummyProject.Parent);
             }
+
+            [Fact]
+            public void Should_Properly_Parse_Projects_With_Empty_Lines()
+            {
+                // Given
+                var fixture = new SolutionParserFixture();
+                var slnFilePath = fixture.WithSolutionFile(Resources.Solution_WithProjectsAndFoldersAndMissingLine);
+                var solutionParser = new SolutionParser(fixture.FileSystem, fixture.Environment);
+
+                // When
+                var result = solutionParser.Parse(slnFilePath);
+
+                // Then
+                Assert.NotNull(result);
+                Assert.NotNull(result.Projects);
+                Assert.Equal(5, result.Projects.Count);
+                var onlyProjects = result.Projects.Where(x => !(x is SolutionFolder)).ToList();
+                Assert.Equal(3, onlyProjects.Count);
+            }
         }
     }
 }

--- a/src/Cake.Common/Solution/SolutionParser.cs
+++ b/src/Cake.Common/Solution/SolutionParser.cs
@@ -73,6 +73,12 @@ namespace Cake.Common.Solution
             foreach (var line in file.ReadLines(Encoding.UTF8))
             {
                 var trimmed = line.Trim();
+
+                if (trimmed == string.Empty)
+                {
+                    continue;
+                }
+
                 if (line.StartsWith("Project(\"{"))
                 {
                     var project = ParseSolutionProjectLine(file, line);


### PR DESCRIPTION
Fixes #3143 

Should I care about Rider changing unrelated lines of code in Resources.Designer.cs?