### PR TITLE
GH3771: Add support for Chocolatey Export Command

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/Export/ChocolateyExportFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/Export/ChocolateyExportFixture.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.Chocolatey.Export;
+
+namespace Cake.Common.Tests.Fixtures.Tools.Chocolatey.Export
+{
+    internal sealed class ChocolateyExportFixture : ChocolateyFixture<ChocolateyExportSettings>
+    {
+        public ChocolateyExportFixture()
+        {
+        }
+
+        protected override void RunTool()
+        {
+            var tool = new ChocolateyExporter(FileSystem, Environment, ProcessRunner, Tools, Resolver);
+            tool.Export(Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Export/ChocolateyExporterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Export/ChocolateyExporterTests.cs
@@ -257,8 +257,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Export
             }
 
             [Theory]
-            [InlineData(@"c:\temp", "export -y --output-file-path \"c:\\temp\"")]
-            [InlineData("", "export -y")]
+            [InlineData(@"c:\temp", "export -y --output-file-path \"c:/temp\"")]
+            [InlineData(null, "export -y")]
             public void Should_Add_OutputFilePath_To_Arguments_If_Set(string outputFilePath, string expected)
             {
                 // Given

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Export/ChocolateyExporterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Export/ChocolateyExporterTests.cs
@@ -1,0 +1,292 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tests.Fixtures.Tools.Chocolatey.Export;
+using Cake.Testing;
+using Cake.Testing.Xunit;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Export
+{
+    public sealed class ChocolateyExporterTests
+    {
+        public sealed class TheExportMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Chocolatey_Executable_Was_Not_Found()
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, "Chocolatey: Could not locate executable.");
+            }
+
+            [Theory]
+            [InlineData("/bin/chocolatey/choco.exe", "/bin/chocolatey/choco.exe")]
+            [InlineData("./chocolatey/choco.exe", "/Working/chocolatey/choco.exe")]
+            public void Should_Use_Chocolatey_Executable_From_Tool_Path_If_Provided(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.ToolPath = toolPath;
+                fixture.GivenSettingsToolPathExist();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Path.FullPath);
+            }
+
+            [WindowsTheory]
+            [InlineData("C:/ProgramData/chocolatey/choco.exe", "C:/ProgramData/chocolatey/choco.exe")]
+            public void Should_Use_Chocolatey_Executable_From_Tool_Path_If_Provided_On_Windows(string toolPath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.ToolPath = toolPath;
+                fixture.GivenSettingsToolPathExist();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Path.FullPath);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, "Chocolatey: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.GivenProcessExitsWithCode(1);
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, "Chocolatey: Process returned an error (exit code 1).");
+            }
+
+            [Fact]
+            public void Should_Find_Chocolatey_Executable_If_Tool_Path_Not_Provided()
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/Working/tools/choco.exe", result.Path.FullPath);
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("export -y", result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "export -d -y")]
+            [InlineData(false, "export -y")]
+            public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.Debug = debug;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "export -v -y")]
+            [InlineData(false, "export -y")]
+            public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.Verbose = verbose;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "export -y -f")]
+            [InlineData(false, "export -y")]
+            public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.Force = force;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "export -y --noop")]
+            [InlineData(false, "export -y")]
+            public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.Noop = noop;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "export -y -r")]
+            [InlineData(false, "export -y")]
+            public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.LimitOutput = limitOutput;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(5, "export -y --execution-timeout \"5\"")]
+            [InlineData(0, "export -y")]
+            public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.ExecutionTimeout = executionTimeout;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(@"c:\temp", "export -y -c \"c:\\temp\"")]
+            [InlineData("", "export -y")]
+            public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.CacheLocation = cacheLocation;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "export -y --allowunofficial")]
+            [InlineData(false, "export -y")]
+            public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.AllowUnofficial = allowUnofficial;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(@"c:\temp", "export -y --output-file-path \"c:\\temp\"")]
+            [InlineData("", "export -y")]
+            public void Should_Add_OutputFilePath_To_Arguments_If_Set(string outputFilePath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.OutputFilePath = outputFilePath;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "export -y --include-version-numbers")]
+            [InlineData(false, "export -y")]
+            public void Should_Add_IncludeVersionNumbers_Flag_To_Arguments_If_Set(bool includeVersionNumbers, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.IncludeVersionNumbers = includeVersionNumbers;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using Cake.Common.Tools.Chocolatey.ApiKey;
 using Cake.Common.Tools.Chocolatey.Config;
 using Cake.Common.Tools.Chocolatey.Download;
+using Cake.Common.Tools.Chocolatey.Export;
 using Cake.Common.Tools.Chocolatey.Features;
 using Cake.Common.Tools.Chocolatey.Install;
 using Cake.Common.Tools.Chocolatey.New;
@@ -1204,6 +1205,53 @@ namespace Cake.Common.Tools.Chocolatey
             var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
             var runner = new ChocolateyDownloader(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools, resolver);
             runner.Download(packageId, settings);
+        }
+
+        /// <summary>
+        /// Exports the currently installed Chocolatey packages to a packages.config file in the current working directory.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <example>
+        /// <code>
+        /// ChocolateyExport();
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Export")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Export")]
+        public static void ChocolateyExport(this ICakeContext context)
+        {
+            var settings = new ChocolateyExportSettings();
+            ChocolateyExport(context, settings);
+        }
+
+        /// <summary>
+        /// Exports the currently installed Chocolatey packages using the specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <para>Exported information should contain the package version numbers:</para>
+        /// <code>
+        /// ChocolateyExport(
+        ///     new ChocolateyExportSettings {
+        ///         IncludeVersionNumbers = true
+        ///     });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Export")]
+        [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.Export")]
+        public static void ChocolateyExport(this ICakeContext context, ChocolateyExportSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
+            var runner = new ChocolateyExporter(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools, resolver);
+            runner.Export(settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/Chocolatey/Export/ChocolateyExporter.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Export/ChocolateyExporter.cs
@@ -1,0 +1,124 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.Chocolatey.Export
+{
+    /// <summary>
+    /// The Chocolatey package exporter used to export Chocolatey packages.
+    /// </summary>
+    public sealed class ChocolateyExporter : ChocolateyTool<ChocolateyExportSettings>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChocolateyExporter"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="tools">The tool locator.</param>
+        /// <param name="resolver">The Chocolatey tool resolver.</param>
+        public ChocolateyExporter(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IToolLocator tools,
+            IChocolateyToolResolver resolver) : base(fileSystem, environment, processRunner, tools, resolver)
+        {
+        }
+
+        /// <summary>
+        /// Exports the currently installed Chocolatey packages using the specified settings.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        public void Export(ChocolateyExportSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            Run(settings, GetArguments(settings));
+        }
+
+        private ProcessArgumentBuilder GetArguments(ChocolateyExportSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("export");
+
+            // Debug
+            if (settings.Debug)
+            {
+                builder.Append("-d");
+            }
+
+            // Verbose
+            if (settings.Verbose)
+            {
+                builder.Append("-v");
+            }
+
+            // Always say yes, so as to not show interactive prompt
+            builder.Append("-y");
+
+            // Force
+            if (settings.Force)
+            {
+                builder.Append("-f");
+            }
+
+            // Noop
+            if (settings.Noop)
+            {
+                builder.Append("--noop");
+            }
+
+            // Limit Output
+            if (settings.LimitOutput)
+            {
+                builder.Append("-r");
+            }
+
+            // Execution Timeout
+            if (settings.ExecutionTimeout != 0)
+            {
+                builder.Append("--execution-timeout");
+                builder.AppendQuoted(settings.ExecutionTimeout.ToString(CultureInfo.InvariantCulture));
+            }
+
+            // Cache Location
+            if (!string.IsNullOrWhiteSpace(settings.CacheLocation))
+            {
+                builder.Append("-c");
+                builder.AppendQuoted(settings.CacheLocation);
+            }
+
+            // Allow Unofficial
+            if (settings.AllowUnofficial)
+            {
+                builder.Append("--allowunofficial");
+            }
+
+            // Output File Path
+            if (!string.IsNullOrWhiteSpace(settings.OutputFilePath))
+            {
+                builder.Append("--output-file-path");
+                builder.AppendQuoted(settings.OutputFilePath);
+            }
+
+            // Include Version Numbers
+            if (settings.IncludeVersionNumbers)
+            {
+                builder.Append("--include-version-numbers");
+            }
+
+            return builder;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/Export/ChocolateyExporter.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Export/ChocolateyExporter.cs
@@ -106,10 +106,10 @@ namespace Cake.Common.Tools.Chocolatey.Export
             }
 
             // Output File Path
-            if (!string.IsNullOrWhiteSpace(settings.OutputFilePath))
+            if (settings.OutputFilePath != null)
             {
                 builder.Append("--output-file-path");
-                builder.AppendQuoted(settings.OutputFilePath);
+                builder.AppendQuoted(settings.OutputFilePath.FullPath);
             }
 
             // Include Version Numbers

--- a/src/Cake.Common/Tools/Chocolatey/Export/ChocolateyExporterSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Export/ChocolateyExporterSettings.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.Chocolatey.Export
+{
+    /// <summary>
+    /// Contains settings used by <see cref="ChocolateyExporter"/>.
+    /// </summary>
+    public sealed class ChocolateyExportSettings : ToolSettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in debug mode.
+        /// </summary>
+        /// <value>The debug flag.</value>
+        public bool Debug { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in verbose mode.
+        /// </summary>
+        /// <value>The verbose flag.</value>
+        public bool Verbose { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in forced mode.
+        /// </summary>
+        /// <value>The force flag.</value>
+        public bool Force { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in noop mode.
+        /// </summary>
+        /// <value>The noop flag.</value>
+        public bool Noop { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in limited output mode.
+        /// </summary>
+        /// <value>The limit output flag.</value>
+        public bool LimitOutput { get; set; }
+
+        /// <summary>
+        /// Gets or sets the execution timeout value.
+        /// </summary>
+        /// <value>The execution timeout.</value>
+        /// <remarks>Default is 2700 seconds.</remarks>
+        public int ExecutionTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the location of the download cache.
+        /// </summary>
+        /// <value>The download cache location.</value>
+        public string CacheLocation { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in allow unofficial mode.
+        /// </summary>
+        /// <value>The allow unofficial flag.</value>
+        public bool AllowUnofficial { get; set; }
+
+        /// <summary>
+        /// Gets or sets teh path to the file that will be generated.
+        /// </summary>
+        /// <value>The path to the file that is generated.</value>
+        public string OutputFilePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include version numbers for installed packages.
+        /// </summary>
+        /// <value>The include version numbers flag.</value>
+        public bool IncludeVersionNumbers { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/Export/ChocolateyExporterSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Export/ChocolateyExporterSettings.cs
@@ -62,10 +62,10 @@ namespace Cake.Common.Tools.Chocolatey.Export
         public bool AllowUnofficial { get; set; }
 
         /// <summary>
-        /// Gets or sets teh path to the file that will be generated.
+        /// Gets or sets the path to the file that will be generated.
         /// </summary>
         /// <value>The path to the file that is generated.</value>
-        public string OutputFilePath { get; set; }
+        public FilePath OutputFilePath { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to include version numbers for installed packages.

--- a/tests/integration/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cake
+++ b/tests/integration/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cake
@@ -1,0 +1,29 @@
+#load "./../../../utilities/paths.cake"
+#load "./../../../utilities/xunit.cake"
+
+Task("Cake.Common.Tools.Chocolatey.ChocolateyAliases.ChocolateyExport")
+    .Does(() => {
+    // Given
+    var directoryPath = Paths.Temp.Combine("./Cake.Common/Tools/Chocolatey/ChocolateyExport");
+    var filePath = directoryPath.CombineWithFilePath("packages.config");
+    EnsureDirectoryExists(directoryPath);
+
+    var settings = new ChocolateyExportSettings {
+        OutputFilePath = filePath.FullPath
+    };
+
+    // When
+    ChocolateyExport(settings);
+
+    // Then
+    Assert.True(FileExists(filePath), $"{filePath.FullPath} missing");
+});
+
+
+var chocolateyAliasesTask = Task("Cake.Common.Tools.Chocolatey.ChocolateyAliases");
+
+if (IsRunningOnWindows() && Context.Tools.Resolve("choco.exe") is FilePath)
+{
+    chocolateyAliasesTask
+        .IsDependentOn("Cake.Common.Tools.Chocolatey.ChocolateyAliases.ChocolateyExport");
+}

--- a/tests/integration/build.cake
+++ b/tests/integration/build.cake
@@ -95,6 +95,9 @@ Task("Cake.Common")
 Task("Cake.NuGet")
     .IsDependentOn("Cake.NuGet.InProcessInstaller");
 
+Task("Cake.Chocolatey")
+    .IsDependentOn("Cake.Common.Tools.Chocolatey.ChocolateyAliases");
+
 Task("Run-All-Tests")
     .IsDependentOn("Setup-Tests")
     .IsDependentOn("Cake.Core")

--- a/tests/integration/build.cake
+++ b/tests/integration/build.cake
@@ -103,7 +103,8 @@ Task("Run-All-Tests")
     .IsDependentOn("Cake.Core")
     .IsDependentOn("Cake.Common")
     .IsDependentOn("Cake.DotNetTool.Module")
-    .IsDependentOn("Cake.NuGet");
+    .IsDependentOn("Cake.NuGet")
+    .IsDependentOn("Cake.Chocolatey");
 
 //////////////////////////////////////////////////
 

--- a/tests/integration/build.cake
+++ b/tests/integration/build.cake
@@ -27,6 +27,7 @@
 #load "./Cake.Common/Tools/DotNet/DotNetAliases.cake"
 #load "./Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cake"
 #load "./Cake.Common/Tools/NuGet/NuGetAliases.cake"
+#load "./Cake.Common/Tools/Chocolatey/ChocolateyAliases.cake"
 #load "./Cake.Common/Tools/TextTransform/TextTransformAliases.cake"
 #load "./Cake.Core/Diagnostics/ICakeLog.cake"
 #load "./Cake.Core/IO/Path.cake"


### PR DESCRIPTION
This command was added in 0.11.0 of Chocolatey, providing the ability
for a user to export a file that contains information about all the
currently installed Chocolatey packages on a machine.

This information can be useful, therefore creating a Cake alias to
support it makes sense.

Fixes #3771 