### PR TITLE
(GH-3654) Change IsRunningOnAzurePipelines to ignore agent type

### DIFF
--- a/build/version.cake
+++ b/build/version.cake
@@ -22,7 +22,7 @@ public record BuildVersion(
             // Temp Workaround GitVersion Azure Pipelines
             var azurePipelines = context.AzurePipelines();
             string sourceBranch = string.Empty;
-            if ((azurePipelines.IsRunningOnAzurePipelinesHosted || azurePipelines.IsRunningOnAzurePipelines) && azurePipelines.Environment.PullRequest.Number > 0)
+            if (azurePipelines.IsRunningOnAzurePipelines && azurePipelines.Environment.PullRequest.Number > 0)
             {
                  sourceBranch = $"PullRequest{azurePipelines.Environment.PullRequest.Number}";
                  context.Information("Overriding Azure Pipelines branch name with: {0}", sourceBranch);

--- a/src/Cake.Common.Tests/Fixtures/Build/AzurePipelinesFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/AzurePipelinesFixture.cs
@@ -26,20 +26,9 @@ namespace Cake.Common.Tests.Fixtures.Build
             Writer = new FakeBuildSystemServiceMessageWriter();
         }
 
-        public void IsRunningOnTFS() => IsRunningOnAzurePipelines();
-
-        public void IsRunningOnVSTS() => IsRunningOnAzurePipelinesHosted();
-
         public void IsRunningOnAzurePipelines()
         {
             Environment.GetEnvironmentVariable("TF_BUILD").Returns("True");
-            Environment.GetEnvironmentVariable("AGENT_NAME").Returns("On Premises");
-        }
-
-        public void IsRunningOnAzurePipelinesHosted(string agentHostName = "Hosted Agent")
-        {
-            Environment.GetEnvironmentVariable("TF_BUILD").Returns("True");
-            Environment.GetEnvironmentVariable("AGENT_NAME").Returns(agentHostName);
         }
 
         public AzurePipelinesProvider CreateAzurePipelinesService() => new AzurePipelinesProvider(Environment, Writer);

--- a/src/Cake.Common.Tests/Unit/Build/AzurePipelines/AzurePipelinesProviderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/AzurePipelines/AzurePipelinesProviderTests.cs
@@ -65,55 +65,6 @@ namespace Cake.Common.Tests.Unit.Build.AzurePipelines
             }
         }
 
-        public sealed class TheIsRunningOnAzurePipelinesHostedProperty
-        {
-            [Fact]
-            public void Should_Return_True_If_Running_On_AzurePipelinesHosted()
-            {
-                // Given
-                var fixture = new AzurePipelinesFixture();
-                fixture.IsRunningOnAzurePipelinesHosted();
-                var tfBuild = fixture.CreateAzurePipelinesService();
-
-                // When
-                var result = tfBuild.IsRunningOnAzurePipelinesHosted;
-
-                // Then
-                Assert.True(result);
-            }
-
-            [Fact]
-            public void Should_Return_False_If_Not_Running_On_AzurePipelinesHosted()
-            {
-                // Given
-                var fixture = new AzurePipelinesFixture();
-                var tfBuild = fixture.CreateAzurePipelinesService();
-
-                // When
-                var result = tfBuild.IsRunningOnAzurePipelinesHosted;
-
-                // Then
-                Assert.False(result);
-            }
-
-            [Theory]
-            [InlineData("Hosted Agent 2")]
-            [InlineData("Azure Pipelines 3")]
-            public void Should_Return_True_If_Running_On_AzurePipelinesExtraAgent(string agentName)
-            {
-                // Given
-                var fixture = new AzurePipelinesFixture();
-                fixture.IsRunningOnAzurePipelinesHosted(agentName);
-                var tfBuild = fixture.CreateAzurePipelinesService();
-
-                // When
-                var result = tfBuild.IsRunningOnAzurePipelinesHosted;
-
-                // Then
-                Assert.True(result);
-            }
-        }
-
         public sealed class TheEnvironmentProperty
         {
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Build/BuildSystemTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/BuildSystemTests.cs
@@ -715,38 +715,6 @@ namespace Cake.Common.Tests.Unit.Build
             }
         }
 
-        public sealed class TheIsRunningOnAzurePipelinesHostedProperty
-        {
-            [Fact]
-            public void Should_Return_True_If_Running_On_AzurePipelinesHosted()
-            {
-                // Given
-                var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
-                var teamCityProvider = Substitute.For<ITeamCityProvider>();
-                var myGetProvider = Substitute.For<IMyGetProvider>();
-                var bambooProvider = Substitute.For<IBambooProvider>();
-                var continuaCIProvider = Substitute.For<IContinuaCIProvider>();
-                var jenkinsProvider = Substitute.For<IJenkinsProvider>();
-                var bitriseProvider = Substitute.For<IBitriseProvider>();
-                var travisCIProvider = Substitute.For<ITravisCIProvider>();
-                var bitbucketPipelinesProvider = Substitute.For<IBitbucketPipelinesProvider>();
-                var goCDProvider = Substitute.For<IGoCDProvider>();
-                var gitLabCIProvider = Substitute.For<IGitLabCIProvider>();
-                var gitHubActionsProvider = Substitute.For<IGitHubActionsProvider>();
-                var azurePipelinesProvider = Substitute.For<IAzurePipelinesProvider>();
-                var azurePipelinesEnvironment = new AzurePipelinesInfoFixture().CreateEnvironmentInfo();
-
-                azurePipelinesProvider.IsRunningOnAzurePipelinesHosted.Returns(true);
-                azurePipelinesProvider.Environment.Returns(azurePipelinesEnvironment);
-
-                // When
-                var buildSystem = new BuildSystem(appVeyorProvider, teamCityProvider, myGetProvider, bambooProvider, continuaCIProvider, jenkinsProvider, bitriseProvider, travisCIProvider, bitbucketPipelinesProvider, goCDProvider, gitLabCIProvider, gitHubActionsProvider, azurePipelinesProvider);
-
-                // Then
-                Assert.True(buildSystem.IsRunningOnAzurePipelinesHosted);
-            }
-        }
-
         public sealed class TheIsRunningOnGitHubActionsProperty
         {
             [Fact]
@@ -782,22 +750,21 @@ namespace Cake.Common.Tests.Unit.Build
         public sealed class TheProviderProperty
         {
             [Theory]
-            [InlineData(false, false, false, false, false, false, false, false, false, false, false, false, false, false, BuildProvider.Local)]
-            [InlineData(true, false, false, false, false, false, false, false, false, false, false, false, false, false, BuildProvider.AppVeyor)]
-            [InlineData(false, true, false, false, false, false, false, false, false, false, false, false, false, false, BuildProvider.TeamCity)]
-            [InlineData(false, false, true, false, false, false, false, false, false, false, false, false, false, false, BuildProvider.MyGet)]
-            [InlineData(false, false, false, true, false, false, false, false, false, false, false, false, false, false, BuildProvider.Bamboo)]
-            [InlineData(false, false, false, false, true, false, false, false, false, false, false, false, false, false, BuildProvider.ContinuaCI)]
-            [InlineData(false, false, false, false, false, true, false, false, false, false, false, false, false, false, BuildProvider.Jenkins)]
-            [InlineData(false, false, false, false, false, false, true, false, false, false, false, false, false, false, BuildProvider.Bitrise)]
-            [InlineData(false, false, false, false, false, false, false, true, false, false, false, false, false, false, BuildProvider.TravisCI)]
-            [InlineData(false, false, false, false, false, false, false, false, true, false, false, false, false, false, BuildProvider.BitbucketPipelines)]
-            [InlineData(false, false, false, false, false, false, false, false, false, true, false, false, false, false, BuildProvider.GoCD)]
-            [InlineData(false, false, false, false, false, false, false, false, false, false, true, false, false, false, BuildProvider.GitLabCI)]
-            [InlineData(false, false, false, false, false, false, false, false, false, false, false, true, false, false, BuildProvider.AzurePipelines)]
-            [InlineData(false, false, false, false, false, false, false, false, false, false, false, false, true, false, BuildProvider.AzurePipelinesHosted)]
-            [InlineData(false, false, false, false, false, false, false, false, false, false, false, false, false, true, BuildProvider.GitHubActions)]
-            public void Should_Return_Provider_If_Running_On_Provider(bool appVeyor, bool teamCity, bool myGet, bool bamboo, bool continuaCI, bool jenkins, bool bitrise, bool travisCI, bool bitbucketPipelines, bool goCD, bool gitLabCI, bool azurePipelines, bool azurePipelinesHosted, bool gitHubActions, BuildProvider provider)
+            [InlineData(false, false, false, false, false, false, false, false, false, false, false, false, false, BuildProvider.Local)]
+            [InlineData(true, false, false, false, false, false, false, false, false, false, false, false, false, BuildProvider.AppVeyor)]
+            [InlineData(false, true, false, false, false, false, false, false, false, false, false, false, false, BuildProvider.TeamCity)]
+            [InlineData(false, false, true, false, false, false, false, false, false, false, false, false, false, BuildProvider.MyGet)]
+            [InlineData(false, false, false, true, false, false, false, false, false, false, false, false, false, BuildProvider.Bamboo)]
+            [InlineData(false, false, false, false, true, false, false, false, false, false, false, false, false, BuildProvider.ContinuaCI)]
+            [InlineData(false, false, false, false, false, true, false, false, false, false, false, false, false, BuildProvider.Jenkins)]
+            [InlineData(false, false, false, false, false, false, true, false, false, false, false, false, false, BuildProvider.Bitrise)]
+            [InlineData(false, false, false, false, false, false, false, true, false, false, false, false, false, BuildProvider.TravisCI)]
+            [InlineData(false, false, false, false, false, false, false, false, true, false, false, false, false, BuildProvider.BitbucketPipelines)]
+            [InlineData(false, false, false, false, false, false, false, false, false, true, false, false, false, BuildProvider.GoCD)]
+            [InlineData(false, false, false, false, false, false, false, false, false, false, true, false, false, BuildProvider.GitLabCI)]
+            [InlineData(false, false, false, false, false, false, false, false, false, false, false, true, false, BuildProvider.AzurePipelines)]
+            [InlineData(false, false, false, false, false, false, false, false, false, false, false, false, true, BuildProvider.GitHubActions)]
+            public void Should_Return_Provider_If_Running_On_Provider(bool appVeyor, bool teamCity, bool myGet, bool bamboo, bool continuaCI, bool jenkins, bool bitrise, bool travisCI, bool bitbucketPipelines, bool goCD, bool gitLabCI, bool azurePipelines, bool gitHubActions, BuildProvider provider)
             {
                 // Given
                 var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
@@ -844,7 +811,6 @@ namespace Cake.Common.Tests.Unit.Build
                 gitHubActionsProvider.IsRunningOnGitHubActions.Returns(gitHubActions);
                 gitHubActionsProvider.Environment.Returns(gitHubActionsEnvironment);
                 azurePipelinesProvider.IsRunningOnAzurePipelines.Returns(azurePipelines);
-                azurePipelinesProvider.IsRunningOnAzurePipelinesHosted.Returns(azurePipelinesHosted);
                 azurePipelinesProvider.Environment.Returns(azurePipelinesEnvironment);
 
                 // When
@@ -858,22 +824,21 @@ namespace Cake.Common.Tests.Unit.Build
         public sealed class TheIsLocalBuildProperty
         {
             [Theory]
-            [InlineData(false, false, false, false, false, false, false, false, false, false, false, false, false, false, true)]
-            [InlineData(true, false, false, false, false, false, false, false, false, false, false, false, false, false, false)]
-            [InlineData(false, true, false, false, false, false, false, false, false, false, false, false, false, false, false)]
-            [InlineData(false, false, true, false, false, false, false, false, false, false, false, false, false, false, false)]
-            [InlineData(false, false, false, true, false, false, false, false, false, false, false, false, false, false, false)]
-            [InlineData(false, false, false, false, true, false, false, false, false, false, false, false, false, false, false)]
-            [InlineData(false, false, false, false, false, true, false, false, false, false, false, false, false, false, false)]
-            [InlineData(false, false, false, false, false, false, true, false, false, false, false, false, false, false, false)]
-            [InlineData(false, false, false, false, false, false, false, true, false, false, false, false, false, false, false)]
-            [InlineData(false, false, false, false, false, false, false, false, true, false, false, false, false, false, false)]
-            [InlineData(false, false, false, false, false, false, false, false, false, true, false, false, false, false, false)]
-            [InlineData(false, false, false, false, false, false, false, false, false, false, true, false, false, false, false)]
-            [InlineData(false, false, false, false, false, false, false, false, false, false, false, true, false, false, false)]
-            [InlineData(false, false, false, false, false, false, false, false, false, false, false, false, true, false, false)]
-            [InlineData(false, false, false, false, false, false, false, false, false, false, false, false, false, true, false)]
-            public void Should_Return_Whether_Or_Not_Running_On_Provider(bool appVeyor, bool teamCity, bool myGet, bool bamboo, bool continuaCI, bool jenkins, bool bitrise, bool travisCI, bool bitbucketPipelines, bool goCD, bool gitLabCI, bool azurePipelines, bool azurePipelinesHosted, bool gitHubActions, bool isLocalBuild)
+            [InlineData(false, false, false, false, false, false, false, false, false, false, false, false, false, true)]
+            [InlineData(true, false, false, false, false, false, false, false, false, false, false, false, false, false)]
+            [InlineData(false, true, false, false, false, false, false, false, false, false, false, false, false, false)]
+            [InlineData(false, false, true, false, false, false, false, false, false, false, false, false, false, false)]
+            [InlineData(false, false, false, true, false, false, false, false, false, false, false, false, false, false)]
+            [InlineData(false, false, false, false, true, false, false, false, false, false, false, false, false, false)]
+            [InlineData(false, false, false, false, false, true, false, false, false, false, false, false, false, false)]
+            [InlineData(false, false, false, false, false, false, true, false, false, false, false, false, false, false)]
+            [InlineData(false, false, false, false, false, false, false, true, false, false, false, false, false, false)]
+            [InlineData(false, false, false, false, false, false, false, false, true, false, false, false, false, false)]
+            [InlineData(false, false, false, false, false, false, false, false, false, true, false, false, false, false)]
+            [InlineData(false, false, false, false, false, false, false, false, false, false, true, false, false, false)]
+            [InlineData(false, false, false, false, false, false, false, false, false, false, false, true, false, false)]
+            [InlineData(false, false, false, false, false, false, false, false, false, false, false, false, true, false)]
+            public void Should_Return_Whether_Or_Not_Running_On_Provider(bool appVeyor, bool teamCity, bool myGet, bool bamboo, bool continuaCI, bool jenkins, bool bitrise, bool travisCI, bool bitbucketPipelines, bool goCD, bool gitLabCI, bool azurePipelines, bool gitHubActions, bool isLocalBuild)
             {
                 // Given
                 var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
@@ -920,7 +885,6 @@ namespace Cake.Common.Tests.Unit.Build
                 gitHubActionsProvider.IsRunningOnGitHubActions.Returns(gitHubActions);
                 gitHubActionsProvider.Environment.Returns(gitHubActionsEnvironment);
                 azurePipelinesProvider.IsRunningOnAzurePipelines.Returns(azurePipelines);
-                azurePipelinesProvider.IsRunningOnAzurePipelinesHosted.Returns(azurePipelinesHosted);
                 azurePipelinesProvider.Environment.Returns(azurePipelinesEnvironment);
 
                 // When
@@ -935,22 +899,21 @@ namespace Cake.Common.Tests.Unit.Build
         public sealed class TheIsPullRequestProperty
         {
             [Theory]
-            [InlineData(false, false, false, false, false, false, false, false, false, false, false, false, false, false, false)] // none
-            [InlineData(true, false, false, false, false, false, false, false, false, false, false, false, false, false, true)] // appveyor
-            [InlineData(false, true, false, false, false, false, false, false, false, false, false, false, false, false, true)] // teamcity
-            [InlineData(false, false, true, false, false, false, false, false, false, false, false, false, false, false, false)] // myget
-            [InlineData(false, false, false, true, false, false, false, false, false, false, false, false, false, false, false)] // bamboo
-            [InlineData(false, false, false, false, true, false, false, false, false, false, false, false, false, false, false)] // continua
-            [InlineData(false, false, false, false, false, true, false, false, false, false, false, false, false, false, true)] // jenkins
-            [InlineData(false, false, false, false, false, false, true, false, false, false, false, false, false, false, true)] // bitrise
-            [InlineData(false, false, false, false, false, false, false, true, false, false, false, false, false, false, true)] // travis
-            [InlineData(false, false, false, false, false, false, false, false, true, false, false, false, false, false, true)] // bitbucket
-            [InlineData(false, false, false, false, false, false, false, false, false, true, false, false, false, false, false)] // gocd
-            [InlineData(false, false, false, false, false, false, false, false, false, false, true, false, false, false, true)] // gitlab
-            [InlineData(false, false, false, false, false, false, false, false, false, false, false, true, false, false, true)] // az pipelines
-            [InlineData(false, false, false, false, false, false, false, false, false, false, false, false, true, false, true)] // az pipelines hosted
-            [InlineData(false, false, false, false, false, false, false, false, false, false, false, false, false, true, true)] // gh actions
-            public void Should_Return_True_If_Running_On_Supported_Provider(bool appVeyor, bool teamCity, bool myGet, bool bamboo, bool continuaCI, bool jenkins, bool bitrise, bool travisCI, bool bitbucketPipelines, bool goCD, bool gitLabCI, bool azurePipelines, bool azurePipelinesHosted, bool gitHubActions, bool isPullRequest)
+            [InlineData(false, false, false, false, false, false, false, false, false, false, false, false, false, false)] // none
+            [InlineData(true, false, false, false, false, false, false, false, false, false, false, false, false, true)] // appveyor
+            [InlineData(false, true, false, false, false, false, false, false, false, false, false, false, false, true)] // teamcity
+            [InlineData(false, false, true, false, false, false, false, false, false, false, false, false, false, false)] // myget
+            [InlineData(false, false, false, true, false, false, false, false, false, false, false, false, false, false)] // bamboo
+            [InlineData(false, false, false, false, true, false, false, false, false, false, false, false, false, false)] // continua
+            [InlineData(false, false, false, false, false, true, false, false, false, false, false, false, false, true)] // jenkins
+            [InlineData(false, false, false, false, false, false, true, false, false, false, false, false, false, true)] // bitrise
+            [InlineData(false, false, false, false, false, false, false, true, false, false, false, false, false, true)] // travis
+            [InlineData(false, false, false, false, false, false, false, false, true, false, false, false, false, true)] // bitbucket
+            [InlineData(false, false, false, false, false, false, false, false, false, true, false, false, false, false)] // gocd
+            [InlineData(false, false, false, false, false, false, false, false, false, false, true, false, false, true)] // gitlab
+            [InlineData(false, false, false, false, false, false, false, false, false, false, false, true, false, true)] // az pipelines
+            [InlineData(false, false, false, false, false, false, false, false, false, false, false, false, true, true)] // gh actions
+            public void Should_Return_True_If_Running_On_Supported_Provider(bool appVeyor, bool teamCity, bool myGet, bool bamboo, bool continuaCI, bool jenkins, bool bitrise, bool travisCI, bool bitbucketPipelines, bool goCD, bool gitLabCI, bool azurePipelines, bool gitHubActions, bool isPullRequest)
             {
                 // Given
                 var appVeyorProvider = Substitute.For<IAppVeyorProvider>();
@@ -997,7 +960,6 @@ namespace Cake.Common.Tests.Unit.Build
                 gitHubActionsProvider.IsRunningOnGitHubActions.Returns(gitHubActions);
                 gitHubActionsProvider.Environment.Returns(gitHubActionsEnvironment);
                 azurePipelinesProvider.IsRunningOnAzurePipelines.Returns(azurePipelines);
-                azurePipelinesProvider.IsRunningOnAzurePipelinesHosted.Returns(azurePipelinesHosted);
                 azurePipelinesProvider.Environment.Returns(azurePipelinesEnvironment);
 
                 // When

--- a/src/Cake.Common/Build/AzurePipelines/AzurePipelinesProvider.cs
+++ b/src/Cake.Common/Build/AzurePipelines/AzurePipelinesProvider.cs
@@ -30,11 +30,7 @@ namespace Cake.Common.Build.AzurePipelines
 
         /// <inheritdoc/>
         public bool IsRunningOnAzurePipelines
-            => !string.IsNullOrWhiteSpace(_environment.GetEnvironmentVariable("TF_BUILD")) && !IsHostedAgent;
-
-        /// <inheritdoc/>
-        public bool IsRunningOnAzurePipelinesHosted
-            => !string.IsNullOrWhiteSpace(_environment.GetEnvironmentVariable("TF_BUILD")) && IsHostedAgent;
+            => !string.IsNullOrWhiteSpace(_environment.GetEnvironmentVariable("TF_BUILD"));
 
         /// <inheritdoc/>
         public AzurePipelinesEnvironmentInfo Environment { get; }

--- a/src/Cake.Common/Build/AzurePipelines/Data/AzurePipelinesAgentInfo.cs
+++ b/src/Cake.Common/Build/AzurePipelines/Data/AzurePipelinesAgentInfo.cs
@@ -101,10 +101,10 @@ namespace Cake.Common.Build.AzurePipelines.Data
         public FilePath ToolsDirectory => GetEnvironmentString("AGENT_TOOLSDIRECTORY");
 
         /// <summary>
-        /// Gets a value indicating whether the current agent is a hosted agent.
+        /// Gets a value indicating whether the current agent is a Microsoft hosted agent.
         /// </summary>
         /// <value>
-        /// <c>true</c> if the current agent is a hosted agent; otherwise, <c>false</c>.
+        /// <c>true</c> if the current agent is a Microsoft hosted agent. <c>false</c> if the current agent is a self hosted agent.
         /// </value>
         public bool IsHosted => Name != null && (Name.StartsWith("Hosted") || Name.StartsWith("Azure Pipelines"));
     }

--- a/src/Cake.Common/Build/AzurePipelines/IAzurePipelinesProvider.cs
+++ b/src/Cake.Common/Build/AzurePipelines/IAzurePipelinesProvider.cs
@@ -20,14 +20,6 @@ namespace Cake.Common.Build.AzurePipelines
         bool IsRunningOnAzurePipelines { get; }
 
         /// <summary>
-        /// Gets a value indicating whether the current build is running on hosted Azure Pipelines.
-        /// </summary>
-        /// <value>
-        /// <c>true</c> if the current build is running on hosted Azure Pipelines; otherwise, <c>false</c>.
-        /// </value>
-        bool IsRunningOnAzurePipelinesHosted { get; }
-
-        /// <summary>
         /// Gets the Azure Pipelines environment.
         /// </summary>
         /// <value>

--- a/src/Cake.Common/Build/BuildProvider.cs
+++ b/src/Cake.Common/Build/BuildProvider.cs
@@ -78,11 +78,6 @@ namespace Cake.Common.Build
         AzurePipelines = 2048,
 
         /// <summary>
-        /// AzurePipelinesHosted build provider.
-        /// </summary>
-        AzurePipelinesHosted = 4096,
-
-        /// <summary>
         /// GitHubActions build provider.
         /// </summary>
         GitHubActions = 8192

--- a/src/Cake.Common/Build/BuildSystem.cs
+++ b/src/Cake.Common/Build/BuildSystem.cs
@@ -135,8 +135,7 @@ namespace Cake.Common.Build
                 | (GoCD.IsRunningOnGoCD ? BuildProvider.GoCD : BuildProvider.Local)
                 | (GitLabCI.IsRunningOnGitLabCI ? BuildProvider.GitLabCI : BuildProvider.Local)
                 | (GitHubActions.IsRunningOnGitHubActions ? BuildProvider.GitHubActions : BuildProvider.Local)
-                | (AzurePipelines.IsRunningOnAzurePipelines ? BuildProvider.AzurePipelines : BuildProvider.Local)
-                | (AzurePipelines.IsRunningOnAzurePipelinesHosted ? BuildProvider.AzurePipelinesHosted : BuildProvider.Local);
+                | (AzurePipelines.IsRunningOnAzurePipelines ? BuildProvider.AzurePipelines : BuildProvider.Local);
 
             IsLocalBuild = Provider == BuildProvider.Local;
 
@@ -146,7 +145,7 @@ namespace Cake.Common.Build
                 || ((Provider & BuildProvider.TravisCI) != 0 && TravisCI.Environment.PullRequest.IsPullRequest)
                 || ((Provider & BuildProvider.BitbucketPipelines) != 0 && BitbucketPipelines.Environment.PullRequest.IsPullRequest)
                 || ((Provider & BuildProvider.GitLabCI) != 0 && GitLabCI.Environment.PullRequest.IsPullRequest)
-                || ((Provider & (BuildProvider.AzurePipelines | BuildProvider.AzurePipelinesHosted)) != 0 && AzurePipelines.Environment.PullRequest.IsPullRequest)
+                || ((Provider & BuildProvider.AzurePipelines) != 0 && AzurePipelines.Environment.PullRequest.IsPullRequest)
                 || ((Provider & BuildProvider.GitHubActions) != 0 && GitHubActions.Environment.PullRequest.IsPullRequest)
                 || ((Provider & BuildProvider.Jenkins) != 0 && Jenkins.Environment.Change.IsPullRequest);
         }
@@ -514,23 +513,6 @@ namespace Cake.Common.Build
         /// <c>true</c> if this instance is running on Azure Pipelines; otherwise, <c>false</c>.
         /// </value>
         public bool IsRunningOnAzurePipelines => AzurePipelines.IsRunningOnAzurePipelines;
-
-        /// <summary>
-        /// Gets a value indicating whether this instance is running on hosted Azure Pipelines.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// if (BuildSystem.IsRunningOnAzurePipelinesHosted)
-        /// {
-        ///     // Get the build commit hash.
-        ///     var commitHash = BuildSystem.AzurePipelines.Environment.Repository.SourceVersion;
-        /// }
-        /// </code>
-        /// </example>
-        /// <value>
-        /// <c>true</c> if this instance is running on hosted Azure Pipelines; otherwise, <c>false</c>.
-        /// </value>
-        public bool IsRunningOnAzurePipelinesHosted => AzurePipelines.IsRunningOnAzurePipelinesHosted;
 
         /// <summary>
         /// Gets the Azure Pipelines Provider.

--- a/src/Cake.sln
+++ b/src/Cake.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30516.212
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31808.319
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Meta", "Meta", "{E9FAF832-F327-4F36-8AB3-2A96345DB1A9}"
 	ProjectSection(SolutionItems) = preProject


### PR DESCRIPTION
Change IsRunningOnAzurePipelines to only check if it is running on Azure Pipelines and ignoring the type of the agent to be consistent with other build providers.

This PR introduces some breaking changes to clean up the Azure Pipelines build provider:

- `IAzurePipelinesProvider.IsRunningOnAzurePipelines` only checks if running on Azure Pipelines and ignores type of agent
- `IAzurePipelinesProvider.IsRunningOnAzurePipelinesHosted` removed. `AzurePipelinesAgentInfo.IsHosted` can be used instead
- `BuildSystem.IsRunningOnAzurePipelines` only checks if running on Azure Pipelines and ignores type of agent
- `BuildSystem.IsRunningOnAzurePipelinesHosted` removed
- `BuildProvider.AzurePipelinesHosted` enum value removed

See also discussion https://github.com/cake-build/cake/discussions/3589

Fixes #3654