### PR TITLE
GH3125: Adds ReportGenerator missing report types

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/ReportGenerator/ReportGeneratorRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/ReportGenerator/ReportGeneratorRunnerTests.cs
@@ -175,6 +175,10 @@ namespace Cake.Common.Tests.Unit.Tools.ReportGenerator
             [InlineData("MHtml", 15)]
             [InlineData("SonarQube", 16)]
             [InlineData("HtmlInline_AzurePipelines_Dark", 17)]
+            [InlineData("Clover", 18)]
+            [InlineData("JsonSummary", 19)]
+            [InlineData("lcov", 20)]
+            [InlineData("TeamCitySummary", 21)]
             public void Should_Set_Report_Types(string expected, int enumValue)
             {
                 // Given

--- a/src/Cake.Common/Tools/ReportGenerator/ReportGeneratorReportType.cs
+++ b/src/Cake.Common/Tools/ReportGenerator/ReportGeneratorReportType.cs
@@ -98,6 +98,38 @@ namespace Cake.Common.Tools.ReportGenerator
         /// <remarks>
         /// Requires ReportGenerator 4.0.10+
         /// </remarks>
-        HtmlInline_AzurePipelines_Dark = 17
+        HtmlInline_AzurePipelines_Dark = 17,
+
+        /// <summary>
+        /// Creates xml report in Clover format.
+        /// </summary>
+        /// <remarks>
+        /// Requires ReportGenerator 4.0.6+
+        /// </remarks>
+        Clover = 18,
+
+        /// <summary>
+        /// Creates summary report in JSON format.
+        /// </summary>
+        /// <remarks>
+        /// Requires ReportGenerator 4.5.2+
+        /// </remarks>
+        JsonSummary = 19,
+
+        /// <summary>
+        /// Creates summary report in lcov format.
+        /// </summary>
+        /// <remarks>
+        /// Requires ReportGenerator 4.3.0+
+        /// </remarks>
+        lcov = 20,
+
+        /// <summary>
+        /// Outputs summary report as TeamCity statistics messages.
+        /// </summary>
+        /// <remarks>
+        /// Requires ReportGenerator 4.1.3+
+        /// </remarks>
+        TeamCitySummary = 21
     }
 }


### PR DESCRIPTION
- [x] Clover 
- [x] JsonSummary 
- [x] lcov 
- [x] TeamCitySummary

 fixes #3125
