### PR TITLE
GH-2165: Add sources attribute to DotNetCoreBuildSettings

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Build/DotNetCoreBuilderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Build/DotNetCoreBuilderTests.cs
@@ -101,12 +101,13 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Build
                 fixture.Settings.NoLogo = true;
                 fixture.Project = "./src/*";
                 fixture.Settings.Verbosity = DotNetCoreVerbosity.Minimal;
+                fixture.Settings.Sources = new[] { "https://api.nuget.org/v3/index.json" };
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("build \"./src/*\" --runtime runtime1 --framework net451 --configuration Release --version-suffix rc1 --nologo --verbosity minimal", result.Args);
+                Assert.Equal("build \"./src/*\" --runtime runtime1 --framework net451 --configuration Release --version-suffix rc1 --nologo --source \"https://api.nuget.org/v3/index.json\" --verbosity minimal", result.Args);
             }
 
             [Fact]

--- a/src/Cake.Common/Tools/DotNetCore/Build/DotNetCoreBuildSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Build/DotNetCoreBuildSettings.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Core.IO;
 
@@ -64,6 +65,14 @@ namespace Cake.Common.Tools.DotNetCore.Build
         /// Available since .NET Core 3.0 SDK.
         /// </remarks>
         public bool NoLogo { get; set; }
+
+        /// <summary>
+        /// Gets or sets the specified NuGet package sources to use during the build.
+        /// </summary>
+        /// <remarks>
+        /// Requires .NET Core 2.x or newer.
+        /// </remarks>
+        public ICollection<string> Sources { get; set; } = new List<string>();
 
         /// <summary>
         /// Gets or sets additional arguments to be passed to MSBuild.

--- a/src/Cake.Common/Tools/DotNetCore/Build/DotNetCoreBuilder.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Build/DotNetCoreBuilder.cs
@@ -128,6 +128,16 @@ namespace Cake.Common.Tools.DotNetCore.Build
                 builder.AppendMSBuildSettings(settings.MSBuildSettings, _environment);
             }
 
+            // Sources
+            if (settings.Sources != null)
+            {
+                foreach (var source in settings.Sources)
+                {
+                    builder.Append("--source");
+                    builder.AppendQuoted(source);
+                }
+            }
+
             return builder;
         }
     }


### PR DESCRIPTION
Add sources .NET Core build parameter.

Close #2165