### PR TITLE
GH3553: Add DotNetNuGetPush aliases (synonym to DotNetCoreNuGetPush)

### DIFF
--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
@@ -10,6 +10,7 @@ using Cake.Common.Tools.DotNet.BuildServer;
 using Cake.Common.Tools.DotNet.Clean;
 using Cake.Common.Tools.DotNet.Execute;
 using Cake.Common.Tools.DotNet.MSBuild;
+using Cake.Common.Tools.DotNet.NuGet.Push;
 using Cake.Common.Tools.DotNet.Pack;
 using Cake.Common.Tools.DotNet.Publish;
 using Cake.Common.Tools.DotNet.Restore;
@@ -22,6 +23,7 @@ using Cake.Common.Tools.DotNetCore.BuildServer;
 using Cake.Common.Tools.DotNetCore.Clean;
 using Cake.Common.Tools.DotNetCore.Execute;
 using Cake.Common.Tools.DotNetCore.MSBuild;
+using Cake.Common.Tools.DotNetCore.NuGet.Push;
 using Cake.Common.Tools.DotNetCore.Pack;
 using Cake.Common.Tools.DotNetCore.Publish;
 using Cake.Common.Tools.DotNetCore.Restore;
@@ -557,6 +559,67 @@ namespace Cake.Common.Tools.DotNet
 
             var cleaner = new DotNetCoreCleaner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             cleaner.Clean(project, settings);
+        }
+
+        /// <summary>
+        /// Pushes one or more packages to a server.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="packageFilePath"><see cref="FilePath"/> of the package to push.</param>
+        /// <example>
+        /// <code>
+        /// // With FilePath instance
+        /// var packageFilePath = GetFiles("*.nupkg").Single();
+        /// DotNetNuGetPush(packageFilePath);
+        /// // With string parameter
+        /// DotNetNuGetPush("foo*.nupkg");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("NuGet")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.NuGet.Push")]
+        public static void DotNetNuGetPush(this ICakeContext context, FilePath packageFilePath)
+        {
+            context.DotNetNuGetPush(packageFilePath, null);
+        }
+
+        /// <summary>
+        /// Pushes one or more packages to a server using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="packageFilePath"><see cref="FilePath"/> of the package to push.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// var settings = new DotNetNuGetPushSettings
+        /// {
+        ///     Source = "https://www.example.com/nugetfeed",
+        ///     ApiKey = "4003d786-cc37-4004-bfdf-c4f3e8ef9b3a"
+        /// };
+        /// // With FilePath instance
+        /// var packageFilePath = GetFiles("foo*.nupkg").Single();
+        /// DotNetNuGetPush(packageFilePath);
+        /// // With string parameter
+        /// DotNetNuGetPush("foo*.nupkg", settings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("NuGet")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.NuGet.Push")]
+        public static void DotNetNuGetPush(this ICakeContext context, FilePath packageFilePath, DotNetNuGetPushSettings settings)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (settings is null)
+            {
+                settings = new DotNetNuGetPushSettings();
+            }
+
+            var restorer = new DotNetCoreNuGetPusher(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            restorer.Push(packageFilePath?.FullPath, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DotNet/NuGet/Push/DotNetNuGetPushSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/NuGet/Push/DotNetNuGetPushSettings.cs
@@ -1,0 +1,89 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNetCore;
+using Cake.Common.Tools.DotNetCore.NuGet.Push;
+
+namespace Cake.Common.Tools.DotNet.NuGet.Push
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetCoreNuGetPusher" />.
+    /// </summary>
+    public class DotNetNuGetPushSettings : DotNetCoreSettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating the server URL.
+        /// </summary>
+        /// <remarks>
+        /// This option is required unless DefaultPushSource config value is set in the NuGet config file.
+        /// </remarks>
+        public string Source { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating the symbol server URL.
+        /// </summary>
+        public string SymbolSource { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to append "api/v2/package" to the source URL.
+        /// </summary>
+        /// <remarks>
+        /// Available since .NET Core 2.1 SDK.
+        /// </remarks>
+        public bool NoServiceEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to block and require manual action for operations like authentication.
+        /// </summary>
+        /// <remarks>
+        /// Available since .NET Core 2.2 SDK.
+        /// </remarks>
+        public bool Interactive { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating timeout for pushing to a server in seconds.
+        /// <remarks>
+        /// Defaults to 300 seconds (5 minutes). Specifying 0 (zero seconds) applies the default value.
+        /// </remarks>
+        /// </summary>
+        public int? Timeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating the API key for the server.
+        /// </summary>
+        public string ApiKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating the API key for the symbol server.
+        /// </summary>
+        public string SymbolApiKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether buffering is disabled when pushing to an HTTP(S) server.
+        /// </summary>
+        /// <remarks>
+        /// This decreases memory usage.
+        /// </remarks>
+        public bool DisableBuffering { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether symbols should be not be pushed if present.
+        /// </summary>
+        public bool IgnoreSymbols { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether, when pushing multiple packages to an HTTP(S) server,
+        /// to treat any 409 Conflict response as a warning so that the push can continue.
+        /// </summary>
+        /// <remarks>
+        /// Available since .NET Core 3.1 SDK.
+        /// </remarks>
+        public bool SkipDuplicate { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to force command-line output in English.
+        /// </summary>
+        public bool ForceEnglishOutput { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -11,6 +11,7 @@ using Cake.Common.Tools.DotNet.BuildServer;
 using Cake.Common.Tools.DotNet.Clean;
 using Cake.Common.Tools.DotNet.Execute;
 using Cake.Common.Tools.DotNet.MSBuild;
+using Cake.Common.Tools.DotNet.NuGet.Push;
 using Cake.Common.Tools.DotNet.Pack;
 using Cake.Common.Tools.DotNet.Publish;
 using Cake.Common.Tools.DotNet.Restore;
@@ -829,6 +830,7 @@ namespace Cake.Common.Tools.DotNetCore
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreNuGetPush is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetNuGetPush(ICakeContext, FilePath)" /> instead.
         /// Pushes one or more packages to a server.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -845,12 +847,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("NuGet")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Push")]
+        [Obsolete("DotNetCoreNuGetPush is obsolete and will be removed in a future release. Use DotNetNuGetPush instead.")]
         public static void DotNetCoreNuGetPush(this ICakeContext context, FilePath packageFilePath)
         {
-            context.DotNetCoreNuGetPush(packageFilePath, null);
+            context.DotNetNuGetPush(packageFilePath);
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreNuGetPush is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetNuGetPush(ICakeContext, FilePath, DotNetNuGetPushSettings)" /> instead.
         /// Pushes one or more packages to a server using the specified settings.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -873,20 +877,10 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("NuGet")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Push")]
+        [Obsolete("DotNetCoreNuGetPush is obsolete and will be removed in a future release. Use DotNetNuGetPush instead.")]
         public static void DotNetCoreNuGetPush(this ICakeContext context, FilePath packageFilePath, DotNetCoreNuGetPushSettings settings)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            if (settings == null)
-            {
-                settings = new DotNetCoreNuGetPushSettings();
-            }
-
-            var restorer = new DotNetCoreNuGetPusher(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            restorer.Push(packageFilePath?.FullPath, settings);
+            context.DotNetNuGetPush(packageFilePath, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DotNetCore/NuGet/Push/DotNetCoreNuGetPushSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/NuGet/Push/DotNetCoreNuGetPushSettings.cs
@@ -2,85 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Common.Tools.DotNet.NuGet.Push;
+
 namespace Cake.Common.Tools.DotNetCore.NuGet.Push
 {
     /// <summary>
     /// Contains settings used by <see cref="DotNetCoreNuGetPusher" />.
     /// </summary>
-    public sealed class DotNetCoreNuGetPushSettings : DotNetCoreSettings
+    public sealed class DotNetCoreNuGetPushSettings : DotNetNuGetPushSettings
     {
-        /// <summary>
-        /// Gets or sets a value indicating the server URL.
-        /// </summary>
-        /// <remarks>
-        /// This option is required unless DefaultPushSource config value is set in the NuGet config file.
-        /// </remarks>
-        public string Source { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating the symbol server URL.
-        /// </summary>
-        public string SymbolSource { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to append "api/v2/package" to the source URL.
-        /// </summary>
-        /// <remarks>
-        /// Available since .NET Core 2.1 SDK.
-        /// </remarks>
-        public bool NoServiceEndpoint { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to block and require manual action for operations like authentication.
-        /// </summary>
-        /// <remarks>
-        /// Available since .NET Core 2.2 SDK.
-        /// </remarks>
-        public bool Interactive { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating timeout for pushing to a server in seconds.
-        /// <remarks>
-        /// Defaults to 300 seconds (5 minutes). Specifying 0 (zero seconds) applies the default value.
-        /// </remarks>
-        /// </summary>
-        public int? Timeout { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating the API key for the server.
-        /// </summary>
-        public string ApiKey { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating the API key for the symbol server.
-        /// </summary>
-        public string SymbolApiKey { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether buffering is disabled when pushing to an HTTP(S) server.
-        /// </summary>
-        /// <remarks>
-        /// This decreases memory usage.
-        /// </remarks>
-        public bool DisableBuffering { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether symbols should be not be pushed if present.
-        /// </summary>
-        public bool IgnoreSymbols { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether, when pushing multiple packages to an HTTP(S) server,
-        /// to treat any 409 Conflict response as a warning so that the push can continue.
-        /// </summary>
-        /// <remarks>
-        /// Available since .NET Core 3.1 SDK.
-        /// </remarks>
-        public bool SkipDuplicate { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to force command-line output in English.
-        /// </summary>
-        public bool ForceEnglishOutput { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/NuGet/Push/DotNetCoreNuGetPusher.cs
+++ b/src/Cake.Common/Tools/DotNetCore/NuGet/Push/DotNetCoreNuGetPusher.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Cake.Common.Tools.DotNet.NuGet.Push;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
@@ -12,7 +13,7 @@ namespace Cake.Common.Tools.DotNetCore.NuGet.Push
     /// <summary>
     /// .NET Core nuget pusher. Pushes a package and its symbols to the server.
     /// </summary>
-    public sealed class DotNetCoreNuGetPusher : DotNetCoreTool<DotNetCoreNuGetPushSettings>
+    public sealed class DotNetCoreNuGetPusher : DotNetCoreTool<DotNetNuGetPushSettings>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DotNetCoreNuGetPusher" /> class.
@@ -34,7 +35,7 @@ namespace Cake.Common.Tools.DotNetCore.NuGet.Push
         /// </summary>
         /// <param name="packageName">The name of the target package.</param>
         /// <param name="settings">The settings.</param>
-        public void Push(string packageName, DotNetCoreNuGetPushSettings settings)
+        public void Push(string packageName, DotNetNuGetPushSettings settings)
         {
             if (settings == null)
             {
@@ -44,7 +45,7 @@ namespace Cake.Common.Tools.DotNetCore.NuGet.Push
             RunCommand(settings, GetArguments(packageName, settings));
         }
 
-        private ProcessArgumentBuilder GetArguments(string packageName, DotNetCoreNuGetPushSettings settings)
+        private ProcessArgumentBuilder GetArguments(string packageName, DotNetNuGetPushSettings settings)
         {
             if (string.IsNullOrWhiteSpace(packageName))
             {


### PR DESCRIPTION
| DotNetCore                    |               | DotNet synonym                    |
| ----------------------------- |:-------------:| --------------------------------- |
| `DotNetCoreNuGetPush`         | :arrow_right: | :new: `DotNetNuGetPush`         |
| `DotNetCoreNuGetPushSettings` | :arrow_right: | :new: `DotNetNuGetPushSettings` |


- New `DotNetNuGetPush` aliases are being introduced
- `DotNetNuGetPush` aliases contain the code of the existing `DotNetCoreNuGetPush` (rename/move)
- Existing `DotNetCoreNuGetPush` aliases are forwarding calls to newly introduced `DotNetNuGetPush` aliases
- New `DotNetNuGetPushSettings` class is being introduced
- `DotNetNuGetPushSettings` class contains the code of `DotNetCoreNuGetPushSettings` (rename/move)
- The previous `DotNetCoreNuGetPushSettings` is now empty and inherits from the new `DotNetNuGetPushSettings`
- Namespaces `Cake.Common.Tools.DotNetCore.NuGetPush.*` have been preserved as to not introduce breaking changes
- Unit Tests and Integration Tests remain the same, and call the old `DotNetCore***` aliases, exercising the new `DotNet***` aliases in the process

---

Closes https://github.com/cake-build/cake/issues/3553
