### PR TITLE
GH-3238: Update DotNetTool module to target netstandard2.0 only

### DIFF
--- a/src/Cake.DotNetTool.Module/Cake.DotNetTool.Module.csproj
+++ b/src/Cake.DotNetTool.Module/Cake.DotNetTool.Module.csproj
@@ -1,7 +1,7 @@
 ﻿ <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Cake.DotNetTool.Module</AssemblyName>
-    <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>


### PR DESCRIPTION
Closes #3238