### PR TITLE
GH2168: Support for `DirectoryPath` and `FilePath` when reading arguments

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -669,6 +669,8 @@ Task("Run-Integration-Tests")
                     .AppendSwitchQuoted("--customarg", " ", "hello")
                     .AppendSwitchQuoted("--multipleargs", "=", "a")
                     .AppendSwitchQuoted("--multipleargs", "=", "b")
+                    .AppendSwitchQuoted("--testAssemblyDirectoryPath", "=", cakeAssembly.GetDirectory().FullPath)
+                    .AppendSwitchQuoted("--testAssemblyFilePath", "=", cakeAssembly.FullPath)
             });
     }
     catch(Exception ex)

--- a/src/Cake.Common.Tests/Unit/ArgumentAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/ArgumentAliasesTests.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core;
+using Cake.Core.IO;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit
+{
+    public sealed class ArgumentAliases
+    {
+        public sealed class TheArgumentOfDirectoryPathMethod
+        {
+            [Fact]
+            public void Should_Convert_A_String_Value_To_A_DirectoryPath_If_Argument_Exist()
+            {
+                var context = Substitute.For<ICakeContext>();
+                context.Arguments.GetArguments("workdir").Returns(new[] { "c:/data/work" });
+
+                var result = context.Argument<DirectoryPath>("workdir");
+
+                Assert.Equal("c:/data/work", result.FullPath);
+            }
+        }
+
+        public sealed class TheArgumentOfFilePathMethod
+        {
+            [Fact]
+            public void Should_Convert_A_String_Value_To_A_FilePath_If_Argument_Exist()
+            {
+                var context = Substitute.For<ICakeContext>();
+                context.Arguments.GetArguments("outputFile").Returns(new[] { "c:/data/work/output.txt" });
+
+                var result = context.Argument<FilePath>("outputFile");
+
+                Assert.Equal("c:/data/work/output.txt", result.FullPath);
+            }
+        }
+    }
+}

--- a/src/Cake.Core.Tests/Unit/IO/DirectoryPathConverterTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/DirectoryPathConverterTests.cs
@@ -1,0 +1,118 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Core.IO;
+using Xunit;
+
+namespace Cake.Core.Tests.Unit.IO
+{
+    public sealed class DirectoryPathConverterTests
+    {
+        public sealed class TheCanConvertFromMethod
+        {
+            [Fact]
+            public void Should_Return_True_When_Source_Type_Is_String()
+            {
+                var converter = new DirectoryPathConverter();
+
+                var result = converter.CanConvertFrom(typeof(string));
+
+                Assert.True(result);
+            }
+
+            [Fact]
+            public void Should_Return_False_When_Source_Type_Is_Not_String()
+            {
+                var converter = new DirectoryPathConverter();
+
+                var result = converter.CanConvertFrom(typeof(DateTime));
+
+                Assert.False(result);
+            }
+        }
+
+        public sealed class TheConvertFromMethod
+        {
+            [Fact]
+            public void Should_Convert_String_Value_To_Directory_Path()
+            {
+                var converter = new DirectoryPathConverter();
+
+                var result = converter.ConvertFrom("c:/data/work");
+
+                Assert.IsType<DirectoryPath>(result);
+                Assert.Equal("c:/data/work", ((DirectoryPath)result).FullPath);
+            }
+
+            [Fact]
+            public void Should_Throw_NotSupportedException_When_Value_Is_Not_A_Valid_Directory_Path()
+            {
+                var converter = new DirectoryPathConverter();
+
+                var result = Record.Exception(() => converter.ConvertFrom(DateTime.Now));
+
+                Assert.IsType<NotSupportedException>(result);
+            }
+        }
+
+        public sealed class TheCanConvertToMethod
+        {
+            [Fact]
+            public void Should_Return_True_When_Destination_Type_Is_String()
+            {
+                var converter = new DirectoryPathConverter();
+
+                var result = converter.CanConvertTo(typeof(string));
+
+                Assert.True(result);
+            }
+
+            [Fact]
+            public void Should_Return_True_When_Destination_Type_Is_DirectoryPath()
+            {
+                var converter = new DirectoryPathConverter();
+
+                var result = converter.CanConvertTo(typeof(DirectoryPath));
+
+                Assert.True(result);
+            }
+
+            [Fact]
+            public void Should_Return_False_When_Source_Type_Is_Not_DirectoryPath()
+            {
+                var converter = new DirectoryPathConverter();
+
+                var result = converter.CanConvertTo(typeof(DateTime));
+
+                Assert.False(result);
+            }
+        }
+
+        public sealed class TheConvertToMethod
+        {
+            [Fact]
+            public void Should_Convert_Directory_Path_To_String_Value_Using_FullPath()
+            {
+                var converter = new DirectoryPathConverter();
+
+                var result = converter.ConvertTo(DirectoryPath.FromString("c:/data/work"), typeof(string));
+
+                Assert.IsType<string>(result);
+                Assert.Equal("c:/data/work", result);
+            }
+
+            [Fact]
+            public void Should_Throw_NotSupportedException_When_Destination_Type_Is_Not_String()
+            {
+                var converter = new DirectoryPathConverter();
+
+                var result = Record.Exception(() =>
+                    converter.ConvertTo(DirectoryPath.FromString("c:/data/work"), typeof(DateTime)));
+
+                Assert.IsType<NotSupportedException>(result);
+            }
+        }
+    }
+}

--- a/src/Cake.Core.Tests/Unit/IO/FilePathConverterTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/FilePathConverterTests.cs
@@ -1,0 +1,118 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Core.IO;
+using Xunit;
+
+namespace Cake.Core.Tests.Unit.IO
+{
+    public sealed class FilePathConverterTests
+    {
+        public sealed class TheCanConvertFromMethod
+        {
+            [Fact]
+            public void Should_Return_True_When_Source_Type_Is_String()
+            {
+                var converter = new FilePathConverter();
+
+                var result = converter.CanConvertFrom(typeof(string));
+
+                Assert.True(result);
+            }
+
+            [Fact]
+            public void Should_Return_False_When_Source_Type_Is_Not_String()
+            {
+                var converter = new FilePathConverter();
+
+                var result = converter.CanConvertFrom(typeof(DateTime));
+
+                Assert.False(result);
+            }
+        }
+
+        public sealed class TheConvertFromMethod
+        {
+            [Fact]
+            public void Should_Convert_String_Value_To_File_Path()
+            {
+                var converter = new FilePathConverter();
+
+                var result = converter.ConvertFrom("c:/data/work/file.txt");
+
+                Assert.IsType<FilePath>(result);
+                Assert.Equal("c:/data/work/file.txt", ((FilePath)result).FullPath);
+            }
+
+            [Fact]
+            public void Should_Throw_NotSupportedException_When_Value_Is_Not_A_Valid_File_Path()
+            {
+                var converter = new FilePathConverter();
+
+                var result = Record.Exception(() => converter.ConvertFrom(DateTime.Now));
+
+                Assert.IsType<NotSupportedException>(result);
+            }
+        }
+
+        public sealed class TheCanConvertToMethod
+        {
+            [Fact]
+            public void Should_Return_True_When_Destination_Type_Is_String()
+            {
+                var converter = new FilePathConverter();
+
+                var result = converter.CanConvertTo(typeof(string));
+
+                Assert.True(result);
+            }
+
+            [Fact]
+            public void Should_Return_True_When_Destination_Type_Is_FilePath()
+            {
+                var converter = new FilePathConverter();
+
+                var result = converter.CanConvertTo(typeof(FilePath));
+
+                Assert.True(result);
+            }
+
+            [Fact]
+            public void Should_Return_False_When_Source_Type_Is_Not_FilePath()
+            {
+                var converter = new FilePathConverter();
+
+                var result = converter.CanConvertTo(typeof(DateTime));
+
+                Assert.False(result);
+            }
+        }
+
+        public sealed class TheConvertToMethod
+        {
+            [Fact]
+            public void Should_Convert_File_Path_To_String_Value_Using_FullPath()
+            {
+                var converter = new FilePathConverter();
+
+                var result = converter.ConvertTo(FilePath.FromString("c:/data/work/file.txt"), typeof(string));
+
+                Assert.IsType<string>(result);
+                Assert.Equal("c:/data/work/file.txt", result);
+            }
+
+            [Fact]
+            public void Should_Throw_NotSupportedException_When_Destination_Type_Is_Not_String()
+            {
+                var converter = new FilePathConverter();
+
+                var result = Record.Exception(() =>
+                    converter.ConvertTo(FilePath.FromString("c:/data/work/file.txt"), typeof(DateTime)));
+
+                Assert.IsType<NotSupportedException>(result);
+            }
+        }
+    }
+}

--- a/src/Cake.Core/IO/DirectoryPath.cs
+++ b/src/Cake.Core/IO/DirectoryPath.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.ComponentModel;
 using System.Linq;
 
 namespace Cake.Core.IO
@@ -10,6 +11,7 @@ namespace Cake.Core.IO
     /// <summary>
     /// Represents a directory path.
     /// </summary>
+    [TypeConverter(typeof(DirectoryPathConverter))]
     public sealed class DirectoryPath : Path
     {
         /// <summary>

--- a/src/Cake.Core/IO/DirectoryPathConverter.cs
+++ b/src/Cake.Core/IO/DirectoryPathConverter.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace Cake.Core.IO
+{
+    /// <summary>
+    /// A type converter for <see cref="DirectoryPath"/>.
+    /// </summary>
+    public sealed class DirectoryPathConverter : TypeConverter
+    {
+        /// <inheritdoc/>
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+        }
+
+        /// <inheritdoc/>
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is string stringValue)
+            {
+                return new DirectoryPath(stringValue);
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
+
+        /// <inheritdoc/>
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            return destinationType == typeof(DirectoryPath) || base.CanConvertTo(context, destinationType);
+        }
+
+        /// <inheritdoc/>
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == typeof(string) && value is DirectoryPath directoryPathValue)
+            {
+                return directoryPathValue.FullPath;
+            }
+
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+    }
+}

--- a/src/Cake.Core/IO/FilePath.cs
+++ b/src/Cake.Core/IO/FilePath.cs
@@ -3,12 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.ComponentModel;
 
 namespace Cake.Core.IO
 {
     /// <summary>
     /// Represents a file path.
     /// </summary>
+    [TypeConverter(typeof(FilePathConverter))]
     public sealed class FilePath : Path
     {
         /// <summary>

--- a/src/Cake.Core/IO/FilePathConverter.cs
+++ b/src/Cake.Core/IO/FilePathConverter.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace Cake.Core.IO
+{
+    /// <summary>
+    /// A type converter for <see cref="FilePath"/>.
+    /// </summary>
+    public sealed class FilePathConverter : TypeConverter
+    {
+        /// <inheritdoc/>
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+        }
+
+        /// <inheritdoc/>
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is string stringValue)
+            {
+                return new FilePath(stringValue);
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
+
+        /// <inheritdoc/>
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            return destinationType == typeof(FilePath) || base.CanConvertTo(context, destinationType);
+        }
+
+        /// <inheritdoc/>
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == typeof(string) && value is FilePath filePathValue)
+            {
+                return filePathValue.FullPath;
+            }
+
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+    }
+}

--- a/src/Cake.Frosting/Internal/Commands/DefaultCommandSettings.cs
+++ b/src/Cake.Frosting/Internal/Commands/DefaultCommandSettings.cs
@@ -18,7 +18,7 @@ namespace Cake.Frosting.Internal
         public string Target { get; set; }
 
         [CommandOption("--working|-w <PATH>")]
-        [TypeConverter(typeof(DirectoryPathConverter))]
+        [TypeConverter(typeof(Cli.DirectoryPathConverter))]
         [Description("Sets the working directory")]
         public DirectoryPath WorkingDirectory { get; set; }
 

--- a/src/Cake/Commands/DefaultCommandSettings.cs
+++ b/src/Cake/Commands/DefaultCommandSettings.cs
@@ -14,7 +14,7 @@ namespace Cake.Commands
     {
         [CommandArgument(0, "[SCRIPT]")]
         [Description("The Cake script. Defaults to [grey]build.cake[/]")]
-        [TypeConverter(typeof(FilePathConverter))]
+        [TypeConverter(typeof(Cli.FilePathConverter))]
         [DefaultValue("build.cake")]
         public FilePath Script { get; set; }
 

--- a/src/Cake/Program.cs
+++ b/src/Cake/Program.cs
@@ -81,7 +81,7 @@ namespace Cake
             var builder = new ContainerBuilder();
 
             // Converters
-            builder.RegisterType<FilePathConverter>();
+            builder.RegisterType<Cli.FilePathConverter>();
             builder.RegisterType<VerbosityConverter>();
 
             // Utilities

--- a/tests/integration/Cake.Common/ArgumentAliases.cake
+++ b/tests/integration/Cake.Common/ArgumentAliases.cake
@@ -53,6 +53,38 @@ Task("Cake.Common.ArgumentAliases.Argument.MultipleArguments")
     Assert.Equal(new[] {"a", "b"}, arg);
 });
 
+Task("Cake.Common.ArgumentAliases.Argument.DirectoryPathArgument")
+    .Does(() =>
+{
+    // Given, When
+    var arg = Argument<DirectoryPath>("testAssemblyDirectoryPath");
+
+    // Then
+    Assert.Equal(Context.Environment.ApplicationRoot.FullPath, arg.FullPath);
+});
+
+Task("Cake.Common.ArgumentAliases.Argument.FilePathArgument")
+    .Does(() =>
+{
+    // Given
+    var testAssemblyPath = Context
+                            .Environment
+                            .ApplicationRoot
+                            .CombineWithFilePath(
+#if NETCOREAPP
+                                "Cake.dll"
+#else
+                                "Cake.exe"
+#endif
+                            );
+
+    // When
+    var arg = Argument<FilePath>("testAssemblyFilePath");
+
+    // Then
+    Assert.Equal(testAssemblyPath.FullPath, arg.FullPath);
+});
+
 //////////////////////////////////////////////////////////////////////////////
 
 Task("Cake.Common.ArgumentAliases")
@@ -60,4 +92,7 @@ Task("Cake.Common.ArgumentAliases")
   .IsDependentOn("Cake.Common.ArgumentAliases.HasArgument.ThatDoNotExist")
   .IsDependentOn("Cake.Common.ArgumentAliases.Argument")
   .IsDependentOn("Cake.Common.ArgumentAliases.Argument.WithDefaultValue")
-  .IsDependentOn("Cake.Common.ArgumentAliases.Argument.MultipleArguments");
+  .IsDependentOn("Cake.Common.ArgumentAliases.Argument.MultipleArguments")
+  .IsDependentOn("Cake.Common.ArgumentAliases.Argument.DirectoryPathArgument")
+  .IsDependentOn("Cake.Common.ArgumentAliases.Argument.FilePathArgument")
+;


### PR DESCRIPTION
Add support for using `DirectoryPath` and `FilePath` types directly when reading arguments passed to the Cake build.

eg.

```csharp
var outputFolder = Argument<DirectoryPath>("outputFolder");
var logFile = Argument<FilePath>("logFile");
```

---

Closes #2168
