### PR TITLE
GH-3243: Ensure expected order of writes to Console by flushing after writes

### DIFF
--- a/src/Cake.Common/Build/IBuildSystemServiceMessageWriter.cs
+++ b/src/Cake.Common/Build/IBuildSystemServiceMessageWriter.cs
@@ -20,6 +20,7 @@ namespace Cake.Common.Build
         public void Write(string format, params object[] args)
         {
             Console.Out.WriteLine(format, args);
+            Console.Out.Flush();
         }
     }
 }

--- a/src/Cake.Core/CakeConsole.cs
+++ b/src/Cake.Core/CakeConsole.cs
@@ -50,24 +50,28 @@ namespace Cake.Core
         public void Write(string format, params object[] arg)
         {
             Console.Write(format, arg);
+            Console.Out.Flush();
         }
 
         /// <inheritdoc/>
         public void WriteLine(string format, params object[] arg)
         {
             Console.WriteLine(format, arg);
+            Console.Out.Flush();
         }
 
         /// <inheritdoc/>
         public void WriteError(string format, params object[] arg)
         {
             Console.Error.Write(format, arg);
+            Console.Error.Flush();
         }
 
         /// <inheritdoc/>
         public void WriteErrorLine(string format, params object[] arg)
         {
             Console.Error.WriteLine(format, arg);
+            Console.Error.Flush();
         }
 
         /// <inheritdoc/>

--- a/src/Cake.Core/Scripting/ScriptConventions.cs
+++ b/src/Cake.Core/Scripting/ScriptConventions.cs
@@ -141,6 +141,8 @@ namespace Cake.Core.Scripting
 
                 default:
                     Console.Error.WriteLine(_runtime.BuiltFramework.FullName);
+                    Console.Error.Flush();
+
                     return "NETSTANDARD2_0";
             }
         }


### PR DESCRIPTION
### Before this PR:

![image](https://user-images.githubusercontent.com/177608/110259879-3ebc4780-7f80-11eb-9e53-d79f339ee248.png)

### After this PR:

![image](https://user-images.githubusercontent.com/177608/110259886-44199200-7f80-11eb-8915-c1fb6793725d.png)

---

```cakescript
Task("build")
    .Does(() =>
{
    Information("Hello from {0}! This is written to stdout (1).", "Cake");
    Error("Hello from {0}! This is written to stderr (1).", "Cake");

    Information("Hello from {0}! This is written to stdout (2).", "Cake");
    Error("Hello from {0}! This is written to stderr (2).", "Cake");

    Information("Hello from {0}! This is written to stdout (3).", "Cake");
    Error("Hello from {0}! This is written to stderr (3).", "Cake");

    Information("Hello from {0}! This is written to stdout (4).", "Cake");
    Error("Hello from {0}! This is written to stderr (4).", "Cake");
});

RunTarget("build");
```

---

Closes #3243