### PR TITLE
Pin Cake GitHub action to v1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
             include-prerelease: 'true'
 
       - name: Run Cake script
-        uses: cake-build/cake-action@master
+        uses: cake-build/cake-action@v1
         with:
           target: Run-Integration-Tests
           cake-version: tool-manifest


### PR DESCRIPTION
Cake GitHub Action supports tool manifests starting with 1.4.