### PR TITLE
GH3559: Add all nupkgs to GitHub Release

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -556,6 +556,12 @@ Task("Publish-GitHub-Release")
 {
     GitReleaseManagerAddAssets(parameters.GitHub.Token, "cake-build", "cake", parameters.Version.Milestone, parameters.Paths.Files.ZipArtifactPathDesktop.ToString());
     GitReleaseManagerAddAssets(parameters.GitHub.Token, "cake-build", "cake", parameters.Version.Milestone, parameters.Paths.Files.ZipArtifactPathCoreClr.ToString());
+
+    foreach(var package in GetFiles(parameters.Paths.Directories.NuGetRoot + "/*"))
+    {
+        GitReleaseManagerAddAssets(parameters.GitHub.Token, "cake-build", "cake", parameters.Version.Milestone, package.FullPath);
+    }
+
     GitReleaseManagerClose(parameters.GitHub.Token, "cake-build", "cake", parameters.Version.Milestone);
 })
 .OnError<BuildParameters>((exception, parameters) =>


### PR DESCRIPTION
Currently, the only artifacts that are added to the GitHub release are
the zip files of both the .NET and .NET Core builds. This commit adds
all the nupkgs that are released into the Release as well.

Fixes #3559 
