### PR TITLE
GH-3219: Update nuspec iconUrl in packages to use CDN URL

### DIFF
--- a/nuspec/Cake.CoreCLR.nuspec
+++ b/nuspec/Cake.CoreCLR.nuspec
@@ -9,7 +9,7 @@
     <license type="expression">MIT</license>
     <projectUrl>https://cakebuild.net</projectUrl>
     <icon>cake-medium.png</icon>
-    <iconUrl>https://raw.githubusercontent.com/cake-build/graphics/master/png/cake-medium.png</iconUrl>
+    <iconUrl>https://cdn.jsdelivr.net/gh/cake-build/graphics/png/cake-medium.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <repository type="git" url="https://github.com/cake-build/cake"/>
     <copyright>Copyright (c) .NET Foundation and contributors</copyright>

--- a/nuspec/Cake.Portable.nuspec
+++ b/nuspec/Cake.Portable.nuspec
@@ -17,7 +17,7 @@
     <copyright>Copyright (c) .NET Foundation and contributors</copyright>
     <licenseUrl>https://github.com/cake-build/cake/blob/develop/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <iconUrl>https://raw.githubusercontent.com/cake-build/graphics/master/png/cake-medium.png</iconUrl>
+    <iconUrl>https://cdn.jsdelivr.net/gh/cake-build/graphics/png/cake-medium.png</iconUrl>
   </metadata>
   <files></files>
 </package>

--- a/nuspec/Cake.nuspec
+++ b/nuspec/Cake.nuspec
@@ -9,7 +9,7 @@
     <license type="expression">MIT</license>
     <projectUrl>https://cakebuild.net</projectUrl>
     <icon>cake-medium.png</icon>
-    <iconUrl>https://raw.githubusercontent.com/cake-build/graphics/master/png/cake-medium.png</iconUrl>
+    <iconUrl>https://cdn.jsdelivr.net/gh/cake-build/graphics/png/cake-medium.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <repository type="git" url="https://github.com/cake-build/cake"/>
     <copyright>Copyright (c) .NET Foundation and contributors</copyright>


### PR DESCRIPTION
Closes #3219
Relates to #3213