### PR TITLE
GH3641: Add DotNetNuGetHasSource aliases (synonym to DotNetCoreNuGetHasSource)

### DIFF
--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
@@ -897,6 +897,56 @@ namespace Cake.Common.Tools.DotNet
         }
 
         /// <summary>
+        /// Determines whether the specified NuGet source exists.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="name">The name of the source.</param>
+        /// <returns>Whether the specified NuGet source exists.</returns>
+        /// <example>
+        /// <code>
+        /// var exists = DotNetNuGetHasSource("example");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("NuGet")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.NuGet.Source")]
+        public static bool DotNetNuGetHasSource(this ICakeContext context, string name)
+        {
+            return context.DotNetNuGetHasSource(name, null);
+        }
+
+        /// <summary>
+        /// Determines whether the specified NuGet source exists.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="name">The name of the source.</param>
+        /// <param name="settings">The settings.</param>
+        /// <returns>Whether the specified NuGet source exists.</returns>
+        /// <example>
+        /// <code>
+        /// var settings = new DotNetNuGetSourceSettings
+        /// {
+        ///     ConfigFile = "NuGet.config"
+        /// };
+        ///
+        /// var exists = DotNetNuGetHasSource("example", settings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("NuGet")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.NuGet.Source")]
+        public static bool DotNetNuGetHasSource(this ICakeContext context, string name, DotNetNuGetSourceSettings settings)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var sourcer = new DotNetCoreNuGetSourcer(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            return sourcer.HasSource(name, settings ?? new DotNetNuGetSourceSettings());
+        }
+
+        /// <summary>
         /// Package all projects.
         /// </summary>
         /// <param name="context">The context.</param>

--- a/src/Cake.Common/Tools/DotNet/NuGet/Source/DotNetNuGetHasSourceSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/NuGet/Source/DotNetNuGetHasSourceSettings.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNetCore.NuGet.Source;
+
+namespace Cake.Common.Tools.DotNet.NuGet.Source
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetCoreNuGetSourcer" /> for checking if a NuGet source exists.
+    /// </summary>
+    public class DotNetNuGetHasSourceSettings : DotNetNuGetSourceSettings
+    {
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/NuGet/Source/DotNetNuGetListSourceSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/NuGet/Source/DotNetNuGetListSourceSettings.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNetCore.NuGet.Source;
+
+namespace Cake.Common.Tools.DotNet.NuGet.Source
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetCoreNuGetSourcer" /> for listing NuGet sources.
+    /// </summary>
+    public class DotNetNuGetListSourceSettings : DotNetNuGetSourceSettings
+    {
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -1009,6 +1009,7 @@ namespace Cake.Common.Tools.DotNetCore
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreNuGetHasSource is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetNuGetHasSource(ICakeContext, string)" /> instead.
         /// Determines whether the specified NuGet source exists.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -1022,12 +1023,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("NuGet")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Source")]
+        [Obsolete("DotNetCoreNuGetHasSource is obsolete and will be removed in a future release. Use DotNetNuGetHasSource instead.")]
         public static bool DotNetCoreNuGetHasSource(this ICakeContext context, string name)
         {
-            return context.DotNetCoreNuGetHasSource(name, null);
+            return context.DotNetNuGetHasSource(name);
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreNuGetHasSource is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetNuGetHasSource(ICakeContext, string, DotNetNuGetSourceSettings)" /> instead.
         /// Determines whether the specified NuGet source exists.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -1047,15 +1050,10 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("NuGet")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Source")]
+        [Obsolete("DotNetCoreNuGetHasSource is obsolete and will be removed in a future release. Use DotNetNuGetHasSource instead.")]
         public static bool DotNetCoreNuGetHasSource(this ICakeContext context, string name, DotNetCoreNuGetSourceSettings settings)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            var sourcer = new DotNetCoreNuGetSourcer(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            return sourcer.HasSource(name, settings ?? new DotNetCoreNuGetSourceSettings());
+            return context.DotNetNuGetHasSource(name, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DotNetCore/NuGet/Source/DotNetCoreNuGetSourcer.cs
+++ b/src/Cake.Common/Tools/DotNetCore/NuGet/Source/DotNetCoreNuGetSourcer.cs
@@ -106,7 +106,7 @@ namespace Cake.Common.Tools.DotNetCore.NuGet.Source
         /// <param name="name">The name of the source.</param>
         /// <param name="settings">The settings.</param>
         /// <returns>Whether the specified NuGet source exists.</returns>
-        public bool HasSource(string name, DotNetCoreNuGetSourceSettings settings)
+        public bool HasSource(string name, DotNetNuGetSourceSettings settings)
         {
             if (string.IsNullOrWhiteSpace(name))
             {
@@ -130,7 +130,7 @@ namespace Cake.Common.Tools.DotNetCore.NuGet.Source
         /// <param name="format">The output format. Accepts two values: detailed (the default) and short.</param>
         /// <param name="settings">The settings.</param>
         /// <returns>The NuGet sources.</returns>
-        public string ListSource(string format, DotNetCoreNuGetSourceSettings settings)
+        public string ListSource(string format, DotNetNuGetSourceSettings settings)
         {
             if (settings == null)
             {
@@ -245,7 +245,7 @@ namespace Cake.Common.Tools.DotNetCore.NuGet.Source
             return builder;
         }
 
-        private ProcessArgumentBuilder GetListSourceArguments(string format, DotNetCoreNuGetSourceSettings settings)
+        private ProcessArgumentBuilder GetListSourceArguments(string format, DotNetNuGetSourceSettings settings)
         {
             var builder = CreateArgumentBuilder(settings);
 


### PR DESCRIPTION
| DotNetCore                 |               | DotNet synonym                        |
| -------------------------- |:-------------:| ------------------------------------- |
| `DotNetCoreNuGetHasSource` | :arrow_right: | :new: `DotNetNuGetHasSource`          |
|                            | :arrow_right: | :new: `DotNetNuGetHasSourceSettings`  |
|                            | :arrow_right: | :new: `DotNetNuGetListSourceSettings` |


- New `DotNetNuGetHasSource` aliases are being introduced
- `DotNetNuGetHasSource` aliases contain the code of the existing `DotNetCoreNuGetHasSource` (rename/move)
- Existing `DotNetCoreNuGetHasSource` aliases are forwarding calls to newly introduced `DotNetNuGetHasSource` aliases
- New `DotNetNuGetSourceSettings` and `DotNetNuGetHasSourceSettings` class is being introduced
- `DotNetNuGetSourceSettings` class contains the code of `DotNetCoreNuGetSourceSettings` (rename/move)
- The previous `DotNetCoreNuGetSourceSettings` is now empty and inherits from the new `DotNetNuGetSourceSettings`
- Namespaces `Cake.Common.Tools.DotNetCore.NuGet.Source.*` have been preserved as to not introduce breaking changes
- Unit Tests and Integration Tests remain the same, and call the old `DotNetCore***` aliases, exercising the new `DotNet***` aliases in the process

---

Closes https://github.com/cake-build/cake/issues/3641
Closes https://github.com/cake-build/cake/issues/3642
