### PR TITLE
GH3316: Bump NuGet command-line tool

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -7,7 +7,7 @@
 #tool "nuget:https://api.nuget.org/v3/index.json?package=coveralls.io&version=1.4.2"
 #tool "nuget:https://api.nuget.org/v3/index.json?package=OpenCover&version=4.7.922"
 #tool "nuget:https://api.nuget.org/v3/index.json?package=ReportGenerator&version=4.7.1"
-#tool "nuget:https://api.nuget.org/v3/index.json?package=NuGet.CommandLine&version=5.8.1"
+#tool "nuget:https://api.nuget.org/v3/index.json?package=NuGet.CommandLine&version=5.9.1"
 
 // Install .NET Core Global tools.
 #tool "dotnet:https://api.nuget.org/v3/index.json?package=GitVersion.Tool&version=5.1.2"

--- a/tests/integration/Cake.Common/Tools/NuGet/NuGetAliases.cake
+++ b/tests/integration/Cake.Common/Tools/NuGet/NuGetAliases.cake
@@ -1,4 +1,4 @@
-#tool "nuget:https://api.nuget.org/v3/index.json?package=NuGet.CommandLine&version=5.8.1"
+#tool "nuget:https://api.nuget.org/v3/index.json?package=NuGet.CommandLine&version=5.9.1"
 #load "./../../../utilities/xunit.cake"
 #load "./../../../utilities/paths.cake"
 


### PR DESCRIPTION
Following up from #3317; [NuGet.CommandLine](https://www.nuget.org/packages/NuGet.CommandLine/) v5.9.1 is finally available so we can use the same version everywhere.