### PR TITLE
GH3547: Add DotNetBuild alias (synonym to DotNetCoreBuild)

### DIFF
--- a/src/Cake.Common/Tools/DotNet/Build/DotNetBuildSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Build/DotNetBuildSettings.cs
@@ -1,0 +1,84 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Cake.Common.Tools.DotNetCore;
+using Cake.Common.Tools.DotNetCore.Build;
+using Cake.Common.Tools.DotNetCore.MSBuild;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotNet.Build
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetCoreBuilder" />.
+    /// </summary>
+    public class DotNetBuildSettings : DotNetCoreSettings
+    {
+        /// <summary>
+        /// Gets or sets the output directory.
+        /// </summary>
+        public DirectoryPath OutputDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the target runtime.
+        /// </summary>
+        public string Runtime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the configuration under which to build.
+        /// </summary>
+        public string Configuration { get; set; }
+
+        /// <summary>
+        /// Gets or sets the specific framework to compile.
+        /// </summary>
+        public string Framework { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value that defines what `*` should be replaced with in version field in project.json.
+        /// </summary>
+        public string VersionSuffix { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to mark the build as unsafe for incrementality.
+        /// This turns off incremental compilation and forces a clean rebuild of the project dependency graph.
+        /// </summary>
+        public bool NoIncremental { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to ignore project to project references and only build the root project.
+        /// </summary>
+        public bool NoDependencies { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to not do implicit NuGet package restore.
+        /// This makes build faster, but requires restore to be done before build is executed.
+        /// </summary>
+        /// <remarks>
+        /// Requires .NET Core 2.x or newer.
+        /// </remarks>
+        public bool NoRestore { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to display the startup banner or the copyright message.
+        /// </summary>
+        /// <remarks>
+        /// Available since .NET Core 3.0 SDK.
+        /// </remarks>
+        public bool NoLogo { get; set; }
+
+        /// <summary>
+        /// Gets or sets the specified NuGet package sources to use during the build.
+        /// </summary>
+        /// <remarks>
+        /// Requires .NET Core 2.x or newer.
+        /// </remarks>
+        public ICollection<string> Sources { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets additional arguments to be passed to MSBuild.
+        /// </summary>
+        public DotNetCoreMSBuildSettings MSBuildSettings { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
@@ -5,12 +5,14 @@
 using System;
 using System.Collections.Generic;
 using Cake.Common.IO;
+using Cake.Common.Tools.DotNet.Build;
 using Cake.Common.Tools.DotNet.Clean;
 using Cake.Common.Tools.DotNet.Execute;
 using Cake.Common.Tools.DotNet.MSBuild;
 using Cake.Common.Tools.DotNet.Restore;
 using Cake.Common.Tools.DotNet.Run;
 using Cake.Common.Tools.DotNet.Tool;
+using Cake.Common.Tools.DotNetCore.Build;
 using Cake.Common.Tools.DotNetCore.Clean;
 using Cake.Common.Tools.DotNetCore.Execute;
 using Cake.Common.Tools.DotNetCore.MSBuild;
@@ -213,6 +215,61 @@ namespace Cake.Common.Tools.DotNet
 
             var restorer = new DotNetCoreRestorer(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools, context.Log);
             restorer.Restore(root, settings);
+        }
+
+        /// <summary>
+        /// Build all projects.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="project">The projects path.</param>
+        /// <example>
+        /// <code>
+        /// DotNetBuild("./src/*");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Build")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Build")]
+        public static void DotNetBuild(this ICakeContext context, string project)
+        {
+            context.DotNetBuild(project, null);
+        }
+
+        /// <summary>
+        /// Build all projects.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="project">The projects path.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// var settings = new DotNetBuildSettings
+        /// {
+        ///     Framework = "netcoreapp2.0",
+        ///     Configuration = "Debug",
+        ///     OutputDirectory = "./artifacts/"
+        /// };
+        ///
+        /// DotNetBuild("./src/*", settings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Build")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Build")]
+        public static void DotNetBuild(this ICakeContext context, string project, DotNetBuildSettings settings)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (settings is null)
+            {
+                settings = new DotNetBuildSettings();
+            }
+
+            var builder = new DotNetCoreBuilder(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            builder.Build(project, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DotNetCore/Build/DotNetCoreBuildSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Build/DotNetCoreBuildSettings.cs
@@ -2,81 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using Cake.Common.Tools.DotNetCore.MSBuild;
-using Cake.Core.IO;
+using Cake.Common.Tools.DotNet.Build;
 
 namespace Cake.Common.Tools.DotNetCore.Build
 {
     /// <summary>
     /// Contains settings used by <see cref="DotNetCoreBuilder" />.
     /// </summary>
-    public sealed class DotNetCoreBuildSettings : DotNetCoreSettings
+    public sealed class DotNetCoreBuildSettings : DotNetBuildSettings
     {
-        /// <summary>
-        /// Gets or sets the output directory.
-        /// </summary>
-        public DirectoryPath OutputDirectory { get; set; }
-
-        /// <summary>
-        /// Gets or sets the target runtime.
-        /// </summary>
-        public string Runtime { get; set; }
-
-        /// <summary>
-        /// Gets or sets the configuration under which to build.
-        /// </summary>
-        public string Configuration { get; set; }
-
-        /// <summary>
-        /// Gets or sets the specific framework to compile.
-        /// </summary>
-        public string Framework { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value that defines what `*` should be replaced with in version field in project.json.
-        /// </summary>
-        public string VersionSuffix { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to mark the build as unsafe for incrementality.
-        /// This turns off incremental compilation and forces a clean rebuild of the project dependency graph.
-        /// </summary>
-        public bool NoIncremental { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to ignore project to project references and only build the root project.
-        /// </summary>
-        public bool NoDependencies { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to not do implicit NuGet package restore.
-        /// This makes build faster, but requires restore to be done before build is executed.
-        /// </summary>
-        /// <remarks>
-        /// Requires .NET Core 2.x or newer.
-        /// </remarks>
-        public bool NoRestore { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to display the startup banner or the copyright message.
-        /// </summary>
-        /// <remarks>
-        /// Available since .NET Core 3.0 SDK.
-        /// </remarks>
-        public bool NoLogo { get; set; }
-
-        /// <summary>
-        /// Gets or sets the specified NuGet package sources to use during the build.
-        /// </summary>
-        /// <remarks>
-        /// Requires .NET Core 2.x or newer.
-        /// </remarks>
-        public ICollection<string> Sources { get; set; } = new List<string>();
-
-        /// <summary>
-        /// Gets or sets additional arguments to be passed to MSBuild.
-        /// </summary>
-        public DotNetCoreMSBuildSettings MSBuildSettings { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/Build/DotNetCoreBuilder.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Build/DotNetCoreBuilder.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Cake.Common.Tools.DotNet.Build;
 using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Core;
 using Cake.Core.IO;
@@ -13,7 +14,7 @@ namespace Cake.Common.Tools.DotNetCore.Build
     /// <summary>
     /// .NET Core project builder.
     /// </summary>
-    public sealed class DotNetCoreBuilder : DotNetCoreTool<DotNetCoreBuildSettings>
+    public sealed class DotNetCoreBuilder : DotNetCoreTool<DotNetBuildSettings>
     {
         private readonly ICakeEnvironment _environment;
 
@@ -38,7 +39,7 @@ namespace Cake.Common.Tools.DotNetCore.Build
         /// </summary>
         /// <param name="project">The target project path.</param>
         /// <param name="settings">The settings.</param>
-        public void Build(string project, DotNetCoreBuildSettings settings)
+        public void Build(string project, DotNetBuildSettings settings)
         {
             if (project == null)
             {
@@ -52,7 +53,7 @@ namespace Cake.Common.Tools.DotNetCore.Build
             RunCommand(settings, GetArguments(project, settings));
         }
 
-        private ProcessArgumentBuilder GetArguments(string project, DotNetCoreBuildSettings settings)
+        private ProcessArgumentBuilder GetArguments(string project, DotNetBuildSettings settings)
         {
             var builder = CreateArgumentBuilder(settings);
 

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using Cake.Common.IO;
 using Cake.Common.Tools.DotNet;
+using Cake.Common.Tools.DotNet.Build;
 using Cake.Common.Tools.DotNet.Clean;
 using Cake.Common.Tools.DotNet.Execute;
 using Cake.Common.Tools.DotNet.MSBuild;
@@ -213,6 +214,7 @@ namespace Cake.Common.Tools.DotNetCore
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreBuild is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetBuild(ICakeContext, string)" /> instead.
         /// Build all projects.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -225,12 +227,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Build")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Build")]
+        [Obsolete("DotNetCoreBuild is obsolete and will be removed in a future release. Use DotNetBuild instead.")]
         public static void DotNetCoreBuild(this ICakeContext context, string project)
         {
-            context.DotNetCoreBuild(project, null);
+            context.DotNetBuild(project);
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreBuild is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetBuild(ICakeContext, string, DotNetBuildSettings)" /> instead.
         /// Build all projects.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -251,20 +255,10 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Build")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Build")]
+        [Obsolete("DotNetCoreBuild is obsolete and will be removed in a future release. Use DotNetBuild instead.")]
         public static void DotNetCoreBuild(this ICakeContext context, string project, DotNetCoreBuildSettings settings)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            if (settings == null)
-            {
-                settings = new DotNetCoreBuildSettings();
-            }
-
-            var builder = new DotNetCoreBuilder(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            builder.Build(project, settings);
+            context.DotNetBuild(project, settings);
         }
 
         /// <summary>


### PR DESCRIPTION
| DotNetCore                |               | DotNet synonym              |
| ------------------------- |:-------------:| --------------------------- |
| `DotNetCoreBuild`         | :arrow_right: | :new: `DotNetBuild`         |
| `DotNetCoreBuildSettings` | :arrow_right: | :new: `DotNetBuildSettings` |


- New `DotNetBuild` aliases are being introduced
- `DotNetBuild` aliases contain the code of the existing `DotNetCoreBuild` (rename/move)
- Existing `DotNetCoreBuild` aliases are forwarding calls to newly introduced `DotNetBuild` aliases
- New `DotNetBuildSettings` class is being introduced
- `DotNetBuildSettings` class contains the code of `DotNetCoreBuildSettings` (rename/move)
- The previous `DotNetCoreBuildSettings` is now empty and inherits from the new `DotNetBuildSettings`
- Namespaces `Cake.Common.Tools.DotNetCore.Build.*` have been preserved as to not introduce breaking changes
- Unit Tests and Integration Tests remain the same, and call the old `DotNetCore***` aliases, exercising the new `DotNet***` aliases in the process

---

Closes https://github.com/cake-build/cake/issues/3547
