### PR TITLE
Fixes#3291: Add target argument to cake.frosting arguments list

### DIFF
--- a/src/Cake.Frosting.Tests/CakeHostTests.cs
+++ b/src/Cake.Frosting.Tests/CakeHostTests.cs
@@ -313,5 +313,22 @@ namespace Cake.Frosting.Tests
             fixture.Installer.Received(1).Install(
                 Arg.Is<PackageReference>(p => p.OriginalString == "foo:?package=Bar"));
         }
+
+        [Fact]
+        public void Should_pass_target_within_cakeContext_arguments()
+        {
+            // Given
+            var fixture = new CakeHostFixture();
+            fixture.RegisterTask<DummyTask>();
+            fixture.Strategy = Substitute.For<IExecutionStrategy>();
+
+            // When
+            fixture.Run("--target", nameof(DummyTask));
+
+            // Then
+            fixture.Strategy
+                .Received(1)
+                .ExecuteAsync(Arg.Any<CakeTask>(), Arg.Is<ICakeContext>(cc => cc.Arguments.HasArgument("target") && cc.Arguments.GetArgument("target").Equals(nameof(DummyTask))));
+        }
     }
 }


### PR DESCRIPTION
Hello,

I added the "target" argument back to the cake arguments in Cake.Frosting for usage.
This should fix #3291.

What's the problem?
The target argument is not passed along in `Cake.Frosting` but in the `dotnet cake tool`. The difference is the `DefaultCommandSettings` object. `Cake.Frosting` specifies a "Target" property for the parsed arguments whereas the `dotnet cake tool` does not. And by specifying this property the used arguments `IRemainingArguments` do not contain the target argument since it has been parsed successfully.

What did I do?
To add the target argument back to the `CakeArguments` I need to manually add the target into the used `ILookup<String,String>` variable with the "true" remaining arguments.

