### PR TITLE
GH3644: Add DotNetNuGetUpdateSource aliases (synonym to DotNetCoreNuGetUpdateSource)

### DIFF
--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
@@ -995,6 +995,40 @@ namespace Cake.Common.Tools.DotNet
         }
 
         /// <summary>
+        /// Update the specified NuGet source.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="name">The name of the source.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// var settings = new DotNetNuGetSourceSettings
+        /// {
+        ///     Source = "https://www.example.com/nugetfeed",
+        ///     UserName = "username",
+        ///     Password = "password",
+        ///     StorePasswordInClearText = true,
+        ///     ValidAuthenticationTypes = "basic,negotiate"
+        /// };
+        ///
+        /// DotNetNuGetUpdateSource("example", settings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("NuGet")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.NuGet.Source")]
+        public static void DotNetNuGetUpdateSource(this ICakeContext context, string name, DotNetNuGetSourceSettings settings)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var sourcer = new DotNetCoreNuGetSourcer(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            sourcer.UpdateSource(name, settings);
+        }
+
+        /// <summary>
         /// Package all projects.
         /// </summary>
         /// <param name="context">The context.</param>

--- a/src/Cake.Common/Tools/DotNet/NuGet/Source/DotNetNuGetUpdateSourceSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/NuGet/Source/DotNetNuGetUpdateSourceSettings.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNetCore.NuGet.Source;
+
+namespace Cake.Common.Tools.DotNet.NuGet.Source
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetCoreNuGetSourcer" /> for updating a NuGet source.
+    /// </summary>
+    public class DotNetNuGetUpdateSourceSettings : DotNetNuGetSourceSettings
+    {
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -1103,6 +1103,7 @@ namespace Cake.Common.Tools.DotNetCore
         }
 
         /// <summary>
+        /// [deprecated] DotNetCoreNuGetUpdateSource is obsolete and will be removed in a future release. Use <see cref="DotNetAliases.DotNetNuGetUpdateSource(ICakeContext, string, DotNetNuGetSourceSettings)" /> instead.
         /// Update the specified NuGet source.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -1125,15 +1126,10 @@ namespace Cake.Common.Tools.DotNetCore
         [CakeMethodAlias]
         [CakeAliasCategory("NuGet")]
         [CakeNamespaceImport("Cake.Common.Tools.DotNetCore.NuGet.Source")]
+        [Obsolete("DotNetCoreNuGetUpdateSource is obsolete and will be removed in a future release. Use DotNetNuGetUpdateSource instead.")]
         public static void DotNetCoreNuGetUpdateSource(this ICakeContext context, string name, DotNetCoreNuGetSourceSettings settings)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            var sourcer = new DotNetCoreNuGetSourcer(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            sourcer.UpdateSource(name, settings);
+            context.DotNetNuGetUpdateSource(name, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DotNetCore/NuGet/Source/DotNetCoreNuGetSourcer.cs
+++ b/src/Cake.Common/Tools/DotNetCore/NuGet/Source/DotNetCoreNuGetSourcer.cs
@@ -169,7 +169,7 @@ namespace Cake.Common.Tools.DotNetCore.NuGet.Source
         /// </summary>
         /// <param name="name">The name of the source.</param>
         /// <param name="settings">The settings.</param>
-        public void UpdateSource(string name, DotNetCoreNuGetSourceSettings settings)
+        public void UpdateSource(string name, DotNetNuGetSourceSettings settings)
         {
             if (string.IsNullOrWhiteSpace(name))
             {
@@ -271,7 +271,7 @@ namespace Cake.Common.Tools.DotNetCore.NuGet.Source
             return builder;
         }
 
-        private ProcessArgumentBuilder GetUpdateSourceArguments(string name, DotNetCoreNuGetSourceSettings settings)
+        private ProcessArgumentBuilder GetUpdateSourceArguments(string name, DotNetNuGetSourceSettings settings)
         {
             var builder = CreateArgumentBuilder(settings);
 


### PR DESCRIPTION
| DotNetCore                    |               | DotNet synonym                          |
| ----------------------------- |:-------------:| --------------------------------------- |
| `DotNetCoreNuGetUpdateSource` | :arrow_right: | :new: `DotNetNuGetUpdateSource`         |
|                               | :arrow_right: | :new: `DotNetNuGetUpdateSourceSettings` |


- New `DotNetNuGetUpdateSource` aliases are being introduced
- `DotNetNuGetUpdateSource` aliases contain the code of the existing `DotNetCoreNuGetUpdateSource` (rename/move)
- Existing `DotNetCoreNuGetUpdateSource` aliases are forwarding calls to newly introduced `DotNetNuGetUpdateSource` aliases
- New `DotNetNuGetSourceSettings` and `DotNetNuGetUpdateSourceSettings` class is being introduced
- `DotNetNuGetSourceSettings` class contains the code of `DotNetCoreNuGetSourceSettings` (rename/move)
- The previous `DotNetCoreNuGetSourceSettings` is now empty and inherits from the new `DotNetNuGetSourceSettings`
- Namespaces `Cake.Common.Tools.DotNetCore.NuGet.Source.*` have been preserved as to not introduce breaking changes
- Unit Tests and Integration Tests remain the same, and call the old `DotNetCore***` aliases, exercising the new `DotNet***` aliases in the process

---

Closes https://github.com/cake-build/cake/issues/3644
