### PR TITLE
GH-2075: Modify alias DotNetCoreNuGetPush to allow using string or FilePath

### DIFF
--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -864,25 +864,29 @@ namespace Cake.Common.Tools.DotNetCore
         /// Pushes one or more packages to a server.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="packageName">Name of package to push.</param>
+        /// <param name="packageFilePath"><see cref="FilePath"/> with the name of package to push.</param>
         /// <example>
         /// <code>
-        /// DotNetCoreNuGetPush("*.nupkg");
+        /// // With FilePath instance
+        /// var packageFilePath = GetFiles("*.nupkg").Single();
+        /// DotNetCoreNuGetPush(packageFilePath);
+        /// // With string parameter
+        /// DotNetCoreNuGetPush("foo*.nupkg");
         /// </code>
         /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("NuGet")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Push")]
-        public static void DotNetCoreNuGetPush(this ICakeContext context, string packageName)
+        public static void DotNetCoreNuGetPush(this ICakeContext context, FilePath packageFilePath)
         {
-            context.DotNetCoreNuGetPush(packageName, null);
+            context.DotNetCoreNuGetPush(packageFilePath, null);
         }
 
         /// <summary>
         /// Pushes one or more packages to a server using the specified settings.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="packageName">Name of package to push.</param>
+        /// <param name="packageFilePath"><see cref="FilePath"/> with the name of package to push.</param>
         /// <param name="settings">The settings.</param>
         /// <example>
         /// <code>
@@ -891,14 +895,17 @@ namespace Cake.Common.Tools.DotNetCore
         ///     Source = "https://www.example.com/nugetfeed",
         ///     ApiKey = "4003d786-cc37-4004-bfdf-c4f3e8ef9b3a"
         /// };
-        ///
+        /// // With FilePath instance
+        /// var packageFilePath = GetFiles("foo*.nupkg").Single();
+        /// DotNetCoreNuGetPush(packageFilePath);
+        /// // With string parameter
         /// DotNetCoreNuGetPush("foo*.nupkg", settings);
         /// </code>
         /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("NuGet")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Push")]
-        public static void DotNetCoreNuGetPush(this ICakeContext context, string packageName, DotNetCoreNuGetPushSettings settings)
+        public static void DotNetCoreNuGetPush(this ICakeContext context, FilePath packageFilePath, DotNetCoreNuGetPushSettings settings)
         {
             if (context == null)
             {
@@ -911,7 +918,7 @@ namespace Cake.Common.Tools.DotNetCore
             }
 
             var restorer = new DotNetCoreNuGetPusher(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            restorer.Push(packageName, settings);
+            restorer.Push(packageFilePath?.FullPath, settings);
         }
 
         /// <summary>


### PR DESCRIPTION
resolves #2075 
The change will allow using FilePath or string as parameter for this
alias. The implicit operator of the FilePath class will convert the
string value into a FilePath automatically.
