### PR TITLE
GH3639: Add DotNetNuGetDisableSource aliases (synonym to DotNetCoreNuGetDisableSource)

### DIFF
--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
@@ -801,6 +801,54 @@ namespace Cake.Common.Tools.DotNet
         }
 
         /// <summary>
+        /// Disable the specified NuGet source.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="name">The name of the source.</param>
+        /// <example>
+        /// <code>
+        /// DotNetNuGetDisableSource("example");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("NuGet")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.NuGet.Source")]
+        public static void DotNetNuGetDisableSource(this ICakeContext context, string name)
+        {
+            context.DotNetNuGetDisableSource(name, null);
+        }
+
+        /// <summary>
+        /// Disable the specified NuGet source.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="name">The name of the source.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// var settings = new DotNetNuGetSourceSettings
+        /// {
+        ///     ConfigFile = "NuGet.config"
+        /// };
+        ///
+        /// DotNetNuGetDisableSource("example", settings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("NuGet")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.NuGet.Source")]
+        public static void DotNetNuGetDisableSource(this ICakeContext context, string name, DotNetNuGetSourceSettings settings)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var sourcer = new DotNetCoreNuGetSourcer(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            sourcer.DisableSource(name, settings ?? new DotNetNuGetSourceSettings());
+        }
+
+        /// <summary>
         /// Package all projects.
         /// </summary>
         /// <param name="context">The context.</param>

--- a/src/Cake.Common/Tools/DotNet/NuGet/Source/DotNetNuGetDisableSourceSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/NuGet/Source/DotNetNuGetDisableSourceSettings.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNetCore.NuGet.Source;
+
+namespace Cake.Common.Tools.DotNet.NuGet.Source
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetCoreNuGetSourcer" /> for disabling NuGet sources.
+    /// </summary>
+    public class DotNetNuGetDisableSourceSettings : DotNetNuGetSourceSettings
+    {
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -917,6 +917,7 @@ namespace Cake.Common.Tools.DotNetCore
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreNuGetDisableSource is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetNuGetDisableSource(ICakeContext, string)" /> instead.
         /// Disable the specified NuGet source.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -929,12 +930,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("NuGet")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Source")]
+        [Obsolete("DotNetCoreNuGetDisableSource is obsolete and will be removed in a future release. Use DotNetNuGetDisableSource instead.")]
         public static void DotNetCoreNuGetDisableSource(this ICakeContext context, string name)
         {
-            context.DotNetCoreNuGetDisableSource(name, null);
+            context.DotNetNuGetDisableSource(name);
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreNuGetDisableSource is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetNuGetDisableSource(ICakeContext, string, DotNetNuGetSourceSettings)" /> instead.
         /// Disable the specified NuGet source.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -953,15 +956,10 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("NuGet")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Source")]
+        [Obsolete("DotNetCoreNuGetDisableSource is obsolete and will be removed in a future release. Use DotNetNuGetDisableSource instead.")]
         public static void DotNetCoreNuGetDisableSource(this ICakeContext context, string name, DotNetCoreNuGetSourceSettings settings)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            var sourcer = new DotNetCoreNuGetSourcer(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            sourcer.DisableSource(name, settings ?? new DotNetCoreNuGetSourceSettings());
+            context.DotNetNuGetDisableSource(name, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DotNetCore/NuGet/Source/DotNetCoreNuGetSourcer.cs
+++ b/src/Cake.Common/Tools/DotNetCore/NuGet/Source/DotNetCoreNuGetSourcer.cs
@@ -65,7 +65,7 @@ namespace Cake.Common.Tools.DotNetCore.NuGet.Source
         /// </summary>
         /// <param name="name">The name of the source.</param>
         /// <param name="settings">The settings.</param>
-        public void DisableSource(string name, DotNetCoreNuGetSourceSettings settings)
+        public void DisableSource(string name, DotNetNuGetSourceSettings settings)
         {
             if (string.IsNullOrWhiteSpace(name))
             {
@@ -223,7 +223,7 @@ namespace Cake.Common.Tools.DotNetCore.NuGet.Source
             return builder;
         }
 
-        private ProcessArgumentBuilder GetDisableSourceArguments(string name, DotNetCoreNuGetSourceSettings settings)
+        private ProcessArgumentBuilder GetDisableSourceArguments(string name, DotNetNuGetSourceSettings settings)
         {
             var builder = CreateArgumentBuilder(settings);
 


### PR DESCRIPTION
| DotNetCore                      |               | DotNet synonym                    |
| ------------------------------- |:-------------:| --------------------------------- |
| `DotNetCoreNuGetDisableSource`  | :arrow_right: | :new: `DotNetNuGetDisableSource`  |
| `DotNetCoreNuGetSourceSettings` | :arrow_right: | :new: `DotNetNuGetSourceSettings` |


- New `DotNetNuGetDisableSource` aliases are being introduced
- `DotNetNuGetDisableSource` aliases contain the code of the existing `DotNetCoreNuGetDisableSource` (rename/move)
- Existing `DotNetCoreNuGetDisableSource` aliases are forwarding calls to newly introduced `DotNetNuGetDisableSource` aliases
- New `DotNetNuGetSourceSettings` and `DotNetNuGetDisableSourceSettings` class is being introduced
- `DotNetNuGetSourceSettings` class contains the code of `DotNetCoreNuGetSourceSettings` (rename/move)
- The previous `DotNetCoreNuGetSourceSettings` is now empty and inherits from the new `DotNetNuGetSourceSettings`
- Namespaces `Cake.Common.Tools.DotNetCore.NuGet.Source.*` have been preserved as to not introduce breaking changes
- Unit Tests and Integration Tests remain the same, and call the old `DotNetCore***` aliases, exercising the new `DotNet***` aliases in the process

---

Closes https://github.com/cake-build/cake/issues/3639
