### PR TITLE
GH3647: Display message of criteria when task fails to run due to criteria not being met

### DIFF
--- a/src/Cake.Core/CakeEngine.cs
+++ b/src/Cake.Core/CakeEngine.cs
@@ -253,8 +253,10 @@ namespace Cake.Core
                 {
                     // It's not OK to skip the target task.
                     // See issue #106 (https://github.com/cake-build/cake/issues/106)
-                    const string format = "Could not reach target '{0}' since it was skipped due to a criteria.";
-                    var message = string.Format(CultureInfo.InvariantCulture, format, task.Name);
+                    var message = string.IsNullOrWhiteSpace(criteria.Message) ?
+                        $"Could not reach target '{task.Name}' since it was skipped due to a criteria." :
+                        $"Could not reach target '{task.Name}' since it was skipped due to a criteria: {criteria.Message}.";
+
                     throw new CakeException(message);
                 }
 


### PR DESCRIPTION
```cakescript
Task("A")
    .WithCriteria(() => DateTime.Now.Second % 2 == 0, "Need even seconds")
    .Does(() =>
{
    Information("Hello!");
});

RunTarget("A");
```

![image](https://user-images.githubusercontent.com/177608/139553184-b0256909-a624-4ae2-be2c-17d7efc19304.png)

---

Closes #3647