### PR TITLE
GH3543: Add DotNetRun alias (synonym to DotNetCoreRun)

### DIFF
--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
@@ -6,8 +6,10 @@ using System;
 using System.Collections.Generic;
 using Cake.Common.IO;
 using Cake.Common.Tools.DotNet.MSBuild;
+using Cake.Common.Tools.DotNet.Run;
 using Cake.Common.Tools.DotNet.Tool;
 using Cake.Common.Tools.DotNetCore.MSBuild;
+using Cake.Common.Tools.DotNetCore.Run;
 using Cake.Common.Tools.DotNetCore.Tool;
 using Cake.Core;
 using Cake.Core.Annotations;
@@ -26,6 +28,122 @@ namespace Cake.Common.Tools.DotNet
     [CakeAliasCategory("DotNet")]
     public static class DotNetAliases
     {
+        /// <summary>
+        /// Run all projects.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <example>
+        /// <code>
+        /// DotNetRun();
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Run")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Run")]
+        public static void DotNetRun(this ICakeContext context)
+        {
+            context.DotNetRun(null, null, null);
+        }
+
+        /// <summary>
+        /// Run project.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="project">The project path.</param>
+        /// <example>
+        /// <code>
+        /// DotNetRun("./src/Project");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Run")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Run")]
+        public static void DotNetRun(this ICakeContext context, string project)
+        {
+            context.DotNetRun(project, null, null);
+        }
+
+        /// <summary>
+        /// Run project with path and arguments.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="project">The project path.</param>
+        /// <param name="arguments">The arguments.</param>
+        /// <example>
+        /// <code>
+        /// DotNetRun("./src/Project", "--args");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Run")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Run")]
+        public static void DotNetRun(this ICakeContext context, string project, ProcessArgumentBuilder arguments)
+        {
+            context.DotNetRun(project, arguments, null);
+        }
+
+        /// <summary>
+        /// Run project with settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="project">The project path.</param>
+        /// <param name="arguments">The arguments.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// var settings = new DotNetRunSettings
+        /// {
+        ///     Framework = "netcoreapp2.0",
+        ///     Configuration = "Release"
+        /// };
+        ///
+        /// DotNetRun("./src/Project", "--args", settings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Run")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Run")]
+        public static void DotNetRun(this ICakeContext context, string project, ProcessArgumentBuilder arguments, DotNetRunSettings settings)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (settings is null)
+            {
+                settings = new DotNetRunSettings();
+            }
+
+            var runner = new DotNetCoreRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            runner.Run(project, arguments, settings);
+        }
+
+        /// <summary>
+        /// Run project with settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="project">The project path.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// var settings = new DotNetRunSettings
+        /// {
+        ///     Framework = "netcoreapp2.0",
+        ///     Configuration = "Release"
+        /// };
+        ///
+        /// DotNetRun("./src/Project", settings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Run")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Run")]
+        public static void DotNetRun(this ICakeContext context, string project, DotNetRunSettings settings)
+        {
+            context.DotNetRun(project, null, settings);
+        }
+
         /// <summary>
         /// Builds the specified targets in a project file found in the current working directory.
         /// </summary>

--- a/src/Cake.Common/Tools/DotNet/Run/DotNetRunSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Run/DotNetRunSettings.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Cake.Common.Tools.DotNetCore;
+using Cake.Common.Tools.DotNetCore.Run;
+
+namespace Cake.Common.Tools.DotNet.Run
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetCoreRunner" />.
+    /// </summary>
+    public class DotNetRunSettings : DotNetCoreSettings
+    {
+        /// <summary>
+        /// Gets or sets a specific framework to compile.
+        /// </summary>
+        public string Framework { get; set; }
+
+        /// <summary>
+        /// Gets or sets the configuration under which to build.
+        /// </summary>
+        public string Configuration { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to not do implicit NuGet package restore.
+        /// This makes run faster, but requires restore to be done before run is executed.
+        /// </summary>
+        public bool NoRestore { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to not do implicit build.
+        /// This makes run faster, but requires build to be done before run is executed.
+        /// </summary>
+        public bool NoBuild { get; set; }
+
+        /// <summary>
+        /// Gets or sets the specified NuGet package sources to use during the run is executed.
+        /// </summary>
+        /// <remarks>
+        /// Requires .NET Core 2.x or newer.
+        /// </remarks>
+        public ICollection<string> Sources { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets the target runtime.
+        /// </summary>
+        public string Runtime { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using Cake.Common.IO;
 using Cake.Common.Tools.DotNet;
 using Cake.Common.Tools.DotNet.MSBuild;
+using Cake.Common.Tools.DotNet.Run;
 using Cake.Common.Tools.DotNet.Tool;
 using Cake.Common.Tools.DotNetCore.Build;
 using Cake.Common.Tools.DotNetCore.BuildServer;
@@ -331,6 +332,7 @@ namespace Cake.Common.Tools.DotNetCore
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreRun is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetRun(ICakeContext)" /> instead.
         /// Run all projects.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -342,12 +344,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Run")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Run")]
+        [Obsolete("DotNetCoreRun is obsolete and will be removed in a future release. Use DotNetRun instead.")]
         public static void DotNetCoreRun(this ICakeContext context)
         {
-            context.DotNetCoreRun(null, null, null);
+            context.DotNetRun();
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreRun is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetRun(ICakeContext, string)" /> instead.
         /// Run project.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -360,12 +364,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Run")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Run")]
+        [Obsolete("DotNetCoreRun is obsolete and will be removed in a future release. Use DotNetRun instead.")]
         public static void DotNetCoreRun(this ICakeContext context, string project)
         {
-            context.DotNetCoreRun(project, null, null);
+            context.DotNetRun(project);
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreRun is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetRun(ICakeContext, string, ProcessArgumentBuilder)" /> instead.
         /// Run project with path and arguments.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -379,12 +385,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Run")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Run")]
+        [Obsolete("DotNetCoreRun is obsolete and will be removed in a future release. Use DotNetRun instead.")]
         public static void DotNetCoreRun(this ICakeContext context, string project, ProcessArgumentBuilder arguments)
         {
-            context.DotNetCoreRun(project, arguments, null);
+            context.DotNetRun(project, arguments);
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreRun is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetRun(ICakeContext, string, ProcessArgumentBuilder, DotNetRunSettings)" /> instead.
         /// Run project with settings.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -405,23 +413,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Run")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Run")]
+        [Obsolete("DotNetCoreRun is obsolete and will be removed in a future release. Use DotNetRun instead.")]
         public static void DotNetCoreRun(this ICakeContext context, string project, ProcessArgumentBuilder arguments, DotNetCoreRunSettings settings)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            if (settings == null)
-            {
-                settings = new DotNetCoreRunSettings();
-            }
-
-            var runner = new DotNetCoreRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Run(project, arguments, settings);
+            context.DotNetRun(project, arguments, settings);
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreRun is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetRun(ICakeContext, string, DotNetRunSettings)" /> instead.
         /// Run project with settings.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -441,9 +440,10 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Run")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Run")]
+        [Obsolete("DotNetCoreRun is obsolete and will be removed in a future release. Use DotNetRun instead.")]
         public static void DotNetCoreRun(this ICakeContext context, string project, DotNetCoreRunSettings settings)
         {
-            context.DotNetCoreRun(project, null, settings);
+            context.DotNetRun(project, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DotNetCore/Run/DotNetCoreRunSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Run/DotNetCoreRunSettings.cs
@@ -2,48 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
+using Cake.Common.Tools.DotNet.Run;
 
 namespace Cake.Common.Tools.DotNetCore.Run
 {
     /// <summary>
     /// Contains settings used by <see cref="DotNetCoreRunner" />.
     /// </summary>
-    public sealed class DotNetCoreRunSettings : DotNetCoreSettings
+    public sealed class DotNetCoreRunSettings : DotNetRunSettings
     {
-        /// <summary>
-        /// Gets or sets a specific framework to compile.
-        /// </summary>
-        public string Framework { get; set; }
-
-        /// <summary>
-        /// Gets or sets the configuration under which to build.
-        /// </summary>
-        public string Configuration { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to not do implicit NuGet package restore.
-        /// This makes run faster, but requires restore to be done before run is executed.
-        /// </summary>
-        public bool NoRestore { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to not do implicit build.
-        /// This makes run faster, but requires build to be done before run is executed.
-        /// </summary>
-        public bool NoBuild { get; set; }
-
-        /// <summary>
-        /// Gets or sets the specified NuGet package sources to use during the run is executed.
-        /// </summary>
-        /// <remarks>
-        /// Requires .NET Core 2.x or newer.
-        /// </remarks>
-        public ICollection<string> Sources { get; set; } = new List<string>();
-
-        /// <summary>
-        /// Gets or sets the target runtime.
-        /// </summary>
-        public string Runtime { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/Run/DotNetCoreRunner.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Run/DotNetCoreRunner.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Cake.Common.Tools.DotNet.Run;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
@@ -12,7 +13,7 @@ namespace Cake.Common.Tools.DotNetCore.Run
     /// <summary>
     /// .NET Core project runner.
     /// </summary>
-    public sealed class DotNetCoreRunner : DotNetCoreTool<DotNetCoreRunSettings>
+    public sealed class DotNetCoreRunner : DotNetCoreTool<DotNetRunSettings>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DotNetCoreRunner" /> class.
@@ -35,7 +36,7 @@ namespace Cake.Common.Tools.DotNetCore.Run
         /// <param name="project">The target project path.</param>
         /// <param name="arguments">The arguments.</param>
         /// <param name="settings">The settings.</param>
-        public void Run(string project, ProcessArgumentBuilder arguments, DotNetCoreRunSettings settings)
+        public void Run(string project, ProcessArgumentBuilder arguments, DotNetRunSettings settings)
         {
             if (settings == null)
             {
@@ -45,7 +46,7 @@ namespace Cake.Common.Tools.DotNetCore.Run
             RunCommand(settings, GetArguments(project, arguments, settings));
         }
 
-        private ProcessArgumentBuilder GetArguments(string project, ProcessArgumentBuilder arguments, DotNetCoreRunSettings settings)
+        private ProcessArgumentBuilder GetArguments(string project, ProcessArgumentBuilder arguments, DotNetRunSettings settings)
         {
             var builder = CreateArgumentBuilder(settings);
 


### PR DESCRIPTION
| DotNetCore              |               | DotNet synonym                |
| ----------------------- |:-------------:| ----------------------------- |
| `DotNetCoreRun`         | :arrow_right: | :new: `DotNetRun`             |
| `DotNetCoreRunSettings` | :arrow_right: | :new: `DotNetRunSettings`     |


- New `DotNetRun` aliases are being introduced
- `DotNetRun` aliases contain the code of the existing `DotNetCoreRun` (rename/move)
- Existing `DotNetCoreRun` aliases are forwarding calls to newly introduced `DotNetRun` aliases
- New `DotNetRunSettings` class is being introduced
- `DotNetRunSettings` class contains the code of `DotNetCoreRunSettings` (rename/move)
- The previous `DotNetCoreRunSettings` is now empty and inherits from the new `DotNetRunSettings`
- Namespaces `Cake.Common.Runs.DotNetCore.*` have been preserved as to not introduce breaking changes
- Unit Tests and Integration Tests remain the same, and call the old `DotNetCore***` aliases, exercising the new `DotNet***` aliases in the process

---

Closes https://github.com/cake-build/cake/issues/3543