### PR TITLE
GH3549: Add DotNetTest alias (synonym to DotNetCoreTest)

### DIFF
--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
@@ -12,6 +12,7 @@ using Cake.Common.Tools.DotNet.Execute;
 using Cake.Common.Tools.DotNet.MSBuild;
 using Cake.Common.Tools.DotNet.Restore;
 using Cake.Common.Tools.DotNet.Run;
+using Cake.Common.Tools.DotNet.Test;
 using Cake.Common.Tools.DotNet.Tool;
 using Cake.Common.Tools.DotNetCore.Build;
 using Cake.Common.Tools.DotNetCore.BuildServer;
@@ -20,6 +21,7 @@ using Cake.Common.Tools.DotNetCore.Execute;
 using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Common.Tools.DotNetCore.Restore;
 using Cake.Common.Tools.DotNetCore.Run;
+using Cake.Common.Tools.DotNetCore.Test;
 using Cake.Common.Tools.DotNetCore.Tool;
 using Cake.Core;
 using Cake.Core.Annotations;
@@ -272,6 +274,173 @@ namespace Cake.Common.Tools.DotNet
 
             var builder = new DotNetCoreBuilder(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             builder.Build(project, settings);
+        }
+
+        /// <summary>
+        /// Test project.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <example>
+        /// <code>
+        /// DotNetTest();
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Test")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Test")]
+        public static void DotNetTest(this ICakeContext context)
+        {
+            context.DotNetTest(null, null, null);
+        }
+
+        /// <summary>
+        /// Test project with path.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="project">The project path.</param>
+        /// <example>
+        /// <para>Specify the path to the .csproj file in the test project.</para>
+        /// <code>
+        /// DotNetTest("./test/Project.Tests/Project.Tests.csproj");
+        /// </code>
+        /// <para>You could also specify a task that runs multiple test projects.</para>
+        /// <para>Cake task:</para>
+        /// <code>
+        /// Task("Test")
+        ///     .Does(() =>
+        /// {
+        ///     var projectFiles = GetFiles("./test/**/*.csproj");
+        ///     foreach(var file in projectFiles)
+        ///     {
+        ///         DotNetTest(file.FullPath);
+        ///     }
+        /// });
+        /// </code>
+        /// <para>If your test project is using project.json, the project parameter should just be the directory path.</para>
+        /// <code>
+        /// DotNetTest("./test/Project.Tests/");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Test")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Test")]
+        public static void DotNetTest(this ICakeContext context, string project)
+        {
+            context.DotNetTest(project, null, null);
+        }
+
+        /// <summary>
+        /// Test project with settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="project">The project path.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// var settings = new DotNetTestSettings
+        /// {
+        ///     Configuration = "Release"
+        /// };
+        ///
+        /// DotNetTest("./test/Project.Tests/Project.Tests.csproj", settings);
+        /// </code>
+        /// <para>You could also specify a task that runs multiple test projects.</para>
+        /// <para>Cake task:</para>
+        /// <code>
+        /// Task("Test")
+        ///     .Does(() =>
+        /// {
+        ///     var settings = new DotNetTestSettings
+        ///     {
+        ///         Configuration = "Release"
+        ///     };
+        ///
+        ///     var projectFiles = GetFiles("./test/**/*.csproj");
+        ///     foreach(var file in projectFiles)
+        ///     {
+        ///         DotNetTest(file.FullPath, settings);
+        ///     }
+        /// });
+        /// </code>
+        /// <para>If your test project is using project.json, the project parameter should just be the directory path.</para>
+        /// <code>
+        /// var settings = new DotNetTestSettings
+        /// {
+        ///     Configuration = "Release"
+        /// };
+        ///
+        /// DotNetTest("./test/Project.Tests/", settings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Test")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Test")]
+        public static void DotNetTest(this ICakeContext context, string project, DotNetTestSettings settings)
+        {
+            context.DotNetTest(project, null, settings);
+        }
+
+        /// <summary>
+        /// Test project with settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="project">The project path.</param>
+        /// <param name="arguments">The arguments.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// var settings = new DotNetTestSettings
+        /// {
+        ///     Configuration = "Release"
+        /// };
+        ///
+        /// DotNetTest("./test/Project.Tests/Project.Tests.csproj", settings);
+        /// </code>
+        /// <para>You could also specify a task that runs multiple test projects.</para>
+        /// <para>Cake task:</para>
+        /// <code>
+        /// Task("Test")
+        ///     .Does(() =>
+        /// {
+        ///     var settings = new DotNetTestSettings
+        ///     {
+        ///         Configuration = "Release"
+        ///     };
+        ///
+        ///     var projectFiles = GetFiles("./test/**/*.csproj");
+        ///     foreach(var file in projectFiles)
+        ///     {
+        ///         DotNetTest(file.FullPath, "MSTest.MapInconclusiveToFailed=true", settings);
+        ///     }
+        /// });
+        /// </code>
+        /// <para>If your test project is using project.json, the project parameter should just be the directory path.</para>
+        /// <code>
+        /// var settings = new DotNetTestSettings
+        /// {
+        ///     Configuration = "Release"
+        /// };
+        ///
+        /// DotNetTest("./test/Project.Tests/", "MSTest.MapInconclusiveToFailed=true", settings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Test")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Test")]
+        public static void DotNetTest(this ICakeContext context, string project, ProcessArgumentBuilder arguments, DotNetTestSettings settings)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (settings is null)
+            {
+                settings = new DotNetTestSettings();
+            }
+
+            var tester = new DotNetCoreTester(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            tester.Test(project, arguments, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DotNet/Test/DotNetTestSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Test/DotNetTestSettings.cs
@@ -1,0 +1,123 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Cake.Common.Tools.DotNetCore;
+using Cake.Common.Tools.DotNetCore.Test;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotNet.Test
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetCoreTester" />.
+    /// </summary>
+    public class DotNetTestSettings : DotNetCoreSettings
+    {
+        /// <summary>
+        /// Gets or sets the settings file to use when running tests.
+        /// </summary>
+        public FilePath Settings { get; set; }
+
+        /// <summary>
+        /// Gets or sets the filter expression to filter out tests in the current project.
+        /// </summary>
+        /// <remarks>
+        /// For more information on filtering support, see https://aka.ms/vstest-filtering.
+        /// </remarks>
+        public string Filter { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to use for the custom test adapter in the test run.
+        /// </summary>
+        public DirectoryPath TestAdapterPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets a logger for test results.
+        /// </summary>
+        [Obsolete("Please use Loggers instead.")]
+        public string Logger { get; set; }
+
+        /// <summary>
+        /// Gets or sets the loggers for test results.
+        /// </summary>
+        public ICollection<string> Loggers { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets the output directory.
+        /// </summary>
+        public DirectoryPath OutputDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the configuration under which to build.
+        /// </summary>
+        public string Configuration { get; set; }
+
+        /// <summary>
+        /// Gets or sets the data collectors for the test run.
+        /// </summary>
+        public ICollection<string> Collectors { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets specific framework to compile.
+        /// </summary>
+        public string Framework { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to not build the project before testing.
+        /// </summary>
+        public bool NoBuild { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to not do implicit NuGet package restore.
+        /// This makes build faster, but requires restore to be done before build is executed.
+        /// </summary>
+        /// <remarks>
+        /// Requires .NET Core 2.x or newer.
+        /// </remarks>
+        public bool NoRestore { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run tests without displaying the Microsoft TestPlatform banner.
+        /// </summary>
+        /// <remarks>
+        /// Available since .NET Core 3.0 SDK.
+        /// </remarks>
+        public bool NoLogo { get; set; }
+
+        /// <summary>
+        /// Gets or sets a file to write diagnostic messages to.
+        /// </summary>
+        public FilePath DiagnosticFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the results directory. This setting is only available from 2.0.0 upward.
+        /// </summary>
+        public DirectoryPath ResultsDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the file path to write VSTest reports to.
+        /// </summary>
+        public FilePath VSTestReportPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the target runtime to test for. This setting is only available from .NET Core 3.x upward.
+        /// </summary>
+        public string Runtime { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run the tests in blame mode. This option is helpful in isolating a problematic test causing the test host to crash.
+        /// Outputs a 'Sequence.xml' file in the current directory that captures the order of execution of test before the crash.
+        /// </summary>
+        public bool Blame { get; set; }
+
+        /// <summary>
+        /// Gets or sets the specified NuGet package sources to use during testing.
+        /// </summary>
+        /// <remarks>
+        /// Requires .NET Core 2.x or newer.
+        /// </remarks>
+        public ICollection<string> Sources { get; set; } = new List<string>();
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -13,6 +13,7 @@ using Cake.Common.Tools.DotNet.Execute;
 using Cake.Common.Tools.DotNet.MSBuild;
 using Cake.Common.Tools.DotNet.Restore;
 using Cake.Common.Tools.DotNet.Run;
+using Cake.Common.Tools.DotNet.Test;
 using Cake.Common.Tools.DotNet.Tool;
 using Cake.Common.Tools.DotNetCore.Build;
 using Cake.Common.Tools.DotNetCore.BuildServer;
@@ -487,6 +488,7 @@ namespace Cake.Common.Tools.DotNetCore
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreTest is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetTest(ICakeContext)" /> instead.
         /// Test project.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -498,12 +500,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Test")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Test")]
+        [Obsolete("DotNetCoreTest is obsolete and will be removed in a future release. Use DotNetTest instead.")]
         public static void DotNetCoreTest(this ICakeContext context)
         {
-            context.DotNetCoreTest(null, null, null);
+            context.DotNetTest();
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreTest is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetTest(ICakeContext, string)" /> instead.
         /// Test project with path.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -534,12 +538,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Test")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Test")]
+        [Obsolete("DotNetCoreTest is obsolete and will be removed in a future release. Use DotNetTest instead.")]
         public static void DotNetCoreTest(this ICakeContext context, string project)
         {
-            context.DotNetCoreTest(project, null, null);
+            context.DotNetTest(project);
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreTest is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetTest(ICakeContext, string, DotNetTestSettings)" /> instead.
         /// Test project with settings.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -585,12 +591,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Test")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Test")]
+        [Obsolete("DotNetCoreTest is obsolete and will be removed in a future release. Use DotNetTest instead.")]
         public static void DotNetCoreTest(this ICakeContext context, string project, DotNetCoreTestSettings settings)
         {
-            context.DotNetCoreTest(project, null, settings);
+            context.DotNetTest(project, settings);
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreTest is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetTest(ICakeContext, string, ProcessArgumentBuilder, DotNetTestSettings)" /> instead.
         /// Test project with settings.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -637,20 +645,10 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Test")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Test")]
+        [Obsolete("DotNetCoreTest is obsolete and will be removed in a future release. Use DotNetTest instead.")]
         public static void DotNetCoreTest(this ICakeContext context, string project, ProcessArgumentBuilder arguments, DotNetCoreTestSettings settings)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            if (settings == null)
-            {
-                settings = new DotNetCoreTestSettings();
-            }
-
-            var tester = new DotNetCoreTester(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            tester.Test(project, arguments, settings);
+            context.DotNetTest(project, arguments, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTestSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTestSettings.cs
@@ -2,120 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using Cake.Core.IO;
+using Cake.Common.Tools.DotNet.Test;
 
 namespace Cake.Common.Tools.DotNetCore.Test
 {
     /// <summary>
     /// Contains settings used by <see cref="DotNetCoreTester" />.
     /// </summary>
-    public sealed class DotNetCoreTestSettings : DotNetCoreSettings
+    public sealed class DotNetCoreTestSettings : DotNetTestSettings
     {
-        /// <summary>
-        /// Gets or sets the settings file to use when running tests.
-        /// </summary>
-        public FilePath Settings { get; set; }
-
-        /// <summary>
-        /// Gets or sets the filter expression to filter out tests in the current project.
-        /// </summary>
-        /// <remarks>
-        /// For more information on filtering support, see https://aka.ms/vstest-filtering.
-        /// </remarks>
-        public string Filter { get; set; }
-
-        /// <summary>
-        /// Gets or sets the path to use for the custom test adapter in the test run.
-        /// </summary>
-        public DirectoryPath TestAdapterPath { get; set; }
-
-        /// <summary>
-        /// Gets or sets a logger for test results.
-        /// </summary>
-        [Obsolete("Please use Loggers instead.")]
-        public string Logger { get; set; }
-
-        /// <summary>
-        /// Gets or sets the loggers for test results.
-        /// </summary>
-        public ICollection<string> Loggers { get; set; } = new List<string>();
-
-        /// <summary>
-        /// Gets or sets the output directory.
-        /// </summary>
-        public DirectoryPath OutputDirectory { get; set; }
-
-        /// <summary>
-        /// Gets or sets the configuration under which to build.
-        /// </summary>
-        public string Configuration { get; set; }
-
-        /// <summary>
-        /// Gets or sets the data collectors for the test run.
-        /// </summary>
-        public ICollection<string> Collectors { get; set; } = new List<string>();
-
-        /// <summary>
-        /// Gets or sets specific framework to compile.
-        /// </summary>
-        public string Framework { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to not build the project before testing.
-        /// </summary>
-        public bool NoBuild { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to not do implicit NuGet package restore.
-        /// This makes build faster, but requires restore to be done before build is executed.
-        /// </summary>
-        /// <remarks>
-        /// Requires .NET Core 2.x or newer.
-        /// </remarks>
-        public bool NoRestore { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run tests without displaying the Microsoft TestPlatform banner.
-        /// </summary>
-        /// <remarks>
-        /// Available since .NET Core 3.0 SDK.
-        /// </remarks>
-        public bool NoLogo { get; set; }
-
-        /// <summary>
-        /// Gets or sets a file to write diagnostic messages to.
-        /// </summary>
-        public FilePath DiagnosticFile { get; set; }
-
-        /// <summary>
-        /// Gets or sets the results directory. This setting is only available from 2.0.0 upward.
-        /// </summary>
-        public DirectoryPath ResultsDirectory { get; set; }
-
-        /// <summary>
-        /// Gets or sets the file path to write VSTest reports to.
-        /// </summary>
-        public FilePath VSTestReportPath { get; set; }
-
-        /// <summary>
-        /// Gets or sets the target runtime to test for. This setting is only available from .NET Core 3.x upward.
-        /// </summary>
-        public string Runtime { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run the tests in blame mode. This option is helpful in isolating a problematic test causing the test host to crash.
-        /// Outputs a 'Sequence.xml' file in the current directory that captures the order of execution of test before the crash.
-        /// </summary>
-        public bool Blame { get; set; }
-
-        /// <summary>
-        /// Gets or sets the specified NuGet package sources to use during testing.
-        /// </summary>
-        /// <remarks>
-        /// Requires .NET Core 2.x or newer.
-        /// </remarks>
-        public ICollection<string> Sources { get; set; } = new List<string>();
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTester.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Test/DotNetCoreTester.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Cake.Common.Tools.DotNet.Test;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
@@ -12,7 +13,7 @@ namespace Cake.Common.Tools.DotNetCore.Test
     /// <summary>
     /// .NET Core project tester.
     /// </summary>
-    public sealed class DotNetCoreTester : DotNetCoreTool<DotNetCoreTestSettings>
+    public sealed class DotNetCoreTester : DotNetCoreTool<DotNetTestSettings>
     {
         private readonly ICakeEnvironment _environment;
 
@@ -38,7 +39,7 @@ namespace Cake.Common.Tools.DotNetCore.Test
         /// <param name="project">The target project path.</param>
         /// <param name="arguments">The arguments.</param>
         /// <param name="settings">The settings.</param>
-        public void Test(string project, ProcessArgumentBuilder arguments, DotNetCoreTestSettings settings)
+        public void Test(string project, ProcessArgumentBuilder arguments, DotNetTestSettings settings)
         {
             if (settings == null)
             {
@@ -48,7 +49,7 @@ namespace Cake.Common.Tools.DotNetCore.Test
             RunCommand(settings, GetArguments(project, arguments, settings));
         }
 
-        private ProcessArgumentBuilder GetArguments(string project, ProcessArgumentBuilder arguments, DotNetCoreTestSettings settings)
+        private ProcessArgumentBuilder GetArguments(string project, ProcessArgumentBuilder arguments, DotNetTestSettings settings)
         {
             var builder = CreateArgumentBuilder(settings);
 


### PR DESCRIPTION
| DotNetCore               |               | DotNet synonym             |
| ------------------------ |:-------------:| -------------------------- |
| `DotNetCoreTest`         | :arrow_right: | :new: `DotNetTest`         |
| `DotNetCoreTestSettings` | :arrow_right: | :new: `DotNetTestSettings` |


- New `DotNetTest` aliases are being introduced
- `DotNetTest` aliases contain the code of the existing `DotNetCoreTest` (rename/move)
- Existing `DotNetCoreTest` aliases are forwarding calls to newly introduced `DotNetTest` aliases
- New `DotNetTestSettings` class is being introduced
- `DotNetTestSettings` class contains the code of `DotNetCoreTestSettings` (rename/move)
- The previous `DotNetCoreTestSettings` is now empty and inherits from the new `DotNetTestSettings`
- Namespaces `Cake.Common.Tools.DotNetCore.Test.*` have been preserved as to not introduce breaking changes
- Unit Tests and Integration Tests remain the same, and call the old `DotNetCore***` aliases, exercising the new `DotNet***` aliases in the process

---

Closes https://github.com/cake-build/cake/issues/3549
