### PR TITLE
GH3550: Add DotNetVSTest alias (synonym to DotNetCoreVSTest)

### DIFF
--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
@@ -14,6 +14,7 @@ using Cake.Common.Tools.DotNet.Restore;
 using Cake.Common.Tools.DotNet.Run;
 using Cake.Common.Tools.DotNet.Test;
 using Cake.Common.Tools.DotNet.Tool;
+using Cake.Common.Tools.DotNet.VSTest;
 using Cake.Common.Tools.DotNetCore.Build;
 using Cake.Common.Tools.DotNetCore.BuildServer;
 using Cake.Common.Tools.DotNetCore.Clean;
@@ -23,6 +24,7 @@ using Cake.Common.Tools.DotNetCore.Restore;
 using Cake.Common.Tools.DotNetCore.Run;
 using Cake.Common.Tools.DotNetCore.Test;
 using Cake.Common.Tools.DotNetCore.Tool;
+using Cake.Common.Tools.DotNetCore.VSTest;
 using Cake.Core;
 using Cake.Core.Annotations;
 using Cake.Core.IO;
@@ -719,6 +721,119 @@ namespace Cake.Common.Tools.DotNet
 
             var builder = new DotNetCoreMSBuildBuilder(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             builder.Build(projectOrDirectory, settings);
+        }
+
+        /// <summary>
+        /// Test one or more projects specified by a path or glob pattern using the VS Test host runner.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="testFile">A path to the test file or glob for one or more test files.</param>
+        /// <example>
+        /// <para>Specify the path to the .csproj file in the test project.</para>
+        /// <code>
+        /// DotNetVSTest("./test/Project.Tests/bin/Release/netcoreapp2.1/Project.Tests.dll");
+        /// </code>
+        /// <para>You could also specify a glob pattern to run multiple test projects.</para>
+        /// <code>
+        /// DotNetVSTest("./**/bin/Release/netcoreapp2.1/*.Tests.dll");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Test")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.VSTest")]
+        public static void DotNetVSTest(this ICakeContext context, GlobPattern testFile) => context.DotNetVSTest(testFile, null);
+
+        /// <summary>
+        /// Test one or more projects specified by a path or glob pattern with settings using the VS Test host runner.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="testFile">A path to the test file or glob for one or more test files.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <para>Specify the path to the .csproj file in the test project.</para>
+        /// <code>
+        /// var settings = new DotNetVSTestSettings
+        /// {
+        ///     Framework = "FrameworkCore10",
+        ///     Platform = "x64"
+        /// };
+        ///
+        /// DotNetTest("./test/Project.Tests/bin/Release/netcoreapp2.1/Project.Tests.dll", settings);
+        /// </code>
+        /// <para>You could also specify a glob pattern to run multiple test projects.</para>
+        /// <code>
+        /// var settings = new DotNetVSTestSettings
+        /// {
+        ///     Framework = "FrameworkCore10",
+        ///     Platform = "x64",
+        ///     Parallel = true
+        /// };
+        ///
+        /// DotNetVSTest("./**/bin/Release/netcoreapp2.1/*.Tests.dll", settings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Test")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.VSTest")]
+        public static void DotNetVSTest(this ICakeContext context, GlobPattern testFile, DotNetVSTestSettings settings)
+        {
+            var testFiles = context.GetFiles(testFile);
+
+            context.DotNetVSTest(testFiles, settings);
+        }
+
+        /// <summary>
+        /// Test one or more specified projects with settings using the VS Test host runner.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="testFiles">The project paths to test.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// var settings = new DotNetVSTestSettings
+        /// {
+        ///     Framework = "FrameworkCore10",
+        ///     Platform = "x64"
+        /// };
+        ///
+        /// DotNetVSTest(new[] { (FilePath)"./test/Project.Tests/bin/Release/netcoreapp2.1/Project.Tests.dll" }, settings);
+        /// </code>
+        /// <para>You could also specify a task that runs multiple test projects.</para>
+        /// <para>Cake task:</para>
+        /// <code>
+        /// Task("Test")
+        ///     .Does(() =>
+        /// {
+        ///     var settings = new DotNetVSTestSettings
+        ///     {
+        ///         Framework = "FrameworkCore10",
+        ///         Platform = "x64",
+        ///         Parallel = true
+        ///     };
+        ///
+        ///     var testFiles = GetFiles("./test/**/bin/Release/netcoreapp2.1/*.Test.dll");
+        ///
+        ///     DotNetVSTest(testFiles, settings);
+        /// });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Test")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.VSTest")]
+        public static void DotNetVSTest(this ICakeContext context, IEnumerable<FilePath> testFiles, DotNetVSTestSettings settings)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (settings is null)
+            {
+                settings = new DotNetVSTestSettings();
+            }
+
+            var tester = new DotNetCoreVSTester(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            tester.Test(testFiles, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DotNet/VSTest/DotNetVSTestSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/VSTest/DotNetVSTestSettings.cs
@@ -1,0 +1,102 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Cake.Common.Tools.DotNetCore;
+using Cake.Common.Tools.DotNetCore.VSTest;
+using Cake.Common.Tools.VSTest;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotNet.VSTest
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetCoreVSTester" />.
+    /// </summary>
+    public class DotNetVSTestSettings : DotNetCoreSettings
+    {
+        /// <summary>
+        /// Gets or sets the settings file to use when running tests.
+        /// </summary>
+        public FilePath Settings { get; set; }
+
+        /// <summary>
+        /// Gets or sets the a list tests to run.
+        /// </summary>
+        public ICollection<string> TestsToRun { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to use for the custom test adapter in the test run.
+        /// </summary>
+        public DirectoryPath TestAdapterPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the target platform architecture to be used for test execution.
+        /// </summary>
+        public VSTestPlatform Platform { get; set; }
+
+        /// <summary>
+        /// Gets or sets specific .Net Framework version to be used for test execution.
+        /// </summary>
+        /// <remarks>
+        /// Valid values are ".NETFramework,Version=v4.6", ".NETCoreApp,Version=v1.0" etc.
+        /// Other supported values are Framework35, Framework40, Framework45 and FrameworkCore10.
+        /// </remarks>
+        public string Framework { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the tests should be executed in parallel.
+        /// </summary>
+        /// <remarks>
+        /// By default up to all available cores on the machine may be used. The number of cores to use may be configured using a settings file.
+        /// </remarks>
+        public bool Parallel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the filter expression to run test that match.
+        /// </summary>
+        /// <remarks>
+        /// For more information on filtering support, see https://aka.ms/vstest-filtering.
+        /// </remarks>
+        public string TestCaseFilter { get; set; }
+
+        /// <summary>
+        /// Gets or sets a logger for test results.
+        /// </summary>
+        public string Logger { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Process Id of the Parent Process responsible for launching current process.
+        /// </summary>
+        public string ParentProcessId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Port for socket connection and receiving the event messages.
+        /// </summary>
+        public int? Port { get; set; }
+
+        /// <summary>
+        /// Gets or sets a file to write diagnostic messages to.
+        /// </summary>
+        public FilePath DiagnosticFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to put the test results in.
+        /// </summary>
+        public DirectoryPath ResultsDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets a list of extra arguments that should be passed to adapter.
+        /// </summary>
+        public IDictionary<string, string> Arguments { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotNetVSTestSettings"/> class.
+        /// </summary>
+        public DotNetVSTestSettings()
+        {
+            TestsToRun = new List<string>();
+            Arguments = new Dictionary<string, string>();
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -15,6 +15,7 @@ using Cake.Common.Tools.DotNet.Restore;
 using Cake.Common.Tools.DotNet.Run;
 using Cake.Common.Tools.DotNet.Test;
 using Cake.Common.Tools.DotNet.Tool;
+using Cake.Common.Tools.DotNet.VSTest;
 using Cake.Common.Tools.DotNetCore.Build;
 using Cake.Common.Tools.DotNetCore.BuildServer;
 using Cake.Common.Tools.DotNetCore.Clean;
@@ -1262,6 +1263,7 @@ namespace Cake.Common.Tools.DotNetCore
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreVSTest is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetVSTest(ICakeContext, GlobPattern)" /> instead.
         /// Test one or more projects specified by a path or glob pattern using the VS Test host runner.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -1279,9 +1281,11 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Test")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.VSTest")]
-        public static void DotNetCoreVSTest(this ICakeContext context, GlobPattern testFile) => context.DotNetCoreVSTest(testFile, null);
+        [Obsolete("DotNetCoreVSTest is obsolete and will be removed in a future release. Use DotNetVSTest instead.")]
+        public static void DotNetCoreVSTest(this ICakeContext context, GlobPattern testFile) => context.DotNetVSTest(testFile);
 
         /// <summary>
+        /// [deprecated] DotNetCoreVSTest is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetVSTest(ICakeContext, GlobPattern, DotNetVSTestSettings)" /> instead.
         /// Test one or more projects specified by a path or glob pattern with settings using the VS Test host runner.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -1313,14 +1317,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Test")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.VSTest")]
+        [Obsolete("DotNetCoreVSTest is obsolete and will be removed in a future release. Use DotNetVSTest instead.")]
         public static void DotNetCoreVSTest(this ICakeContext context, GlobPattern testFile, DotNetCoreVSTestSettings settings)
         {
-            var testFiles = context.GetFiles(testFile);
-
-            context.DotNetCoreVSTest(testFiles, settings);
+            context.DotNetVSTest(testFile, settings);
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreVSTest is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetVSTest(ICakeContext, IEnumerable{FilePath}, DotNetVSTestSettings)" /> instead.
         /// Test one or more specified projects with settings using the VS Test host runner.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -1358,20 +1362,10 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Test")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.VSTest")]
+        [Obsolete("DotNetCoreVSTest is obsolete and will be removed in a future release. Use DotNetVSTest instead.")]
         public static void DotNetCoreVSTest(this ICakeContext context, IEnumerable<FilePath> testFiles, DotNetCoreVSTestSettings settings)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            if (settings == null)
-            {
-                settings = new DotNetCoreVSTestSettings();
-            }
-
-            var tester = new DotNetCoreVSTester(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            tester.Test(testFiles, settings);
+            context.DotNetVSTest(testFiles, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DotNetCore/VSTest/DotNetCoreVSTestSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/VSTest/DotNetCoreVSTestSettings.cs
@@ -2,99 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using Cake.Common.Tools.VSTest;
-using Cake.Core.IO;
+using Cake.Common.Tools.DotNet.VSTest;
 
 namespace Cake.Common.Tools.DotNetCore.VSTest
 {
     /// <summary>
     /// Contains settings used by <see cref="DotNetCoreVSTester" />.
     /// </summary>
-    public sealed class DotNetCoreVSTestSettings : DotNetCoreSettings
+    public sealed class DotNetCoreVSTestSettings : DotNetVSTestSettings
     {
-        /// <summary>
-        /// Gets or sets the settings file to use when running tests.
-        /// </summary>
-        public FilePath Settings { get; set; }
-
-        /// <summary>
-        /// Gets or sets the a list tests to run.
-        /// </summary>
-        public ICollection<string> TestsToRun { get; set; }
-
-        /// <summary>
-        /// Gets or sets the path to use for the custom test adapter in the test run.
-        /// </summary>
-        public DirectoryPath TestAdapterPath { get; set; }
-
-        /// <summary>
-        /// Gets or sets the target platform architecture to be used for test execution.
-        /// </summary>
-        public VSTestPlatform Platform { get; set; }
-
-        /// <summary>
-        /// Gets or sets specific .Net Framework version to be used for test execution.
-        /// </summary>
-        /// <remarks>
-        /// Valid values are ".NETFramework,Version=v4.6", ".NETCoreApp,Version=v1.0" etc.
-        /// Other supported values are Framework35, Framework40, Framework45 and FrameworkCore10.
-        /// </remarks>
-        public string Framework { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the tests should be executed in parallel.
-        /// </summary>
-        /// <remarks>
-        /// By default up to all available cores on the machine may be used. The number of cores to use may be configured using a settings file.
-        /// </remarks>
-        public bool Parallel { get; set; }
-
-        /// <summary>
-        /// Gets or sets the filter expression to run test that match.
-        /// </summary>
-        /// <remarks>
-        /// For more information on filtering support, see https://aka.ms/vstest-filtering.
-        /// </remarks>
-        public string TestCaseFilter { get; set; }
-
-        /// <summary>
-        /// Gets or sets a logger for test results.
-        /// </summary>
-        public string Logger { get; set; }
-
-        /// <summary>
-        /// Gets or sets the Process Id of the Parent Process responsible for launching current process.
-        /// </summary>
-        public string ParentProcessId { get; set; }
-
-        /// <summary>
-        /// Gets or sets the Port for socket connection and receiving the event messages.
-        /// </summary>
-        public int? Port { get; set; }
-
-        /// <summary>
-        /// Gets or sets a file to write diagnostic messages to.
-        /// </summary>
-        public FilePath DiagnosticFile { get; set; }
-
-        /// <summary>
-        /// Gets or sets the path to put the test results in.
-        /// </summary>
-        public DirectoryPath ResultsDirectory { get; set; }
-
-        /// <summary>
-        /// Gets or sets a list of extra arguments that should be passed to adapter.
-        /// </summary>
-        public IDictionary<string, string> Arguments { get; set; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DotNetCoreVSTestSettings"/> class.
-        /// </summary>
-        public DotNetCoreVSTestSettings()
-        {
-            TestsToRun = new List<string>();
-            Arguments = new Dictionary<string, string>();
-        }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/VSTest/DotNetCoreVSTester.cs
+++ b/src/Cake.Common/Tools/DotNetCore/VSTest/DotNetCoreVSTester.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Cake.Common.Tools.DotNet.VSTest;
 using Cake.Common.Tools.VSTest;
 using Cake.Core;
 using Cake.Core.IO;
@@ -15,7 +16,7 @@ namespace Cake.Common.Tools.DotNetCore.VSTest
     /// <summary>
     /// .NET Core VSTest tester.
     /// </summary>
-    public sealed class DotNetCoreVSTester : DotNetCoreTool<DotNetCoreVSTestSettings>
+    public sealed class DotNetCoreVSTester : DotNetCoreTool<DotNetVSTestSettings>
     {
         private readonly ICakeEnvironment _environment;
 
@@ -40,7 +41,7 @@ namespace Cake.Common.Tools.DotNetCore.VSTest
         /// </summary>
         /// <param name="testFiles">A list of test files to run.</param>
         /// <param name="settings">The settings.</param>
-        public void Test(IEnumerable<FilePath> testFiles, DotNetCoreVSTestSettings settings)
+        public void Test(IEnumerable<FilePath> testFiles, DotNetVSTestSettings settings)
         {
             if (settings == null)
             {
@@ -55,7 +56,7 @@ namespace Cake.Common.Tools.DotNetCore.VSTest
             RunCommand(settings, GetArguments(testFiles, settings));
         }
 
-        private ProcessArgumentBuilder GetArguments(IEnumerable<FilePath> testFiles, DotNetCoreVSTestSettings settings)
+        private ProcessArgumentBuilder GetArguments(IEnumerable<FilePath> testFiles, DotNetVSTestSettings settings)
         {
             var builder = CreateArgumentBuilder(settings);
 


### PR DESCRIPTION
| DotNetCore                 |               | DotNet synonym               |
| -------------------------- |:-------------:| ---------------------------- |
| `DotNetCoreVSTest`         | :arrow_right: | :new: `DotNetVSTest`         |
| `DotNetCoreVSTestSettings` | :arrow_right: | :new: `DotNetVSTestSettings` |


- New `DotNetVSTest` aliases are being introduced
- `DotNetVSTest` aliases contain the code of the existing `DotNetCoreVSTest` (rename/move)
- Existing `DotNetCoreVSTest` aliases are forwarding calls to newly introduced `DotNetVSTest` aliases
- New `DotNetVSTestSettings` class is being introduced
- `DotNetVSTestSettings` class contains the code of `DotNetCoreVSTestSettings` (rename/move)
- The previous `DotNetCoreVSTestSettings` is now empty and inherits from the new `DotNetVSTestSettings`
- Namespaces `Cake.Common.Tools.DotNetCore.VSTest.*` have been preserved as to not introduce breaking changes
- Unit Tests and Integration Tests remain the same, and call the old `DotNetCore***` aliases, exercising the new `DotNet***` aliases in the process

---

Closes https://github.com/cake-build/cake/issues/3550
