### PR TITLE
GH1111: Update DotNetRestore alias XML Docs to match official docs

### DIFF
--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
@@ -151,10 +151,10 @@ namespace Cake.Common.Tools.DotNet
         /// Restore all NuGet Packages in the specified path.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="root">List of projects and project folders to restore. Each value can be: a path to a project.json or global.json file, or a folder to recursively search for project.json files.</param>
+        /// <param name="root">Path to the project file to restore.</param>
         /// <example>
         /// <code>
-        /// DotNetRestore("./src/*");
+        /// DotNetRestore("./src/MyProject/MyProject.csproj");
         /// </code>
         /// </example>
         [CakeMethodAlias]
@@ -197,7 +197,7 @@ namespace Cake.Common.Tools.DotNet
         /// Restore all NuGet Packages in the specified path with settings.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="root">List of projects and project folders to restore. Each value can be: a path to a project.json or global.json file, or a folder to recursively search for project.json files.</param>
+        /// <param name="root">Path to the project file to restore.</param>
         /// <param name="settings">The settings.</param>
         /// <example>
         /// <code>
@@ -211,7 +211,7 @@ namespace Cake.Common.Tools.DotNet
         ///     InferRuntimes = new[] {"runtime1", "runtime2"}
         /// };
         ///
-        /// DotNetRestore("./src/*", settings);
+        /// DotNetRestore("./src/MyProject/MyProject.csproj", settings);
         /// </code>
         /// </example>
         [CakeMethodAlias]

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cs
@@ -145,10 +145,10 @@ namespace Cake.Common.Tools.DotNetCore
         /// Restore all NuGet Packages in the specified path.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="root">List of projects and project folders to restore. Each value can be: a path to a project.json or global.json file, or a folder to recursively search for project.json files.</param>
+        /// <param name="root">Path to the project file to restore.</param>
         /// <example>
         /// <code>
-        /// DotNetCoreRestore("./src/*");
+        /// DotNetCoreRestore("./src/MyProject/MyProject.csproj");
         /// </code>
         /// </example>
         [CakeMethodAlias]
@@ -195,7 +195,7 @@ namespace Cake.Common.Tools.DotNetCore
         /// Restore all NuGet Packages in the specified path with settings.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="root">List of projects and project folders to restore. Each value can be: a path to a project.json or global.json file, or a folder to recursively search for project.json files.</param>
+        /// <param name="root">Path to the project file to restore.</param>
         /// <param name="settings">The settings.</param>
         /// <example>
         /// <code>
@@ -209,7 +209,7 @@ namespace Cake.Common.Tools.DotNetCore
         ///     InferRuntimes = new[] {"runtime1", "runtime2"}
         /// };
         ///
-        /// DotNetCoreRestore("./src/*", settings);
+        /// DotNetCoreRestore("./src/MyProject/MyProject.csproj", settings);
         /// </code>
         /// </example>
         [CakeMethodAlias]


### PR DESCRIPTION
Matches [official docs on `dotnet restore`](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-restore#arguments) as of this writing:

![image](https://user-images.githubusercontent.com/177608/140622642-597e7022-01b0-4bb0-a80d-8c7a823217c4.png)

---

Closes #1111
