### PR TITLE
GH1669: fixed parsing of versions with prerelease

### DIFF
--- a/src/Cake.Common.Tests/Unit/ReleaseNotesAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/ReleaseNotesAliasesTests.cs
@@ -61,6 +61,7 @@ namespace Cake.Common.Tests.Unit
 
                 // Then
                 Assert.Equal("1.2.3", result[0].Version.ToString());
+                Assert.Equal("1.2.3", result[0].SemVersion.ToString());
             }
         }
 
@@ -82,6 +83,7 @@ namespace Cake.Common.Tests.Unit
 
                 // Then
                 Assert.Equal("1.2.5", result.Version.ToString());
+                Assert.Equal("1.2.5", result.SemVersion.ToString());
             }
         }
     }

--- a/src/Cake.Common.Tests/Unit/ReleaseNotesParserTests.cs
+++ b/src/Cake.Common.Tests/Unit/ReleaseNotesParserTests.cs
@@ -1,10 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
 using Cake.Core;
 using Xunit;
-
 namespace Cake.Common.Tests.Unit
 {
     public sealed class ReleaseNotesParserTests
@@ -67,6 +65,7 @@ namespace Cake.Common.Tests.Unit
 
                     // Then
                     Assert.Equal("0.1.9", result[0].Version.ToString());
+                    Assert.Equal("0.1.9", result[0].SemVersion.ToString());
                 }
 
                 [Fact]
@@ -129,6 +128,8 @@ namespace Cake.Common.Tests.Unit
                     Assert.Equal(2, result.Count);
                     Assert.Equal("0.1.10", result[0].Version.ToString());
                     Assert.Equal("0.1.9", result[1].Version.ToString());
+                    Assert.Equal("0.1.10", result[0].SemVersion.ToString());
+                    Assert.Equal("0.1.9", result[1].SemVersion.ToString());
                 }
 
                 [Fact]
@@ -158,6 +159,40 @@ namespace Cake.Common.Tests.Unit
 
                     // Then
                     Assert.Equal("### New in 0.1.9-beta1 (Releases 2014/06/28)", result[0].RawVersionLine);
+                }
+
+                [Fact]
+                public void Should_Parse_Release_Note_Version_With_Prerelease()
+                {
+                    // Given
+                    var parser = new ReleaseNotesParser();
+                    const string content = "### New in 0.1.9-beta1 (Releases 2014/06/28)\nLine 1\n  \n\t\n";
+
+                    // When
+                    var result = parser.Parse(content);
+
+                    // Then
+                    Assert.Equal("0.1.9", result[0].Version.ToString());
+                    Assert.Equal("0.1.9-beta1", result[0].SemVersion.ToString());
+                }
+
+                [Fact]
+                public void Should_Return_Multiple_Release_Notes_With_Prerelease()
+                {
+                    // Given
+                    var parser = new ReleaseNotesParser();
+                    const string content = "### New in 0.1.9-alpha1 (Releases 2014/06/28)\n* Line 1\n" +
+                        "###New in 0.1.10-gamma3\n* Line 2\n Line 3";
+
+                    // When
+                    var result = parser.Parse(content);
+
+                    // Then
+                    Assert.Equal(2, result.Count);
+                    Assert.Equal("0.1.10", result[0].Version.ToString());
+                    Assert.Equal("0.1.9", result[1].Version.ToString());
+                    Assert.Equal("0.1.10-gamma3", result[0].SemVersion.ToString());
+                    Assert.Equal("0.1.9-alpha1", result[1].SemVersion.ToString());
                 }
             }
 
@@ -190,6 +225,7 @@ namespace Cake.Common.Tests.Unit
 
                     // Then
                     Assert.Equal("0.1.9", result[0].Version.ToString());
+                    Assert.Equal("0.1.9", result[0].SemVersion.ToString());
                 }
 
                 [Fact]
@@ -249,6 +285,8 @@ namespace Cake.Common.Tests.Unit
                     Assert.Equal(2, result.Count);
                     Assert.Equal("0.1.10", result[0].Version.ToString());
                     Assert.Equal("0.1.9", result[1].Version.ToString());
+                    Assert.Equal("0.1.10", result[0].SemVersion.ToString());
+                    Assert.Equal("0.1.9", result[1].SemVersion.ToString());
                 }
             }
         }

--- a/src/Cake.Common.Tests/Unit/ReleaseNotesTests.cs
+++ b/src/Cake.Common.Tests/Unit/ReleaseNotesTests.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
+using System;
 using System.Linq;
 using Xunit;
 
@@ -15,10 +15,22 @@ namespace Cake.Common.Tests.Unit
             public void Should_Throw_If_Version_Is_Null()
             {
                 // Given, When
-                var result = Record.Exception(() => new ReleaseNotes(null, Enumerable.Empty<string>(), null));
+                Version version = null;
+                var result = Record.Exception(() => new ReleaseNotes(version, Enumerable.Empty<string>(), null));
 
                 // Then
                 AssertEx.IsArgumentNullException(result, "version");
+            }
+
+            [Fact]
+            public void Should_Throw_If_SemVersion_Is_Null()
+            {
+                // Given, When
+                SemVersion semVersion = null;
+                var result = Record.Exception(() => new ReleaseNotes(semVersion, Enumerable.Empty<string>(), null));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "semVersion");
             }
         }
     }

--- a/src/Cake.Common/ReleaseNotes.cs
+++ b/src/Cake.Common/ReleaseNotes.cs
@@ -19,6 +19,12 @@ namespace Cake.Common
         /// Gets the version.
         /// </summary>
         /// <value>The version.</value>
+        public SemVersion SemVersion { get; }
+
+        /// <summary>
+        /// Gets the version.
+        /// </summary>
+        /// <value>The version.</value>
         public Version Version { get; }
 
         /// <summary>
@@ -36,16 +42,37 @@ namespace Cake.Common
         /// <summary>
         /// Initializes a new instance of the <see cref="ReleaseNotes"/> class.
         /// </summary>
+        /// <param name="semVersion">The semantic version.</param>
+        /// <param name="notes">The notes.</param>
+        /// <param name="rawVersionLine">The raw text of the version line.</param>
+        public ReleaseNotes(SemVersion semVersion, IEnumerable<string> notes, string rawVersionLine)
+            : this(
+                  semVersion?.AssemblyVersion ?? throw new ArgumentNullException(nameof(semVersion)),
+                  semVersion,
+                  notes,
+                  rawVersionLine)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReleaseNotes"/> class.
+        /// </summary>
         /// <param name="version">The version.</param>
         /// <param name="notes">The notes.</param>
         /// <param name="rawVersionLine">The raw text of the version line.</param>
         public ReleaseNotes(Version version, IEnumerable<string> notes, string rawVersionLine)
+            : this(
+                  version ?? throw new ArgumentNullException(nameof(version)),
+                  new SemVersion(version.Major, version.Minor, version.Build),
+                  notes,
+                  rawVersionLine)
         {
-            if (version == null)
-            {
-                throw new ArgumentNullException(nameof(version));
-            }
-            Version = version;
+        }
+
+        private ReleaseNotes(Version version, SemVersion semVersion, IEnumerable<string> notes, string rawVersionLine)
+        {
+            Version = version ?? throw new ArgumentNullException(nameof(version));
+            SemVersion = semVersion ?? throw new ArgumentNullException(nameof(semVersion));
             RawVersionLine = rawVersionLine;
             _notes = new List<string>(notes ?? Enumerable.Empty<string>());
         }

--- a/src/Cake.Common/ReleaseNotesAliases.cs
+++ b/src/Cake.Common/ReleaseNotesAliases.cs
@@ -17,6 +17,7 @@ namespace Cake.Common
     /// Contains functionality related to release notes.
     /// </summary>
     [CakeAliasCategory("Release Notes")]
+
     public static class ReleaseNotesAliases
     {
         private static readonly ReleaseNotesParser _parser;

--- a/src/Cake.Common/SemanticVersion.cs
+++ b/src/Cake.Common/SemanticVersion.cs
@@ -1,0 +1,339 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Cake.Common
+{
+    /// <summary>
+    /// Class for representing semantic versions.
+    /// </summary>
+    public class SemVersion : IComparable, IComparable<SemVersion>, IEquatable<SemVersion>
+    {
+        /// <summary>
+        /// Gets the default version of a SemanticVersion.
+        /// </summary>
+        public static SemVersion Zero { get; } = new SemVersion(0, 0, 0, null, null, "0.0.0");
+
+        /// <summary>
+        /// Regex property for parsing a semantic version number.
+        /// </summary>
+        public static readonly Regex SemVerRegex =
+            new Regex(
+                @"(?<Major>0|(?:[1-9]\d*))(?:\.(?<Minor>0|(?:[1-9]\d*))(?:\.(?<Patch>0|(?:[1-9]\d*)))?(?:\-(?<PreRelease>[0-9A-Z\.-]+))?(?:\+(?<Meta>[0-9A-Z\.-]+))?)?",
+                RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
+
+        /// <summary>
+        /// Gets the major number of the version.
+        /// </summary>
+        public int Major { get; }
+
+        /// <summary>
+        /// Gets the minor number of the version.
+        /// </summary>
+        public int Minor { get; }
+
+        /// <summary>
+        /// Gets the patch number of the version.
+        /// </summary>
+        public int Patch { get; }
+
+        /// <summary>
+        /// Gets the prerelease of the version.
+        /// </summary>
+        public string PreRelease { get; }
+
+        /// <summary>
+        /// Gets the meta of the version.
+        /// </summary>
+        public string Meta { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether semantic version is a prerelease or not.
+        /// </summary>
+        public bool IsPreRelease { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether semantic version has meta or not.
+        /// </summary>
+        public bool HasMeta { get; }
+
+        /// <summary>
+        /// Gets the VersionString of the semantic version.
+        /// </summary>
+        public string VersionString { get; }
+
+        /// <summary>
+        /// Gets the AssemblyVersion of the semantic version.
+        /// </summary>
+        public Version AssemblyVersion { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SemVersion"/> class.
+        /// </summary>
+        /// <param name="major">Major number.</param>
+        /// <param name="minor">Minor number.</param>
+        /// <param name="patch">Patch number.</param>
+        /// <param name="preRelease">Prerelease string.</param>
+        /// <param name="meta">Meta string.</param>
+        public SemVersion(int major, int minor, int patch, string preRelease = null, string meta = null) : this(major, minor, patch, preRelease, meta, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SemVersion"/> class.
+        /// </summary>
+        /// <param name="major">Major number.</param>
+        /// <param name="minor">Minor number.</param>
+        /// <param name="patch">Patch number.</param>
+        /// <param name="preRelease">Prerelease string.</param>
+        /// <param name="meta">Meta string.</param>
+        /// <param name="versionString">The complete version number.</param>
+        public SemVersion(int major, int minor, int patch, string preRelease, string meta, string versionString)
+        {
+            Major = major;
+            Minor = minor;
+            Patch = patch;
+            AssemblyVersion = new Version(major, minor, patch);
+            IsPreRelease = !string.IsNullOrEmpty(preRelease);
+            HasMeta = !string.IsNullOrEmpty(meta);
+            PreRelease = IsPreRelease ? preRelease : null;
+            Meta = HasMeta ? meta : null;
+
+            if (!string.IsNullOrEmpty(versionString))
+            {
+                VersionString = versionString;
+            }
+            else
+            {
+                var sb = new StringBuilder();
+                sb.AppendFormat(CultureInfo.InvariantCulture, "{0}.{1}.{2}", Major, Minor, Patch);
+
+                if (IsPreRelease)
+                {
+                    sb.AppendFormat(CultureInfo.InvariantCulture, "-{0}", PreRelease);
+                }
+
+                if (HasMeta)
+                {
+                    sb.AppendFormat(CultureInfo.InvariantCulture, "+{0}", Meta);
+                }
+
+                VersionString = sb.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Method which tries to parse a semantic version string.
+        /// </summary>
+        /// <param name="version">the version that should be parsed.</param>
+        /// <param name="semVersion">the out parameter the parsed version should be stored in.</param>
+        /// <returns>Returns a boolean indicating if the parse was successful.</returns>
+        public static bool TryParse(string version,
+                                    out SemVersion semVersion)
+        {
+            semVersion = Zero;
+
+            if (string.IsNullOrEmpty(version))
+            {
+                return false;
+            }
+
+            var match = SemVerRegex.Match(version);
+            if (!match.Success)
+            {
+                return false;
+            }
+
+            if (!int.TryParse(
+                    match.Groups["Major"].Value,
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out var major) ||
+                !int.TryParse(
+                    match.Groups["Minor"].Value,
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out var minor) ||
+                !int.TryParse(
+                    match.Groups["Patch"].Value,
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out var patch))
+            {
+                return false;
+            }
+
+            semVersion = new SemVersion(
+                major,
+                minor,
+                patch,
+                match.Groups["PreRelease"]?.Value,
+                match.Groups["Meta"]?.Value,
+                version);
+
+            return true;
+        }
+
+        /// <summary>
+        /// Checks if two SemVersion objects are equal.
+        /// </summary>
+        /// <param name="other">the other SemVersion want to test equality to.</param>
+        /// <returns>A boolean indicating whether the objecst we're equal or not.</returns>
+        public bool Equals(SemVersion other)
+        {
+            return other is object
+                   && Major == other.Major
+                   && Minor == other.Minor
+                   && Patch == other.Patch
+                   && string.Equals(PreRelease, other.PreRelease, StringComparison.OrdinalIgnoreCase)
+                   && string.Equals(Meta, other.Meta, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Compares to SemVersion objects to and another.
+        /// </summary>
+        /// <param name="other">The SemVersion object we compare with.</param>
+        /// <returns>Return 0 if the objects are identical, 1 if the version is newer and -1 if the version is older.</returns>
+        public int CompareTo(SemVersion other)
+        {
+            if (Equals(other))
+            {
+                return 0;
+            }
+
+            if (Major > other.Major)
+            {
+                return 1;
+            }
+
+            if (Major < other.Major)
+            {
+                return -1;
+            }
+
+            if (Minor > other.Minor)
+            {
+                return 1;
+            }
+
+            if (Minor < other.Minor)
+            {
+                return -1;
+            }
+
+            if (Patch > other.Patch)
+            {
+                return 1;
+            }
+
+            if (Patch < other.Patch)
+            {
+                return -1;
+            }
+
+            switch (StringComparer.InvariantCultureIgnoreCase.Compare(PreRelease, other.PreRelease))
+            {
+                case 1:
+                    return 1;
+
+                case -1:
+                    return -1;
+
+                default:
+                    return StringComparer.InvariantCultureIgnoreCase.Compare(Meta, other.Meta);
+            }
+        }
+
+        /// <summary>
+        /// Compares to SemVersion objects to and another.
+        /// </summary>
+        /// <param name="obj">The object we compare with.</param>
+        /// <returns>Return 0 if the objects are identical, 1 if the version is newer and -1 if the version is older.</returns>
+        public int CompareTo(object obj)
+        {
+            return (obj is SemVersion semVersion)
+                ? CompareTo(semVersion)
+                : -1;
+        }
+
+        /// <summary>
+        /// Equals-method for the SemVersion class.
+        /// </summary>
+        /// <param name="obj">the other SemVersion want to test equality to.</param>
+        /// <returns>A boolean indicating whether the objecst we're equal or not.</returns>
+        public override bool Equals(object obj)
+        {
+            return (obj is SemVersion semVersion)
+                   && Equals(semVersion);
+        }
+
+        /// <summary>
+        /// Method for getting the hashcode of the SemVersion object.
+        /// </summary>
+        /// <returns>The hashcode of the SemVersion object.</returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Major;
+                hashCode = (hashCode * 397) ^ Minor;
+                hashCode = (hashCode * 397) ^ Patch;
+                hashCode = (hashCode * 397) ^ (PreRelease != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(PreRelease) : 0);
+                hashCode = (hashCode * 397) ^ (Meta != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(Meta) : 0);
+                return hashCode;
+            }
+        }
+
+        /// <summary>
+        /// Returns the string representation of an SemVersion object.
+        /// </summary>
+        /// <returns>The string representation of the object.</returns>
+        public override string ToString()
+        {
+            int[] verParts = { Major, Minor, Patch };
+            string ver = string.Join(".", verParts);
+            return $"{ver}{(IsPreRelease ? "-" : string.Empty)}{PreRelease}{Meta}";
+        }
+
+        /// <summary>
+        /// The greater than-operator for the SemVersion class.
+        /// </summary>
+        /// <param name="operand1">first SemVersion.</param>
+        /// <param name="operand2">second. SemVersion.</param>
+        /// <returns>A value indicating if the operand1 was greater than operand2.</returns>
+        public static bool operator >(SemVersion operand1, SemVersion operand2)
+            => operand1.CompareTo(operand2) == 1;
+
+        /// <summary>
+        /// The less than-operator for the SemVersion class.
+        /// </summary>
+        /// <param name="operand1">first SemVersion.</param>
+        /// <param name="operand2">second. SemVersion.</param>
+        /// <returns>A value indicating if the operand1 was less than operand2.</returns>
+        public static bool operator <(SemVersion operand1, SemVersion operand2)
+            => operand1.CompareTo(operand2) == -1;
+
+        /// <summary>
+        /// The greater than or equal to-operator for the SemVersion class.
+        /// </summary>
+        /// <param name="operand1">first SemVersion.</param>
+        /// <param name="operand2">second. SemVersion.</param>
+        /// <returns>A value indicating if the operand1 was greater than or equal to operand2.</returns>
+        public static bool operator >=(SemVersion operand1, SemVersion operand2)
+            => operand1.CompareTo(operand2) >= 0;
+
+        /// <summary>
+        /// The lesser than or equal to-operator for the SemVersion class.
+        /// </summary>
+        /// <param name="operand1">first SemVersion.</param>
+        /// <param name="operand2">second. SemVersion.</param>
+        /// <returns>A value indicating if the operand1 was lesser than or equal to operand2.</returns>
+        public static bool operator <=(SemVersion operand1, SemVersion operand2)
+            => operand1.CompareTo(operand2) <= 0;
+    }
+}

--- a/tests/integration/Cake.Common/ReleaseNotesAliases.cake
+++ b/tests/integration/Cake.Common/ReleaseNotesAliases.cake
@@ -1,6 +1,5 @@
 #load "./../utilities/xunit.cake"
 #load "./../utilities/paths.cake"
-
 Task("Cake.Common.ReleaseNotesAliases.ParseAllReleaseNotes")
     .Does(() =>
 {
@@ -8,7 +7,7 @@ Task("Cake.Common.ReleaseNotesAliases.ParseAllReleaseNotes")
     var path = Paths.Resources.Combine("./Cake.Common");
     var file = path.CombineWithFilePath("./ReleaseNotes.md");
     var expectFirst = new ReleaseNotes(
-        version: new Version("0.15.2"),
+        version: new Version(0, 15, 2),
         notes: new [] {
             "Ensured that WiX candle definitions are enclosed in quotes",
             "Corrected issue with WixHeat HarvestType Out parameter"
@@ -16,7 +15,7 @@ Task("Cake.Common.ReleaseNotesAliases.ParseAllReleaseNotes")
         rawVersionLine: "### New on 0.15.2 (Released 2016/07/29)"
         );
     var expectLast = new ReleaseNotes(
-        version: new Version("0.15.1"),
+        version: new Version(0, 15, 1),
         notes: new [] {
             "Corrected Issues found with 0.15.0 AppVeyor updates"
             },
@@ -50,7 +49,7 @@ Task("Cake.Common.ReleaseNotesAliases.ParseReleaseNotes")
     var path = Paths.Resources.Combine("./Cake.Common");
     var file = path.CombineWithFilePath("./ReleaseNotes.md");
     var expect = new ReleaseNotes(
-        version: new Version("0.15.2"),
+        version: new Version(0, 15, 2),
         notes: new [] {
             "Ensured that WiX candle definitions are enclosed in quotes",
             "Corrected issue with WixHeat HarvestType Out parameter"
@@ -68,6 +67,78 @@ Task("Cake.Common.ReleaseNotesAliases.ParseReleaseNotes")
     Assert.Equal(expect.Notes, result.Notes);
 });
 
+Task("Cake.Common.ReleaseNotesAliases.ParseAllReleaseNotesSemVer")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Resources.Combine("./Cake.Common");
+    var file = path.CombineWithFilePath("./ReleaseNotesSemVer.md");
+    var expectFirst = new ReleaseNotes(
+        semVersion: new SemVersion(0, 15, 2, "alpha001"),
+        notes: new [] {
+            "Ensured that WiX candle definitions are enclosed in quotes",
+            "Corrected issue with WixHeat HarvestType Out parameter"
+            },
+        rawVersionLine: "### New on 0.15.2-alpha001 (Released 2016/07/29)"
+        );
+    var expectLast = new ReleaseNotes(
+        semVersion: new SemVersion(0, 15, 1, "beta001"),
+        notes: new [] {
+            "Corrected Issues found with 0.15.0 AppVeyor updates"
+            },
+        rawVersionLine: "### New on 0.15.1-beta001 (Released 2016/07/28)"
+        );
+
+    // When
+    var result = ParseAllReleaseNotes(file).ToArray();
+    var first = result.FirstOrDefault();
+    var last = result.LastOrDefault();
+
+    // Then
+    Assert.NotNull(first);
+    Assert.NotNull(last);
+    Assert.NotEqual(first, last);
+    Assert.Equal(2, result.Length);
+
+    Assert.Equal(expectFirst.Version, first.Version);
+    Assert.Equal(expectFirst.SemVersion, first.SemVersion);
+    Assert.Equal(expectFirst.RawVersionLine, first.RawVersionLine);
+    Assert.Equal(expectFirst.Notes, first.Notes);
+
+    Assert.Equal(expectLast.Version, last.Version);
+    Assert.Equal(expectLast.SemVersion, last.SemVersion);
+    Assert.Equal(expectFirst.RawVersionLine, first.RawVersionLine);
+    Assert.Equal(expectFirst.Notes, first.Notes);
+});
+
+Task("Cake.Common.ReleaseNotesAliases.ParseReleaseNotesSemVer")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Resources.Combine("./Cake.Common");
+    var file = path.CombineWithFilePath("./ReleaseNotesSemVer.md");
+    var expect = new ReleaseNotes(
+        semVersion: new SemVersion(0,15,2, "alpha001"),
+        notes: new [] {
+            "Ensured that WiX candle definitions are enclosed in quotes",
+            "Corrected issue with WixHeat HarvestType Out parameter"
+            },
+        rawVersionLine: "### New on 0.15.2-alpha001 (Released 2016/07/29)"
+        );
+
+    // When
+    var result = ParseReleaseNotes(file);
+
+    // Then
+    Assert.NotNull(result);
+    Assert.Equal(expect.Version, result.Version);
+    Assert.Equal(expect.SemVersion, result.SemVersion);
+    Assert.Equal(expect.RawVersionLine, result.RawVersionLine);
+    Assert.Equal(expect.Notes, result.Notes);
+});
+
 Task("Cake.Common.ReleaseNotesAliases")
     .IsDependentOn("Cake.Common.ReleaseNotesAliases.ParseAllReleaseNotes")
-    .IsDependentOn("Cake.Common.ReleaseNotesAliases.ParseReleaseNotes");
+    .IsDependentOn("Cake.Common.ReleaseNotesAliases.ParseReleaseNotes")
+    .IsDependentOn("Cake.Common.ReleaseNotesAliases.ParseAllReleaseNotesSemVer")
+    .IsDependentOn("Cake.Common.ReleaseNotesAliases.ParseReleaseNotesSemVer");

--- a/tests/integration/resources/Cake.Common/ReleaseNotesSemVer.md
+++ b/tests/integration/resources/Cake.Common/ReleaseNotesSemVer.md
@@ -1,0 +1,8 @@
+### New on 0.15.2-alpha001 (Released 2016/07/29)
+
+* Ensured that WiX candle definitions are enclosed in quotes
+* Corrected issue with WixHeat HarvestType Out parameter
+
+### New on 0.15.1-beta001 (Released 2016/07/28)
+
+* Corrected Issues found with 0.15.0 AppVeyor updates


### PR DESCRIPTION
## Issue
Closes #1669

## Reason for PR
Fixed the parsing of version number which includes prereleases.

## Features, i.e. what has been implemented?

Change the ´Version´-class used in the parsing of release notes the another class `SemanticVersion`-class written by [devlead](https://github.com/devlead). This allows the `ReleaseNotesParser` to handle the version number which contains prereleases or similiar. Tests have been added to check that this works.
