### PR TITLE
GH3555: Add DotNetNuGetAddSource aliases (synonym to DotNetCoreNuGetAddSource

### DIFF
--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
@@ -12,6 +12,7 @@ using Cake.Common.Tools.DotNet.Execute;
 using Cake.Common.Tools.DotNet.MSBuild;
 using Cake.Common.Tools.DotNet.NuGet.Delete;
 using Cake.Common.Tools.DotNet.NuGet.Push;
+using Cake.Common.Tools.DotNet.NuGet.Source;
 using Cake.Common.Tools.DotNet.Pack;
 using Cake.Common.Tools.DotNet.Publish;
 using Cake.Common.Tools.DotNet.Restore;
@@ -26,6 +27,7 @@ using Cake.Common.Tools.DotNetCore.Execute;
 using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Common.Tools.DotNetCore.NuGet.Delete;
 using Cake.Common.Tools.DotNetCore.NuGet.Push;
+using Cake.Common.Tools.DotNetCore.NuGet.Source;
 using Cake.Common.Tools.DotNetCore.Pack;
 using Cake.Common.Tools.DotNetCore.Publish;
 using Cake.Common.Tools.DotNetCore.Restore;
@@ -762,6 +764,40 @@ namespace Cake.Common.Tools.DotNet
 
             var restorer = new DotNetCoreNuGetPusher(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             restorer.Push(packageFilePath?.FullPath, settings);
+        }
+
+        /// <summary>
+        /// Add the specified NuGet source.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="name">The name of the source.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// var settings = new DotNetNuGetSourceSettings
+        /// {
+        ///     Source = "https://www.example.com/nugetfeed",
+        ///     UserName = "username",
+        ///     Password = "password",
+        ///     StorePasswordInClearText = true,
+        ///     ValidAuthenticationTypes = "basic,negotiate"
+        /// };
+        ///
+        /// DotNetNuGetAddSource("example", settings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("NuGet")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.NuGet.Source")]
+        public static void DotNetNuGetAddSource(this ICakeContext context, string name, DotNetNuGetSourceSettings settings)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var sourcer = new DotNetCoreNuGetSourcer(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            sourcer.AddSource(name, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DotNet/NuGet/Source/DotNetNuGetAddSourceSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/NuGet/Source/DotNetNuGetAddSourceSettings.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNetCore.NuGet.Source;
+
+namespace Cake.Common.Tools.DotNet.NuGet.Source
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetCoreNuGetSourcer" /> for adding new sources.
+    /// </summary>
+    public class DotNetNuGetAddSourceSettings : DotNetNuGetSourceSettings
+    {
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/NuGet/Source/DotNetNuGetSourceSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/NuGet/Source/DotNetNuGetSourceSettings.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNetCore;
+using Cake.Common.Tools.DotNetCore.NuGet.Source;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotNet.NuGet.Source
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetCoreNuGetSourcer" />.
+    /// </summary>
+    public class DotNetNuGetSourceSettings : DotNetCoreSettings
+    {
+        /// <summary>
+        /// Gets or sets the path to the package(s) source.
+        /// </summary>
+        public string Source { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this source contains sensitive data, i.e. authentication token in url.
+        /// </summary>
+        public bool IsSensitiveSource { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user name to be used when connecting to an authenticated source.
+        /// </summary>
+        public string UserName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the password to be used when connecting to an authenticated source.
+        /// </summary>
+        public string Password { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to enable storing portable package source credentials by disabling password encryption.
+        /// </summary>
+        public bool StorePasswordInClearText { get; set; }
+
+        /// <summary>
+        /// Gets or sets the comma-separated list of valid authentication types for this source.
+        /// </summary>
+        /// <remarks>
+        /// By default, all authentication types are valid. Example: basic,negotiate.
+        /// </remarks>
+        public string ValidAuthenticationTypes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the NuGet configuration file.
+        /// </summary>
+        public FilePath ConfigFile { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -13,6 +13,7 @@ using Cake.Common.Tools.DotNet.Execute;
 using Cake.Common.Tools.DotNet.MSBuild;
 using Cake.Common.Tools.DotNet.NuGet.Delete;
 using Cake.Common.Tools.DotNet.NuGet.Push;
+using Cake.Common.Tools.DotNet.NuGet.Source;
 using Cake.Common.Tools.DotNet.Pack;
 using Cake.Common.Tools.DotNet.Publish;
 using Cake.Common.Tools.DotNet.Restore;
@@ -886,6 +887,7 @@ namespace Cake.Common.Tools.DotNetCore
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreNuGetAddSource is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetNuGetAddSource(ICakeContext, string, DotNetNuGetSourceSettings)" /> instead.
         /// Add the specified NuGet source.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -908,15 +910,10 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("NuGet")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Source")]
+        [Obsolete("DotNetCoreNuGetAddSource is obsolete and will be removed in a future release. Use DotNetNuGetAddSource instead.")]
         public static void DotNetCoreNuGetAddSource(this ICakeContext context, string name, DotNetCoreNuGetSourceSettings settings)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            var sourcer = new DotNetCoreNuGetSourcer(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            sourcer.AddSource(name, settings);
+            context.DotNetNuGetAddSource(name, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DotNetCore/NuGet/Source/DotNetCoreNuGetSourceSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/NuGet/Source/DotNetCoreNuGetSourceSettings.cs
@@ -2,51 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Core.IO;
+using Cake.Common.Tools.DotNet.NuGet.Source;
 
 namespace Cake.Common.Tools.DotNetCore.NuGet.Source
 {
     /// <summary>
     /// Contains settings used by <see cref="DotNetCoreNuGetSourcer" />.
     /// </summary>
-    public sealed class DotNetCoreNuGetSourceSettings : DotNetCoreSettings
+    public sealed class DotNetCoreNuGetSourceSettings : DotNetNuGetSourceSettings
     {
-        /// <summary>
-        /// Gets or sets the path to the package(s) source.
-        /// </summary>
-        public string Source { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether this source contains sensitive data, i.e. authentication token in url.
-        /// </summary>
-        public bool IsSensitiveSource { get; set; }
-
-        /// <summary>
-        /// Gets or sets the user name to be used when connecting to an authenticated source.
-        /// </summary>
-        public string UserName { get; set; }
-
-        /// <summary>
-        /// Gets or sets the password to be used when connecting to an authenticated source.
-        /// </summary>
-        public string Password { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to enable storing portable package source credentials by disabling password encryption.
-        /// </summary>
-        public bool StorePasswordInClearText { get; set; }
-
-        /// <summary>
-        /// Gets or sets the comma-separated list of valid authentication types for this source.
-        /// </summary>
-        /// <remarks>
-        /// By default, all authentication types are valid. Example: basic,negotiate.
-        /// </remarks>
-        public string ValidAuthenticationTypes { get; set; }
-
-        /// <summary>
-        /// Gets or sets the NuGet configuration file.
-        /// </summary>
-        public FilePath ConfigFile { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/NuGet/Source/DotNetCoreNuGetSourcer.cs
+++ b/src/Cake.Common/Tools/DotNetCore/NuGet/Source/DotNetCoreNuGetSourcer.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Cake.Common.Tools.DotNet.NuGet.Source;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
@@ -14,7 +15,7 @@ namespace Cake.Common.Tools.DotNetCore.NuGet.Source
     /// <summary>
     /// .NET Core NuGet sourcer.
     /// </summary>
-    public sealed class DotNetCoreNuGetSourcer : DotNetCoreTool<DotNetCoreNuGetSourceSettings>
+    public sealed class DotNetCoreNuGetSourcer : DotNetCoreTool<DotNetNuGetSourceSettings>
     {
         private readonly ICakeEnvironment _environment;
 
@@ -39,7 +40,7 @@ namespace Cake.Common.Tools.DotNetCore.NuGet.Source
         /// </summary>
         /// <param name="name">The name of the source.</param>
         /// <param name="settings">The settings.</param>
-        public void AddSource(string name, DotNetCoreNuGetSourceSettings settings)
+        public void AddSource(string name, DotNetNuGetSourceSettings settings)
         {
             if (string.IsNullOrWhiteSpace(name))
             {
@@ -183,7 +184,7 @@ namespace Cake.Common.Tools.DotNetCore.NuGet.Source
             RunCommand(settings, GetUpdateSourceArguments(name, settings));
         }
 
-        private ProcessArgumentBuilder GetAddSourceArguments(string name, DotNetCoreNuGetSourceSettings settings)
+        private ProcessArgumentBuilder GetAddSourceArguments(string name, DotNetNuGetSourceSettings settings)
         {
             var builder = CreateArgumentBuilder(settings);
 
@@ -312,7 +313,7 @@ namespace Cake.Common.Tools.DotNetCore.NuGet.Source
             return builder;
         }
 
-        private void AddCommonArguments(DotNetCoreNuGetSourceSettings settings, ProcessArgumentBuilder builder)
+        private void AddCommonArguments(DotNetNuGetSourceSettings settings, ProcessArgumentBuilder builder)
         {
             if (settings.ConfigFile != null)
             {


### PR DESCRIPTION
| DotNetCore                      |               | DotNet synonym                    |
| ------------------------------- |:-------------:| --------------------------------- |
| `DotNetCoreNuGetAddSource`      | :arrow_right: | :new: `DotNetNuGetAddSource`      |
| `DotNetCoreNuGetSourceSettings` | :arrow_right: | :new: `DotNetNuGetSourceSettings` |


- New `DotNetNuGetAddSource` aliases are being introduced
- `DotNetNuGetAddSource` aliases contain the code of the existing `DotNetCoreNuGetAddSource` (rename/move)
- Existing `DotNetCoreNuGetAddSource` aliases are forwarding calls to newly introduced `DotNetNuGetAddSource` aliases
- New `DotNetNuGetSourceSettings` and `DotNetNuGetAddSourceSettings` class is being introduced
- `DotNetNuGetSourceSettings` class contains the code of `DotNetCoreNuGetSourceSettings` (rename/move)
- The previous `DotNetCoreNuGetSourceSettings` is now empty and inherits from the new `DotNetNuGetSourceSettings`
- Namespaces `Cake.Common.Tools.DotNetCore.NuGet.Source.*` have been preserved as to not introduce breaking changes
- Unit Tests and Integration Tests remain the same, and call the old `DotNetCore***` aliases, exercising the new `DotNet***` aliases in the process

---

Closes https://github.com/cake-build/cake/issues/3555
