### PR TITLE
GH3683: Use DotNetMSBuildSettings instead of DotNetCoreMSBuildSettings on new dotnet aliases settings

### DIFF
--- a/src/Cake.Common/Tools/DotNet/Build/DotNetBuildSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Build/DotNetBuildSettings.cs
@@ -3,9 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using Cake.Common.Tools.DotNet.MSBuild;
 using Cake.Common.Tools.DotNetCore;
 using Cake.Common.Tools.DotNetCore.Build;
-using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Core.IO;
 
 namespace Cake.Common.Tools.DotNet.Build
@@ -79,6 +79,6 @@ namespace Cake.Common.Tools.DotNet.Build
         /// <summary>
         /// Gets or sets additional arguments to be passed to MSBuild.
         /// </summary>
-        public DotNetCoreMSBuildSettings MSBuildSettings { get; set; }
+        public DotNetMSBuildSettings MSBuildSettings { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Clean/DotNetCleanSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Clean/DotNetCleanSettings.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Common.Tools.DotNet.MSBuild;
 using Cake.Common.Tools.DotNetCore;
 using Cake.Common.Tools.DotNetCore.Clean;
-using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Core.IO;
 
 namespace Cake.Common.Tools.DotNet.Clean
@@ -45,6 +45,6 @@ namespace Cake.Common.Tools.DotNet.Clean
         /// <summary>
         /// Gets or sets additional arguments to be passed to MSBuild.
         /// </summary>
-        public DotNetCoreMSBuildSettings MSBuildSettings { get; set; }
+        public DotNetMSBuildSettings MSBuildSettings { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Pack/DotNetPackSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Pack/DotNetPackSettings.cs
@@ -3,8 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using Cake.Common.Tools.DotNet.MSBuild;
 using Cake.Common.Tools.DotNetCore;
-using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Common.Tools.DotNetCore.Pack;
 using Cake.Core.IO;
 
@@ -101,6 +101,6 @@ namespace Cake.Common.Tools.DotNet.Pack
         /// <summary>
         /// Gets or sets additional arguments to be passed to MSBuild.
         /// </summary>
-        public DotNetCoreMSBuildSettings MSBuildSettings { get; set; }
+        public DotNetMSBuildSettings MSBuildSettings { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Publish/DotNetPublishSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Publish/DotNetPublishSettings.cs
@@ -3,8 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using Cake.Common.Tools.DotNet.MSBuild;
 using Cake.Common.Tools.DotNetCore;
-using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Common.Tools.DotNetCore.Publish;
 using Cake.Core.IO;
 
@@ -175,6 +175,6 @@ namespace Cake.Common.Tools.DotNet.Publish
         /// <summary>
         /// Gets or sets additional arguments to be passed to MSBuild.
         /// </summary>
-        public DotNetCoreMSBuildSettings MSBuildSettings { get; set; }
+        public DotNetMSBuildSettings MSBuildSettings { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Restore/DotNetRestoreSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Restore/DotNetRestoreSettings.cs
@@ -3,8 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using Cake.Common.Tools.DotNet.MSBuild;
 using Cake.Common.Tools.DotNetCore;
-using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Common.Tools.DotNetCore.Restore;
 using Cake.Core.IO;
 
@@ -113,6 +113,6 @@ namespace Cake.Common.Tools.DotNet.Restore
         /// <summary>
         /// Gets or sets additional arguments to be passed to MSBuild.
         /// </summary>
-        public DotNetCoreMSBuildSettings MSBuildSettings { get; set; }
+        public DotNetMSBuildSettings MSBuildSettings { get; set; }
     }
 }


### PR DESCRIPTION
Closes https://github.com/cake-build/cake/issues/3683
