### PR TITLE
GH-2788: Changed the register-property in OpenCover/OpenCoverSettings.cs from string to OpenCoverRegisterOption

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/OpenCover/OpenCoverTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/OpenCover/OpenCoverTests.cs
@@ -229,7 +229,7 @@ namespace Cake.Common.Tests.Unit.Tools.OpenCover
             {
                 // Given
                 var fixture = new OpenCoverFixture();
-                fixture.Settings.Register = "Path32";
+                fixture.Settings.Register = new OpenCoverRegisterOptionDll("Path32");
 
                 // When
                 var result = fixture.Run();
@@ -238,6 +238,72 @@ namespace Cake.Common.Tests.Unit.Tools.OpenCover
                 Assert.Equal("-target:\"/Working/tools/Test.exe\" " +
                              "-targetargs:\"-argument\" " +
                              "-register:Path32 -output:\"/Working/result.xml\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Use_No_Register()
+            {
+                // Given
+                var fixture = new OpenCoverFixture();
+                fixture.Settings.Register = null;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-target:\"/Working/tools/Test.exe\" " +
+                             "-targetargs:\"-argument\" " +
+                             "-output:\"/Working/result.xml\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Use_Admin_Register()
+            {
+                // Given
+                var fixture = new OpenCoverFixture();
+                fixture.Settings.Register = new OpenCoverRegisterOptionAdmin();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-target:\"/Working/tools/Test.exe\" " +
+                             "-targetargs:\"-argument\" " +
+                             "-register -output:\"/Working/result.xml\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Use_User_Register()
+            {
+                // Given
+                var fixture = new OpenCoverFixture();
+                fixture.Settings.Register = new OpenCoverRegisterOptionUser();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-target:\"/Working/tools/Test.exe\" " +
+                             "-targetargs:\"-argument\" " +
+                             "-register:user -output:\"/Working/result.xml\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_break_when_old_string_registrations_are_used()
+            {
+                // Given
+                var fixture = new OpenCoverFixture();
+#pragma warning disable CS0618 // Type or member is obsolete
+                fixture.Settings.Register = "Path64";
+#pragma warning restore CS0618 // Type or member is obsolete
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-target:\"/Working/tools/Test.exe\" " +
+                             "-targetargs:\"-argument\" " +
+                             "-register:Path64 -output:\"/Working/result.xml\"", result.Args);
             }
 
             [Fact]

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverRegisterOption.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverRegisterOption.cs
@@ -1,0 +1,145 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.OpenCover
+{
+    /// <summary>
+    /// Represents the register-options:
+    /// <list type="bullet">
+    /// <item>
+    /// <term>empty</term>
+    /// <description>Registers and de-register the code coverage profiler. (Administrative permissions to the registry are required.)</description>
+    /// </item>
+    /// <item>
+    /// <term>"user"</term>
+    /// <description>Does per-user registration where the user account does not have administrative permissions.</description>
+    /// </item>
+    /// <item>
+    /// <term>path</term>
+    /// <description>If you do not want to use the registry entries, use -register:path to select the profiler.</description>
+    /// </item>
+    /// </list>
+    /// </summary>
+    public abstract class OpenCoverRegisterOption
+    {
+        private readonly string commandLineValue;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenCoverRegisterOption"/> class.
+        /// </summary>
+        /// <param name="commandLineValue">The value, as required for the commandline.</param>
+        /// <remarks>
+        /// Note that no value (<c>null</c> or <c>string.Empty</c>) is valid.
+        /// However, if a value exists it NEEDS to start with a colon (":").
+        /// </remarks>
+        protected OpenCoverRegisterOption(string commandLineValue)
+        {
+            if (string.IsNullOrEmpty(commandLineValue))
+            {
+                commandLineValue = string.Empty;
+            }
+
+            if (!string.IsNullOrEmpty(commandLineValue))
+            {
+                if (!commandLineValue.StartsWith(":", StringComparison.Ordinal))
+                {
+                    throw new ArgumentException(nameof(commandLineValue), "if a non-empty value is given, it needs to start with ':'");
+                }
+            }
+
+            this.commandLineValue = commandLineValue;
+        }
+
+        /// <summary>
+        /// Converts to string.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String" /> that represents this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            return commandLineValue;
+        }
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="System.String"/> to <see cref="OpenCoverRegisterOption"/>.
+        /// (Since the switch from pure string to <see cref="OpenCoverRegisterOption"/> is a breaking change.)
+        /// </summary>
+        /// <param name="option">The option.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+        [Obsolete("use new OpenCoverRegisterOption() instead.")]
+        public static implicit operator OpenCoverRegisterOption(string option)
+        {
+            if (string.IsNullOrEmpty(option))
+            {
+                return new OpenCoverRegisterOptionAdmin();
+            }
+
+            if (option.Equals("user", StringComparison.InvariantCultureIgnoreCase))
+            {
+                return new OpenCoverRegisterOptionUser();
+            }
+
+            return new OpenCoverRegisterOptionDll(new FilePath(option));
+        }
+    }
+
+    /// <summary>
+    /// Gets the register-option representing the "user"-mode.
+    /// (This will translate to "-register:user".)
+    /// </summary>
+    /// <seealso cref="OpenCoverRegisterOption" />
+    public class OpenCoverRegisterOptionUser
+        : OpenCoverRegisterOption
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenCoverRegisterOptionUser"/> class.
+        /// </summary>
+        public OpenCoverRegisterOptionUser()
+            : base(":user")
+        {
+        }
+    }
+
+    /// <summary>
+    /// Gets the register-option representing the "admin"-mode.
+    /// (This will translate to "-register".)
+    /// </summary>
+    /// <seealso cref="OpenCoverRegisterOption" />
+    public class OpenCoverRegisterOptionAdmin
+        : OpenCoverRegisterOption
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenCoverRegisterOptionAdmin"/> class.
+        /// </summary>
+        public OpenCoverRegisterOptionAdmin()
+            : base(string.Empty)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Gets a register-option pointing to a dll.
+    /// (This will translate to "-register:[path-to-dll]".)
+    /// </summary>
+    /// <seealso cref="OpenCoverRegisterOption" />
+    public class OpenCoverRegisterOptionDll
+        : OpenCoverRegisterOption
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenCoverRegisterOptionDll"/> class.
+        /// </summary>
+        /// <param name="pathToDll">Path to the dll.</param>
+        public OpenCoverRegisterOptionDll(FilePath pathToDll)
+            : base($":{pathToDll.FullPath}")
+        {
+        }
+    }
+}

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverRunner.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverRunner.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
@@ -142,7 +143,12 @@ namespace Cake.Common.Tools.OpenCover
                 builder.Append("-mergeoutput");
             }
 
-            builder.AppendSwitch("-register", ":", settings.Register);
+            if (settings.Register != null)
+            {
+                // due to the fact that register sometimes needs a colon-separator and sometimes it does not
+                // there is no separator here but instead it's added in OpenCoverRegisterOption.ToString()
+                builder.AppendSwitch("-register", string.Empty, settings.Register.ToString());
+            }
 
             if (settings.ReturnTargetCodeOffset != null)
             {

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverSettings.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverSettings.cs
@@ -49,7 +49,7 @@ namespace Cake.Common.Tools.OpenCover
         /// <summary>
         /// Gets or sets the register option.
         /// </summary>
-        public string Register { get; set; }
+        public OpenCoverRegisterOption Register { get; set; }
 
         /// <summary>
         /// Gets or sets the Return target code offset to be used.
@@ -118,7 +118,7 @@ namespace Cake.Common.Tools.OpenCover
             _filters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             _excludedAttributeFilters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             _excludedFileFilters = new HashSet<string>(StringComparer.Ordinal);
-            Register = "user";
+            Register = new OpenCoverRegisterOptionUser();
             LogLevel = OpenCoverLogLevel.Info;
             HideSkippedOption = OpenCoverHideSkippedOption.None;
             _excludeDirectories = new HashSet<DirectoryPath>();

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverSettingsExtensions.cs
@@ -4,6 +4,8 @@
 
 using System;
 
+using Cake.Core.IO;
+
 namespace Cake.Common.Tools.OpenCover
 {
     /// <summary>
@@ -57,6 +59,67 @@ namespace Cake.Common.Tools.OpenCover
                 throw new ArgumentNullException(nameof(settings));
             }
             settings.ExcludedFileFilters.Add(filter);
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the register-option to "none".
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The same <see cref="OpenCoverSettings"/> instance so that multiple calls can be chained.</returns>
+        public static OpenCoverSettings WithoutRegister(this OpenCoverSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            settings.Register = null;
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the register-option to admin-registry-access.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The same <see cref="OpenCoverSettings"/> instance so that multiple calls can be chained.</returns>
+        public static OpenCoverSettings WithRegisterAdmin(this OpenCoverSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            settings.Register = new OpenCoverRegisterOptionAdmin();
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the register-option to user-registry-access.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The same <see cref="OpenCoverSettings"/> instance so that multiple calls can be chained.</returns>
+        public static OpenCoverSettings WithRegisterUser(this OpenCoverSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            settings.Register = new OpenCoverRegisterOptionUser();
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the register-option to dll-registration (i.e no registry-access).
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="path">The path.</param>
+        /// <returns>The same <see cref="OpenCoverSettings"/> instance so that multiple calls can be chained.</returns>
+        public static OpenCoverSettings WithRegisterDll(this OpenCoverSettings settings, FilePath path)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            settings.Register = new OpenCoverRegisterOptionDll(path);
             return settings;
         }
     }


### PR DESCRIPTION
…to a custom OpenCoverRegisterOption to make it clearer what the actual options are. 

As suggested in #2788 this commit implements an `OpenCoverRegisterOption` with predifined static accessors:
* `OpenCoverRegisterOption.User` 
* `OpenCoverRegisterOption.Admin` 
* `OpenCoverRegisterOption.Dll(FilePath)` 

additionally I introduced extensions to `OpenCoverSettings`:

* `WithoutRegister()` this will set the register property to `null` an thereby omitting register alltogether
* `WithRegisterAdmin()` this will set the register property to `OpenCoverRegisterOption.Admin`
* `WithRegisterUser()` this will set the register property to `OpenCoverRegisterOption.User`
* `WithRegisterDll(FilePath)` this will set the register property to `OpenCoverRegisterOption.Dll(FilePath)`

To avoid breaking changes I have implemented an implicit cast from string to the new OpenCoverRegisterOption. So all cake file using the "old" syntax will continue to work without problems.
