### PR TITLE
GH3545: Add DotNetClean alias (synonym to DotNetCoreClean)

### DIFF
--- a/src/Cake.Common/Tools/DotNet/Clean/DotNetCleanSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Clean/DotNetCleanSettings.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNetCore;
+using Cake.Common.Tools.DotNetCore.Clean;
+using Cake.Common.Tools.DotNetCore.MSBuild;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotNet.Clean
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetCoreCleaner" />.
+    /// </summary>
+    public class DotNetCleanSettings : DotNetCoreSettings
+    {
+        /// <summary>
+        /// Gets or sets the output directory.
+        /// </summary>
+        public DirectoryPath OutputDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the configuration under which to build.
+        /// </summary>
+        public string Configuration { get; set; }
+
+        /// <summary>
+        /// Gets or sets the specific framework to compile.
+        /// </summary>
+        public string Framework { get; set; }
+
+        /// <summary>
+        /// Gets or sets the target runtime.
+        /// </summary>
+        public string Runtime { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to display the startup banner or the copyright message.
+        /// </summary>
+        /// <remarks>
+        /// Available since .NET Core 3.0 SDK.
+        /// </remarks>
+        public bool NoLogo { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional arguments to be passed to MSBuild.
+        /// </summary>
+        public DotNetCoreMSBuildSettings MSBuildSettings { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
@@ -5,10 +5,12 @@
 using System;
 using System.Collections.Generic;
 using Cake.Common.IO;
+using Cake.Common.Tools.DotNet.Clean;
 using Cake.Common.Tools.DotNet.Execute;
 using Cake.Common.Tools.DotNet.MSBuild;
 using Cake.Common.Tools.DotNet.Run;
 using Cake.Common.Tools.DotNet.Tool;
+using Cake.Common.Tools.DotNetCore.Clean;
 using Cake.Common.Tools.DotNetCore.Execute;
 using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Common.Tools.DotNetCore.Run;
@@ -106,6 +108,61 @@ namespace Cake.Common.Tools.DotNet
 
             var executor = new DotNetCoreExecutor(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             executor.Execute(assemblyPath, arguments, settings);
+        }
+
+        /// <summary>
+        /// Cleans a project's output.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="project">The project's path.</param>
+        /// <example>
+        /// <code>
+        /// DotNetClean("./src/project");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Clean")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Clean")]
+        public static void DotNetClean(this ICakeContext context, string project)
+        {
+            context.DotNetClean(project, null);
+        }
+
+        /// <summary>
+        /// Cleans a project's output.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="project">The projects path.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// var settings = new DotNetCleanSettings
+        /// {
+        ///     Framework = "netcoreapp2.0",
+        ///     Configuration = "Debug",
+        ///     OutputDirectory = "./artifacts/"
+        /// };
+        ///
+        /// DotNetClean("./src/project", settings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Clean")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Clean")]
+        public static void DotNetClean(this ICakeContext context, string project, DotNetCleanSettings settings)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (settings is null)
+            {
+                settings = new DotNetCleanSettings();
+            }
+
+            var cleaner = new DotNetCoreCleaner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            cleaner.Clean(project, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DotNetCore/Clean/DotNetCoreCleanSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Clean/DotNetCoreCleanSettings.cs
@@ -2,47 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Common.Tools.DotNetCore.MSBuild;
-using Cake.Core.IO;
+using Cake.Common.Tools.DotNet.Clean;
 
 namespace Cake.Common.Tools.DotNetCore.Clean
 {
     /// <summary>
     /// Contains settings used by <see cref="DotNetCoreCleaner" />.
     /// </summary>
-    public sealed class DotNetCoreCleanSettings : DotNetCoreSettings
+    public sealed class DotNetCoreCleanSettings : DotNetCleanSettings
     {
-        /// <summary>
-        /// Gets or sets the output directory.
-        /// </summary>
-        public DirectoryPath OutputDirectory { get; set; }
-
-        /// <summary>
-        /// Gets or sets the configuration under which to build.
-        /// </summary>
-        public string Configuration { get; set; }
-
-        /// <summary>
-        /// Gets or sets the specific framework to compile.
-        /// </summary>
-        public string Framework { get; set; }
-
-        /// <summary>
-        /// Gets or sets the target runtime.
-        /// </summary>
-        public string Runtime { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to display the startup banner or the copyright message.
-        /// </summary>
-        /// <remarks>
-        /// Available since .NET Core 3.0 SDK.
-        /// </remarks>
-        public bool NoLogo { get; set; }
-
-        /// <summary>
-        /// Gets or sets additional arguments to be passed to MSBuild.
-        /// </summary>
-        public DotNetCoreMSBuildSettings MSBuildSettings { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/Clean/DotNetCoreCleaner.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Clean/DotNetCoreCleaner.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Cake.Common.Tools.DotNet.Clean;
 using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Core;
 using Cake.Core.IO;
@@ -13,7 +14,7 @@ namespace Cake.Common.Tools.DotNetCore.Clean
     /// <summary>
     /// .NET Core project cleaner.
     /// </summary>
-    public sealed class DotNetCoreCleaner : DotNetCoreTool<DotNetCoreCleanSettings>
+    public sealed class DotNetCoreCleaner : DotNetCoreTool<DotNetCleanSettings>
     {
         private readonly ICakeEnvironment _environment;
 
@@ -38,7 +39,7 @@ namespace Cake.Common.Tools.DotNetCore.Clean
         /// </summary>
         /// <param name="project">The target project path.</param>
         /// <param name="settings">The settings.</param>
-        public void Clean(string project, DotNetCoreCleanSettings settings)
+        public void Clean(string project, DotNetCleanSettings settings)
         {
             if (project == null)
             {
@@ -52,7 +53,7 @@ namespace Cake.Common.Tools.DotNetCore.Clean
             RunCommand(settings, GetArguments(project, settings));
         }
 
-        private ProcessArgumentBuilder GetArguments(string project, DotNetCoreCleanSettings settings)
+        private ProcessArgumentBuilder GetArguments(string project, DotNetCleanSettings settings)
         {
             var builder = CreateArgumentBuilder(settings);
 

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using Cake.Common.IO;
 using Cake.Common.Tools.DotNet;
+using Cake.Common.Tools.DotNet.Clean;
 using Cake.Common.Tools.DotNet.Execute;
 using Cake.Common.Tools.DotNet.MSBuild;
 using Cake.Common.Tools.DotNet.Run;
@@ -660,6 +661,7 @@ namespace Cake.Common.Tools.DotNetCore
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreClean is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetClean(ICakeContext, string)" /> instead.
         /// Cleans a project's output.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -672,12 +674,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Clean")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Clean")]
+        [Obsolete("DotNetCoreClean is obsolete and will be removed in a future release. Use DotNetClean instead.")]
         public static void DotNetCoreClean(this ICakeContext context, string project)
         {
-            context.DotNetCoreClean(project, null);
+            context.DotNetClean(project);
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreClean is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetClean(ICakeContext, string, DotNetCleanSettings)" /> instead.
         /// Cleans a project's output.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -698,20 +702,10 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Clean")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Clean")]
+        [Obsolete("DotNetCoreClean is obsolete and will be removed in a future release. Use DotNetClean instead.")]
         public static void DotNetCoreClean(this ICakeContext context, string project, DotNetCoreCleanSettings settings)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            if (settings == null)
-            {
-                settings = new DotNetCoreCleanSettings();
-            }
-
-            var cleaner = new DotNetCoreCleaner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            cleaner.Clean(project, settings);
+            context.DotNetClean(project, settings);
         }
 
         /// <summary>


### PR DESCRIPTION
| DotNetCore                |               | DotNet synonym              |
| ------------------------- |:-------------:| --------------------------- |
| `DotNetCoreClean`         | :arrow_right: | :new: `DotNetClean`         |
| `DotNetCoreCleanSettings` | :arrow_right: | :new: `DotNetCleanSettings` |


- New `DotNetClean` aliases are being introduced
- `DotNetClean` aliases contain the code of the existing `DotNetCoreClean` (rename/move)
- Existing `DotNetCoreClean` aliases are forwarding calls to newly introduced `DotNetClean` aliases
- New `DotNetCleanSettings` class is being introduced
- `DotNetCleanSettings` class contains the code of `DotNetCoreCleanSettings` (rename/move)
- The previous `DotNetCoreCleanSettings` is now empty and inherits from the new `DotNetCleanSettings`
- Namespaces `Cake.Common.Clean.DotNetCore.*` have been preserved as to not introduce breaking changes
- Unit Tests and Integration Tests remain the same, and call the old `DotNetCore***` aliases, exercising the new `DotNet***` aliases in the process

---

Closes https://github.com/cake-build/cake/issues/3545

