### PR TITLE
GH-3501: Add sources attribute to DotNetCorePackSettings

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Pack/DotNetCorePackerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Pack/DotNetCorePackerTests.cs
@@ -118,12 +118,13 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Pack
                 fixture.Settings.Serviceable = true;
                 fixture.Settings.Runtime = "win7-x86";
                 fixture.Settings.Verbosity = DotNetCoreVerbosity.Minimal;
+                fixture.Settings.Sources = new[] { "https://api.nuget.org/v3/index.json" };
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("pack --output \"/Working/artifacts\" --no-build --no-dependencies --no-restore --nologo --include-symbols -p:SymbolPackageFormat=snupkg --include-source --configuration Release --version-suffix rc1 --serviceable --runtime win7-x86 --verbosity minimal", result.Args);
+                Assert.Equal("pack --output \"/Working/artifacts\" --no-build --no-dependencies --no-restore --nologo --include-symbols -p:SymbolPackageFormat=snupkg --include-source --configuration Release --version-suffix rc1 --serviceable --runtime win7-x86 --source \"https://api.nuget.org/v3/index.json\" --verbosity minimal", result.Args);
             }
 
             [Fact]

--- a/src/Cake.Common/Tools/DotNetCore/Pack/DotNetCorePackSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Pack/DotNetCorePackSettings.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Core.IO;
 
@@ -86,6 +87,14 @@ namespace Cake.Common.Tools.DotNetCore.Pack
         /// Gets or sets the target runtime.
         /// </summary>
         public string Runtime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the specified NuGet package sources to use during the packing.
+        /// </summary>
+        /// <remarks>
+        /// Requires .NET Core 2.x or newer.
+        /// </remarks>
+        public ICollection<string> Sources { get; set; } = new List<string>();
 
         /// <summary>
         /// Gets or sets additional arguments to be passed to MSBuild.

--- a/src/Cake.Common/Tools/DotNetCore/Pack/DotNetCorePacker.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Pack/DotNetCorePacker.cs
@@ -136,6 +136,16 @@ namespace Cake.Common.Tools.DotNetCore.Pack
                 builder.Append(settings.Runtime);
             }
 
+            // Sources
+            if (settings.Sources != null)
+            {
+                foreach (var source in settings.Sources)
+                {
+                    builder.Append("--source");
+                    builder.AppendQuoted(source);
+                }
+            }
+
             if (settings.MSBuildSettings != null)
             {
                 builder.AppendMSBuildSettings(settings.MSBuildSettings, _environment);


### PR DESCRIPTION

Add sources attribute to DotNetCorePackSettings.

Close #3501 