### PR TITLE
GH2443: Fix Erroneous "Target path must be an absolute path" when preserveFolderStructure is used with CopyFiles

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/IO/FileCopierFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/IO/FileCopierFixture.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tests.Fixtures;
+using Cake.Testing;
+
+namespace Cake.Common.Tests.Fixtures.IO
+{
+    internal sealed class FileCopierFixture
+    {
+        private readonly FakeEnvironment _environment;
+        private readonly FakeFileSystem _fileSystem;
+        private readonly IGlobber _globber;
+
+        public FileCopierFixture()
+        {
+            _environment = FakeEnvironment.CreateUnixEnvironment();
+            _environment.WorkingDirectory = "/working";
+            _fileSystem = new FakeFileSystem(_environment);
+            _globber = new Globber(_fileSystem, _environment);
+            Context = new CakeContextFixture { Environment = _environment, FileSystem = _fileSystem, Globber = _globber }.CreateContext();
+        }
+
+        public CakeContext Context { get; }
+
+        public bool ExistsFile(FilePath path)
+        {
+            var file = _fileSystem.GetFile(path.MakeAbsolute(Context.Environment));
+            return file != null;
+        }
+
+        public FilePath MakeAbsolute(FilePath inputPath)
+        {
+            return inputPath.MakeAbsolute(Context.Environment);
+        }
+
+        public void EnsureFileExists(FilePath filePath)
+        {
+            var fullPath = filePath.MakeAbsolute(Context.Environment);
+            _fileSystem.CreateFile(fullPath).SetContent(Guid.NewGuid().ToString("D"));
+        }
+
+        public void EnsureDirectoryExists(DirectoryPath directoryPath)
+        {
+            var fullPath = directoryPath.MakeAbsolute(Context.Environment);
+            _fileSystem.CreateDirectory(fullPath);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/IO/FileCopierTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/FileCopierTests.cs
@@ -1,0 +1,201 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Cake.Common.IO;
+using Cake.Common.Tests.Fixtures.IO;
+using Cake.Core.IO;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.IO
+{
+    public sealed class FileCopierTests
+    {
+        public sealed class FileCopierTestsMethod
+        {
+            [Fact]
+            public void Should_Copy_Single_File_Relative_Path()
+            {
+                const string filePath = "./src/a/a.txt";
+                const string dstPath = "./dst";
+
+                // Given
+                var fixture = new FileCopierFixture();
+                fixture.EnsureFileExists(filePath);
+                fixture.EnsureDirectoryExists(dstPath);
+
+                // When
+                FileCopier.CopyFiles(
+                    fixture.Context,
+                    new FilePath[]
+                    {
+                        filePath
+                    },
+                    new DirectoryPath(dstPath),
+                    true);
+
+                // Then
+                Assert.True(fixture.ExistsFile($"{dstPath}/a/a.txt"));
+            }
+
+            [Fact]
+            public void Should_Copy_Single_File_Absolute_Path()
+            {
+                const string filePath = "./src/a/a.txt";
+                const string dstPath = "./dst";
+
+                // Given
+                var fixture = new FileCopierFixture();
+                fixture.EnsureFileExists(filePath);
+                fixture.EnsureDirectoryExists(dstPath);
+
+                // When
+                FileCopier.CopyFiles(
+                    fixture.Context,
+                    new[] { fixture.MakeAbsolute(filePath) },
+                    new DirectoryPath(dstPath),
+                    true);
+
+                // Then
+                Assert.True(fixture.ExistsFile($"{dstPath}/a/a.txt"));
+            }
+
+            [Fact]
+            public void Should_Copy_Multiple_Files_Relative_Path()
+            {
+                const string filePath1 = "./src/a/a.txt";
+                const string filePath2 = "./src/b/b.txt";
+                const string dstPath = "./dst";
+
+                // Given
+                var fixture = new FileCopierFixture();
+                fixture.EnsureFileExists(filePath1);
+                fixture.EnsureFileExists(filePath2);
+                fixture.EnsureDirectoryExists(dstPath);
+
+                // When
+                FileCopier.CopyFiles(
+                    fixture.Context,
+                    new FilePath[]
+                    {
+                        filePath1,
+                        filePath2
+                    },
+                    new DirectoryPath(dstPath),
+                    true);
+
+                // Then
+                Assert.True(fixture.ExistsFile($"{dstPath}/a/a.txt"));
+                Assert.True(fixture.ExistsFile($"{dstPath}/b/b.txt"));
+            }
+
+            [Fact]
+            public void Should_Copy_Multiple_Files_Absolute_Path()
+            {
+                const string filePath1 = "./src/a/a.txt";
+                const string filePath2 = "./src/b/b.txt";
+                const string dstPath = "./dst";
+
+                // Given
+                var fixture = new FileCopierFixture();
+                fixture.EnsureFileExists(filePath1);
+                fixture.EnsureFileExists(filePath2);
+                fixture.EnsureDirectoryExists(dstPath);
+
+                // When
+                FileCopier.CopyFiles(
+                    fixture.Context,
+                    new[]
+                        {
+                            fixture.MakeAbsolute(filePath1),
+                            fixture.MakeAbsolute(filePath2)
+                        },
+                    new DirectoryPath(dstPath),
+                    true);
+
+                // Then
+                Assert.True(fixture.ExistsFile($"{dstPath}/a/a.txt"));
+                Assert.True(fixture.ExistsFile($"{dstPath}/b/b.txt"));
+            }
+
+            [Fact]
+            public void Should_Copy_Multiple_Files_Mixed_Path()
+            {
+                const string filePath1 = "./src/a/a.txt";
+                const string filePath2 = "./src/b/b.txt";
+                const string dstPath = "./dst";
+
+                // Given
+                var fixture = new FileCopierFixture();
+                fixture.EnsureFileExists(filePath1);
+                fixture.EnsureFileExists(filePath2);
+                fixture.EnsureDirectoryExists(dstPath);
+
+                // When
+                FileCopier.CopyFiles(
+                    fixture.Context,
+                    new[]
+                    {
+                        filePath1,
+                        fixture.MakeAbsolute(filePath2)
+                    },
+                    new DirectoryPath(dstPath),
+                    true);
+
+                // Then
+                Assert.True(fixture.ExistsFile($"{dstPath}/a/a.txt"));
+                Assert.True(fixture.ExistsFile($"{dstPath}/b/b.txt"));
+            }
+
+            [Fact]
+            public void Should_Throw_If_Context_Is_Null()
+            {
+                // When
+                var result = Record.Exception(() => FileCopier.CopyFiles(null, Enumerable.Empty<FilePath>(), new DirectoryPath(""), true));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "context");
+            }
+
+            [Fact]
+            public void Should_Throw_If_File_Paths_Is_Null()
+            {
+                // Given
+                var fixture = new FileCopierFixture();
+
+                // When
+                var result = Record.Exception(() => FileCopier.CopyFiles(fixture.Context, (List<FilePath>)null, new DirectoryPath(""), true));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "filePaths");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Target_Directory_Path_Is_Null()
+            {
+                // Given
+                var fixture = new FileCopierFixture();
+
+                // When
+                var result = Record.Exception(() => FileCopier.CopyFiles(fixture.Context, Enumerable.Empty<FilePath>(), null, true));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "targetDirectoryPath");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Target_Directory_Does_Not_Exist()
+            {
+                const string dstPath = "/dst";
+
+                // Given
+                var fixture = new FileCopierFixture();
+
+                // When
+                var result = Record.Exception(() => FileCopier.CopyFiles(fixture.Context, Enumerable.Empty<FilePath>(), new DirectoryPath(dstPath), true));
+
+                // Then
+                AssertEx.IsExceptionWithMessage<DirectoryNotFoundException>(result, $"The directory '{dstPath}' does not exist.");
+            }
+        }
+    }
+}

--- a/src/Cake.Common/IO/FileCopier.cs
+++ b/src/Cake.Common/IO/FileCopier.cs
@@ -85,18 +85,21 @@ namespace Cake.Common.IO
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
             if (filePaths == null)
             {
-                throw new ArgumentNullException("filePaths");
+                throw new ArgumentNullException(nameof(filePaths));
             }
             if (targetDirectoryPath == null)
             {
-                throw new ArgumentNullException("targetDirectoryPath");
+                throw new ArgumentNullException(nameof(targetDirectoryPath));
             }
 
+            // Make all path absolute
             var absoluteTargetDirectoryPath = targetDirectoryPath.MakeAbsolute(context.Environment);
+
+            var absoluteFilePaths = filePaths.Select(x => x.MakeAbsolute(context.Environment)).ToList();
 
             // Make sure the target directory exist.
             if (!context.FileSystem.Exist(absoluteTargetDirectoryPath))
@@ -109,18 +112,18 @@ namespace Cake.Common.IO
             if (preserverFolderStructure)
             {
                 var commonPath = string.Empty;
-                var separatedPath = filePaths
-                    .First(str => str.ToString().Length == filePaths.Max(st2 => st2.ToString().Length)).ToString()
-                    .Split(new string[] { "/" }, StringSplitOptions.RemoveEmptyEntries)
+                var separatedPath = absoluteFilePaths
+                    .First(str => str.ToString().Length == absoluteFilePaths.Max(st2 => st2.ToString().Length)).ToString()
+                    .Split(new[] { "/" }, StringSplitOptions.RemoveEmptyEntries)
                     .ToList();
 
                 foreach (string pathSegment in separatedPath)
                 {
-                    if (commonPath.Length == 0 && filePaths.All(str => str.ToString().StartsWith(pathSegment)))
+                    if (commonPath.Length == 0 && absoluteFilePaths.All(str => str.ToString().StartsWith(pathSegment)))
                     {
                         commonPath = pathSegment;
                     }
-                    else if (filePaths.All(str => str.ToString().StartsWith(commonPath + "/" + pathSegment)))
+                    else if (absoluteFilePaths.All(str => str.ToString().StartsWith(commonPath + "/" + pathSegment)))
                     {
                         commonPath += "/" + pathSegment;
                     }
@@ -130,8 +133,25 @@ namespace Cake.Common.IO
                     }
                 }
 
+                if (absoluteFilePaths.Count == 1 && absoluteFilePaths.First().FullPath.Contains(context.Environment.WorkingDirectory.FullPath))
+                {
+                    var relativePath = absoluteFilePaths.First().FullPath.Remove(0, context.Environment.WorkingDirectory.FullPath.Length + 1);
+                    var relativePathParts = relativePath.Split('/').ToList();
+
+                    if (relativePathParts.Count > 2)
+                    {
+                        relativePathParts.RemoveAt(0);
+                        var workdirRelativeStructurePath = string.Join("/", relativePathParts.ToArray());
+
+                        var index = commonPath.IndexOf(workdirRelativeStructurePath, StringComparison.Ordinal);
+                        commonPath = index < 0
+                            ? commonPath
+                            : commonPath.Remove(index, workdirRelativeStructurePath.Length);
+                    }
+                }
+
                 // Iterate all files and copy them.
-                foreach (var filePath in filePaths)
+                foreach (var filePath in absoluteFilePaths)
                 {
                     CopyFileCore(context, filePath, absoluteTargetDirectoryPath.GetFilePath(filePath), context.DirectoryExists(commonPath) ? commonPath : null);
                 }
@@ -139,13 +159,13 @@ namespace Cake.Common.IO
             else
             {
                 // #1663: For empty enumerations, just return.
-                if (!filePaths.Any())
+                if (!absoluteFilePaths.Any())
                 {
                     return;
                 }
 
                 // Iterate all files and copy them.
-                foreach (var filePath in filePaths)
+                foreach (var filePath in absoluteFilePaths)
                 {
                     CopyFileCore(context, filePath, absoluteTargetDirectoryPath.GetFilePath(filePath), null);
                 }


### PR DESCRIPTION
Fixed: #2443 

@augustoproiete I think I have a fix for you, but unfortunately I wasn't able to test it. There wasn't any documentation about testing my changes. And I had a hard time figuring out anything about building my solution. 

I tested all the edge cases and as it was stated in the issue #2443 **destinationPath** is always absolute, but **FilePaths** aren't. 

When **preserverFolderStructure** was set true, the function wanted to find the common path between all paths and create directories according the **FilePaths**. But when all the paths are not absolute (e. g. "CommonPath/File1.txt" and "source/file10.txt"), the function wasn't able to find a common directory and threw an Error. 

In my solution I'm converting all the **FilePaths** to absolute, so it is able to find a common directory.

Note:
Error is not thrown when you give the full path to the file (e. g. "C:/example/CommonPath/File1.txt" and "C:/example/source/file10.txt")
