### PR TITLE
GH-3065: Add DOTNET_ROLL_FORWARD setting to DotNetCoreSettings

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Run/DotNetCoreRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Run/DotNetCoreRunnerTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Cake.Common.Tests.Fixtures.Tools.DotNetCore.Run;
+using Cake.Common.Tools.DotNetCore;
 using Cake.Testing;
 using Xunit;
 
@@ -94,12 +95,13 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Run
                 fixture.Settings.Configuration = "Release";
                 fixture.Settings.Runtime = "win7-x86";
                 fixture.Settings.Sources = new[] { "https://api.nuget.org/v3/index.json" };
+                fixture.Settings.RollForward = DotNetCoreRollForward.Major;
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("run --framework dnxcore50 --configuration Release --runtime win7-x86 --source \"https://api.nuget.org/v3/index.json\"", result.Args);
+                Assert.Equal("run --framework dnxcore50 --configuration Release --runtime win7-x86 --source \"https://api.nuget.org/v3/index.json\" --roll-forward Major", result.Args);
             }
 
             [Fact]
@@ -114,6 +116,26 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Run
 
                 // Then
                 Assert.Equal("--diagnostics run", result.Args);
+            }
+
+            [Theory]
+            [InlineData(DotNetCoreRollForward.Minor, "run --roll-forward Minor")]
+            [InlineData(DotNetCoreRollForward.LatestPatch, "run --roll-forward LatestPatch")]
+            [InlineData(DotNetCoreRollForward.Major, "run --roll-forward Major")]
+            [InlineData(DotNetCoreRollForward.LatestMinor, "run --roll-forward LatestMinor")]
+            [InlineData(DotNetCoreRollForward.LatestMajor, "run --roll-forward LatestMajor")]
+            [InlineData(DotNetCoreRollForward.Disable, "run --roll-forward Disable")]
+            public void Should_Add_RollForward_Arguments(DotNetCoreRollForward rollForward, string expected)
+            {
+                // Given
+                var fixture = new DotNetCoreRunnerFixture();
+                fixture.Settings.RollForward = rollForward;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
             }
         }
     }

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreRollForward.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreRollForward.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Tools.DotNetCore
+{
+    /// <summary>
+    /// Contains the roll forward policy to be used.
+    /// </summary>
+    public enum DotNetCoreRollForward
+    {
+        /// <summary>
+        /// Roll forward to the lowest higher minor version, if requested minor version is missing.
+        /// </summary>
+        Minor,
+
+        /// <summary>
+        /// Roll forward to the highest patch version. This disables minor version roll forward.
+        /// </summary>
+        LatestPatch,
+
+        /// <summary>
+        /// Roll forward to lowest higher major version, and lowest minor version, if requested major version is missing.
+        /// </summary>
+        Major,
+
+        /// <summary>
+        /// Roll forward to highest minor version, even if requested minor version is present.
+        /// </summary>
+        LatestMinor,
+
+        /// <summary>
+        /// Roll forward to highest major and highest minor version, even if requested major is present.
+        /// </summary>
+        LatestMajor,
+
+        /// <summary>
+        /// Don't roll forward. Only bind to specified version.
+        /// </summary>
+        Disable,
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreSettings.cs
@@ -20,5 +20,10 @@ namespace Cake.Common.Tools.DotNetCore
         /// Gets or sets a value indicating whether to not enable diagnostic output.
         /// </summary>
         public bool DiagnosticOutput { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dotnet roll forward policy.
+        /// </summary>
+        public DotNetCoreRollForward? RollForward { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/Run/DotNetCoreRunner.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Run/DotNetCoreRunner.cs
@@ -101,6 +101,13 @@ namespace Cake.Common.Tools.DotNetCore.Run
                 }
             }
 
+            // Roll Forward Policy
+            if (!(settings.RollForward is null))
+            {
+                builder.Append("--roll-forward");
+                builder.Append(settings.RollForward.Value.ToString("F"));
+            }
+
             // Arguments
             if (!arguments.IsNullOrEmpty())
             {


### PR DESCRIPTION
Add DOTNET_ROLL_FORWARD setting to DotNetCoreSettings
Closes #3065 