### PR TITLE
Add Xamarin.iOS platform targets to MSBuildSettings PlatformTarget enumeration

### DIFF
--- a/src/Cake.Common/Tools/MSBuild/PlatformTarget.cs
+++ b/src/Cake.Common/Tools/MSBuild/PlatformTarget.cs
@@ -41,6 +41,24 @@ namespace Cake.Common.Tools.MSBuild
         /// Platform target: <c>ARM64</c>
         /// </summary>
         // ReSharper disable once InconsistentNaming
-        ARM64 = 5
+        ARM64 = 5,
+
+        /// <summary>
+        /// Platform target: <c>ARMv6</c>
+        /// </summary>
+        // ReSharper disable once InconsistentNaming
+        ARMv6 = 6,
+
+        /// <summary>
+        /// Platform target: <c>ARMv7</c>
+        /// </summary>
+        // ReSharper disable once InconsistentNaming
+        ARMv7 = 7,
+
+        /// <summary>
+        /// Platform target: <c>ARMv7s</c>
+        /// </summary>
+        // ReSharper disable once InconsistentNaming
+        ARMv7s = 8
     }
 }


### PR DESCRIPTION
Issue: #3222

Add Xamarin.iOS platform targets to MSBuildSettings PlatformTarget enumeration:

- ARMv6
- ARMv7
- ARMv7s

Please review
Thank you in advance