### PR TITLE
GH3554: Add DotNetNuGetDelete aliases (synonym to DotNetCoreNuGetDelete)

### DIFF
--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
@@ -10,6 +10,7 @@ using Cake.Common.Tools.DotNet.BuildServer;
 using Cake.Common.Tools.DotNet.Clean;
 using Cake.Common.Tools.DotNet.Execute;
 using Cake.Common.Tools.DotNet.MSBuild;
+using Cake.Common.Tools.DotNet.NuGet.Delete;
 using Cake.Common.Tools.DotNet.NuGet.Push;
 using Cake.Common.Tools.DotNet.Pack;
 using Cake.Common.Tools.DotNet.Publish;
@@ -23,6 +24,7 @@ using Cake.Common.Tools.DotNetCore.BuildServer;
 using Cake.Common.Tools.DotNetCore.Clean;
 using Cake.Common.Tools.DotNetCore.Execute;
 using Cake.Common.Tools.DotNetCore.MSBuild;
+using Cake.Common.Tools.DotNetCore.NuGet.Delete;
 using Cake.Common.Tools.DotNetCore.NuGet.Push;
 using Cake.Common.Tools.DotNetCore.Pack;
 using Cake.Common.Tools.DotNetCore.Publish;
@@ -559,6 +561,146 @@ namespace Cake.Common.Tools.DotNet
 
             var cleaner = new DotNetCoreCleaner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             cleaner.Clean(project, settings);
+        }
+
+        /// <summary>
+        /// Delete a NuGet Package from a server.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <example>
+        /// <code>
+        /// DotNetNuGetDelete();
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("NuGet")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.NuGet.Delete")]
+        public static void DotNetNuGetDelete(this ICakeContext context)
+        {
+            context.DotNetNuGetDelete(null, null, null);
+        }
+
+        /// <summary>
+        /// Deletes a package from nuget.org.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="packageName">Name of package to delete.</param>
+        /// <example>
+        /// <code>
+        /// DotNetNuGetDelete("Microsoft.AspNetCore.Mvc");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("NuGet")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.NuGet.Delete")]
+        public static void DotNetNuGetDelete(this ICakeContext context, string packageName)
+        {
+            context.DotNetNuGetDelete(packageName, null, null);
+        }
+
+        /// <summary>
+        /// Deletes a specific version of a package from nuget.org.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="packageName">Name of package to delete.</param>
+        /// <param name="packageVersion">Version of package to delete.</param>
+        /// <example>
+        /// <code>
+        /// DotNetRestore("Microsoft.AspNetCore.Mvc", "1.0");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("NuGet")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.NuGet.Delete")]
+        public static void DotNetNuGetDelete(this ICakeContext context, string packageName, string packageVersion)
+        {
+            context.DotNetNuGetDelete(packageName, packageVersion, null);
+        }
+
+        /// <summary>
+        /// Deletes a package from a server.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="packageName">Name of package to delete.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// var settings = new DotNetNuGetDeleteSettings
+        /// {
+        ///     Source = "https://www.example.com/nugetfeed",
+        ///     NonInteractive = true
+        /// };
+        ///
+        /// DotNetNuGetDelete("Microsoft.AspNetCore.Mvc", settings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("NuGet")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.NuGet.Delete")]
+        public static void DotNetNuGetDelete(this ICakeContext context, string packageName, DotNetNuGetDeleteSettings settings)
+        {
+            context.DotNetNuGetDelete(packageName, null, settings);
+        }
+
+        /// <summary>
+        /// Deletes a package from a server using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// var settings = new DotNetNuGetDeleteSettings
+        /// {
+        ///     Source = "https://www.example.com/nugetfeed",
+        ///     NonInteractive = true
+        /// };
+        ///
+        /// DotNetNuGetDelete(settings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("NuGet")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.NuGet.Delete")]
+        public static void DotNetNuGetDelete(this ICakeContext context, DotNetNuGetDeleteSettings settings)
+        {
+            context.DotNetNuGetDelete(null, null, settings);
+        }
+
+        /// <summary>
+        /// Deletes a package from a server using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="packageName">Name of package to delete.</param>
+        /// <param name="packageVersion">Version of package to delete.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// var settings = new DotNetNuGetDeleteSettings
+        /// {
+        ///     Source = "https://www.example.com/nugetfeed",
+        ///     NonInteractive = true
+        /// };
+        ///
+        /// DotNetNuGetDelete("Microsoft.AspNetCore.Mvc", "1.0", settings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("NuGet")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.NuGet.Delete")]
+        public static void DotNetNuGetDelete(this ICakeContext context, string packageName, string packageVersion, DotNetNuGetDeleteSettings settings)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (settings is null)
+            {
+                settings = new DotNetNuGetDeleteSettings();
+            }
+
+            var nugetDeleter = new DotNetCoreNuGetDeleter(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            nugetDeleter.Delete(packageName, packageVersion, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DotNet/NuGet/Delete/DotNetNuGetDeleteSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/NuGet/Delete/DotNetNuGetDeleteSettings.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNetCore;
+using Cake.Common.Tools.DotNetCore.NuGet.Delete;
+
+namespace Cake.Common.Tools.DotNet.NuGet.Delete
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetCoreNuGetDeleter" />.
+    /// </summary>
+    public class DotNetNuGetDeleteSettings : DotNetCoreSettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating the server URL.
+        /// </summary>
+        /// <remarks>
+        /// Supported URLs for nuget.org include http://www.nuget.org, http://www.nuget.org/api/v3,
+        /// and http://www.nuget.org/api/v2/package. For private feeds, substitute the host name
+        /// (for example, %hostname%/api/v3).
+        /// </remarks>
+        public string Source { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to append "api/v2/package" to the source URL.
+        /// </summary>
+        /// <remarks>
+        /// Available since .NET Core 2.1 SDK.
+        /// </remarks>
+        public bool NoServiceEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to block and require manual action for operations like authentication.
+        /// </summary>
+        /// <remarks>
+        /// Available since .NET Core 2.2 SDK.
+        /// </remarks>
+        public bool Interactive { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to prompt for user input or confirmations.
+        /// </summary>
+        public bool NonInteractive { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating the API key for the server.
+        /// </summary>
+        public string ApiKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to force command-line output in English.
+        /// </summary>
+        public bool ForceEnglishOutput { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -11,6 +11,7 @@ using Cake.Common.Tools.DotNet.BuildServer;
 using Cake.Common.Tools.DotNet.Clean;
 using Cake.Common.Tools.DotNet.Execute;
 using Cake.Common.Tools.DotNet.MSBuild;
+using Cake.Common.Tools.DotNet.NuGet.Delete;
 using Cake.Common.Tools.DotNet.NuGet.Push;
 using Cake.Common.Tools.DotNet.Pack;
 using Cake.Common.Tools.DotNet.Publish;
@@ -690,6 +691,7 @@ namespace Cake.Common.Tools.DotNetCore
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreNuGetDelete is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetNuGetDelete(ICakeContext)" /> instead.
         /// Delete a NuGet Package from a server.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -701,12 +703,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("NuGet")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Delete")]
+        [Obsolete("DotNetCoreNuGetDelete is obsolete and will be removed in a future release. Use DotNetNuGetDelete instead.")]
         public static void DotNetCoreNuGetDelete(this ICakeContext context)
         {
-            context.DotNetCoreNuGetDelete(null, null, null);
+            context.DotNetNuGetDelete();
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreNuGetDelete is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetNuGetDelete(ICakeContext, string)" /> instead.
         /// Deletes a package from nuget.org.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -719,12 +723,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("NuGet")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Delete")]
+        [Obsolete("DotNetCoreNuGetDelete is obsolete and will be removed in a future release. Use DotNetNuGetDelete instead.")]
         public static void DotNetCoreNuGetDelete(this ICakeContext context, string packageName)
         {
-            context.DotNetCoreNuGetDelete(packageName, null, null);
+            context.DotNetNuGetDelete(packageName);
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreNuGetDelete is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetNuGetDelete(ICakeContext, string, string)" /> instead.
         /// Deletes a specific version of a package from nuget.org.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -738,12 +744,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("NuGet")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Delete")]
+        [Obsolete("DotNetCoreNuGetDelete is obsolete and will be removed in a future release. Use DotNetNuGetDelete instead.")]
         public static void DotNetCoreNuGetDelete(this ICakeContext context, string packageName, string packageVersion)
         {
-            context.DotNetCoreNuGetDelete(packageName, packageVersion, null);
+            context.DotNetNuGetDelete(packageName, packageVersion);
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreNuGetDelete is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetNuGetDelete(ICakeContext, string, DotNetNuGetDeleteSettings)" /> instead.
         /// Deletes a package from a server.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -763,12 +771,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("NuGet")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Delete")]
+        [Obsolete("DotNetCoreNuGetDelete is obsolete and will be removed in a future release. Use DotNetNuGetDelete instead.")]
         public static void DotNetCoreNuGetDelete(this ICakeContext context, string packageName, DotNetCoreNuGetDeleteSettings settings)
         {
-            context.DotNetCoreNuGetDelete(packageName, null, settings);
+            context.DotNetNuGetDelete(packageName, settings);
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreNuGetDelete is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetNuGetDelete(ICakeContext, DotNetNuGetDeleteSettings)" /> instead.
         /// Deletes a package from a server using the specified settings.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -787,12 +797,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("NuGet")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Delete")]
+        [Obsolete("DotNetCoreNuGetDelete is obsolete and will be removed in a future release. Use DotNetNuGetDelete instead.")]
         public static void DotNetCoreNuGetDelete(this ICakeContext context, DotNetCoreNuGetDeleteSettings settings)
         {
-            context.DotNetCoreNuGetDelete(null, null, settings);
+            context.DotNetNuGetDelete(settings);
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreNuGetDelete is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetNuGetDelete(ICakeContext, string, string, DotNetNuGetDeleteSettings)" /> instead.
         /// Deletes a package from a server using the specified settings.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -813,20 +825,10 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("NuGet")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Delete")]
+        [Obsolete("DotNetCoreNuGetDelete is obsolete and will be removed in a future release. Use DotNetNuGetDelete instead.")]
         public static void DotNetCoreNuGetDelete(this ICakeContext context, string packageName, string packageVersion, DotNetCoreNuGetDeleteSettings settings)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            if (settings == null)
-            {
-                settings = new DotNetCoreNuGetDeleteSettings();
-            }
-
-            var nugetDeleter = new DotNetCoreNuGetDeleter(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            nugetDeleter.Delete(packageName, packageVersion, settings);
+            context.DotNetNuGetDelete(packageName, packageVersion, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DotNetCore/NuGet/Delete/DotNetCoreNuGetDeleteSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/NuGet/Delete/DotNetCoreNuGetDeleteSettings.cs
@@ -2,52 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Common.Tools.DotNet.NuGet.Delete;
+
 namespace Cake.Common.Tools.DotNetCore.NuGet.Delete
 {
     /// <summary>
     /// Contains settings used by <see cref="DotNetCoreNuGetDeleter" />.
     /// </summary>
-    public sealed class DotNetCoreNuGetDeleteSettings : DotNetCoreSettings
+    public sealed class DotNetCoreNuGetDeleteSettings : DotNetNuGetDeleteSettings
     {
-        /// <summary>
-        /// Gets or sets a value indicating the server URL.
-        /// </summary>
-        /// <remarks>
-        /// Supported URLs for nuget.org include http://www.nuget.org, http://www.nuget.org/api/v3,
-        /// and http://www.nuget.org/api/v2/package. For private feeds, substitute the host name
-        /// (for example, %hostname%/api/v3).
-        /// </remarks>
-        public string Source { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to append "api/v2/package" to the source URL.
-        /// </summary>
-        /// <remarks>
-        /// Available since .NET Core 2.1 SDK.
-        /// </remarks>
-        public bool NoServiceEndpoint { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to block and require manual action for operations like authentication.
-        /// </summary>
-        /// <remarks>
-        /// Available since .NET Core 2.2 SDK.
-        /// </remarks>
-        public bool Interactive { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to prompt for user input or confirmations.
-        /// </summary>
-        public bool NonInteractive { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating the API key for the server.
-        /// </summary>
-        public string ApiKey { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to force command-line output in English.
-        /// </summary>
-        public bool ForceEnglishOutput { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/NuGet/Delete/DotNetCoreNuGetDeleter.cs
+++ b/src/Cake.Common/Tools/DotNetCore/NuGet/Delete/DotNetCoreNuGetDeleter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Cake.Common.Tools.DotNet.NuGet.Delete;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
@@ -12,7 +13,7 @@ namespace Cake.Common.Tools.DotNetCore.NuGet.Delete
     /// <summary>
     /// .NET Core NuGet deleter. Deletes or unlists a package from the server.
     /// </summary>
-    public sealed class DotNetCoreNuGetDeleter : DotNetCoreTool<DotNetCoreNuGetDeleteSettings>
+    public sealed class DotNetCoreNuGetDeleter : DotNetCoreTool<DotNetNuGetDeleteSettings>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DotNetCoreNuGetDeleter" /> class.
@@ -35,7 +36,7 @@ namespace Cake.Common.Tools.DotNetCore.NuGet.Delete
         /// <param name="packageName">The name of the target package.</param>
         /// <param name="version">Version of the package.</param>
         /// <param name="settings">The settings.</param>
-        public void Delete(string packageName, string version, DotNetCoreNuGetDeleteSettings settings)
+        public void Delete(string packageName, string version, DotNetNuGetDeleteSettings settings)
         {
             if (settings == null)
             {
@@ -45,7 +46,7 @@ namespace Cake.Common.Tools.DotNetCore.NuGet.Delete
             RunCommand(settings, GetArguments(packageName, version, settings));
         }
 
-        private ProcessArgumentBuilder GetArguments(string packageName, string packageVersion, DotNetCoreNuGetDeleteSettings settings)
+        private ProcessArgumentBuilder GetArguments(string packageName, string packageVersion, DotNetNuGetDeleteSettings settings)
         {
             var builder = CreateArgumentBuilder(settings);
 


### PR DESCRIPTION
| DotNetCore                      |               | DotNet synonym                    |
| ------------------------------- |:-------------:| --------------------------------- |
| `DotNetCoreNuGetDelete`         | :arrow_right: | :new: `DotNetNuGetDelete`         |
| `DotNetCoreNuGetDeleteSettings` | :arrow_right: | :new: `DotNetNuGetDeleteSettings` |


- New `DotNetNuGetDelete` aliases are being introduced
- `DotNetNuGetDelete` aliases contain the code of the existing `DotNetCoreNuGetDelete` (rename/move)
- Existing `DotNetCoreNuGetDelete` aliases are forwarding calls to newly introduced `DotNetNuGetDelete` aliases
- New `DotNetNuGetDeleteSettings` class is being introduced
- `DotNetNuGetDeleteSettings` class contains the code of `DotNetCoreNuGetDeleteSettings` (rename/move)
- The previous `DotNetCoreNuGetDeleteSettings` is now empty and inherits from the new `DotNetNuGetDeleteSettings`
- Namespaces `Cake.Common.Tools.DotNetCore.NuGetDelete.*` have been preserved as to not introduce breaking changes
- Unit Tests and Integration Tests remain the same, and call the old `DotNetCore***` aliases, exercising the new `DotNet***` aliases in the process

---

Closes https://github.com/cake-build/cake/issues/3554
