### PR TITLE
GH-3190: Set working directory before getting the build context

### DIFF
--- a/src/Cake.Frosting/Internal/Commands/DefaultCommand.cs
+++ b/src/Cake.Frosting/Internal/Commands/DefaultCommand.cs
@@ -53,14 +53,14 @@ namespace Cake.Frosting.Internal
                 var log = provider.GetRequiredService<ICakeLog>();
                 log.Verbosity = settings.Verbosity;
 
+                // Set the working directory
+                SetWorkingDirectory(provider, settings);
+
                 // Run
                 var runner = GetFrostingEngine(provider, settings);
 
                 // Install tools
                 InstallTools(provider);
-
-                // Set the working directory
-                SetWorkingDirectory(provider, settings);
 
                 if (settings.Exclusive)
                 {


### PR DESCRIPTION
Closes #3190

---

#### After this PR:

```
C:\augustoproiete\TestFrostingWorkDir>dotnet run -w C:\Temp
Context ctor C:/Temp

========================================
Hello
========================================
Hello task C:/Temp

========================================
Default
========================================

Task                          Duration
--------------------------------------------------
Hello                         00:00:00.0039034
--------------------------------------------------
Total:                        00:00:00.0045129
```
