### PR TITLE
GH3693: Remove 'Core' suffix of some settings classes

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -415,6 +415,8 @@ Task("Run-Integration-Tests")
                     .AppendSwitchQuoted("--multipleargs", "=", "b")
                     .AppendSwitchQuoted("--testAssemblyDirectoryPath", "=", cakeAssembly.GetDirectory().FullPath)
                     .AppendSwitchQuoted("--testAssemblyFilePath", "=", cakeAssembly.FullPath)
+                    .AppendSwitchQuoted("--testDotNetCoreVerbosity", "=", "Diagnostic")
+                    .AppendSwitchQuoted("--testDotNetRollForward", "=", "LatestMajor")
             });
     }
     catch(Exception ex)

--- a/src/Cake.Common.Tests/Fixtures/Tools/DotNetCore/Build/DotNetCoreBuilderFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/DotNetCore/Build/DotNetCoreBuilderFixture.cs
@@ -2,11 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Common.Tools.DotNet.Build;
 using Cake.Common.Tools.DotNetCore.Build;
 
 namespace Cake.Common.Tests.Fixtures.Tools.DotNetCore.Build
 {
-    internal sealed class DotNetCoreBuilderFixture : DotNetCoreFixture<DotNetCoreBuildSettings>
+    internal sealed class DotNetCoreBuilderFixture : DotNetCoreFixture<DotNetBuildSettings>
     {
         public string Project { get; set; }
 

--- a/src/Cake.Common.Tests/Fixtures/Tools/DotNetCore/BuildServer/DotNetCoreBuildServerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/DotNetCore/BuildServer/DotNetCoreBuildServerFixture.cs
@@ -2,11 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Common.Tools.DotNet.BuildServer;
 using Cake.Common.Tools.DotNetCore.BuildServer;
 
 namespace Cake.Common.Tests.Fixtures.Tools.DotNetCore.Build
 {
-    internal sealed class DotNetCoreBuildServerFixture : DotNetCoreFixture<DotNetCoreBuildServerSettings>
+    internal sealed class DotNetCoreBuildServerFixture : DotNetCoreFixture<DotNetBuildServerShutdownSettings>
     {
         protected override void RunTool()
         {

--- a/src/Cake.Common.Tests/Fixtures/Tools/DotNetCore/Clean/DotNetCoreCleanerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/DotNetCore/Clean/DotNetCoreCleanerFixture.cs
@@ -2,11 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Common.Tools.DotNet.Clean;
 using Cake.Common.Tools.DotNetCore.Clean;
 
 namespace Cake.Common.Tests.Fixtures.Tools.DotNetCore.Clean
 {
-    internal sealed class DotNetCoreCleanerFixture : DotNetCoreFixture<DotNetCoreCleanSettings>
+    internal sealed class DotNetCoreCleanerFixture : DotNetCoreFixture<DotNetCleanSettings>
     {
         public string Project { get; set; }
 

--- a/src/Cake.Common.Tests/Fixtures/Tools/DotNetCore/DotNetCoreFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/DotNetCore/DotNetCoreFixture.cs
@@ -2,14 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Common.Tools.DotNetCore;
+using Cake.Common.Tools.DotNet;
 using Cake.Core.IO;
 using Cake.Testing.Fixtures;
 
 namespace Cake.Common.Tests.Fixtures.Tools.DotNetCore
 {
     internal abstract class DotNetCoreFixture<TSettings> : ToolFixture<TSettings, ToolFixtureResult>
-        where TSettings : DotNetCoreSettings, new()
+        where TSettings : DotNetSettings, new()
     {
         protected DotNetCoreFixture()
             : base("dotnet.exe")

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Build/DotNetCoreBuilderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Build/DotNetCoreBuilderTests.cs
@@ -57,7 +57,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Build
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+                AssertEx.IsCakeException(result, ".NET CLI: Process was not started.");
             }
 
             [Fact]
@@ -72,7 +72,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Build
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/BuildServer/DotNetCoreBuildServerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/BuildServer/DotNetCoreBuildServerTests.cs
@@ -40,7 +40,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.BuildServer
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+                AssertEx.IsCakeException(result, ".NET CLI: Process was not started.");
             }
 
             [Fact]
@@ -54,7 +54,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.BuildServer
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Clean/DotNetCoreCleanTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Clean/DotNetCoreCleanTests.cs
@@ -58,7 +58,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Clean
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+                AssertEx.IsCakeException(result, ".NET CLI: Process was not started.");
             }
 
             [Fact]
@@ -73,7 +73,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Clean
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Execute/DotNetCoreExecutorTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Execute/DotNetCoreExecutorTests.cs
@@ -44,7 +44,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Execute
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+                AssertEx.IsCakeException(result, ".NET CLI: Process was not started.");
             }
 
             [Fact]
@@ -61,7 +61,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Execute
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/MSBuild/DotNetCoreMSBuildBuilderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/MSBuild/DotNetCoreMSBuildBuilderTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using Cake.Common.Tests.Fixtures.Tools.DotNetCore.MSBuild;
+using Cake.Common.Tools.DotNet;
 using Cake.Common.Tools.DotNetCore;
 using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Common.Tools.MSBuild;
@@ -64,7 +65,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.MSBuild
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+                AssertEx.IsCakeException(result, ".NET CLI: Process was not started.");
             }
 
             [Fact]
@@ -81,7 +82,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.MSBuild
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
             }
 
             [Fact]
@@ -1013,12 +1014,12 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.MSBuild
             }
 
             [Theory]
-            [InlineData(DotNetCoreVerbosity.Quiet)]
-            [InlineData(DotNetCoreVerbosity.Minimal)]
-            [InlineData(DotNetCoreVerbosity.Normal)]
-            [InlineData(DotNetCoreVerbosity.Detailed)]
-            [InlineData(DotNetCoreVerbosity.Diagnostic)]
-            public void Should_Append_Verbosity_If_Specified(DotNetCoreVerbosity verbosity)
+            [InlineData(DotNetVerbosity.Quiet)]
+            [InlineData(DotNetVerbosity.Minimal)]
+            [InlineData(DotNetVerbosity.Normal)]
+            [InlineData(DotNetVerbosity.Detailed)]
+            [InlineData(DotNetVerbosity.Diagnostic)]
+            public void Should_Append_Verbosity_If_Specified(DotNetVerbosity verbosity)
             {
                 // Given
                 var fixture = new DotNetCoreMSBuildBuilderFixture();
@@ -1270,12 +1271,12 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.MSBuild
             }
 
             [Theory]
-            [InlineData(DotNetCoreVerbosity.Quiet)]
-            [InlineData(DotNetCoreVerbosity.Minimal)]
-            [InlineData(DotNetCoreVerbosity.Normal)]
-            [InlineData(DotNetCoreVerbosity.Detailed)]
-            [InlineData(DotNetCoreVerbosity.Diagnostic)]
-            public void Should_Append_Verbosity_If_Specified(DotNetCoreVerbosity verbosity)
+            [InlineData(DotNetVerbosity.Quiet)]
+            [InlineData(DotNetVerbosity.Minimal)]
+            [InlineData(DotNetVerbosity.Normal)]
+            [InlineData(DotNetVerbosity.Detailed)]
+            [InlineData(DotNetVerbosity.Diagnostic)]
+            public void Should_Append_Verbosity_If_Specified(DotNetVerbosity verbosity)
             {
                 // Given
                 var fixture = new DotNetCoreMSBuildBuilderFixture();

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/NuGet/Delete/DotNetCoreNuGetDeleterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/NuGet/Delete/DotNetCoreNuGetDeleterTests.cs
@@ -76,7 +76,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.NuGet.Delete
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+                AssertEx.IsCakeException(result, ".NET CLI: Process was not started.");
             }
 
             [Fact]
@@ -90,7 +90,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.NuGet.Delete
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/NuGet/Push/DotNetCoreNuGetPusherTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/NuGet/Push/DotNetCoreNuGetPusherTests.cs
@@ -58,7 +58,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.NuGet.Push
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+                AssertEx.IsCakeException(result, ".NET CLI: Process was not started.");
             }
 
             [Fact]
@@ -73,7 +73,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.NuGet.Push
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/NuGet/Source/DotNetCoreNuGetSourcerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/NuGet/Source/DotNetCoreNuGetSourcerTests.cs
@@ -73,7 +73,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.NuGet.Source
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+                AssertEx.IsCakeException(result, ".NET CLI: Process was not started.");
             }
 
             [Fact]
@@ -88,7 +88,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.NuGet.Source
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
             }
 
             [Fact]
@@ -185,7 +185,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.NuGet.Source
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+                AssertEx.IsCakeException(result, ".NET CLI: Process was not started.");
             }
 
             [Fact]
@@ -199,7 +199,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.NuGet.Source
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
             }
 
             [Fact]
@@ -274,7 +274,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.NuGet.Source
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+                AssertEx.IsCakeException(result, ".NET CLI: Process was not started.");
             }
 
             [Fact]
@@ -288,7 +288,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.NuGet.Source
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
             }
 
             [Fact]
@@ -363,7 +363,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.NuGet.Source
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+                AssertEx.IsCakeException(result, ".NET CLI: Process was not started.");
             }
 
             [Fact]
@@ -377,7 +377,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.NuGet.Source
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
             }
 
             [Fact]
@@ -459,7 +459,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.NuGet.Source
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+                AssertEx.IsCakeException(result, ".NET CLI: Process was not started.");
             }
 
             [Fact]
@@ -473,7 +473,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.NuGet.Source
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
             }
 
             [Fact]
@@ -562,7 +562,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.NuGet.Source
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+                AssertEx.IsCakeException(result, ".NET CLI: Process was not started.");
             }
 
             [Fact]
@@ -576,7 +576,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.NuGet.Source
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
             }
 
             [Fact]
@@ -651,7 +651,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.NuGet.Source
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+                AssertEx.IsCakeException(result, ".NET CLI: Process was not started.");
             }
 
             [Fact]
@@ -665,7 +665,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.NuGet.Source
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Pack/DotNetCorePackerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Pack/DotNetCorePackerTests.cs
@@ -39,7 +39,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Pack
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+                AssertEx.IsCakeException(result, ".NET CLI: Process was not started.");
             }
 
             [Fact]
@@ -53,7 +53,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Pack
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Publish/DotNetCorePublisherTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Publish/DotNetCorePublisherTests.cs
@@ -39,7 +39,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Publish
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+                AssertEx.IsCakeException(result, ".NET CLI: Process was not started.");
             }
 
             [Fact]
@@ -53,7 +53,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Publish
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Restore/DotNetCoreRestorerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Restore/DotNetCoreRestorerTests.cs
@@ -41,7 +41,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Restore
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+                AssertEx.IsCakeException(result, ".NET CLI: Process was not started.");
             }
 
             [Fact]
@@ -55,7 +55,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Restore
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Run/DotNetCoreRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Run/DotNetCoreRunnerTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Cake.Common.Tests.Fixtures.Tools.DotNetCore.Run;
+using Cake.Common.Tools.DotNet;
 using Cake.Common.Tools.DotNetCore;
 using Cake.Testing;
 using Xunit;
@@ -41,7 +42,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Run
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+                AssertEx.IsCakeException(result, ".NET CLI: Process was not started.");
             }
 
             [Fact]
@@ -56,7 +57,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Run
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
             }
 
             [Fact]
@@ -119,13 +120,13 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Run
             }
 
             [Theory]
-            [InlineData(DotNetCoreRollForward.Minor, "run --roll-forward Minor")]
-            [InlineData(DotNetCoreRollForward.LatestPatch, "run --roll-forward LatestPatch")]
-            [InlineData(DotNetCoreRollForward.Major, "run --roll-forward Major")]
-            [InlineData(DotNetCoreRollForward.LatestMinor, "run --roll-forward LatestMinor")]
-            [InlineData(DotNetCoreRollForward.LatestMajor, "run --roll-forward LatestMajor")]
-            [InlineData(DotNetCoreRollForward.Disable, "run --roll-forward Disable")]
-            public void Should_Add_RollForward_Arguments(DotNetCoreRollForward rollForward, string expected)
+            [InlineData(DotNetRollForward.Minor, "run --roll-forward Minor")]
+            [InlineData(DotNetRollForward.LatestPatch, "run --roll-forward LatestPatch")]
+            [InlineData(DotNetRollForward.Major, "run --roll-forward Major")]
+            [InlineData(DotNetRollForward.LatestMinor, "run --roll-forward LatestMinor")]
+            [InlineData(DotNetRollForward.LatestMajor, "run --roll-forward LatestMajor")]
+            [InlineData(DotNetRollForward.Disable, "run --roll-forward Disable")]
+            public void Should_Add_RollForward_Arguments(DotNetRollForward rollForward, string expected)
             {
                 // Given
                 var fixture = new DotNetCoreRunnerFixture();

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Test/DotNetCoreTesterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Test/DotNetCoreTesterTests.cs
@@ -41,7 +41,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Test
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+                AssertEx.IsCakeException(result, ".NET CLI: Process was not started.");
             }
 
             [Fact]
@@ -56,7 +56,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Test
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Tool/DotNetCoreToolTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/Tool/DotNetCoreToolTests.cs
@@ -77,7 +77,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Tool
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+                AssertEx.IsCakeException(result, ".NET CLI: Process was not started.");
             }
 
             [Fact]
@@ -94,7 +94,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.Tool
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
             }
         }
     }

--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/VSTest/DotNetCoreVSTesterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/VSTest/DotNetCoreVSTesterTests.cs
@@ -44,7 +44,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.VSTest
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process was not started.");
+                AssertEx.IsCakeException(result, ".NET CLI: Process was not started.");
             }
 
             [Fact]
@@ -58,7 +58,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.VSTest
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, ".NET Core CLI: Process returned an error (exit code 1).");
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
             }
 
             [Fact]

--- a/src/Cake.Common/Tools/DotNet/Build/DotNetBuildSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Build/DotNetBuildSettings.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using Cake.Common.Tools.DotNet.MSBuild;
-using Cake.Common.Tools.DotNetCore;
 using Cake.Common.Tools.DotNetCore.Build;
 using Cake.Core.IO;
 
@@ -13,7 +12,7 @@ namespace Cake.Common.Tools.DotNet.Build
     /// <summary>
     /// Contains settings used by <see cref="DotNetCoreBuilder" />.
     /// </summary>
-    public class DotNetBuildSettings : DotNetCoreSettings
+    public class DotNetBuildSettings : DotNetSettings
     {
         /// <summary>
         /// Gets or sets the output directory.

--- a/src/Cake.Common/Tools/DotNet/BuildServer/DotNetBuildServerSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/BuildServer/DotNetBuildServerSettings.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Common.Tools.DotNetCore;
 using Cake.Common.Tools.DotNetCore.BuildServer;
 
 namespace Cake.Common.Tools.DotNet.BuildServer
@@ -10,7 +9,7 @@ namespace Cake.Common.Tools.DotNet.BuildServer
     /// <summary>
     /// Contains settings used by <see cref="DotNetCoreBuildServer" />.
     /// </summary>
-    public abstract class DotNetBuildServerSettings : DotNetCoreSettings
+    public abstract class DotNetBuildServerSettings : DotNetSettings
     {
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Clean/DotNetCleanSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Clean/DotNetCleanSettings.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Cake.Common.Tools.DotNet.MSBuild;
-using Cake.Common.Tools.DotNetCore;
 using Cake.Common.Tools.DotNetCore.Clean;
 using Cake.Core.IO;
 
@@ -12,7 +11,7 @@ namespace Cake.Common.Tools.DotNet.Clean
     /// <summary>
     /// Contains settings used by <see cref="DotNetCoreCleaner" />.
     /// </summary>
-    public class DotNetCleanSettings : DotNetCoreSettings
+    public class DotNetCleanSettings : DotNetSettings
     {
         /// <summary>
         /// Gets or sets the output directory.

--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
@@ -42,9 +42,9 @@ using Cake.Core.IO;
 namespace Cake.Common.Tools.DotNet
 {
     /// <summary>
-    /// <para>Contains functionality related to <see href="https://github.com/dotnet/cli">.NET Core CLI</see>.</para>
+    /// <para>Contains functionality related to <see href="https://github.com/dotnet/cli">.NET CLI</see>.</para>
     /// <para>
-    /// In order to use the commands for this alias, the .Net Core CLI tools will need to be installed on the machine where
+    /// In order to use the commands for this alias, the .NET CLI tools will need to be installed on the machine where
     /// the Cake script is being executed.  See this <see href="https://www.microsoft.com/net/core">page</see> for information
     /// on how to install.
     /// </para>

--- a/src/Cake.Common/Tools/DotNet/DotNetRollForward.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetRollForward.cs
@@ -2,43 +2,41 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Common.Tools.DotNetCore;
-
 namespace Cake.Common.Tools.DotNet
 {
     /// <summary>
     /// Contains the roll forward policy to be used.
     /// </summary>
-    public sealed class DotNetRollForward
+    public enum DotNetRollForward
     {
         /// <summary>
         /// Roll forward to the lowest higher minor version, if requested minor version is missing.
         /// </summary>
-        public const DotNetCoreRollForward Minor = DotNetCoreRollForward.Minor;
+        Minor,
 
         /// <summary>
         /// Roll forward to the highest patch version. This disables minor version roll forward.
         /// </summary>
-        public const DotNetCoreRollForward LatestPatch = DotNetCoreRollForward.LatestPatch;
+        LatestPatch,
 
         /// <summary>
         /// Roll forward to lowest higher major version, and lowest minor version, if requested major version is missing.
         /// </summary>
-        public const DotNetCoreRollForward Major = DotNetCoreRollForward.Major;
+        Major,
 
         /// <summary>
         /// Roll forward to highest minor version, even if requested minor version is present.
         /// </summary>
-        public const DotNetCoreRollForward LatestMinor = DotNetCoreRollForward.LatestMinor;
+        LatestMinor,
 
         /// <summary>
         /// Roll forward to highest major and highest minor version, even if requested major is present.
         /// </summary>
-        public const DotNetCoreRollForward LatestMajor = DotNetCoreRollForward.LatestMajor;
+        LatestMajor,
 
         /// <summary>
         /// Don't roll forward. Only bind to specified version.
         /// </summary>
-        public const DotNetCoreRollForward Disable = DotNetCoreRollForward.Disable;
+        Disable,
     }
 }

--- a/src/Cake.Common/Tools/DotNet/DotNetSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetSettings.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Common.Tools.DotNetCore;
 using Cake.Core.Tooling;
 
 namespace Cake.Common.Tools.DotNet
@@ -15,7 +14,7 @@ namespace Cake.Common.Tools.DotNet
         /// <summary>
         /// Gets or sets the verbosity of logging to use.
         /// </summary>
-        public DotNetCoreVerbosity? Verbosity { get; set; }
+        public DotNetVerbosity? Verbosity { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to not enable diagnostic output.
@@ -25,6 +24,6 @@ namespace Cake.Common.Tools.DotNet
         /// <summary>
         /// Gets or sets the dotnet roll forward policy.
         /// </summary>
-        public DotNetCoreRollForward? RollForward { get; set; }
+        public DotNetRollForward? RollForward { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/DotNetTool.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetTool.cs
@@ -39,7 +39,7 @@ namespace Cake.Common.Tools.DotNet
         /// <returns>The name of the tool.</returns>
         protected override string GetToolName()
         {
-            return ".NET Core CLI";
+            return ".NET CLI";
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/DotNet/DotNetVerbosity.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetVerbosity.cs
@@ -2,38 +2,36 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Common.Tools.DotNetCore;
-
 namespace Cake.Common.Tools.DotNet
 {
     /// <summary>
     /// Contains the verbosity of logging to use.
     /// </summary>
-    public sealed class DotNetVerbosity
+    public enum DotNetVerbosity
     {
         /// <summary>
         /// Quiet level.
         /// </summary>
-        public const DotNetCoreVerbosity Quiet = DotNetCoreVerbosity.Quiet;
+        Quiet,
 
         /// <summary>
         /// Minimal level.
         /// </summary>
-        public const DotNetCoreVerbosity Minimal = DotNetCoreVerbosity.Minimal;
+        Minimal,
 
         /// <summary>
         /// Normal level.
         /// </summary>
-        public const DotNetCoreVerbosity Normal = DotNetCoreVerbosity.Normal;
+        Normal,
 
         /// <summary>
         /// Detailed level.
         /// </summary>
-        public const DotNetCoreVerbosity Detailed = DotNetCoreVerbosity.Detailed;
+        Detailed,
 
         /// <summary>
         /// Diagnostic level.
         /// </summary>
-        public const DotNetCoreVerbosity Diagnostic = DotNetCoreVerbosity.Diagnostic;
+        Diagnostic,
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Execute/DotNetExecuteSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Execute/DotNetExecuteSettings.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Common.Tools.DotNetCore;
 using Cake.Common.Tools.DotNetCore.Execute;
 
 namespace Cake.Common.Tools.DotNet.Execute
@@ -10,7 +9,7 @@ namespace Cake.Common.Tools.DotNet.Execute
     /// <summary>
     /// Contains settings used by <see cref="DotNetCoreExecutor" />.
     /// </summary>
-    public class DotNetExecuteSettings : DotNetCoreSettings
+    public class DotNetExecuteSettings : DotNetSettings
     {
         /// <summary>
         /// Gets or sets the version of the installed Shared Framework to use to run the application.

--- a/src/Cake.Common/Tools/DotNet/MSBuild/DotNetMSBuildSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/MSBuild/DotNetMSBuildSettings.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using Cake.Common.Tools.DotNetCore;
 using Cake.Common.Tools.DotNetCore.MSBuild;
 using Cake.Common.Tools.MSBuild;
 using Cake.Core.IO;
@@ -14,7 +13,7 @@ namespace Cake.Common.Tools.DotNet.MSBuild
     /// <summary>
     /// Contains settings used by <see cref="DotNetCoreMSBuildBuilder" />.
     /// </summary>
-    public class DotNetMSBuildSettings : DotNetCoreSettings
+    public class DotNetMSBuildSettings : DotNetSettings
     {
         /// <summary>
         /// Gets or sets a value indicating whether to show detailed information at the end of the build log about the configurations that were built and how they were scheduled to nodes.

--- a/src/Cake.Common/Tools/DotNet/NuGet/Delete/DotNetNuGetDeleteSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/NuGet/Delete/DotNetNuGetDeleteSettings.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Common.Tools.DotNetCore;
 using Cake.Common.Tools.DotNetCore.NuGet.Delete;
 
 namespace Cake.Common.Tools.DotNet.NuGet.Delete
@@ -10,7 +9,7 @@ namespace Cake.Common.Tools.DotNet.NuGet.Delete
     /// <summary>
     /// Contains settings used by <see cref="DotNetCoreNuGetDeleter" />.
     /// </summary>
-    public class DotNetNuGetDeleteSettings : DotNetCoreSettings
+    public class DotNetNuGetDeleteSettings : DotNetSettings
     {
         /// <summary>
         /// Gets or sets a value indicating the server URL.

--- a/src/Cake.Common/Tools/DotNet/NuGet/Push/DotNetNuGetPushSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/NuGet/Push/DotNetNuGetPushSettings.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Common.Tools.DotNetCore;
 using Cake.Common.Tools.DotNetCore.NuGet.Push;
 
 namespace Cake.Common.Tools.DotNet.NuGet.Push
@@ -10,7 +9,7 @@ namespace Cake.Common.Tools.DotNet.NuGet.Push
     /// <summary>
     /// Contains settings used by <see cref="DotNetCoreNuGetPusher" />.
     /// </summary>
-    public class DotNetNuGetPushSettings : DotNetCoreSettings
+    public class DotNetNuGetPushSettings : DotNetSettings
     {
         /// <summary>
         /// Gets or sets a value indicating the server URL.

--- a/src/Cake.Common/Tools/DotNet/NuGet/Source/DotNetNuGetSourceSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/NuGet/Source/DotNetNuGetSourceSettings.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Common.Tools.DotNetCore;
 using Cake.Common.Tools.DotNetCore.NuGet.Source;
 using Cake.Core.IO;
 
@@ -11,7 +10,7 @@ namespace Cake.Common.Tools.DotNet.NuGet.Source
     /// <summary>
     /// Contains settings used by <see cref="DotNetCoreNuGetSourcer" />.
     /// </summary>
-    public class DotNetNuGetSourceSettings : DotNetCoreSettings
+    public class DotNetNuGetSourceSettings : DotNetSettings
     {
         /// <summary>
         /// Gets or sets the path to the package(s) source.

--- a/src/Cake.Common/Tools/DotNet/Pack/DotNetPackSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Pack/DotNetPackSettings.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using Cake.Common.Tools.DotNet.MSBuild;
-using Cake.Common.Tools.DotNetCore;
 using Cake.Common.Tools.DotNetCore.Pack;
 using Cake.Core.IO;
 
@@ -13,7 +12,7 @@ namespace Cake.Common.Tools.DotNet.Pack
     /// <summary>
     /// Contains settings used by <see cref="DotNetCorePacker" />.
     /// </summary>
-    public class DotNetPackSettings : DotNetCoreSettings
+    public class DotNetPackSettings : DotNetSettings
     {
         /// <summary>
         /// Gets or sets the output directory.

--- a/src/Cake.Common/Tools/DotNet/Publish/DotNetPublishSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Publish/DotNetPublishSettings.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using Cake.Common.Tools.DotNet.MSBuild;
-using Cake.Common.Tools.DotNetCore;
 using Cake.Common.Tools.DotNetCore.Publish;
 using Cake.Core.IO;
 
@@ -13,7 +12,7 @@ namespace Cake.Common.Tools.DotNet.Publish
     /// <summary>
     /// Contains settings used by <see cref="DotNetCorePublisher" />.
     /// </summary>
-    public class DotNetPublishSettings : DotNetCoreSettings
+    public class DotNetPublishSettings : DotNetSettings
     {
         /// <summary>
         /// Gets or sets the output directory.

--- a/src/Cake.Common/Tools/DotNet/Restore/DotNetRestoreSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Restore/DotNetRestoreSettings.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using Cake.Common.Tools.DotNet.MSBuild;
-using Cake.Common.Tools.DotNetCore;
 using Cake.Common.Tools.DotNetCore.Restore;
 using Cake.Core.IO;
 
@@ -13,7 +12,7 @@ namespace Cake.Common.Tools.DotNet.Restore
     /// <summary>
     /// Contains settings used by <see cref="DotNetCoreRestoreSettings" />.
     /// </summary>
-    public class DotNetRestoreSettings : DotNetCoreSettings
+    public class DotNetRestoreSettings : DotNetSettings
     {
         /// <summary>
         /// Gets or sets the specified NuGet package sources to use during the restore.

--- a/src/Cake.Common/Tools/DotNet/Run/DotNetRunSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Run/DotNetRunSettings.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using Cake.Common.Tools.DotNetCore;
 using Cake.Common.Tools.DotNetCore.Run;
 
 namespace Cake.Common.Tools.DotNet.Run
@@ -11,7 +10,7 @@ namespace Cake.Common.Tools.DotNet.Run
     /// <summary>
     /// Contains settings used by <see cref="DotNetCoreRunner" />.
     /// </summary>
-    public class DotNetRunSettings : DotNetCoreSettings
+    public class DotNetRunSettings : DotNetSettings
     {
         /// <summary>
         /// Gets or sets a specific framework to compile.

--- a/src/Cake.Common/Tools/DotNet/Test/DotNetTestSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Test/DotNetTestSettings.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using Cake.Common.Tools.DotNetCore;
 using Cake.Common.Tools.DotNetCore.Test;
 using Cake.Core.IO;
 
@@ -13,7 +12,7 @@ namespace Cake.Common.Tools.DotNet.Test
     /// <summary>
     /// Contains settings used by <see cref="DotNetCoreTester" />.
     /// </summary>
-    public class DotNetTestSettings : DotNetCoreSettings
+    public class DotNetTestSettings : DotNetSettings
     {
         /// <summary>
         /// Gets or sets the settings file to use when running tests.

--- a/src/Cake.Common/Tools/DotNet/Tool/DotNetToolSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Tool/DotNetToolSettings.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Common.Tools.DotNetCore;
 using Cake.Common.Tools.DotNetCore.Tool;
 
 namespace Cake.Common.Tools.DotNet.Tool
@@ -10,7 +9,7 @@ namespace Cake.Common.Tools.DotNet.Tool
     /// <summary>
     /// Contains settings used by <see cref="DotNetCoreToolRunner" />.
     /// </summary>
-    public class DotNetToolSettings : DotNetCoreSettings
+    public class DotNetToolSettings : DotNetSettings
     {
     }
 }

--- a/src/Cake.Common/Tools/DotNet/VSTest/DotNetVSTestSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/VSTest/DotNetVSTestSettings.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using Cake.Common.Tools.DotNetCore;
 using Cake.Common.Tools.DotNetCore.VSTest;
 using Cake.Common.Tools.VSTest;
 using Cake.Core.IO;
@@ -13,7 +12,7 @@ namespace Cake.Common.Tools.DotNet.VSTest
     /// <summary>
     /// Contains settings used by <see cref="DotNetCoreVSTester" />.
     /// </summary>
-    public class DotNetVSTestSettings : DotNetCoreSettings
+    public class DotNetVSTestSettings : DotNetSettings
     {
         /// <summary>
         /// Gets or sets the settings file to use when running tests.

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreRollForward.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreRollForward.cs
@@ -2,41 +2,307 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.ComponentModel;
+using Cake.Common.Tools.DotNet;
+
 namespace Cake.Common.Tools.DotNetCore
 {
     /// <summary>
     /// Contains the roll forward policy to be used.
     /// </summary>
-    public enum DotNetCoreRollForward
+    [TypeConverter(typeof(DotNetCoreRollForwardConverter))]
+    public sealed class DotNetCoreRollForward : IEquatable<DotNetCoreRollForward>, IComparable, IConvertible, IFormattable
     {
+        private readonly DotNetRollForward _value;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotNetCoreRollForward" /> class.
+        /// </summary>
+        public DotNetCoreRollForward()
+        {
+            _value = default;
+        }
+
+        internal DotNetCoreRollForward(string stringValue)
+        {
+            _value = (DotNetRollForward)Enum.Parse(typeof(DotNetRollForward), stringValue);
+        }
+
+        private DotNetCoreRollForward(DotNetRollForward value)
+        {
+            _value = value;
+        }
+
         /// <summary>
         /// Roll forward to the lowest higher minor version, if requested minor version is missing.
         /// </summary>
-        Minor,
+        public static readonly DotNetCoreRollForward Minor = new DotNetCoreRollForward(DotNetRollForward.Minor);
 
         /// <summary>
         /// Roll forward to the highest patch version. This disables minor version roll forward.
         /// </summary>
-        LatestPatch,
+        public static readonly DotNetCoreRollForward LatestPatch = new DotNetCoreRollForward(DotNetRollForward.LatestPatch);
 
         /// <summary>
         /// Roll forward to lowest higher major version, and lowest minor version, if requested major version is missing.
         /// </summary>
-        Major,
+        public static readonly DotNetCoreRollForward Major = new DotNetCoreRollForward(DotNetRollForward.Major);
 
         /// <summary>
         /// Roll forward to highest minor version, even if requested minor version is present.
         /// </summary>
-        LatestMinor,
+        public static readonly DotNetCoreRollForward LatestMinor = new DotNetCoreRollForward(DotNetRollForward.LatestMinor);
 
         /// <summary>
         /// Roll forward to highest major and highest minor version, even if requested major is present.
         /// </summary>
-        LatestMajor,
+        public static readonly DotNetCoreRollForward LatestMajor = new DotNetCoreRollForward(DotNetRollForward.LatestMajor);
 
         /// <summary>
         /// Don't roll forward. Only bind to specified version.
         /// </summary>
-        Disable,
+        public static readonly DotNetCoreRollForward Disable = new DotNetCoreRollForward(DotNetRollForward.Disable);
+
+        /// <summary>
+        /// Explicitly converts <see cref="DotNetCoreRollForward"/> to <see cref="int"/>.
+        /// </summary>
+        /// <param name="rollForward">The <see cref="DotNetCoreRollForward"/>.</param>
+        public static explicit operator int(DotNetCoreRollForward rollForward)
+        {
+            return (int)rollForward._value;
+        }
+
+        /// <summary>
+        /// Implicitly converts <see cref="DotNetCoreRollForward"/> to <see cref="DotNetRollForward"/>.
+        /// </summary>
+        /// <param name="rollForward">The <see cref="DotNetCoreRollForward"/>.</param>
+        public static implicit operator DotNetRollForward(DotNetCoreRollForward rollForward)
+        {
+            return rollForward._value;
+        }
+
+        /// <summary>
+        /// Implicitly converts <see cref="DotNetRollForward"/> to <see cref="DotNetCoreRollForward"/>.
+        /// </summary>
+        /// <param name="rollForward">The <see cref="DotNetRollForward"/>.</param>
+        public static implicit operator DotNetCoreRollForward(DotNetRollForward rollForward)
+        {
+            return rollForward switch
+            {
+                DotNetRollForward.Minor => Minor,
+                DotNetRollForward.LatestPatch => LatestPatch,
+                DotNetRollForward.Major => Major,
+                DotNetRollForward.LatestMinor => LatestMinor,
+                DotNetRollForward.LatestMajor => LatestMajor,
+                DotNetRollForward.Disable => Disable,
+                _ => new DotNetCoreRollForward(rollForward),
+            };
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <param name="left">The object to compare with the right-hand side object.</param>
+        /// <param name="right">The object to compare with the left-hand side object.</param>
+        /// <returns><see langword="true"/> if the specified object is equal to the current object; otherwise, <see langword="false"/>.</returns>
+        public static bool operator ==(DotNetCoreRollForward left, DotNetCoreRollForward right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is not equal to the current object.
+        /// </summary>
+        /// <param name="left">The object to compare with the right-hand side object.</param>
+        /// <param name="right">The object to compare with the left-hand side object.</param>
+        /// <returns><see langword="true"/> if the specified object is not equal to the current object; otherwise, <see langword="false"/>.</returns>
+        public static bool operator !=(DotNetCoreRollForward left, DotNetCoreRollForward right)
+        {
+            return !(left == right);
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return _value.ToString();
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            return _value.GetHashCode();
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            if (obj is null)
+            {
+                return false;
+            }
+
+            if (!(obj is DotNetCoreRollForward))
+            {
+                return false;
+            }
+
+            return Equals((DotNetCoreRollForward)obj);
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(DotNetCoreRollForward other)
+        {
+            return _value.Equals(other._value);
+        }
+
+        /// <summary>
+        /// Determines whether one or more bit fields are set in the current instance.
+        /// </summary>
+        /// <param name="flag">An enumeration value.</param>
+        /// <returns>
+        /// <see langword="true"/> if the bit field or bit fields that are set in flag are also set in the
+        /// current instance; otherwise, <see langword="false"/>.
+        /// </returns>
+        public bool HasFlag(DotNetCoreRollForward flag)
+        {
+            return _value.HasFlag(flag._value);
+        }
+
+        /// <summary>
+        /// Determines whether one or more bit fields are set in the current instance.
+        /// </summary>
+        /// <param name="flag">An enumeration value.</param>
+        /// <returns>
+        /// <see langword="true"/> if the bit field or bit fields that are set in flag are also set in the
+        /// current instance; otherwise, <see langword="false"/>.
+        /// </returns>
+        public bool HasFlag(Enum flag)
+        {
+            return _value.HasFlag(flag);
+        }
+
+        /// <inheritdoc/>
+        public int CompareTo(object obj)
+        {
+            return _value.CompareTo(obj);
+        }
+
+        /// <inheritdoc/>
+        public TypeCode GetTypeCode()
+        {
+            return Convert.GetTypeCode(_value);
+        }
+
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider)
+        {
+            return Convert.ToBoolean(_value, provider);
+        }
+
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider)
+        {
+            return Convert.ToByte(_value, provider);
+        }
+
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider)
+        {
+            return Convert.ToChar(_value, provider);
+        }
+
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider)
+        {
+            return Convert.ToDateTime(_value, provider);
+        }
+
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider)
+        {
+            return Convert.ToDecimal(_value, provider);
+        }
+
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider)
+        {
+            return Convert.ToDouble(_value, provider);
+        }
+
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider)
+        {
+            return Convert.ToInt16(_value, provider);
+        }
+
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider)
+        {
+            return Convert.ToInt32(_value, provider);
+        }
+
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider)
+        {
+            return Convert.ToInt64(_value, provider);
+        }
+
+        /// <inheritdoc/>
+#pragma warning disable CS3002 // Return type is not CLS-compliant
+        sbyte IConvertible.ToSByte(IFormatProvider provider)
+#pragma warning restore CS3002 // Return type is not CLS-compliant
+        {
+            return Convert.ToSByte(_value, provider);
+        }
+
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider)
+        {
+            return Convert.ToSingle(_value, provider);
+        }
+
+        /// <inheritdoc/>
+        string IConvertible.ToString(IFormatProvider provider)
+        {
+            return Convert.ToString(_value, provider);
+        }
+
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider)
+        {
+            return Convert.ChangeType(_value, conversionType, provider);
+        }
+
+        /// <inheritdoc/>
+#pragma warning disable CS3002 // Return type is not CLS-compliant
+        ushort IConvertible.ToUInt16(IFormatProvider provider)
+#pragma warning restore CS3002 // Return type is not CLS-compliant
+        {
+            return Convert.ToUInt16(_value, provider);
+        }
+
+        /// <inheritdoc/>
+#pragma warning disable CS3002 // Return type is not CLS-compliant
+        uint IConvertible.ToUInt32(IFormatProvider provider)
+#pragma warning restore CS3002 // Return type is not CLS-compliant
+        {
+            return Convert.ToUInt32(_value, provider);
+        }
+
+        /// <inheritdoc/>
+#pragma warning disable CS3002 // Return type is not CLS-compliant
+        ulong IConvertible.ToUInt64(IFormatProvider provider)
+#pragma warning restore CS3002 // Return type is not CLS-compliant
+        {
+            return Convert.ToUInt64(_value, provider);
+        }
+
+        /// <inheritdoc/>
+        [Obsolete("The provider argument is not used. Please use ToString(String).")]
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            return _value.ToString(format, formatProvider);
+        }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreRollForwardConverter.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreRollForwardConverter.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace Cake.Common.Tools.DotNetCore
+{
+    /// <summary>
+    /// A type converter for <see cref="DotNetCoreRollForward"/>.
+    /// </summary>
+    public class DotNetCoreRollForwardConverter : TypeConverter
+    {
+        /// <inheritdoc/>
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+        }
+
+        /// <inheritdoc/>
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is string stringValue)
+            {
+                return new DotNetCoreRollForward(stringValue);
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
+
+        /// <inheritdoc/>
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            return destinationType == typeof(DotNetCoreRollForward) || base.CanConvertTo(context, destinationType);
+        }
+
+        /// <inheritdoc/>
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == typeof(string) && value is DotNetCoreRollForward dotNetRollForwardValue)
+            {
+                return dotNetRollForwardValue.ToString();
+            }
+
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreTool.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreTool.cs
@@ -14,7 +14,7 @@ namespace Cake.Common.Tools.DotNetCore
     /// </summary>
     /// <typeparam name="TSettings">The settings type.</typeparam>
     public abstract class DotNetCoreTool<TSettings> : DotNetTool<TSettings>
-        where TSettings : DotNetCoreSettings
+        where TSettings : DotNetSettings
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DotNetCoreTool{TSettings}" /> class.

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreVerbosity.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreVerbosity.cs
@@ -2,36 +2,301 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.ComponentModel;
+using Cake.Common.Tools.DotNet;
+
 namespace Cake.Common.Tools.DotNetCore
 {
     /// <summary>
     /// Contains the verbosity of logging to use.
     /// </summary>
-    public enum DotNetCoreVerbosity
+    [TypeConverter(typeof(DotNetCoreVerbosityConverter))]
+    public sealed class DotNetCoreVerbosity : IEquatable<DotNetCoreVerbosity>, IComparable, IConvertible, IFormattable
     {
+        private readonly DotNetVerbosity _value;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotNetCoreVerbosity" /> class.
+        /// </summary>
+        public DotNetCoreVerbosity()
+        {
+            _value = default;
+        }
+
+        internal DotNetCoreVerbosity(string stringValue)
+        {
+            _value = (DotNetVerbosity)Enum.Parse(typeof(DotNetVerbosity), stringValue);
+        }
+
+        private DotNetCoreVerbosity(DotNetVerbosity value)
+        {
+            _value = value;
+        }
+
         /// <summary>
         /// Quiet level.
         /// </summary>
-        Quiet,
+        public static readonly DotNetCoreVerbosity Quiet = new DotNetCoreVerbosity(DotNetVerbosity.Quiet);
 
         /// <summary>
         /// Minimal level.
         /// </summary>
-        Minimal,
+        public static readonly DotNetCoreVerbosity Minimal = new DotNetCoreVerbosity(DotNetVerbosity.Minimal);
 
         /// <summary>
         /// Normal level.
         /// </summary>
-        Normal,
+        public static readonly DotNetCoreVerbosity Normal = new DotNetCoreVerbosity(DotNetVerbosity.Normal);
 
         /// <summary>
         /// Detailed level.
         /// </summary>
-        Detailed,
+        public static readonly DotNetCoreVerbosity Detailed = new DotNetCoreVerbosity(DotNetVerbosity.Detailed);
 
         /// <summary>
         /// Diagnostic level.
         /// </summary>
-        Diagnostic
+        public static readonly DotNetCoreVerbosity Diagnostic = new DotNetCoreVerbosity(DotNetVerbosity.Diagnostic);
+
+        /// <summary>
+        /// Explicitly converts <see cref="DotNetCoreVerbosity"/> to <see cref="int"/>.
+        /// </summary>
+        /// <param name="verbosity">The <see cref="DotNetCoreVerbosity"/>.</param>
+        public static explicit operator int(DotNetCoreVerbosity verbosity)
+        {
+            return (int)verbosity._value;
+        }
+
+        /// <summary>
+        /// Implicitly converts <see cref="DotNetCoreVerbosity"/> to <see cref="DotNetVerbosity"/>.
+        /// </summary>
+        /// <param name="verbosity">The <see cref="DotNetCoreVerbosity"/>.</param>
+        public static implicit operator DotNetVerbosity(DotNetCoreVerbosity verbosity)
+        {
+            return verbosity._value;
+        }
+
+        /// <summary>
+        /// Implicitly converts <see cref="DotNetVerbosity"/> to <see cref="DotNetCoreVerbosity"/>.
+        /// </summary>
+        /// <param name="verbosity">The <see cref="DotNetVerbosity"/>.</param>
+        public static implicit operator DotNetCoreVerbosity(DotNetVerbosity verbosity)
+        {
+            return verbosity switch
+            {
+                DotNetVerbosity.Quiet => Quiet,
+                DotNetVerbosity.Minimal => Minimal,
+                DotNetVerbosity.Normal => Normal,
+                DotNetVerbosity.Detailed => Detailed,
+                DotNetVerbosity.Diagnostic => Diagnostic,
+                _ => new DotNetCoreVerbosity(verbosity),
+            };
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <param name="left">The object to compare with the right-hand side object.</param>
+        /// <param name="right">The object to compare with the left-hand side object.</param>
+        /// <returns><see langword="true"/> if the specified object is equal to the current object; otherwise, <see langword="false"/>.</returns>
+        public static bool operator ==(DotNetCoreVerbosity left, DotNetCoreVerbosity right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is not equal to the current object.
+        /// </summary>
+        /// <param name="left">The object to compare with the right-hand side object.</param>
+        /// <param name="right">The object to compare with the left-hand side object.</param>
+        /// <returns><see langword="true"/> if the specified object is not equal to the current object; otherwise, <see langword="false"/>.</returns>
+        public static bool operator !=(DotNetCoreVerbosity left, DotNetCoreVerbosity right)
+        {
+            return !(left == right);
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return _value.ToString();
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            return _value.GetHashCode();
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            if (obj is null)
+            {
+                return false;
+            }
+
+            if (!(obj is DotNetCoreVerbosity))
+            {
+                return false;
+            }
+
+            return Equals((DotNetCoreVerbosity)obj);
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(DotNetCoreVerbosity other)
+        {
+            return _value.Equals(other._value);
+        }
+
+        /// <summary>
+        /// Determines whether one or more bit fields are set in the current instance.
+        /// </summary>
+        /// <param name="flag">An enumeration value.</param>
+        /// <returns>
+        /// <see langword="true"/> if the bit field or bit fields that are set in flag are also set in the
+        /// current instance; otherwise, <see langword="false"/>.
+        /// </returns>
+        public bool HasFlag(DotNetCoreVerbosity flag)
+        {
+            return _value.HasFlag(flag._value);
+        }
+
+        /// <summary>
+        /// Determines whether one or more bit fields are set in the current instance.
+        /// </summary>
+        /// <param name="flag">An enumeration value.</param>
+        /// <returns>
+        /// <see langword="true"/> if the bit field or bit fields that are set in flag are also set in the
+        /// current instance; otherwise, <see langword="false"/>.
+        /// </returns>
+        public bool HasFlag(Enum flag)
+        {
+            return _value.HasFlag(flag);
+        }
+
+        /// <inheritdoc/>
+        public int CompareTo(object obj)
+        {
+            return _value.CompareTo(obj);
+        }
+
+        /// <inheritdoc/>
+        public TypeCode GetTypeCode()
+        {
+            return Convert.GetTypeCode(_value);
+        }
+
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider)
+        {
+            return Convert.ToBoolean(_value, provider);
+        }
+
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider)
+        {
+            return Convert.ToByte(_value, provider);
+        }
+
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider)
+        {
+            return Convert.ToChar(_value, provider);
+        }
+
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider)
+        {
+            return Convert.ToDateTime(_value, provider);
+        }
+
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider)
+        {
+            return Convert.ToDecimal(_value, provider);
+        }
+
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider)
+        {
+            return Convert.ToDouble(_value, provider);
+        }
+
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider)
+        {
+            return Convert.ToInt16(_value, provider);
+        }
+
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider)
+        {
+            return Convert.ToInt32(_value, provider);
+        }
+
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider)
+        {
+            return Convert.ToInt64(_value, provider);
+        }
+
+        /// <inheritdoc/>
+#pragma warning disable CS3002 // Return type is not CLS-compliant
+        sbyte IConvertible.ToSByte(IFormatProvider provider)
+#pragma warning restore CS3002 // Return type is not CLS-compliant
+        {
+            return Convert.ToSByte(_value, provider);
+        }
+
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider)
+        {
+            return Convert.ToSingle(_value, provider);
+        }
+
+        /// <inheritdoc/>
+        string IConvertible.ToString(IFormatProvider provider)
+        {
+            return Convert.ToString(_value, provider);
+        }
+
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider)
+        {
+            return Convert.ChangeType(_value, conversionType, provider);
+        }
+
+        /// <inheritdoc/>
+#pragma warning disable CS3002 // Return type is not CLS-compliant
+        ushort IConvertible.ToUInt16(IFormatProvider provider)
+#pragma warning restore CS3002 // Return type is not CLS-compliant
+        {
+            return Convert.ToUInt16(_value, provider);
+        }
+
+        /// <inheritdoc/>
+#pragma warning disable CS3002 // Return type is not CLS-compliant
+        uint IConvertible.ToUInt32(IFormatProvider provider)
+#pragma warning restore CS3002 // Return type is not CLS-compliant
+        {
+            return Convert.ToUInt32(_value, provider);
+        }
+
+        /// <inheritdoc/>
+#pragma warning disable CS3002 // Return type is not CLS-compliant
+        ulong IConvertible.ToUInt64(IFormatProvider provider)
+#pragma warning restore CS3002 // Return type is not CLS-compliant
+        {
+            return Convert.ToUInt64(_value, provider);
+        }
+
+        /// <inheritdoc/>
+        [Obsolete("The provider argument is not used. Please use ToString(String).")]
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            return _value.ToString(format, formatProvider);
+        }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/DotNetCoreVerbosityConverter.cs
+++ b/src/Cake.Common/Tools/DotNetCore/DotNetCoreVerbosityConverter.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace Cake.Common.Tools.DotNetCore
+{
+    /// <summary>
+    /// A type converter for <see cref="DotNetCoreVerbosity"/>.
+    /// </summary>
+    public class DotNetCoreVerbosityConverter : TypeConverter
+    {
+        /// <inheritdoc/>
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+        }
+
+        /// <inheritdoc/>
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is string stringValue)
+            {
+                return new DotNetCoreVerbosity(stringValue);
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
+
+        /// <inheritdoc/>
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            return destinationType == typeof(DotNetCoreVerbosity) || base.CanConvertTo(context, destinationType);
+        }
+
+        /// <inheritdoc/>
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == typeof(string) && value is DotNetCoreVerbosity dotNetVerbosityValue)
+            {
+                return dotNetVerbosityValue.ToString();
+            }
+
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNetCore/MSBuild/MSBuildLoggerSettings.cs
+++ b/src/Cake.Common/Tools/DotNetCore/MSBuild/MSBuildLoggerSettings.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Common.Tools.DotNet;
+
 namespace Cake.Common.Tools.DotNetCore.MSBuild
 {
     /// <summary>
@@ -63,6 +65,6 @@ namespace Cake.Common.Tools.DotNetCore.MSBuild
         /// <summary>
         /// Gets or sets a value that overrides the /verbosity setting for this logger.
         /// </summary>
-        public DotNetCoreVerbosity? Verbosity { get; set; }
+        public DotNetVerbosity? Verbosity { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotNetCore/Tool/DotNetCoreToolRunner.cs
+++ b/src/Cake.Common/Tools/DotNetCore/Tool/DotNetCoreToolRunner.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Cake.Common.Tools.DotNet;
 using Cake.Common.Tools.DotNet.Tool;
 using Cake.Core;
 using Cake.Core.IO;
@@ -13,7 +14,7 @@ namespace Cake.Common.Tools.DotNetCore.Tool
     /// <summary>
     /// .NET Core Extensibility Commands Runner.
     /// </summary>
-    public sealed class DotNetCoreToolRunner : DotNetCoreTool<DotNetCoreSettings>
+    public sealed class DotNetCoreToolRunner : DotNetCoreTool<DotNetSettings>
     {
         private readonly ICakeEnvironment _environment;
 

--- a/tests/integration/Cake.Common/ArgumentAliases.cake
+++ b/tests/integration/Cake.Common/ArgumentAliases.cake
@@ -79,6 +79,26 @@ Task("Cake.Common.ArgumentAliases.Argument.FilePathArgument")
     Assert.Equal(testAssemblyPath.FullPath, arg.FullPath);
 });
 
+Task("Cake.Common.ArgumentAliases.Argument.DotNetCoreVerbosityArgument")
+    .Does(() =>
+{
+    // Given, When
+    var arg = Argument<DotNetCoreVerbosity>("testDotNetCoreVerbosity");
+
+    // Then
+    Assert.Equal(DotNetCoreVerbosity.Diagnostic, arg);
+});
+
+Task("Cake.Common.ArgumentAliases.Argument.DotNetCoreRollForwardArgument")
+    .Does(() =>
+{
+    // Given, When
+    var arg = Argument<DotNetCoreRollForward>("testDotNetRollForward");
+
+    // Then
+    Assert.Equal(DotNetCoreRollForward.LatestMajor, arg);
+});
+
 //////////////////////////////////////////////////////////////////////////////
 
 Task("Cake.Common.ArgumentAliases")
@@ -89,4 +109,6 @@ Task("Cake.Common.ArgumentAliases")
   .IsDependentOn("Cake.Common.ArgumentAliases.Argument.MultipleArguments")
   .IsDependentOn("Cake.Common.ArgumentAliases.Argument.DirectoryPathArgument")
   .IsDependentOn("Cake.Common.ArgumentAliases.Argument.FilePathArgument")
+  .IsDependentOn("Cake.Common.ArgumentAliases.Argument.DotNetCoreVerbosityArgument")
+  .IsDependentOn("Cake.Common.ArgumentAliases.Argument.DotNetCoreRollForwardArgument")
 ;

--- a/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
+++ b/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
@@ -239,7 +239,7 @@ Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTest.Fail")
     // Then
     Assert.NotNull(exception);
     Assert.IsType<CakeException>(exception);
-    Assert.Equal(exception.Message, ".NET Core CLI: Process returned an error (exit code 1).");
+    Assert.Equal(exception.Message, ".NET CLI: Process returned an error (exit code 1).");
 });
 
 

--- a/tests/integration/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cake
+++ b/tests/integration/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cake
@@ -239,7 +239,7 @@ Task("Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetCoreTest.Fail")
     // Then
     Assert.NotNull(exception);
     Assert.IsType<CakeException>(exception);
-    Assert.Equal(exception.Message, ".NET Core CLI: Process returned an error (exit code 1).");
+    Assert.Equal(exception.Message, ".NET CLI: Process returned an error (exit code 1).");
 });
 
 


### PR DESCRIPTION
Summary of changes:

- Update `DotNetXXXSettings.Verbosity` to use the new `DotNetVerbosity` (was `DotNetCoreVerbosity`)
- Update `DotNetXXXSettings.RollForward` to use the new `DotNetRollForward` (was `DotNetCoreRollForward`)
- Update all `DotNetXXXSettings` to inherit from the new `DotNetSettings` (was `DotNetCoreSettings`)
- `DotNetVerbosity` is now a regular enum the same way that `DotNetCoreVerbosity` was
- `DotNetRollForward` is now a regular enum the same way that `DotNetCoreRollForward` was
- `DotNetCoreVerbosity` is no longer an enum... It's a class that attempts to offer all the features of an enum, and is implicit convertible to `DotNetVerbosity` for backward compatibility
- `DotNetCoreRollForward` is no longer an enum... It's a class that attempts to offer all the features of an enum, and is implicit convertible to `DotNetRollForward` for backward compatibility

---

Closes https://github.com/cake-build/cake/issues/3693
