### PR TITLE
GH2654: Add Support for TestParams flag in NUnit3

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/NUnit/NUnit3RunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/NUnit/NUnit3RunnerTests.cs
@@ -244,6 +244,12 @@ namespace Cake.Common.Tests.Unit.Tools.NUnit
                     ["two"] = "2",
                     ["three"] = "3"
                 };
+                fixture.Settings.TestParams = new Dictionary<string, string>
+                {
+                    ["uno"] = "1",
+                    ["dos"] = "2",
+                    ["tres"] = "3"
+                };
 
                 // When
                 var result = fixture.Run();
@@ -262,7 +268,10 @@ namespace Cake.Common.Tests.Unit.Tools.NUnit
                         "\"--configfile=/Working/app.config\" " +
                         "\"--params=one=1\" " +
                         "\"--params=two=2\" " +
-                        "\"--params=three=3\"", result.Args);
+                        "\"--params=three=3\" " +
+                        "\"--testparam:uno=1\" " +
+                        "\"--testparam:dos=2\" " +
+                        "\"--testparam:tres=3\"", result.Args);
             }
 
             [Fact]

--- a/src/Cake.Common/Tools/NUnit/NUnit3Runner.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnit3Runner.cs
@@ -220,6 +220,14 @@ namespace Cake.Common.Tools.NUnit
                 }
             }
 
+            if (settings.TestParams != null && settings.TestParams.Count > 0)
+            {
+                foreach (var testParam in settings.TestParams)
+                {
+                    builder.AppendQuoted(string.Format(CultureInfo.InvariantCulture, "--testparam:{0}={1}", testParam.Key, testParam.Value));
+                }
+            }
+
             return builder;
         }
 

--- a/src/Cake.Common/Tools/NUnit/NUnit3Settings.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnit3Settings.cs
@@ -237,6 +237,16 @@ namespace Cake.Common.Tools.NUnit
             new Dictionary<string, string>(StringComparer.Ordinal);
 
         /// <summary>
+        /// Gets or sets the test parameters that should be passed to the runner.
+        /// </summary>
+        /// <value>
+        /// List of test parameters (key/value) which are passed to the runner.
+        /// </value>
+        public IDictionary<string, string> TestParams { get; set; } =
+            // “Case-sensitive.” https://github.com/nunit/docs/wiki/Console-Command-Line#options
+            new Dictionary<string, string>(StringComparer.Ordinal);
+
+        /// <summary>
         /// Gets or sets the level of detail at which the runner should write to its internal trace log.
         /// Corresponds to the -trace=LEVEL command line argument.
         /// If <c>null</c>, no argument will be specified.


### PR DESCRIPTION
Resolves #2654.

I wasn't sure if it was better to add TestParams as its own property, or to convert the Params to the new `--testparam:key=value` syntax in NUnit v3.10+. I opted for creating a new property so that we have support for both, but am willing to change to converting the output if that's deemed better. 

As it stands, the only issue that I can see with this is that we might make it confusing to allow both, but this was allows us to support multiple versions of the runner, and lets Cake scripts migrate as they're ready (for now) without any breaking changes.