### PR TITLE
Bump NuGet client libraries and command-line tool

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -7,7 +7,7 @@
 #tool "nuget:https://api.nuget.org/v3/index.json?package=coveralls.io&version=1.4.2"
 #tool "nuget:https://api.nuget.org/v3/index.json?package=OpenCover&version=4.7.922"
 #tool "nuget:https://api.nuget.org/v3/index.json?package=ReportGenerator&version=4.7.1"
-#tool "nuget:https://api.nuget.org/v3/index.json?package=nuget.commandline&version=5.7.0"
+#tool "nuget:https://api.nuget.org/v3/index.json?package=NuGet.CommandLine&version=5.8.1"
 
 // Install .NET Core Global tools.
 #tool "dotnet:https://api.nuget.org/v3/index.json?package=GitVersion.Tool&version=5.1.2"

--- a/src/Cake.NuGet/Cake.NuGet.csproj
+++ b/src/Cake.NuGet/Cake.NuGet.csproj
@@ -19,12 +19,12 @@
   </ItemGroup>
   <!-- Global packages -->
   <ItemGroup>
-    <PackageReference Include="NuGet.Frameworks" Version="5.9.0" />
-    <PackageReference Include="NuGet.Versioning" Version="5.9.0" />
-    <PackageReference Include="NuGet.Protocol" Version="5.9.0" />
-    <PackageReference Include="NuGet.Packaging" Version="5.9.0" />
-    <PackageReference Include="NuGet.Resolver" Version="5.9.0" />
-    <PackageReference Include="NuGet.Common" Version="5.9.0" />
+    <PackageReference Include="NuGet.Frameworks" Version="5.9.1" />
+    <PackageReference Include="NuGet.Versioning" Version="5.9.1" />
+    <PackageReference Include="NuGet.Protocol" Version="5.9.1" />
+    <PackageReference Include="NuGet.Packaging" Version="5.9.1" />
+    <PackageReference Include="NuGet.Resolver" Version="5.9.1" />
+    <PackageReference Include="NuGet.Common" Version="5.9.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
   </ItemGroup>

--- a/tests/integration/Cake.Common/Tools/NuGet/NuGetAliases.cake
+++ b/tests/integration/Cake.Common/Tools/NuGet/NuGetAliases.cake
@@ -1,4 +1,4 @@
-#tool "nuget:https://api.nuget.org/v3/index.json?package=nuget.commandline&version=5.7.0"
+#tool "nuget:https://api.nuget.org/v3/index.json?package=NuGet.CommandLine&version=5.8.1"
 #load "./../../../utilities/xunit.cake"
 #load "./../../../utilities/paths.cake"
 


### PR DESCRIPTION
Fixes #3316. Note: [NuGet.CommandLine](https://www.nuget.org/packages/NuGet.CommandLine/) v5.9.1 is still not available.