### PR TITLE
GH-3598:,GH-3599: VS2022 MSBuild remove preview  & add to default

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/MSBuildRunnerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/MSBuildRunnerFixture.cs
@@ -36,8 +36,8 @@ namespace Cake.Common.Tests.Fixtures.Tools
                 "/Program86/Microsoft Visual Studio/2017/Enterprise/MSBuild/15.0/Bin/amd64/MSBuild.exe",
                 "/Program86/Microsoft Visual Studio/2019/Professional/MSBuild/Current/Bin/MSBuild.exe",
                 "/Program86/Microsoft Visual Studio/2019/Professional/MSBuild/Current/Bin/amd64/MSBuild.exe",
-                "/Program/Microsoft Visual Studio/2022/Preview/MSBuild/Current/Bin/MSBuild.exe",
-                "/Program/Microsoft Visual Studio/2022/Preview/MSBuild/Current/Bin/amd64/MSBuild.exe",
+                "/Program/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin/MSBuild.exe",
+                "/Program/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin/amd64/MSBuild.exe",
                 "/usr/bin/msbuild",
                 "/Library/Frameworks/Mono.framework/Versions/Current/Commands/msbuild"
             };
@@ -77,6 +77,7 @@ namespace Cake.Common.Tests.Fixtures.Tools
             }
             FileSystem.GetDirectory("/Windows").Delete(true);
             FileSystem.GetDirectory("/Program86").Delete(true);
+            FileSystem.GetDirectory("/Program").Delete(true);
         }
 
         protected override void RunTool()

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -156,8 +156,8 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             }
 
             [Theory]
-            [InlineData(MSBuildToolVersion.VS2022, PlatformTarget.x64, PlatformFamily.Windows, false, "/Program/Microsoft Visual Studio/2022/Preview/MSBuild/Current/Bin/amd64/MSBuild.exe")]
-            [InlineData(MSBuildToolVersion.VS2022, PlatformTarget.x86, PlatformFamily.Windows, false, "/Program/Microsoft Visual Studio/2022/Preview/MSBuild/Current/Bin/MSBuild.exe")]
+            [InlineData(MSBuildToolVersion.VS2022, PlatformTarget.x64, PlatformFamily.Windows, false, "/Program/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin/amd64/MSBuild.exe")]
+            [InlineData(MSBuildToolVersion.VS2022, PlatformTarget.x86, PlatformFamily.Windows, false, "/Program/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin/MSBuild.exe")]
             [InlineData(MSBuildToolVersion.VS2022, PlatformTarget.x64, PlatformFamily.Linux, false, "/usr/bin/msbuild")]
             [InlineData(MSBuildToolVersion.VS2022, PlatformTarget.x64, PlatformFamily.OSX, false, "/Library/Frameworks/Mono.framework/Versions/Current/Commands/msbuild")]
             public void Should_Get_Correct_Path_To_MSBuild_Version_17(MSBuildToolVersion version, PlatformTarget target, PlatformFamily family, bool is64BitOperativeSystem, string expected)

--- a/src/Cake.Common/Tools/MSBuild/MSBuildResolver.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildResolver.cs
@@ -59,7 +59,7 @@ namespace Cake.Common.Tools.MSBuild
         {
             var versions = new[]
             {
-                // MSBuildVersion.MSBuild17, /*Since it's still in preview, do not search unless specified. Uncomment after stable version released*/
+                MSBuildVersion.MSBuild17,
                 MSBuildVersion.MSBuild16,
                 MSBuildVersion.MSBuild15,
                 MSBuildVersion.MSBuild14,
@@ -212,8 +212,7 @@ namespace Cake.Common.Tools.MSBuild
                 "Enterprise",
                 "Professional",
                 "Community",
-                "BuildTools",
-                "Preview" // Remove after stable version released
+                "BuildTools"
             };
 
             var visualStudio2022Path = environment.GetSpecialPath(SpecialPath.ProgramFiles);


### PR DESCRIPTION
* Remove Preview from VS2022 MSBuild Resolver, fixes #3598
* Add VS2022 to default MSBuild Resolver, fixes #3599
