### PR TITLE
Issue #3223: Adding environment variable substitution support for cake.config

### DIFF
--- a/src/Cake.Core/Configuration/Parser/ConfigurationParser.cs
+++ b/src/Cake.Core/Configuration/Parser/ConfigurationParser.cs
@@ -37,11 +37,11 @@ namespace Cake.Core.Configuration.Parser
             using (var stream = file.OpenRead())
             using (var reader = new StreamReader(stream))
             {
-                return Read(reader.ReadToEnd());
+                return Read(_environment, reader.ReadToEnd());
             }
         }
 
-        private static IDictionary<string, string> Read(string text)
+        private static IDictionary<string, string> Read(ICakeEnvironment environment, string text)
         {
             var tokens = ConfigurationTokenizer.Tokenize(text);
             var section = string.Empty;
@@ -56,7 +56,7 @@ namespace Cake.Core.Configuration.Parser
                         break;
                     case ConfigurationTokenKind.Value:
                         var pair = ParseKeyAndValue(tokens, section);
-                        result[pair.Key] = pair.Value;
+                        result[pair.Key] = environment.ExpandEnvironmentVariables(pair.Value);
                         break;
                     default:
                         throw new InvalidOperationException("Encountered unexpected token.");


### PR DESCRIPTION
This pullrequests adds basic environment variable substitution to `cake.config`, as requested in #3223 

I've used the windows syntax for environment variables, as that is what nuget does for `nuget.config`.
([See Microsoft docs on this topic](https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#environment-variables-in-configuration))
The effect is that environment variable substitution will work cross-platform, but windows environment variable syntax must be used.  This might look somewhat odd in unix environments, but can be justified with the .ini syntax in cake.config 😄 

This should probably be documented somehow, but I can't find any documentation in this repo?