### PR TITLE
GH3640: Add DotNetNuGetEnableSource aliases (synonym to DotNetCoreNuGetEnableSource)

### DIFF
--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
@@ -849,6 +849,54 @@ namespace Cake.Common.Tools.DotNet
         }
 
         /// <summary>
+        /// Enable the specified NuGet source.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="name">The name of the source.</param>
+        /// <example>
+        /// <code>
+        /// DotNetNuGetEnableSource("example");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("NuGet")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.NuGet.Source")]
+        public static void DotNetNuGetEnableSource(this ICakeContext context, string name)
+        {
+            context.DotNetNuGetEnableSource(name, null);
+        }
+
+        /// <summary>
+        /// Enable the specified NuGet source.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="name">The name of the source.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// var settings = new DotNetNuGetSourceSettings
+        /// {
+        ///     ConfigFile = "NuGet.config"
+        /// };
+        ///
+        /// DotNetNuGetEnableSource("example", settings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("NuGet")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.NuGet.Source")]
+        public static void DotNetNuGetEnableSource(this ICakeContext context, string name, DotNetNuGetSourceSettings settings)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var sourcer = new DotNetCoreNuGetSourcer(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            sourcer.EnableSource(name, settings ?? new DotNetNuGetSourceSettings());
+        }
+
+        /// <summary>
         /// Package all projects.
         /// </summary>
         /// <param name="context">The context.</param>

--- a/src/Cake.Common/Tools/DotNet/NuGet/Source/DotNetNuGetEnableSourceSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/NuGet/Source/DotNetNuGetEnableSourceSettings.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNetCore.NuGet.Source;
+
+namespace Cake.Common.Tools.DotNet.NuGet.Source
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetCoreNuGetSourcer" /> for enabling a NuGet source.
+    /// </summary>
+    public class DotNetNuGetEnableSourceSettings : DotNetNuGetSourceSettings
+    {
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -963,6 +963,7 @@ namespace Cake.Common.Tools.DotNetCore
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreNuGetEnableSource is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetNuGetEnableSource(ICakeContext, string)" /> instead.
         /// Enable the specified NuGet source.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -975,12 +976,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("NuGet")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Source")]
+        [Obsolete("DotNetCoreNuGetEnableSource is obsolete and will be removed in a future release. Use DotNetNuGetEnableSource instead.")]
         public static void DotNetCoreNuGetEnableSource(this ICakeContext context, string name)
         {
-            context.DotNetCoreNuGetEnableSource(name, null);
+            context.DotNetNuGetEnableSource(name);
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreNuGetEnableSource is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetNuGetEnableSource(ICakeContext, string, DotNetNuGetSourceSettings)" /> instead.
         /// Enable the specified NuGet source.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -999,15 +1002,10 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("NuGet")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Source")]
+        [Obsolete("DotNetCoreNuGetEnableSource is obsolete and will be removed in a future release. Use DotNetNuGetEnableSource instead.")]
         public static void DotNetCoreNuGetEnableSource(this ICakeContext context, string name, DotNetCoreNuGetSourceSettings settings)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            var sourcer = new DotNetCoreNuGetSourcer(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            sourcer.EnableSource(name, settings ?? new DotNetCoreNuGetSourceSettings());
+            context.DotNetNuGetEnableSource(name, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DotNetCore/NuGet/Source/DotNetCoreNuGetSourcer.cs
+++ b/src/Cake.Common/Tools/DotNetCore/NuGet/Source/DotNetCoreNuGetSourcer.cs
@@ -85,7 +85,7 @@ namespace Cake.Common.Tools.DotNetCore.NuGet.Source
         /// </summary>
         /// <param name="name">The name of the source.</param>
         /// <param name="settings">The settings.</param>
-        public void EnableSource(string name, DotNetCoreNuGetSourceSettings settings)
+        public void EnableSource(string name, DotNetNuGetSourceSettings settings)
         {
             if (string.IsNullOrWhiteSpace(name))
             {
@@ -234,7 +234,7 @@ namespace Cake.Common.Tools.DotNetCore.NuGet.Source
             return builder;
         }
 
-        private ProcessArgumentBuilder GetEnableSourceArguments(string name, DotNetCoreNuGetSourceSettings settings)
+        private ProcessArgumentBuilder GetEnableSourceArguments(string name, DotNetNuGetSourceSettings settings)
         {
             var builder = CreateArgumentBuilder(settings);
 


### PR DESCRIPTION
| DotNetCore                      |               | DotNet synonym                          |
| ------------------------------- |:-------------:| --------------------------------------- |
| `DotNetCoreNuGetEnableSource`   | :arrow_right: | :new: `DotNetNuGetEnableSource`         |
|                                 | :arrow_right: | :new: `DotNetNuGetEnableSourceSettings` |


- New `DotNetNuGetEnableSource` aliases are being introduced
- `DotNetNuGetEnableSource` aliases contain the code of the existing `DotNetCoreNuGetEnableSource` (rename/move)
- Existing `DotNetCoreNuGetEnableSource` aliases are forwarding calls to newly introduced `DotNetNuGetEnableSource` aliases
- New `DotNetNuGetSourceSettings` and `DotNetNuGetEnableSourceSettings` class is being introduced
- `DotNetNuGetSourceSettings` class contains the code of `DotNetCoreNuGetSourceSettings` (rename/move)
- The previous `DotNetCoreNuGetSourceSettings` is now empty and inherits from the new `DotNetNuGetSourceSettings`
- Namespaces `Cake.Common.Tools.DotNetCore.NuGet.Source.*` have been preserved as to not introduce breaking changes
- Unit Tests and Integration Tests remain the same, and call the old `DotNetCore***` aliases, exercising the new `DotNet***` aliases in the process

---

Closes https://github.com/cake-build/cake/issues/3640
