### PR TITLE
GH3643: Add DotNetNuGetRemoveSource aliases (synonym to DotNetCoreNuGetRemoveSource)

### DIFF
--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
@@ -947,6 +947,54 @@ namespace Cake.Common.Tools.DotNet
         }
 
         /// <summary>
+        /// Remove the specified NuGet source.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="name">The name of the source.</param>
+        /// <example>
+        /// <code>
+        /// DotNetNuGetRemoveSource("example");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("NuGet")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.NuGet.Source")]
+        public static void DotNetNuGetRemoveSource(this ICakeContext context, string name)
+        {
+            context.DotNetNuGetRemoveSource(name, null);
+        }
+
+        /// <summary>
+        /// Remove the specified NuGet source.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="name">The name of the source.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// var settings = new DotNetNuGetSourceSettings
+        /// {
+        ///     ConfigFile = "NuGet.config"
+        /// };
+        ///
+        /// DotNetNuGetRemoveSource("example", settings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("NuGet")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.NuGet.Source")]
+        public static void DotNetNuGetRemoveSource(this ICakeContext context, string name, DotNetNuGetSourceSettings settings)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var sourcer = new DotNetCoreNuGetSourcer(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            sourcer.RemoveSource(name, settings ?? new DotNetNuGetSourceSettings());
+        }
+
+        /// <summary>
         /// Package all projects.
         /// </summary>
         /// <param name="context">The context.</param>

--- a/src/Cake.Common/Tools/DotNet/NuGet/Source/DotNetNuGetRemoveSourceSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/NuGet/Source/DotNetNuGetRemoveSourceSettings.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNetCore.NuGet.Source;
+
+namespace Cake.Common.Tools.DotNet.NuGet.Source
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetCoreNuGetSourcer" /> for removing a NuGet source.
+    /// </summary>
+    public class DotNetNuGetRemoveSourceSettings : DotNetNuGetSourceSettings
+    {
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -1057,6 +1057,7 @@ namespace Cake.Common.Tools.DotNetCore
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreNuGetRemoveSource is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetNuGetRemoveSource(ICakeContext, string)" /> instead.
         /// Remove the specified NuGet source.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -1069,12 +1070,14 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("NuGet")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Source")]
+        [Obsolete("DotNetCoreNuGetRemoveSource is obsolete and will be removed in a future release. Use DotNetNuGetRemoveSource instead.")]
         public static void DotNetCoreNuGetRemoveSource(this ICakeContext context, string name)
         {
-            context.DotNetCoreNuGetRemoveSource(name, null);
+            context.DotNetNuGetRemoveSource(name);
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreNuGetRemoveSource is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetNuGetRemoveSource(ICakeContext, string, DotNetNuGetSourceSettings)" /> instead.
         /// Remove the specified NuGet source.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -1093,15 +1096,10 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("NuGet")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Source")]
+        [Obsolete("DotNetCoreNuGetRemoveSource is obsolete and will be removed in a future release. Use DotNetNuGetRemoveSource instead.")]
         public static void DotNetCoreNuGetRemoveSource(this ICakeContext context, string name, DotNetCoreNuGetSourceSettings settings)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            var sourcer = new DotNetCoreNuGetSourcer(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            sourcer.RemoveSource(name, settings ?? new DotNetCoreNuGetSourceSettings());
+            context.DotNetNuGetRemoveSource(name, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DotNetCore/NuGet/Source/DotNetCoreNuGetSourcer.cs
+++ b/src/Cake.Common/Tools/DotNetCore/NuGet/Source/DotNetCoreNuGetSourcer.cs
@@ -149,7 +149,7 @@ namespace Cake.Common.Tools.DotNetCore.NuGet.Source
         /// </summary>
         /// <param name="name">The name of the source.</param>
         /// <param name="settings">The settings.</param>
-        public void RemoveSource(string name, DotNetCoreNuGetSourceSettings settings)
+        public void RemoveSource(string name, DotNetNuGetSourceSettings settings)
         {
             if (string.IsNullOrWhiteSpace(name))
             {
@@ -260,7 +260,7 @@ namespace Cake.Common.Tools.DotNetCore.NuGet.Source
             return builder;
         }
 
-        private ProcessArgumentBuilder GetRemoveSourceArguments(string name, DotNetCoreNuGetSourceSettings settings)
+        private ProcessArgumentBuilder GetRemoveSourceArguments(string name, DotNetNuGetSourceSettings settings)
         {
             var builder = CreateArgumentBuilder(settings);
 


### PR DESCRIPTION
| DotNetCore                    |               | DotNet synonym                          |
| ----------------------------- |:-------------:| --------------------------------------- |
| `DotNetCoreNuGetRemoveSource` | :arrow_right: | :new: `DotNetNuGetRemoveSource`         |
|                               | :arrow_right: | :new: `DotNetNuGetRemoveSourceSettings` |


- New `DotNetNuGetRemoveSource` aliases are being introduced
- `DotNetNuGetRemoveSource` aliases contain the code of the existing `DotNetCoreNuGetRemoveSource` (rename/move)
- Existing `DotNetCoreNuGetRemoveSource` aliases are forwarding calls to newly introduced `DotNetNuGetRemoveSource` aliases
- New `DotNetNuGetSourceSettings` and `DotNetNuGetRemoveSourceSettings` class is being introduced
- `DotNetNuGetSourceSettings` class contains the code of `DotNetCoreNuGetSourceSettings` (rename/move)
- The previous `DotNetCoreNuGetSourceSettings` is now empty and inherits from the new `DotNetNuGetSourceSettings`
- Namespaces `Cake.Common.Tools.DotNetCore.NuGet.Source.*` have been preserved as to not introduce breaking changes
- Unit Tests and Integration Tests remain the same, and call the old `DotNetCore***` aliases, exercising the new `DotNet***` aliases in the process

---

Closes https://github.com/cake-build/cake/issues/3643
