### PR TITLE
GH3552: Add DotNetPack alias (synonym to DotNetCorePack)

### DIFF
--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
@@ -10,6 +10,7 @@ using Cake.Common.Tools.DotNet.BuildServer;
 using Cake.Common.Tools.DotNet.Clean;
 using Cake.Common.Tools.DotNet.Execute;
 using Cake.Common.Tools.DotNet.MSBuild;
+using Cake.Common.Tools.DotNet.Pack;
 using Cake.Common.Tools.DotNet.Publish;
 using Cake.Common.Tools.DotNet.Restore;
 using Cake.Common.Tools.DotNet.Run;
@@ -21,6 +22,7 @@ using Cake.Common.Tools.DotNetCore.BuildServer;
 using Cake.Common.Tools.DotNetCore.Clean;
 using Cake.Common.Tools.DotNetCore.Execute;
 using Cake.Common.Tools.DotNetCore.MSBuild;
+using Cake.Common.Tools.DotNetCore.Pack;
 using Cake.Common.Tools.DotNetCore.Publish;
 using Cake.Common.Tools.DotNetCore.Restore;
 using Cake.Common.Tools.DotNetCore.Run;
@@ -555,6 +557,60 @@ namespace Cake.Common.Tools.DotNet
 
             var cleaner = new DotNetCoreCleaner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             cleaner.Clean(project, settings);
+        }
+
+        /// <summary>
+        /// Package all projects.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="project">The projects path.</param>
+        /// <example>
+        /// <code>
+        /// DotNetPack("./src/*");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Pack")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Pack")]
+        public static void DotNetPack(this ICakeContext context, string project)
+        {
+            context.DotNetPack(project, null);
+        }
+
+        /// <summary>
+        /// Package all projects.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="project">The projects path.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// var settings = new DotNetPackSettings
+        /// {
+        ///     Configuration = "Release",
+        ///     OutputDirectory = "./artifacts/"
+        /// };
+        ///
+        /// DotNetPack("./src/*", settings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Pack")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Pack")]
+        public static void DotNetPack(this ICakeContext context, string project, DotNetPackSettings settings)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (settings is null)
+            {
+                settings = new DotNetPackSettings();
+            }
+
+            var packer = new DotNetCorePacker(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            packer.Pack(project, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DotNet/Pack/DotNetPackSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Pack/DotNetPackSettings.cs
@@ -1,0 +1,106 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Cake.Common.Tools.DotNetCore;
+using Cake.Common.Tools.DotNetCore.MSBuild;
+using Cake.Common.Tools.DotNetCore.Pack;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotNet.Pack
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetCorePacker" />.
+    /// </summary>
+    public class DotNetPackSettings : DotNetCoreSettings
+    {
+        /// <summary>
+        /// Gets or sets the output directory.
+        /// </summary>
+        public DirectoryPath OutputDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the configuration under which to build.
+        /// </summary>
+        public string Configuration { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value that defines what `*` should be replaced with in version field in project.json.
+        /// </summary>
+        public string VersionSuffix { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to not build project before packing.
+        /// </summary>
+        public bool NoBuild { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to ignore project to project references and only build the root project.
+        /// </summary>
+        /// <remarks>
+        /// Requires .NET Core 2.x or newer.
+        /// </remarks>
+        public bool NoDependencies { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to not do implicit NuGet package restore.
+        /// This makes build faster, but requires restore to be done before build is executed.
+        /// </summary>
+        /// <remarks>
+        /// Requires .NET Core 2.x or newer.
+        /// </remarks>
+        public bool NoRestore { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to display the startup banner or the copyright message.
+        /// </summary>
+        /// <remarks>
+        /// Available since .NET Core 3.0 SDK.
+        /// </remarks>
+        public bool NoLogo { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to generate the symbols package.
+        /// </summary>
+        public bool IncludeSymbols { get; set; }
+
+        /// <summary>
+        /// Gets or sets the symbol package format.
+        /// </summary>
+        /// <value>The symbol package format.</value>
+        public string SymbolPackageFormat { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to includes the source files in the NuGet package.
+        /// The sources files are included in the src folder within the nupkg.
+        /// </summary>
+        public bool IncludeSource { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to set the serviceable flag in the package.
+        /// </summary>
+        /// <remarks>
+        /// For more information, see https://aka.ms/nupkgservicing.
+        /// </remarks>
+        public bool Serviceable { get; set; }
+
+        /// <summary>
+        /// Gets or sets the target runtime.
+        /// </summary>
+        public string Runtime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the specified NuGet package sources to use during the packing.
+        /// </summary>
+        /// <remarks>
+        /// Requires .NET Core 2.x or newer.
+        /// </remarks>
+        public ICollection<string> Sources { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets additional arguments to be passed to MSBuild.
+        /// </summary>
+        public DotNetCoreMSBuildSettings MSBuildSettings { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -11,6 +11,7 @@ using Cake.Common.Tools.DotNet.BuildServer;
 using Cake.Common.Tools.DotNet.Clean;
 using Cake.Common.Tools.DotNet.Execute;
 using Cake.Common.Tools.DotNet.MSBuild;
+using Cake.Common.Tools.DotNet.Pack;
 using Cake.Common.Tools.DotNet.Publish;
 using Cake.Common.Tools.DotNet.Restore;
 using Cake.Common.Tools.DotNet.Run;
@@ -266,6 +267,7 @@ namespace Cake.Common.Tools.DotNetCore
         }
 
         /// <summary>
+        /// [deprecated] DotNetCorePack is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetPack(ICakeContext, string)" /> instead.
         /// Package all projects.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -278,12 +280,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Pack")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Pack")]
+        [Obsolete("DotNetCorePack is obsolete and will be removed in a future release. Use DotNetPack instead.")]
         public static void DotNetCorePack(this ICakeContext context, string project)
         {
-            context.DotNetCorePack(project, null);
+            context.DotNetPack(project);
         }
 
         /// <summary>
+        /// [deprecated] DotNetCorePack is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetPack(ICakeContext, string, DotNetPackSettings)" /> instead.
         /// Package all projects.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -303,20 +307,10 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("Pack")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.Pack")]
+        [Obsolete("DotNetCorePack is obsolete and will be removed in a future release. Use DotNetPack instead.")]
         public static void DotNetCorePack(this ICakeContext context, string project, DotNetCorePackSettings settings)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            if (settings == null)
-            {
-                settings = new DotNetCorePackSettings();
-            }
-
-            var packer = new DotNetCorePacker(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            packer.Pack(project, settings);
+            context.DotNetPack(project, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DotNetCore/Pack/DotNetCorePackSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Pack/DotNetCorePackSettings.cs
@@ -2,103 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using Cake.Common.Tools.DotNetCore.MSBuild;
-using Cake.Core.IO;
+using Cake.Common.Tools.DotNet.Pack;
 
 namespace Cake.Common.Tools.DotNetCore.Pack
 {
     /// <summary>
     /// Contains settings used by <see cref="DotNetCorePacker" />.
     /// </summary>
-    public sealed class DotNetCorePackSettings : DotNetCoreSettings
+    public sealed class DotNetCorePackSettings : DotNetPackSettings
     {
-        /// <summary>
-        /// Gets or sets the output directory.
-        /// </summary>
-        public DirectoryPath OutputDirectory { get; set; }
-
-        /// <summary>
-        /// Gets or sets the configuration under which to build.
-        /// </summary>
-        public string Configuration { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value that defines what `*` should be replaced with in version field in project.json.
-        /// </summary>
-        public string VersionSuffix { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to not build project before packing.
-        /// </summary>
-        public bool NoBuild { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to ignore project to project references and only build the root project.
-        /// </summary>
-        /// <remarks>
-        /// Requires .NET Core 2.x or newer.
-        /// </remarks>
-        public bool NoDependencies { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to not do implicit NuGet package restore.
-        /// This makes build faster, but requires restore to be done before build is executed.
-        /// </summary>
-        /// <remarks>
-        /// Requires .NET Core 2.x or newer.
-        /// </remarks>
-        public bool NoRestore { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to display the startup banner or the copyright message.
-        /// </summary>
-        /// <remarks>
-        /// Available since .NET Core 3.0 SDK.
-        /// </remarks>
-        public bool NoLogo { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to generate the symbols package.
-        /// </summary>
-        public bool IncludeSymbols { get; set; }
-
-        /// <summary>
-        /// Gets or sets the symbol package format.
-        /// </summary>
-        /// <value>The symbol package format.</value>
-        public string SymbolPackageFormat { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to includes the source files in the NuGet package.
-        /// The sources files are included in the src folder within the nupkg.
-        /// </summary>
-        public bool IncludeSource { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to set the serviceable flag in the package.
-        /// </summary>
-        /// <remarks>
-        /// For more information, see https://aka.ms/nupkgservicing.
-        /// </remarks>
-        public bool Serviceable { get; set; }
-
-        /// <summary>
-        /// Gets or sets the target runtime.
-        /// </summary>
-        public string Runtime { get; set; }
-
-        /// <summary>
-        /// Gets or sets the specified NuGet package sources to use during the packing.
-        /// </summary>
-        /// <remarks>
-        /// Requires .NET Core 2.x or newer.
-        /// </remarks>
-        public ICollection<string> Sources { get; set; } = new List<string>();
-
-        /// <summary>
-        /// Gets or sets additional arguments to be passed to MSBuild.
-        /// </summary>
-        public DotNetCoreMSBuildSettings MSBuildSettings { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/Pack/DotNetCorePacker.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Pack/DotNetCorePacker.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Cake.Common.Tools.DotNet.Pack;
 using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Core;
 using Cake.Core.IO;
@@ -13,7 +14,7 @@ namespace Cake.Common.Tools.DotNetCore.Pack
     /// <summary>
     /// .NET Core project packer.
     /// </summary>
-    public sealed class DotNetCorePacker : DotNetCoreTool<DotNetCorePackSettings>
+    public sealed class DotNetCorePacker : DotNetCoreTool<DotNetPackSettings>
     {
         private readonly ICakeEnvironment _environment;
 
@@ -38,7 +39,7 @@ namespace Cake.Common.Tools.DotNetCore.Pack
         /// </summary>
         /// <param name="project">The target file path.</param>
         /// <param name="settings">The settings.</param>
-        public void Pack(string project, DotNetCorePackSettings settings)
+        public void Pack(string project, DotNetPackSettings settings)
         {
             if (settings == null)
             {
@@ -48,7 +49,7 @@ namespace Cake.Common.Tools.DotNetCore.Pack
             RunCommand(settings, GetArguments(project, settings));
         }
 
-        private ProcessArgumentBuilder GetArguments(string project, DotNetCorePackSettings settings)
+        private ProcessArgumentBuilder GetArguments(string project, DotNetPackSettings settings)
         {
             var builder = CreateArgumentBuilder(settings);
 


### PR DESCRIPTION
| DotNetCore               |               | DotNet synonym             |
| ------------------------ |:-------------:| -------------------------- |
| `DotNetCorePack`         | :arrow_right: | :new: `DotNetPack`         |
| `DotNetCorePackSettings` | :arrow_right: | :new: `DotNetPackSettings` |


- New `DotNetPack` aliases are being introduced
- `DotNetPack` aliases contain the code of the existing `DotNetCorePack` (rename/move)
- Existing `DotNetCorePack` aliases are forwarding calls to newly introduced `DotNetPack` aliases
- New `DotNetPackSettings` class is being introduced
- `DotNetPackSettings` class contains the code of `DotNetCorePackSettings` (rename/move)
- The previous `DotNetCorePackSettings` is now empty and inherits from the new `DotNetPackSettings`
- Namespaces `Cake.Common.Tools.DotNetCore.Pack.*` have been preserved as to not introduce breaking changes
- Unit Tests and Integration Tests remain the same, and call the old `DotNetCore***` aliases, exercising the new `DotNet***` aliases in the process

---

Closes https://github.com/cake-build/cake/issues/3552
