### PR TITLE
GH3701: Add cake-module tag to Cake.DotNetTool.Module NuGet package

### DIFF
--- a/src/Cake.DotNetTool.Module/Cake.DotNetTool.Module.csproj
+++ b/src/Cake.DotNetTool.Module/Cake.DotNetTool.Module.csproj
@@ -4,6 +4,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageTags>$(PackageTags);dotnettool;module;cake-build;cake-module</PackageTags>
   </PropertyGroup>
   <PropertyGroup>
     <CodeAnalysisRuleSet>Cake.DotNetTool.Module.ruleset</CodeAnalysisRuleSet>


### PR DESCRIPTION
Add tags that were [previously included in the `Cake.DotNetTool.Module`](https://github.com/cake-contrib/Cake.DotNetTool.Module/blob/1.0.1/Source/Cake.DotNetTool.Module/Cake.DotNetTool.Module.csproj#L29) package before we brought the code into this repo + the `cake-module` tag

---

Closes https://github.com/cake-build/cake/issues/3701
