### PR TITLE
#3330 changes to Cake.Frosting.Template metadata

### DIFF
--- a/src/Cake.Frosting.Template/Cake.Frosting.Template.csproj
+++ b/src/Cake.Frosting.Template/Cake.Frosting.Template.csproj
@@ -16,6 +16,7 @@
   <Import Project="$(MSBuildThisFileDirectory)..\Shared.msbuild" />
 
   <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)../../nuspec/cake-medium.png" Pack="true" PackagePath="content\templates\cakefrosting\.template.config\image.png" />
     <Content Include="templates\**\*" Exclude="templates\**\bin\**;templates\**\obj\**" />
     <Compile Remove="**\*" />
   </ItemGroup>

--- a/src/Cake.Frosting.Template/templates/cakefrosting/.template.config/ide.host.json
+++ b/src/Cake.Frosting.Template/templates/cakefrosting/.template.config/ide.host.json
@@ -1,0 +1,5 @@
+﻿{
+  "$schema": "http://json.schemastore.org/vs-2017.3.host",
+  "icon": "image.png",
+  "learnMoreLink": "https://cakebuild.net/"
+}

--- a/src/Cake.Frosting.Template/templates/cakefrosting/.template.config/template.json
+++ b/src/Cake.Frosting.Template/templates/cakefrosting/.template.config/template.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json.schemastore.org/template",
   "author": "Patrik Svensson, Mattias Karlsson, Gary Ewan Park, Alistair Chapman, Martin Björkström, Dave Glick, Pascal Berger, Jérémie Desautels, Enrico Campidoglio, C. Augusto Proiete, Nils Andresen, and contributors",
   "classifications": [ "Cake", "Frosting" ],
   "name": "Cake Frosting Build Script",
@@ -6,6 +7,9 @@
   "shortName": "cakefrosting",
   "sourceName": "temp",
   "tags": {
-    "language": "C#"
-  }
+    "language": "C#",
+    "type": "project"
+  },
+  "groupIdentity": "Cake",
+  "description": "Create a Cake.Frosting build project."
 }


### PR DESCRIPTION
to make the template show up in Visual Studio "new project" dialog.

Using these changes the `Cake.Frosting` .NET CLI template will show up in Visual Studio "new project" dialog. (If [the experimental feature to show .NET CLI templates](https://devblogs.microsoft.com/dotnet/net-cli-templates-in-visual-studio/) has been activated.)

The template will show up under the "Cake" project type group. (Templates from *Cake for VS* use the same group, so they all will show up nicely together.)

This will look in VS like this:
![image](https://user-images.githubusercontent.com/349188/116934952-ecd52c80-ac65-11eb-8a05-336bbf37dd95.png)

One drawback currently is the visualization in dark mode:
![image](https://user-images.githubusercontent.com/349188/116935165-44739800-ac66-11eb-9910-a525a27a49a3.png)
Somehow the image get's distorted. I hope that's temporary (showing .NET CLI templates in VS is an experimental feature, after all...) 

fixes #3330 