### PR TITLE
GH3546: Add DotNetRestore alias (synonym to DotNetCoreRestore)

### DIFF
--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
@@ -8,11 +8,13 @@ using Cake.Common.IO;
 using Cake.Common.Tools.DotNet.Clean;
 using Cake.Common.Tools.DotNet.Execute;
 using Cake.Common.Tools.DotNet.MSBuild;
+using Cake.Common.Tools.DotNet.Restore;
 using Cake.Common.Tools.DotNet.Run;
 using Cake.Common.Tools.DotNet.Tool;
 using Cake.Common.Tools.DotNetCore.Clean;
 using Cake.Common.Tools.DotNetCore.Execute;
 using Cake.Common.Tools.DotNetCore.MSBuild;
+using Cake.Common.Tools.DotNetCore.Restore;
 using Cake.Common.Tools.DotNetCore.Run;
 using Cake.Common.Tools.DotNetCore.Tool;
 using Cake.Core;
@@ -108,6 +110,109 @@ namespace Cake.Common.Tools.DotNet
 
             var executor = new DotNetCoreExecutor(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             executor.Execute(assemblyPath, arguments, settings);
+        }
+
+        /// <summary>
+        /// Restore all NuGet Packages.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <example>
+        /// <code>
+        /// DotNetRestore();
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Restore")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Restore")]
+        public static void DotNetRestore(this ICakeContext context)
+        {
+            context.DotNetRestore(null, null);
+        }
+
+        /// <summary>
+        /// Restore all NuGet Packages in the specified path.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="root">List of projects and project folders to restore. Each value can be: a path to a project.json or global.json file, or a folder to recursively search for project.json files.</param>
+        /// <example>
+        /// <code>
+        /// DotNetRestore("./src/*");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Restore")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Restore")]
+        public static void DotNetRestore(this ICakeContext context, string root)
+        {
+            context.DotNetRestore(root, null);
+        }
+
+        /// <summary>
+        /// Restore all NuGet Packages with the settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// var settings = new DotNetRestoreSettings
+        /// {
+        ///     Sources = new[] {"https://www.example.com/nugetfeed", "https://www.example.com/nugetfeed2"},
+        ///     FallbackSources = new[] {"https://www.example.com/fallbacknugetfeed"},
+        ///     PackagesDirectory = "./packages",
+        ///     Verbosity = Information,
+        ///     DisableParallel = true,
+        ///     InferRuntimes = new[] {"runtime1", "runtime2"}
+        /// };
+        ///
+        /// DotNetRestore(settings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Restore")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Restore")]
+        public static void DotNetRestore(this ICakeContext context, DotNetRestoreSettings settings)
+        {
+            context.DotNetRestore(null, settings);
+        }
+
+        /// <summary>
+        /// Restore all NuGet Packages in the specified path with settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="root">List of projects and project folders to restore. Each value can be: a path to a project.json or global.json file, or a folder to recursively search for project.json files.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// var settings = new DotNetRestoreSettings
+        /// {
+        ///     Sources = new[] {"https://www.example.com/nugetfeed", "https://www.example.com/nugetfeed2"},
+        ///     FallbackSources = new[] {"https://www.example.com/fallbacknugetfeed"},
+        ///     PackagesDirectory = "./packages",
+        ///     Verbosity = Information,
+        ///     DisableParallel = true,
+        ///     InferRuntimes = new[] {"runtime1", "runtime2"}
+        /// };
+        ///
+        /// DotNetRestore("./src/*", settings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Restore")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Restore")]
+        public static void DotNetRestore(this ICakeContext context, string root, DotNetRestoreSettings settings)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (settings is null)
+            {
+                settings = new DotNetRestoreSettings();
+            }
+
+            var restorer = new DotNetCoreRestorer(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools, context.Log);
+            restorer.Restore(root, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DotNet/Restore/DotNetRestoreSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Restore/DotNetRestoreSettings.cs
@@ -1,0 +1,118 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Cake.Common.Tools.DotNetCore;
+using Cake.Common.Tools.DotNetCore.MSBuild;
+using Cake.Common.Tools.DotNetCore.Restore;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotNet.Restore
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetCoreRestoreSettings" />.
+    /// </summary>
+    public class DotNetRestoreSettings : DotNetCoreSettings
+    {
+        /// <summary>
+        /// Gets or sets the specified NuGet package sources to use during the restore.
+        /// </summary>
+        public ICollection<string> Sources { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets the NuGet configuration file to use.
+        /// </summary>
+        public FilePath ConfigFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the directory to install packages in.
+        /// </summary>
+        public DirectoryPath PackagesDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to do not cache packages and http requests.
+        /// </summary>
+        public bool NoCache { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to disable restoring multiple projects in parallel.
+        /// </summary>
+        public bool DisableParallel { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to only warning failed sources if there are packages meeting version requirement.
+        /// </summary>
+        public bool IgnoreFailedSources { get; set; }
+
+        /// <summary>
+        /// Gets or sets the target runtime to restore packages for.
+        /// </summary>
+        public string Runtime { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to ignore project to project references and restore only the root project.
+        /// </summary>
+        public bool NoDependencies { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to force all dependencies to be resolved even if the last restore was successful.
+        /// This is equivalent to deleting the project.assets.json file.
+        ///
+        /// Note: This flag was introduced with the .NET Core 2.x release.
+        /// </summary>
+        public bool Force { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to stop and wait for user input or action (for example to complete authentication).
+        /// </summary>
+        /// <remarks>
+        /// Supported by .NET SDK version 2.1.400 and above.
+        /// </remarks>
+        public bool Interactive { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to enable project lock file to be generated and used with restore.
+        /// </summary>
+        /// <remarks>
+        /// Supported by .NET SDK version 2.1.500 and above.
+        /// </remarks>
+        public bool UseLockFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to not allow updating project lock file.
+        /// </summary>
+        /// <remarks>
+        /// When set to true, restore will fail if the lock file is out of sync.
+        /// Useful for CI builds when you do not want the build to continue if the package closure has changed than what is present in the lock file.
+        /// <para>
+        /// Supported by .NET SDK version 2.1.500 and above.
+        /// </para>
+        /// </remarks>
+        public bool LockedMode { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating output location where project lock file is written.
+        /// </summary>
+        /// <remarks>
+        /// If not set, 'dotnet restore' defaults to 'PROJECT_ROOT\packages.lock.json'.
+        /// <para>
+        /// Supported by .NET SDK version 2.1.500 and above.
+        /// </para>
+        /// </remarks>
+        public FilePath LockFilePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to force restore to reevaluate all dependencies even if a lock file already exists.
+        /// </summary>
+        /// <remarks>
+        /// Supported by .NET SDK version 2.1.500 and above.
+        /// </remarks>
+        public bool ForceEvaluate { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional arguments to be passed to MSBuild.
+        /// </summary>
+        public DotNetCoreMSBuildSettings MSBuildSettings { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -9,6 +9,7 @@ using Cake.Common.Tools.DotNet;
 using Cake.Common.Tools.DotNet.Clean;
 using Cake.Common.Tools.DotNet.Execute;
 using Cake.Common.Tools.DotNet.MSBuild;
+using Cake.Common.Tools.DotNet.Restore;
 using Cake.Common.Tools.DotNet.Run;
 using Cake.Common.Tools.DotNet.Tool;
 using Cake.Common.Tools.DotNetCore.Build;
@@ -112,6 +113,7 @@ namespace Cake.Common.Tools.DotNetCore
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreRestore is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetRestore(ICakeContext)" /> instead.
         /// Restore all NuGet Packages.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -123,12 +125,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Restore")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Restore")]
+        [Obsolete("DotNetCoreRestore is obsolete and will be removed in a future release. Use DotNetRestore instead.")]
         public static void DotNetCoreRestore(this ICakeContext context)
         {
-            context.DotNetCoreRestore(null, null);
+            context.DotNetRestore();
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreRestore is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetRestore(ICakeContext, string)" /> instead.
         /// Restore all NuGet Packages in the specified path.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -141,12 +145,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Restore")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Restore")]
+        [Obsolete("DotNetCoreRestore is obsolete and will be removed in a future release. Use DotNetRestore instead.")]
         public static void DotNetCoreRestore(this ICakeContext context, string root)
         {
-            context.DotNetCoreRestore(root, null);
+            context.DotNetRestore(root);
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreRestore is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetRestore(ICakeContext, DotNetRestoreSettings)" /> instead.
         /// Restore all NuGet Packages with the settings.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -169,12 +175,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Restore")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Restore")]
+        [Obsolete("DotNetCoreRestore is obsolete and will be removed in a future release. Use DotNetRestore instead.")]
         public static void DotNetCoreRestore(this ICakeContext context, DotNetCoreRestoreSettings settings)
         {
-            context.DotNetCoreRestore(null, settings);
+            context.DotNetRestore(settings);
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreRestore is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetRestore(ICakeContext, string, DotNetRestoreSettings)" /> instead.
         /// Restore all NuGet Packages in the specified path with settings.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -198,20 +206,10 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Restore")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Restore")]
+        [Obsolete("DotNetCoreRestore is obsolete and will be removed in a future release. Use DotNetRestore instead.")]
         public static void DotNetCoreRestore(this ICakeContext context, string root, DotNetCoreRestoreSettings settings)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            if (settings == null)
-            {
-                settings = new DotNetCoreRestoreSettings();
-            }
-
-            var restorer = new DotNetCoreRestorer(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools, context.Log);
-            restorer.Restore(root, settings);
+            context.DotNetRestore(root, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DotNetCore/Restore/DotNetCoreRestoreSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Restore/DotNetCoreRestoreSettings.cs
@@ -2,115 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using Cake.Common.Tools.DotNetCore.MSBuild;
-using Cake.Core.IO;
+using Cake.Common.Tools.DotNet.Restore;
 
 namespace Cake.Common.Tools.DotNetCore.Restore
 {
     /// <summary>
     /// Contains settings used by <see cref="DotNetCoreRestoreSettings" />.
     /// </summary>
-    public sealed class DotNetCoreRestoreSettings : DotNetCoreSettings
+    public sealed class DotNetCoreRestoreSettings : DotNetRestoreSettings
     {
-        /// <summary>
-        /// Gets or sets the specified NuGet package sources to use during the restore.
-        /// </summary>
-        public ICollection<string> Sources { get; set; } = new List<string>();
-
-        /// <summary>
-        /// Gets or sets the NuGet configuration file to use.
-        /// </summary>
-        public FilePath ConfigFile { get; set; }
-
-        /// <summary>
-        /// Gets or sets the directory to install packages in.
-        /// </summary>
-        public DirectoryPath PackagesDirectory { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to do not cache packages and http requests.
-        /// </summary>
-        public bool NoCache { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to disable restoring multiple projects in parallel.
-        /// </summary>
-        public bool DisableParallel { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to only warning failed sources if there are packages meeting version requirement.
-        /// </summary>
-        public bool IgnoreFailedSources { get; set; }
-
-        /// <summary>
-        /// Gets or sets the target runtime to restore packages for.
-        /// </summary>
-        public string Runtime { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to ignore project to project references and restore only the root project.
-        /// </summary>
-        public bool NoDependencies { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to force all dependencies to be resolved even if the last restore was successful.
-        /// This is equivalent to deleting the project.assets.json file.
-        ///
-        /// Note: This flag was introduced with the .NET Core 2.x release.
-        /// </summary>
-        public bool Force { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to stop and wait for user input or action (for example to complete authentication).
-        /// </summary>
-        /// <remarks>
-        /// Supported by .NET SDK version 2.1.400 and above.
-        /// </remarks>
-        public bool Interactive { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to enable project lock file to be generated and used with restore.
-        /// </summary>
-        /// <remarks>
-        /// Supported by .NET SDK version 2.1.500 and above.
-        /// </remarks>
-        public bool UseLockFile { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to not allow updating project lock file.
-        /// </summary>
-        /// <remarks>
-        /// When set to true, restore will fail if the lock file is out of sync.
-        /// Useful for CI builds when you do not want the build to continue if the package closure has changed than what is present in the lock file.
-        /// <para>
-        /// Supported by .NET SDK version 2.1.500 and above.
-        /// </para>
-        /// </remarks>
-        public bool LockedMode { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating output location where project lock file is written.
-        /// </summary>
-        /// <remarks>
-        /// If not set, 'dotnet restore' defaults to 'PROJECT_ROOT\packages.lock.json'.
-        /// <para>
-        /// Supported by .NET SDK version 2.1.500 and above.
-        /// </para>
-        /// </remarks>
-        public FilePath LockFilePath { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to force restore to reevaluate all dependencies even if a lock file already exists.
-        /// </summary>
-        /// <remarks>
-        /// Supported by .NET SDK version 2.1.500 and above.
-        /// </remarks>
-        public bool ForceEvaluate { get; set; }
-
-        /// <summary>
-        /// Gets or sets additional arguments to be passed to MSBuild.
-        /// </summary>
-        public DotNetCoreMSBuildSettings MSBuildSettings { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/Restore/DotNetCoreRestorer.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Restore/DotNetCoreRestorer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Cake.Common.Tools.DotNet.Restore;
 using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Core;
 using Cake.Core.Diagnostics;
@@ -14,7 +15,7 @@ namespace Cake.Common.Tools.DotNetCore.Restore
     /// <summary>
     /// .NET Core project restorer.
     /// </summary>
-    public sealed class DotNetCoreRestorer : DotNetCoreTool<DotNetCoreRestoreSettings>
+    public sealed class DotNetCoreRestorer : DotNetCoreTool<DotNetRestoreSettings>
     {
         private readonly ICakeEnvironment _environment;
         private readonly ICakeLog _log;
@@ -43,7 +44,7 @@ namespace Cake.Common.Tools.DotNetCore.Restore
         /// </summary>
         /// <param name="root">List of projects and project folders to restore. Each value can be: a path to a project.json or global.json file, or a folder to recursively search for project.json files.</param>
         /// <param name="settings">The settings.</param>
-        public void Restore(string root, DotNetCoreRestoreSettings settings)
+        public void Restore(string root, DotNetRestoreSettings settings)
         {
             if (settings == null)
             {
@@ -53,7 +54,7 @@ namespace Cake.Common.Tools.DotNetCore.Restore
             RunCommand(settings, GetArguments(root, settings));
         }
 
-        private ProcessArgumentBuilder GetArguments(string root, DotNetCoreRestoreSettings settings)
+        private ProcessArgumentBuilder GetArguments(string root, DotNetRestoreSettings settings)
         {
             var builder = CreateArgumentBuilder(settings);
 


### PR DESCRIPTION
| DotNetCore                  |               | DotNet synonym                |
| --------------------------- |:-------------:| ----------------------------- |
| `DotNetCoreRestore`         | :arrow_right: | :new: `DotNetRestore`         |
| `DotNetCoreRestoreSettings` | :arrow_right: | :new: `DotNetRestoreSettings` |


- New `DotNetRestore` aliases are being introduced
- `DotNetRestore` aliases contain the code of the existing `DotNetCoreRestore` (rename/move)
- Existing `DotNetCoreRestore` aliases are forwarding calls to newly introduced `DotNetRestore` aliases
- New `DotNetRestoreSettings` class is being introduced
- `DotNetRestoreSettings` class contains the code of `DotNetCoreRestoreSettings` (rename/move)
- The previous `DotNetCoreRestoreSettings` is now empty and inherits from the new `DotNetRestoreSettings`
- Namespaces `Cake.Common.Restore.DotNetCore.*` have been preserved as to not introduce breaking changes
- Unit Tests and Integration Tests remain the same, and call the old `DotNetCore***` aliases, exercising the new `DotNet***` aliases in the process

---

Closes https://github.com/cake-build/cake/issues/3546
