### PR TITLE
GH-2314: Allow setting MSBuild Platform using custom string

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsExtensionsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsExtensionsTests.cs
@@ -98,6 +98,36 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             }
         }
 
+        public sealed class TheSetPlatformTargetStringMethod
+        {
+            [Fact]
+            public void Should_Set_Platform_Target_Via_Property()
+            {
+                // Given
+                var settings = new MSBuildSettings();
+
+                // When
+                settings.SetPlatformTarget("Custom");
+
+                // Then
+                Assert.True(settings.Properties.ContainsKey("Platform"));
+                Assert.Equal("Custom", string.Join(string.Empty, settings.Properties["Platform"]));
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration()
+            {
+                // Given
+                var settings = new MSBuildSettings();
+
+                // When
+                var result = settings.SetPlatformTarget("Custom");
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+        }
+
         public sealed class TheWithPropertyMethod
         {
             [Fact]

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
@@ -63,6 +63,23 @@ namespace Cake.Common.Tools.MSBuild
         }
 
         /// <summary>
+        /// Sets the platform target.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="target">The target.</param>
+        /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static MSBuildSettings SetPlatformTarget(this MSBuildSettings settings, string target)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            settings.WithProperty("Platform", target);
+            return settings;
+        }
+
+        /// <summary>
         /// Sets the MSBuild platform.
         /// </summary>
         /// <param name="settings">The settings.</param>


### PR DESCRIPTION
> Related discussion: [SetPlatform for the new Arm7](https://github.com/cake-build/cake/discussions/3218)

The `MSBuildSettings` extension `SetPlatformTarget` expects a valid value from the [PlatformTarget](https://cakebuild.net/api/Cake.Common.Tools.MSBuild/PlatformTarget/) enumeration.

This PR adds an overload which accepts a custom string.

The current workaround without this PR is to either use [`.WithProperty("Platform", "...")`](https://cakebuild.net/api/Cake.Common.Tools.MSBuild/MSBuildSettingsExtensions/D92C8A6A) instead of [`SetPlatformTarget`](https://cakebuild.net/api/Cake.Common.Tools.MSBuild/MSBuildSettingsExtensions/D9A56C8C), or use [`ArgumentCustomization`](https://cakebuild.net/api/Cake.Core.Tooling/ToolSettings/50AAB3A8)

```diff
-    .SetPlatformTarget(BuildParameters.Platform)
+    .WithProperty("Platform", "Custom")
```

---

Closes #2314