### PR TITLE
GH3515: added NuGet.org.md as a "readme" for NuGet.org

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -196,6 +196,10 @@ Task("Copy-Files")
     // Copy icon
     CopyFileToDirectory("./nuspec/cake-medium.png", parameters.Paths.Directories.ArtifactsBinFullFx);
     CopyFileToDirectory("./nuspec/cake-medium.png", parameters.Paths.Directories.ArtifactsBinNetCore);
+
+    // copy NuGet.org-specific ReadMe
+    CopyFileToDirectory("./nuspec/NuGet.org.md", parameters.Paths.Directories.ArtifactsBinFullFx);
+    CopyFileToDirectory("./nuspec/NuGet.org.md", parameters.Paths.Directories.ArtifactsBinNetCore);
 });
 
 Task("Validate-Version")

--- a/nuspec/Cake.CoreCLR.nuspec
+++ b/nuspec/Cake.CoreCLR.nuspec
@@ -14,6 +14,7 @@
     <repository type="git" url="https://github.com/cake-build/cake"/>
     <copyright>Copyright (c) .NET Foundation and contributors</copyright>
     <tags>Cake Script Build</tags>
+    <readme>NuGet.org.md</readme>
   </metadata>
   <files>
   </files>

--- a/nuspec/Cake.nuspec
+++ b/nuspec/Cake.nuspec
@@ -14,6 +14,7 @@
     <repository type="git" url="https://github.com/cake-build/cake"/>
     <copyright>Copyright (c) .NET Foundation and contributors</copyright>
     <tags>Cake Script Build</tags>
+    <readme>NuGet.org.md</readme>
   </metadata>
   <files>
   </files>

--- a/nuspec/NuGet.org.md
+++ b/nuspec/NuGet.org.md
@@ -1,0 +1,74 @@
+﻿# Cake
+
+Cake (C# Make) is a build automation system with a C# DSL to do things like compiling code, copy files/folders, running unit tests, compress files and build NuGet packages.
+
+## Table of Contents
+
+1. [Documentation](https://github.com/cake-build/cake#documentation)
+2. [Contributing](https://github.com/cake-build/cake#contributing)
+3. [Get in touch](https://github.com/cake-build/cake#get-in-touch)
+4. [License](https://github.com/cake-build/cake#license)
+
+## Documentation
+
+You can read the latest documentation at [https://cakebuild.net/](https://cakebuild.net/).
+
+For a simple example to get started see [Setting up a new project](https://cakebuild.net/docs/getting-started/setting-up-a-new-project).
+
+## Contributing
+
+So you’re thinking about contributing to Cake? Great! It’s **really** appreciated.
+
+Make sure you've read the [contribution guidelines](https://cakebuild.net/docs/contributing/contribution-guidelines) before sending that epic pull request. You'll also need to sign the [contribution license agreement](https://cla.dotnetfoundation.org/cake-build/cake) (CLA) for anything other than a trivial change.  **NOTE:** The .NET Foundation CLA Bot will provide a link to this CLA within the PR that you submit if it is deemed as required.
+
+* Fork the repository.
+* Create a branch to work in.
+* Make your feature addition or bug fix.
+* Don't forget the unit tests.
+* Send a pull request.
+
+## Get in touch
+
+[![Follow @cakebuildnet](https://img.shields.io/badge/Twitter-Follow%20%40cakebuildnet-blue.svg)](https://twitter.com/intent/follow?screen_name=cakebuildnet)
+
+[![Join the chat at https://github.com/cake-build/cake/discussions](https://img.shields.io/badge/discussions-join%20chat-brightgreen)](https://github.com/cake-build/cake/discussions?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+## License
+
+Copyright © .NET Foundation, Patrik Svensson, Mattias Karlsson, Gary Ewan Park, Alistair Chapman, Martin Björkström, Dave Glick, Pascal Berger, Jérémie Desautels, Enrico Campidoglio, C. Augusto Proiete, Nils Andresen, and contributors.
+
+Cake is provided as-is under the MIT license. For more information see [LICENSE](https://github.com/cake-build/cake/blob/develop/LICENSE).
+
+* For Roslyn, see https://github.com/dotnet/roslyn/blob/master/License.txt
+* For Autofac, see https://github.com/autofac/Autofac/blob/master/LICENSE
+* For NuGet.Core, see https://github.com/NuGet/Home/blob/dev/LICENSE.txt
+
+## Thanks
+
+A big thank you has to go to [JetBrains](https://www.jetbrains.com) who provide each of the Cake Developers with an [Open Source License](https://www.jetbrains.com/community/opensource/#support) for [ReSharper](https://www.jetbrains.com/resharper/) that helps with the development of Cake.
+
+### Sponsors
+
+Our wonderful sponsors:
+
+[![Sponsors](https://opencollective.com/cake/sponsors.svg)](https://opencollective.com/cake)
+
+### Backers
+
+Our wonderful backers:
+
+[![Backers](https://opencollective.com/cake/backers.svg)](https://opencollective.com/cake)
+
+## Code of Conduct
+
+This project has adopted the code of conduct defined by the [Contributor Covenant](http://contributor-covenant.org/)
+to clarify expected behavior in our community.
+For more information see the [.NET Foundation Code of Conduct](http://www.dotnetfoundation.org/code-of-conduct).
+
+## Contribution License Agreement
+
+By signing the [CLA](https://cla.dotnetfoundation.org/cake-build/cake), the community is free to use your contribution to .NET Foundation projects.
+
+## .NET Foundation
+
+This project is supported by the [.NET Foundation](http://www.dotnetfoundation.org).

--- a/src/Cake.DotNetTool.Module/Cake.DotNetTool.Module.csproj
+++ b/src/Cake.DotNetTool.Module/Cake.DotNetTool.Module.csproj
@@ -19,6 +19,17 @@
 
   <!-- Import shared functionality -->
   <Import Project="..\Shared.msbuild" />
+  
+  <!-- 
+  Cake.DotNetTool.Module ships a snupkg and hence can not currently
+  add  PackageReadmeFile - see https://github.com/NuGet/Home/issues/10791
+  This block can be removed when building is done soely using
+  .NET 6 RC2 or later.
+  -->
+  <PropertyGroup>
+    <PackageReadmeFile></PackageReadmeFile>
+  </PropertyGroup>
+   
   <!-- Project references -->
   <ItemGroup>
     <ProjectReference Include="..\Cake.Core\Cake.Core.csproj" />

--- a/src/Shared.msbuild
+++ b/src/Shared.msbuild
@@ -12,6 +12,7 @@
     <PackageTags>Cake;Script;Build</PackageTags>
     <PackageProjectUrl>https://cakebuild.net</PackageProjectUrl>
     <LangVersion>8.0</LangVersion>
+    <PackageReadmeFile>NuGet.org.md</PackageReadmeFile>
   </PropertyGroup>
 
   <!-- Define .NET Core constants -->
@@ -26,6 +27,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)SolutionInfo.cs" />
     <None Include="../../LICENSE" Pack="true" PackagePath="$(PackageLicenseFile)"/>
     <None Include="../../nuspec/cake-medium.png" Pack="true" PackagePath=""/>
+    <None Include="../../nuspec/NuGet.org.md" Pack="true" PackagePath=""/>
   </ItemGroup>
 
   <!-- Warnings as errors -->


### PR DESCRIPTION
and added it to all packages, except Cake.Cake.DotNetTool.Module.

This first version is a copy of the current README.md with only
non-working images removed, as they won't be rendered on
NuGet.org. (Namely this was the build-status and coverage sections.)

