### PR TITLE
GH3593: Update Microsoft.CodeAnalysis.CSharp.Scripting to 4.0.0-5.final

### DIFF
--- a/src/Cake/Cake.csproj
+++ b/src/Cake/Cake.csproj
@@ -30,7 +30,7 @@
 
   <!-- Global packages -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.0.0-4.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.0.0-5.final" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="5.0.0" />
     <PackageReference Include="Autofac" Version="6.2.0" />


### PR DESCRIPTION
* fixes #3593
