### PR TITLE
GH3519: Update Spectre.Console to 0.42.0

### DIFF
--- a/src/Cake.Cli/Cake.Cli.csproj
+++ b/src/Cake.Cli/Cake.Cli.csproj
@@ -20,6 +20,6 @@
 
     <ItemGroup>
       <PackageReference Include="Autofac" Version="6.2.0" />
-      <PackageReference Include="Spectre.Console" Version="0.41.0" />
+      <PackageReference Include="Spectre.Console" Version="0.42.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* Fixes #3519
