### PR TITLE
GH3714: Use Basic.Reference.Assemblies.* to ensure all reference assemblies are loaded

### DIFF
--- a/src/Cake.Core.Tests/Fixtures/ScriptRunnerFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/ScriptRunnerFixture.cs
@@ -58,9 +58,11 @@ namespace Cake.Core.Tests.Fixtures
             Engine.CreateSession(Arg.Any<IScriptHost>()).Returns(Session);
 
             var runtime = new CakeRuntime();
+            var referenceAssemblyResolver = Substitute.For<IReferenceAssemblyResolver>();
+            referenceAssemblyResolver.GetReferenceAssemblies().Returns(Array.Empty<System.Reflection.Assembly>());
             ScriptAnalyzer = new ScriptAnalyzer(FileSystem, Environment, Log, new[] { new FileLoadDirectiveProvider(Globber, Log) });
             ScriptProcessor = Substitute.For<IScriptProcessor>();
-            ScriptConventions = new ScriptConventions(FileSystem, AssemblyLoader, runtime);
+            ScriptConventions = new ScriptConventions(FileSystem, AssemblyLoader, runtime, referenceAssemblyResolver);
 
             var context = Substitute.For<ICakeContext>();
             context.Environment.Returns(c => Environment);

--- a/src/Cake.Core/Scripting/IReferenceAssemblyResolver.cs
+++ b/src/Cake.Core/Scripting/IReferenceAssemblyResolver.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+
+namespace Cake.Core.Scripting
+{
+    /// <summary>
+    /// Represents a framework reference assembly resolver.
+    /// </summary>
+    public interface IReferenceAssemblyResolver
+    {
+        /// <summary>
+        /// Finds framwork reference assemblies.
+        /// </summary>
+        /// <returns>The resolved reference assemblies.</returns>
+        Assembly[] GetReferenceAssemblies();
+    }
+}

--- a/src/Cake.Core/Scripting/ScriptConventions.cs
+++ b/src/Cake.Core/Scripting/ScriptConventions.cs
@@ -20,6 +20,7 @@ namespace Cake.Core.Scripting
         private readonly IFileSystem _fileSystem;
         private readonly IAssemblyLoader _loader;
         private readonly ICakeRuntime _runtime;
+        private readonly IReferenceAssemblyResolver _referenceAssemblyResolver;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ScriptConventions"/> class.
@@ -27,11 +28,13 @@ namespace Cake.Core.Scripting
         /// <param name="fileSystem">The file system.</param>
         /// <param name="loader">The assembly loader.</param>
         /// <param name="runtime">The Cake runtime.</param>
-        public ScriptConventions(IFileSystem fileSystem, IAssemblyLoader loader, ICakeRuntime runtime)
+        /// <param name="referenceAssemblyResolver">The reference assembly resolver.</param>
+        public ScriptConventions(IFileSystem fileSystem, IAssemblyLoader loader, ICakeRuntime runtime, IReferenceAssemblyResolver referenceAssemblyResolver)
         {
             _fileSystem = fileSystem;
             _loader = loader;
             _runtime = runtime;
+            _referenceAssemblyResolver = referenceAssemblyResolver;
         }
 
         /// <inheritdoc/>
@@ -60,6 +63,8 @@ namespace Cake.Core.Scripting
             result.Add(typeof(Action).GetTypeInfo().Assembly); // mscorlib or System.Private.Core
             result.Add(typeof(IQueryable).GetTypeInfo().Assembly); // System.Core or System.Linq.Expressions
             result.Add(typeof(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo).Assembly); // Dynamic support
+
+            result.AddRange(_referenceAssemblyResolver.GetReferenceAssemblies());
 
             // Load other Cake-related assemblies that we need.
             var cakeAssemblies = LoadCakeAssemblies(root);

--- a/src/Cake/Cake.csproj
+++ b/src/Cake/Cake.csproj
@@ -26,9 +26,12 @@
 
   <!-- Global packages -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.0.0-6.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="6.0.0" />
     <PackageReference Include="Autofac" Version="6.3.0" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net60" Version="1.2.4" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net50" Version="1.2.4" Condition="'$(TargetFramework)' == 'net5.0'" />
+    <PackageReference Include="Basic.Reference.Assemblies.NetCoreApp31" Version="1.2.4" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
   </ItemGroup>
 </Project>

--- a/src/Cake/Infrastructure/ContainerConfigurator.cs
+++ b/src/Cake/Infrastructure/ContainerConfigurator.cs
@@ -33,6 +33,7 @@ namespace Cake.Infrastructure
             registrar.RegisterType<DryRunScriptHost>().Singleton();
             registrar.RegisterType<TreeScriptHost>().Singleton();
             registrar.RegisterType<DescriptionScriptHost>().Singleton();
+            registrar.RegisterType<ReferenceAssemblyResolver>().As<IReferenceAssemblyResolver>().Singleton();
 
             // Diagnostics
             registrar.RegisterType<CakeBuildLog>().As<ICakeLog>().Singleton();

--- a/src/Cake/Infrastructure/Scripting/ReferenceAssemblyResolver.cs
+++ b/src/Cake/Infrastructure/Scripting/ReferenceAssemblyResolver.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Cake.Core.Diagnostics;
+using Cake.Core.Scripting;
+
+namespace Cake.Infrastructure.Scripting
+{
+    public sealed class ReferenceAssemblyResolver : IReferenceAssemblyResolver
+    {
+        private readonly ICakeLog _log;
+
+        public ReferenceAssemblyResolver(ICakeLog log)
+        {
+            _log = log;
+        }
+
+        public Assembly[] GetReferenceAssemblies()
+        {
+            IEnumerable<Assembly> TryGetReferenceAssemblies()
+            {
+                foreach (var reference in
+#if NETCOREAPP3_1
+            Basic.Reference.Assemblies.NetCoreApp31.All)
+#elif NET5_0
+            Basic.Reference.Assemblies.Net50.All)
+#else
+            Basic.Reference.Assemblies.Net60.All)
+#endif
+                {
+                    Assembly assembly;
+                    try
+                    {
+                        assembly = Assembly.Load(System.IO.Path.GetFileNameWithoutExtension(reference.FilePath));
+                    }
+                    catch (Exception ex)
+                    {
+                        _log.Debug(log => log("Failed to load {0}\r\n{1}", reference.FilePath, ex));
+                        continue;
+                    }
+
+                    if (assembly == null)
+                    {
+                        continue;
+                    }
+
+                    yield return assembly;
+
+                    foreach (var assemblyRefName in assembly.GetReferencedAssemblies())
+                    {
+                        Assembly assemblyRef;
+                        try
+                        {
+                            assemblyRef = Assembly.Load(assemblyRefName);
+                        }
+                        catch (Exception ex)
+                        {
+                            _log.Debug(log => log("Failed to load {0}\r\n{1}", reference.FilePath, ex));
+                            continue;
+                        }
+
+                        if (assemblyRef == null)
+                        {
+                            continue;
+                        }
+
+                        yield return assemblyRef;
+                    }
+                }
+            }
+
+            return TryGetReferenceAssemblies().ToArray();
+        }
+    }
+}


### PR DESCRIPTION
* .NET 6.0 - Basic.Reference.Assemblies.Net60
* .NET 5.0 - Basic.Reference.Assemblies.Net50
* .NET Core 3.1 - Basic.Reference.Assemblies.NetCoreApp31
* fixes #3714