### PR TITLE
GH2953: Allow setting MSBuild target via MSBuildSettings using a string

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -745,15 +745,85 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             public void Should_Append_Targets_To_Process_Arguments()
             {
                 // Given
-                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows);
-                fixture.Settings.WithTarget("A");
-                fixture.Settings.WithTarget("B");
+                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows)
+                {
+                    Settings = new MSBuildSettings
+                    {
+                        Target = "A;B"
+                    }
+                };
 
                 // When
                 var result = fixture.Run();
 
                 // Then
                 Assert.Equal("/v:normal /target:A;B " +
+                             "\"C:/Working/src/Solution.sln\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Single_Target_With_Initializer()
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows)
+                {
+                    Settings = new MSBuildSettings
+                    {
+                        Target = "A",
+                        ToolVersion = MSBuildToolVersion.VS2019,
+                    }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/v:normal /target:A " +
+                             "\"C:/Working/src/Solution.sln\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Multiple_Targets_With_Initializer()
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows)
+                {
+                    Settings = new MSBuildSettings
+                    {
+                        Target = "A;B",
+                        ToolVersion = MSBuildToolVersion.VS2019,
+                    }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/v:normal /target:A;B " +
+                             "\"C:/Working/src/Solution.sln\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Multiple_Targets_With_Initializer_And_AddTarget()
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows)
+                {
+                    Settings = new MSBuildSettings
+                    {
+                        Target = "A;B",
+                        ToolVersion = MSBuildToolVersion.VS2019,
+                    }
+                };
+
+                fixture.Settings.WithTarget("C");
+                fixture.Settings.WithTarget("D");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/v:normal /target:A;B;C;D " +
                              "\"C:/Working/src/Solution.sln\"", result.Args);
             }
 

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Cake.Core.Diagnostics;
 using Cake.Core.Tooling;
 
@@ -46,6 +47,16 @@ namespace Cake.Common.Tools.MSBuild
         /// </summary>
         /// <value>The MSBuild platform.</value>
         public MSBuildPlatform MSBuildPlatform { get; set; }
+
+        /// <summary>
+        /// Gets or sets the MSBuild target.
+        /// </summary>
+        /// <value>The MSBuild target.</value>
+        public string Target
+        {
+            get => string.Join(";", Targets);
+            set => SetTargets(value);
+        }
 
         /// <summary>
         /// Gets or sets the tool version.
@@ -269,6 +280,7 @@ namespace Cake.Common.Tools.MSBuild
             Configuration = string.Empty;
             Verbosity = Verbosity.Normal;
             MSBuildPlatform = MSBuildPlatform.Automatic;
+            Target = string.Empty;
         }
 
         private string GetPropertyValueOrDefault(string propertyName, string @default = null)
@@ -280,6 +292,14 @@ namespace Cake.Common.Tools.MSBuild
 
             var propertyValue = string.Join(";", propertyValues);
             return propertyValue;
+        }
+
+        private void SetTargets(string value)
+        {
+            foreach (var target in value.Split(";").Where(p => !string.IsNullOrEmpty(p)))
+            {
+                Targets.Add(target);
+            }
         }
     }
 }

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
@@ -23,7 +23,7 @@ namespace Cake.Common.Tools.MSBuild
         /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
         public static MSBuildSettings WithTarget(this MSBuildSettings settings, string target)
         {
-            if (settings == null)
+            if (settings is null)
             {
                 throw new ArgumentNullException(nameof(settings));
             }


### PR DESCRIPTION
PR to address this feature request:

https://github.com/cake-build/cake/issues/2953