### PR TITLE
GH3182: Update build to addin&modules targeting Cake 1.0

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,10 +1,10 @@
 // Install modules
-#module nuget:?package=Cake.DotNetTool.Module&version=0.4.0
+#module nuget:?package=Cake.DotNetTool.Module&version=1.0.1
 
 // Install addins.
-#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Coveralls&version=0.10.2"
-#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Twitter&version=0.10.1"
-#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Gitter&version=0.11.1"
+#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Coveralls&version=1.0.0"
+#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Twitter&version=1.0.0"
+#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Gitter&version=1.0.1"
 
 // Install tools.
 #tool "nuget:https://api.nuget.org/v3/index.json?package=coveralls.io&version=1.4.2"


### PR DESCRIPTION
- [x] Cake.DotNetTool.Module - 0.4.0 ➡️ ~~1.0.0~~ 1.0.1 
- [x] Cake.Coveralls - 0.10.2 ➡️ 1.0.0
- [x] Cake.Twitter - 0.10.1 ➡️ 1.0.0
- [x] Cake.Gitter - 0.11.1 ➡️ ~~1.0.0~~ 1.0.1 
- fixes #3182
