### PR TITLE
GH3544: Add DotNetExecute alias (synonym to DotNetCoreExecute)

### DIFF
--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
@@ -5,9 +5,11 @@
 using System;
 using System.Collections.Generic;
 using Cake.Common.IO;
+using Cake.Common.Tools.DotNet.Execute;
 using Cake.Common.Tools.DotNet.MSBuild;
 using Cake.Common.Tools.DotNet.Run;
 using Cake.Common.Tools.DotNet.Tool;
+using Cake.Common.Tools.DotNetCore.Execute;
 using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Common.Tools.DotNetCore.Run;
 using Cake.Common.Tools.DotNetCore.Tool;
@@ -28,6 +30,84 @@ namespace Cake.Common.Tools.DotNet
     [CakeAliasCategory("DotNet")]
     public static class DotNetAliases
     {
+        /// <summary>
+        /// Execute an assembly.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="assemblyPath">The assembly path.</param>
+        /// <example>
+        /// <code>
+        /// DotNetExecute("./bin/Debug/app.dll");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Execute")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Execute")]
+        public static void DotNetExecute(this ICakeContext context, FilePath assemblyPath)
+        {
+            context.DotNetExecute(assemblyPath, null);
+        }
+
+        /// <summary>
+        /// Execute an assembly with arguments in the specific path.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="assemblyPath">The assembly path.</param>
+        /// <param name="arguments">The arguments.</param>
+        /// <example>
+        /// <code>
+        /// DotNetExecute("./bin/Debug/app.dll", "--arg");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Execute")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Execute")]
+        public static void DotNetExecute(this ICakeContext context, FilePath assemblyPath, ProcessArgumentBuilder arguments)
+        {
+            context.DotNetExecute(assemblyPath, arguments, null);
+        }
+
+        /// <summary>
+        /// Execute an assembly with arguments in the specific path with settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="assemblyPath">The assembly path.</param>
+        /// <param name="arguments">The arguments.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// var settings = new DotNetExecuteSettings
+        /// {
+        ///     FrameworkVersion = "1.0.3"
+        /// };
+        ///
+        /// DotNetExecute("./bin/Debug/app.dll", "--arg", settings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Execute")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Execute")]
+        public static void DotNetExecute(this ICakeContext context, FilePath assemblyPath, ProcessArgumentBuilder arguments, DotNetExecuteSettings settings)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (assemblyPath is null)
+            {
+                throw new ArgumentNullException(nameof(assemblyPath));
+            }
+
+            if (settings is null)
+            {
+                settings = new DotNetExecuteSettings();
+            }
+
+            var executor = new DotNetCoreExecutor(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            executor.Execute(assemblyPath, arguments, settings);
+        }
+
         /// <summary>
         /// Run all projects.
         /// </summary>

--- a/src/Cake.Common/Tools/DotNet/Execute/DotNetExecuteSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Execute/DotNetExecuteSettings.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNetCore;
+using Cake.Common.Tools.DotNetCore.Execute;
+
+namespace Cake.Common.Tools.DotNet.Execute
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetCoreExecutor" />.
+    /// </summary>
+    public class DotNetExecuteSettings : DotNetCoreSettings
+    {
+        /// <summary>
+        /// Gets or sets the version of the installed Shared Framework to use to run the application.
+        /// </summary>
+        public string FrameworkVersion { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using Cake.Common.IO;
 using Cake.Common.Tools.DotNet;
+using Cake.Common.Tools.DotNet.Execute;
 using Cake.Common.Tools.DotNet.MSBuild;
 using Cake.Common.Tools.DotNet.Run;
 using Cake.Common.Tools.DotNet.Tool;
@@ -42,6 +43,7 @@ namespace Cake.Common.Tools.DotNetCore
     public static class DotNetCoreAliases
     {
         /// <summary>
+        /// [deprecated] DotNetCoreExecute is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetExecute(ICakeContext, FilePath)" /> instead.
         /// Execute an assembly.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -54,12 +56,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Execute")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Execute")]
+        [Obsolete("DotNetCoreExecute is obsolete and will be removed in a future release. Use DotNetExecute instead.")]
         public static void DotNetCoreExecute(this ICakeContext context, FilePath assemblyPath)
         {
-            context.DotNetCoreExecute(assemblyPath, null);
+            context.DotNetExecute(assemblyPath);
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreExecute is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetExecute(ICakeContext, FilePath, ProcessArgumentBuilder)" /> instead.
         /// Execute an assembly with arguments in the specific path.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -73,12 +77,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Execute")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Execute")]
+        [Obsolete("DotNetCoreExecute is obsolete and will be removed in a future release. Use DotNetExecute instead.")]
         public static void DotNetCoreExecute(this ICakeContext context, FilePath assemblyPath, ProcessArgumentBuilder arguments)
         {
-            context.DotNetCoreExecute(assemblyPath, arguments, null);
+            context.DotNetExecute(assemblyPath, arguments);
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreExecute is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetExecute(ICakeContext, FilePath, ProcessArgumentBuilder, DotNetExecuteSettings)" /> instead.
         /// Execute an assembly with arguments in the specific path with settings.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -98,25 +104,10 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Execute")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Execute")]
+        [Obsolete("DotNetCoreExecute is obsolete and will be removed in a future release. Use DotNetExecute instead.")]
         public static void DotNetCoreExecute(this ICakeContext context, FilePath assemblyPath, ProcessArgumentBuilder arguments, DotNetCoreExecuteSettings settings)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            if (assemblyPath == null)
-            {
-                throw new ArgumentNullException(nameof(assemblyPath));
-            }
-
-            if (settings == null)
-            {
-                settings = new DotNetCoreExecuteSettings();
-            }
-
-            var executor = new DotNetCoreExecutor(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            executor.Execute(assemblyPath, arguments, settings);
+            context.DotNetExecute(assemblyPath, arguments, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DotNetCore/Execute/DotNetCoreExecuteSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Execute/DotNetCoreExecuteSettings.cs
@@ -2,16 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Common.Tools.DotNet.Execute;
+
 namespace Cake.Common.Tools.DotNetCore.Execute
 {
     /// <summary>
     /// Contains settings used by <see cref="DotNetCoreExecutor" />.
     /// </summary>
-    public sealed class DotNetCoreExecuteSettings : DotNetCoreSettings
+    public sealed class DotNetCoreExecuteSettings : DotNetExecuteSettings
     {
-        /// <summary>
-        /// Gets or sets the version of the installed Shared Framework to use to run the application.
-        /// </summary>
-        public string FrameworkVersion { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/Execute/DotNetCoreExecutor.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Execute/DotNetCoreExecutor.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Cake.Common.Tools.DotNet;
+using Cake.Common.Tools.DotNet.Execute;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
@@ -12,7 +14,7 @@ namespace Cake.Common.Tools.DotNetCore.Execute
     /// <summary>
     /// .NET Core assembly executor.
     /// </summary>
-    public sealed class DotNetCoreExecutor : DotNetCoreTool<DotNetCoreSettings>
+    public sealed class DotNetCoreExecutor : DotNetTool<DotNetSettings>
     {
         private readonly ICakeEnvironment _environment;
 
@@ -38,7 +40,7 @@ namespace Cake.Common.Tools.DotNetCore.Execute
         /// <param name="assemblyPath">The assembly path.</param>
         /// <param name="arguments">The arguments.</param>
         /// <param name="settings">The settings.</param>
-        public void Execute(FilePath assemblyPath, ProcessArgumentBuilder arguments, DotNetCoreExecuteSettings settings)
+        public void Execute(FilePath assemblyPath, ProcessArgumentBuilder arguments, DotNetExecuteSettings settings)
         {
             if (assemblyPath == null)
             {
@@ -52,7 +54,7 @@ namespace Cake.Common.Tools.DotNetCore.Execute
             RunCommand(settings, GetArguments(assemblyPath, arguments, settings));
         }
 
-        private ProcessArgumentBuilder GetArguments(FilePath assemblyPath, ProcessArgumentBuilder arguments, DotNetCoreExecuteSettings settings)
+        private ProcessArgumentBuilder GetArguments(FilePath assemblyPath, ProcessArgumentBuilder arguments, DotNetExecuteSettings settings)
         {
             var builder = CreateArgumentBuilder(settings);
 


### PR DESCRIPTION
| DotNetCore                  |               | DotNet synonym                |
| --------------------------- |:-------------:| ----------------------------- |
| `DotNetCoreExecute`         | :arrow_right: | :new: `DotNetExecute`         |
| `DotNetCoreExecuteSettings` | :arrow_right: | :new: `DotNetExecuteSettings` |


- New `DotNetExecute` aliases are being introduced
- `DotNetExecute` aliases contain the code of the existing `DotNetCoreExecute` (rename/move)
- Existing `DotNetCoreExecute` aliases are forwarding calls to newly introduced `DotNetExecute` aliases
- New `DotNetExecuteSettings` class is being introduced
- `DotNetExecuteSettings` class contains the code of `DotNetCoreExecuteSettings` (rename/move)
- The previous `DotNetCoreExecuteSettings` is now empty and inherits from the new `DotNetExecuteSettings`
- Namespaces `Cake.Common.Runs.DotNetCore.*` have been preserved as to not introduce breaking changes
- Unit Tests and Integration Tests remain the same, and call the old `DotNetCore***` aliases, exercising the new `DotNet***` aliases in the process

---

Closes https://github.com/cake-build/cake/issues/3544
