### PR TITLE
setup useToolVersion override

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsExtensionsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsExtensionsTests.cs
@@ -67,6 +67,55 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 // Then
                 Assert.Equal(settings, result);
             }
+
+            [Fact]
+            public void Should_Set_Tool_Version_FromStringOverride()
+            {
+                // Given
+                var settings = new MSBuildSettings();
+
+                // When
+                settings.UseToolVersion("net20");
+
+                // Then
+                Assert.Equal(MSBuildToolVersion.NET20, settings.ToolVersion);
+            }
+
+            [Fact]
+            public void Should_Return_The_Same_Configuration_FromStringOverride()
+            {
+                // Given
+                var settings = new MSBuildSettings();
+
+                // When
+                var result = settings.UseToolVersion("net35");
+
+                // Then
+                Assert.Equal(settings, result);
+            }
+
+            [Fact]
+            public void Should_ThrowArgumetnException_When_String_Is_Null()
+            {
+                // Given
+                var settings = new MSBuildSettings();
+
+                // Then
+                Assert.Throws<System.ArgumentException>(() => settings.UseToolVersion(null));
+            }
+
+            [Fact]
+            public void Should_Return_Default_When_Input_Is_Bad()
+            {
+                // Given
+                var settings = new MSBuildSettings();
+
+                // When
+                settings.UseToolVersion("fjaldskjflaksdjflkas");
+
+                // Then
+                Assert.Equal(MSBuildToolVersion.Default, settings.ToolVersion);
+            }
         }
 
         public sealed class TheSetPlatformTargetMethod

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsExtensionsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildSettingsExtensionsTests.cs
@@ -116,6 +116,30 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 // Then
                 Assert.Equal(MSBuildToolVersion.Default, settings.ToolVersion);
             }
+
+            [Fact]
+            public void Should_Return_VSCustom_When_VsVersion_CantBeMatch()
+            {
+                var settings = new MSBuildSettings();
+
+                // When
+                settings.UseToolVersion("2022");
+
+                // Then
+                Assert.Equal(MSBuildToolVersion.VSCustom, settings.ToolVersion);
+            }
+
+            [Fact]
+            public void Should_Return_VSCustom_When_NETFramework_CantBeMatch()
+            {
+                var settings = new MSBuildSettings();
+
+                // When
+                settings.UseToolVersion("5");
+
+                // Then
+                Assert.Equal(MSBuildToolVersion.NETCustom, settings.ToolVersion);
+            }
         }
 
         public sealed class TheSetPlatformTargetMethod

--- a/src/Cake.Common/Tools/MSBuild/MSBuildResolver.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildResolver.cs
@@ -10,7 +10,7 @@ namespace Cake.Common.Tools.MSBuild
 {
     internal static class MSBuildResolver
     {
-        public static FilePath GetMSBuildPath(IFileSystem fileSystem, ICakeEnvironment environment, MSBuildToolVersion version, MSBuildPlatform buildPlatform)
+        public static FilePath GetMSBuildPath(IFileSystem fileSystem, ICakeEnvironment environment, MSBuildToolVersion version, MSBuildPlatform buildPlatform, string customVersion)
         {
             if (environment.Platform.Family == PlatformFamily.OSX)
             {
@@ -44,7 +44,7 @@ namespace Cake.Common.Tools.MSBuild
 
             var binPath = version == MSBuildToolVersion.Default
                 ? GetHighestAvailableMSBuildVersion(fileSystem, environment, buildPlatform)
-                : GetMSBuildPath(fileSystem, environment, (MSBuildVersion)version, buildPlatform);
+                : GetMSBuildPath(fileSystem, environment, (MSBuildVersion)version, buildPlatform, customVersion);
 
             if (binPath == null)
             {
@@ -65,12 +65,12 @@ namespace Cake.Common.Tools.MSBuild
                 MSBuildVersion.MSBuild12,
                 MSBuildVersion.MSBuild4,
                 MSBuildVersion.MSBuild35,
-                MSBuildVersion.MSBuild20
+                MSBuildVersion.MSBuild20,
             };
 
             foreach (var version in versions)
             {
-                var path = GetMSBuildPath(fileSystem, environment, version, buildPlatform);
+                var path = GetMSBuildPath(fileSystem, environment, version, buildPlatform, null);
                 if (fileSystem.Exist(path))
                 {
                     return path;
@@ -79,7 +79,7 @@ namespace Cake.Common.Tools.MSBuild
             return null;
         }
 
-        private static DirectoryPath GetMSBuildPath(IFileSystem fileSystem, ICakeEnvironment environment, MSBuildVersion version, MSBuildPlatform buildPlatform)
+        private static DirectoryPath GetMSBuildPath(IFileSystem fileSystem, ICakeEnvironment environment, MSBuildVersion version, MSBuildPlatform buildPlatform, string customVersion)
         {
             switch (version)
             {
@@ -91,12 +91,20 @@ namespace Cake.Common.Tools.MSBuild
                     return GetVisualStudioPath(environment, buildPlatform, "14.0");
                 case MSBuildVersion.MSBuild12:
                     return GetVisualStudioPath(environment, buildPlatform, "12.0");
+                case MSBuildVersion.MSBuildCustomVS:
+                    return GetVisualStudioPath(environment, buildPlatform, customVersion);
                 case MSBuildVersion.MSBuild4:
                     return GetFrameworkPath(environment, buildPlatform, "v4.0.30319");
                 case MSBuildVersion.MSBuild35:
                     return GetFrameworkPath(environment, buildPlatform, "v3.5");
                 case MSBuildVersion.MSBuild20:
                     return GetFrameworkPath(environment, buildPlatform, "v2.0.50727");
+                case MSBuildVersion.MSBuildNETCustom:
+                    if (!customVersion.Contains("v"))
+                    {
+                        customVersion = "v" + customVersion;
+                    }
+                    return GetFrameworkPath(environment, buildPlatform, customVersion);
                 default:
                     return null;
             }

--- a/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
@@ -351,7 +351,7 @@ namespace Cake.Common.Tools.MSBuild
                 }
             }
 
-            var path = MSBuildResolver.GetMSBuildPath(_fileSystem, _environment, settings.ToolVersion, buildPlatform);
+            var path = MSBuildResolver.GetMSBuildPath(_fileSystem, _environment, settings.ToolVersion, buildPlatform, settings.CustomVersion);
             if (path != null)
             {
                 return new[] { path };

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
@@ -21,6 +21,7 @@ namespace Cake.Common.Tools.MSBuild
         private readonly HashSet<string> _warningsAsErrorCodes;
         private readonly HashSet<string> _warningsAsMessageCodes;
         private readonly HashSet<string> _consoleLoggerParameters;
+        internal string CustomVersion { get; set; }
 
         /// <summary>
         /// Gets the targets.

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
@@ -71,6 +71,7 @@ namespace Cake.Common.Tools.MSBuild
             {
                 settings.CustomVersion = version;
             }
+            settings.ToolVersion = mSBuildToolVersion;
             return settings;
         }
 
@@ -102,7 +103,6 @@ namespace Cake.Common.Tools.MSBuild
                 case "NET46": return MSBuildToolVersion.NET46;
                 case "4.5.2":
                 case "NET452": return MSBuildToolVersion.NET452;
-                case string dotNet when Regex.Match(dotNet, @"^[0-9,.]*$").Success: return MSBuildToolVersion.NETCustom;
                 case "2005":
                 case "VS2005": return MSBuildToolVersion.VS2005;
                 case "2008":
@@ -122,6 +122,7 @@ namespace Cake.Common.Tools.MSBuild
                 case "2019":
                 case "VS2019": return MSBuildToolVersion.VS2019;
                 case string vs when vs.Contains("VS") || Regex.Match(vs, @"\d{4}").Success: return MSBuildToolVersion.VSCustom;
+                case string dotNet when Regex.Match(dotNet, @"^[0-9,.]*$").Success: return MSBuildToolVersion.NETCustom;
                 default: return MSBuildToolVersion.Default;
             }
         }

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Cake.Core.Diagnostics;
 
 namespace Cake.Common.Tools.MSBuild
@@ -64,8 +65,12 @@ namespace Cake.Common.Tools.MSBuild
             {
                 throw new ArgumentException(nameof(version));
             }
-            version = version.Replace(" ", string.Empty);
-            settings.ToolVersion = GetMSBuildToolVersionFromString(version.ToUpper());
+            var sanitizeVersion = version.Replace(" ", string.Empty);
+            var mSBuildToolVersion = GetMSBuildToolVersionFromString(sanitizeVersion.ToUpper());
+            if (mSBuildToolVersion == MSBuildToolVersion.NETCustom || mSBuildToolVersion == MSBuildToolVersion.VSCustom)
+            {
+                settings.CustomVersion = version;
+            }
             return settings;
         }
 
@@ -97,6 +102,7 @@ namespace Cake.Common.Tools.MSBuild
                 case "NET46": return MSBuildToolVersion.NET46;
                 case "4.5.2":
                 case "NET452": return MSBuildToolVersion.NET452;
+                case string dotNet when Regex.Match(dotNet, @"^[0-9,.]*$").Success: return MSBuildToolVersion.NETCustom;
                 case "2005":
                 case "VS2005": return MSBuildToolVersion.VS2005;
                 case "2008":
@@ -115,6 +121,7 @@ namespace Cake.Common.Tools.MSBuild
                 case "VS2017": return MSBuildToolVersion.VS2017;
                 case "2019":
                 case "VS2019": return MSBuildToolVersion.VS2019;
+                case string vs when vs.Contains("VS") || Regex.Match(vs, @"\d{4}").Success: return MSBuildToolVersion.VSCustom;
                 default: return MSBuildToolVersion.Default;
             }
         }

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
@@ -47,6 +47,79 @@ namespace Cake.Common.Tools.MSBuild
         }
 
         /// <summary>
+        /// Sets the tool version.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="version">The string version.</param>
+        /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static MSBuildSettings UseToolVersion(this MSBuildSettings settings, string version)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            // check to see if the version is null/empty or is not a num
+            if (string.IsNullOrEmpty(version))
+            {
+                throw new ArgumentException(nameof(version));
+            }
+            version = version.Replace(" ", string.Empty);
+            settings.ToolVersion = GetMSBuildToolVersionFromString(version.ToUpper());
+            return settings;
+        }
+
+        /// <summary>
+        /// Helper that gets the MSBuildToolVersion from the version string.
+        /// </summary>
+        /// <param name="version">The string version.</param>
+        /// <returns>The matched MSBuildToolVersion enum <see cref="MSBuildToolVersion"/>.</returns>
+        private static MSBuildToolVersion GetMSBuildToolVersionFromString(string version)
+        {
+            switch (version)
+            {
+                case "2":
+                case "2.0":
+                case "NET20": return MSBuildToolVersion.NET20;
+                case "3":
+                case "3.0":
+                case "NET30": return MSBuildToolVersion.NET30;
+                case "3.5":
+                case "NET35": return MSBuildToolVersion.NET35;
+                case "4":
+                case "4.0":
+                case "NET40": return MSBuildToolVersion.NET40;
+                case "4.5":
+                case "NET45": return MSBuildToolVersion.NET45;
+                case "4.5.1":
+                case "NET451": return MSBuildToolVersion.NET451;
+                case "4.6":
+                case "NET46": return MSBuildToolVersion.NET46;
+                case "4.5.2":
+                case "NET452": return MSBuildToolVersion.NET452;
+                case "2005":
+                case "VS2005": return MSBuildToolVersion.VS2005;
+                case "2008":
+                case "VS2008": return MSBuildToolVersion.VS2008;
+                case "2010":
+                case "VS2010": return MSBuildToolVersion.VS2010;
+                case "2011":
+                case "VS2011": return MSBuildToolVersion.VS2011;
+                case "2012":
+                case "VS2012": return MSBuildToolVersion.VS2011;
+                case "2013":
+                case "VS2013": return MSBuildToolVersion.VS2013;
+                case "2015":
+                case "VS2015": return MSBuildToolVersion.VS2015;
+                case "2017":
+                case "VS2017": return MSBuildToolVersion.VS2017;
+                case "2019":
+                case "VS2019": return MSBuildToolVersion.VS2019;
+                default: return MSBuildToolVersion.Default;
+            }
+        }
+
+        /// <summary>
         /// Sets the platform target.
         /// </summary>
         /// <param name="settings">The settings.</param>

--- a/src/Cake.Common/Tools/MSBuild/MSBuildToolVersion.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildToolVersion.cs
@@ -97,6 +97,16 @@ namespace Cake.Common.Tools.MSBuild
         /// <summary>
         /// MSBuild tool version: <c>Visual Studio 2019</c>
         /// </summary>
-        VS2019 = 7
+        VS2019 = 7,
+
+        /// <summary>
+        /// Custom Visual Studio build
+        /// </summary>
+        VSCustom = 8,
+
+        /// <summary>
+        /// Custom Visual Studio build
+        /// </summary>
+        NETCustom = 9
     }
 }

--- a/src/Cake.Common/Tools/MSBuild/MSBuildVersion.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildVersion.cs
@@ -28,6 +28,16 @@ namespace Cake.Common.Tools.MSBuild
         MSBuild15 = 6,
 
         /// <summary>Version 16.0</summary>
-        MSBuild16 = 7
+        MSBuild16 = 7,
+
+        /// <summary>
+        /// Custom VS Version
+        /// </summary>
+        MSBuildCustomVS = 8,
+
+        /// <summary>
+        /// Custom .NET Version
+        /// </summary>
+        MSBuildNETCustom = 9
     }
 }


### PR DESCRIPTION
Added override for UseToolVersion method to take in a string param also added a helper method to map said string to the correct MSBuildToolVersion enum. It's a little big since I wasn't sure on what type of string we should expect. 
https://github.com/cake-build/cake/issues/3237

This is my first time contributing to a open source project so apologies for any mistakes with the process 