### PR TITLE
Added VS2022 to MSTest, VSTest

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/MSTestRunnerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/MSTestRunnerFixture.cs
@@ -18,6 +18,7 @@ namespace Cake.Common.Tests.Fixtures.Tools
         {
             AssemblyPaths = new[] { new FilePath("./Test1.dll") };
             Environment.SetSpecialPath(SpecialPath.ProgramFilesX86, "/ProgramFilesX86");
+            Environment.SetSpecialPath(SpecialPath.ProgramFiles, "/ProgramFiles");
         }
 
         protected override FilePath GetDefaultToolPath(string toolFilename)

--- a/src/Cake.Common.Tests/Fixtures/Tools/VSTestRunnerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/VSTestRunnerFixture.cs
@@ -18,6 +18,7 @@ namespace Cake.Common.Tests.Fixtures.Tools
         {
             AssemblyPaths = new[] { new FilePath("./Test1.dll") };
             Environment.SetSpecialPath(SpecialPath.ProgramFilesX86, "/ProgramFilesX86");
+            Environment.SetSpecialPath(SpecialPath.ProgramFiles, "/ProgramFiles");
         }
 
         protected override FilePath GetDefaultToolPath(string toolFilename)

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -175,8 +175,8 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             }
 
             [Theory]
-            [InlineData(MSBuildToolVersion.VS2022, PlatformTarget.x64, PlatformFamily.Windows, false, "/Program86/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin/amd64/MSBuild.exe")]
-            [InlineData(MSBuildToolVersion.VS2022, PlatformTarget.x86, PlatformFamily.Windows, false, "/Program86/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin/MSBuild.exe")]
+            [InlineData(MSBuildToolVersion.VS2022, PlatformTarget.x64, PlatformFamily.Windows, false, "/Program/Microsoft Visual Studio/2022/BuildTools/MSBuild/Current/Bin/amd64/MSBuild.exe")]
+            [InlineData(MSBuildToolVersion.VS2022, PlatformTarget.x86, PlatformFamily.Windows, false, "/Program/Microsoft Visual Studio/2022/BuildTools/MSBuild/Current/Bin/MSBuild.exe")]
             public void Should_Get_Correct_Path_To_MSBuild_Version_17_When_Only_Build_Tools_Are_Installed(MSBuildToolVersion version, PlatformTarget target, PlatformFamily family, bool is64BitOperativeSystem, string expected)
             {
                 // Given
@@ -186,8 +186,8 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
 
                 fixture.GivenDefaultToolDoNotExist();
                 fixture.GivenMSBuildIsNotInstalled();
-                fixture.FileSystem.CreateFile("/Program86/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin/amd64/MSBuild.exe");
-                fixture.FileSystem.CreateFile("/Program86/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin/MSBuild.exe");
+                fixture.FileSystem.CreateFile("/Program/Microsoft Visual Studio/2022/BuildTools/MSBuild/Current/Bin/amd64/MSBuild.exe");
+                fixture.FileSystem.CreateFile("/Program/Microsoft Visual Studio/2022/BuildTools/MSBuild/Current/Bin/MSBuild.exe");
 
                 // When
                 var result = fixture.Run();
@@ -212,10 +212,10 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
 
                 fixture.GivenDefaultToolDoNotExist();
                 fixture.GivenMSBuildIsNotInstalled();
-                fixture.FileSystem.CreateFile("/Program86/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin/amd64/MSBuild.exe");
-                fixture.FileSystem.CreateFile("/Program86/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin/MSBuild.exe");
-                fixture.FileSystem.CreateFile("/Program86/Microsoft Visual Studio/2022/Preview/MSBuild/Current/Bin/amd64/MSBuild.exe");
-                fixture.FileSystem.CreateFile("/Program86/Microsoft Visual Studio/2022/Preview/MSBuild/Current/Bin/MSBuild.exe");
+                fixture.FileSystem.CreateFile("/Program/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin/amd64/MSBuild.exe");
+                fixture.FileSystem.CreateFile("/Program/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin/MSBuild.exe");
+                fixture.FileSystem.CreateFile("/Program/Microsoft Visual Studio/2022/Preview/MSBuild/Current/Bin/amd64/MSBuild.exe");
+                fixture.FileSystem.CreateFile("/Program/Microsoft Visual Studio/2022/Preview/MSBuild/Current/Bin/MSBuild.exe");
 
                 // When
                 var result = fixture.Run();

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -197,6 +197,41 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             }
 
             [Theory]
+            [InlineData(MSBuildToolVersion.VS2022, PlatformTarget.x64, PlatformFamily.Windows, true)]
+            [InlineData(MSBuildToolVersion.VS2022, PlatformTarget.x86, PlatformFamily.Windows, true)]
+            [InlineData(MSBuildToolVersion.VS2022, PlatformTarget.x64, PlatformFamily.Windows, false)]
+            [InlineData(MSBuildToolVersion.VS2022, PlatformTarget.x86, PlatformFamily.Windows, false)]
+            public void Should_Get_Correct_Path_To_MSBuild_Version_17Preview_When_Preview_Is_Set(MSBuildToolVersion version, PlatformTarget target, PlatformFamily family, bool allowPreview)
+            {
+                // Given
+                var is64BitOperativeSystem = target == PlatformTarget.x64;
+                var fixture = new MSBuildRunnerFixture(is64BitOperativeSystem, family);
+                fixture.Settings.ToolVersion = version;
+                fixture.Settings.PlatformTarget = target;
+                fixture.Settings.AllowPreviewVersion = allowPreview;
+
+                fixture.GivenDefaultToolDoNotExist();
+                fixture.GivenMSBuildIsNotInstalled();
+                fixture.FileSystem.CreateFile("/Program86/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin/amd64/MSBuild.exe");
+                fixture.FileSystem.CreateFile("/Program86/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin/MSBuild.exe");
+                fixture.FileSystem.CreateFile("/Program86/Microsoft Visual Studio/2022/Preview/MSBuild/Current/Bin/amd64/MSBuild.exe");
+                fixture.FileSystem.CreateFile("/Program86/Microsoft Visual Studio/2022/Preview/MSBuild/Current/Bin/MSBuild.exe");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                if (allowPreview)
+                {
+                    Assert.Contains("2022/Preview", result.Path.FullPath);
+                }
+                else
+                {
+                    Assert.False(result.Path.FullPath.Contains("2022/Preview"));
+                }
+            }
+
+            [Theory]
             [InlineData(MSBuildToolVersion.NET40, PlatformTarget.MSIL, true, "/Windows/Microsoft.NET/Framework64/v4.0.30319/MSBuild.exe")]
             [InlineData(MSBuildToolVersion.NET40, PlatformTarget.MSIL, false, "/Windows/Microsoft.NET/Framework/v4.0.30319/MSBuild.exe")]
             [InlineData(MSBuildToolVersion.NET45, PlatformTarget.MSIL, true, "/Windows/Microsoft.NET/Framework64/v4.0.30319/MSBuild.exe")]

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -227,7 +227,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 }
                 else
                 {
-                    Assert.False(result.Path.FullPath.Contains("2022/Preview"));
+                    Assert.DoesNotContain("2022/Preview", result.Path.FullPath);
                 }
             }
 

--- a/src/Cake.Common.Tests/Unit/Tools/MSTest/MSTestRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSTest/MSTestRunnerTests.cs
@@ -293,21 +293,21 @@ namespace Cake.Common.Tests.Unit.Tools.MSTest
         }
 
         [Theory]
-        [InlineData("2017", "Enterprise")]
-        [InlineData("2017", "Professional")]
-        [InlineData("2017", "Community")]
-        [InlineData("2019", "Enterprise")]
-        [InlineData("2019", "Professional")]
-        [InlineData("2019", "Community")]
-        [InlineData("2022", "Enterprise")]
-        [InlineData("2022", "Professional")]
-        [InlineData("2022", "Community")]
-        public void Should_Use_Tool_Path_For_YearAndEdition_Versions(string year, string edition)
+        [InlineData(SpecialPath.ProgramFilesX86, "2017", "Enterprise")]
+        [InlineData(SpecialPath.ProgramFilesX86, "2017", "Professional")]
+        [InlineData(SpecialPath.ProgramFilesX86, "2017", "Community")]
+        [InlineData(SpecialPath.ProgramFilesX86, "2019", "Enterprise")]
+        [InlineData(SpecialPath.ProgramFilesX86, "2019", "Professional")]
+        [InlineData(SpecialPath.ProgramFilesX86, "2019", "Community")]
+        [InlineData(SpecialPath.ProgramFiles, "2022", "Enterprise")]
+        [InlineData(SpecialPath.ProgramFiles, "2022", "Professional")]
+        [InlineData(SpecialPath.ProgramFiles, "2022", "Community")]
+        public void Should_Use_Tool_Path_For_YearAndEdition_Versions(SpecialPath programFiles, string year, string edition)
         {
             // Given
             var fixture = new MSTestRunnerFixture();
             fixture.GivenDefaultToolDoNotExist();
-            var toolPath = fixture.Environment.GetSpecialPath(SpecialPath.ProgramFilesX86)
+            var toolPath = fixture.Environment.GetSpecialPath(programFiles)
                 .CombineWithFilePath($"Microsoft Visual Studio/{year}/{edition}/Common7/IDE/mstest.exe");
             fixture.FileSystem.CreateFile(toolPath);
 
@@ -325,7 +325,7 @@ namespace Cake.Common.Tests.Unit.Tools.MSTest
         {
             // Given
             var fixture = new MSTestRunnerFixture();
-            var previewToolPath = fixture.Environment.GetSpecialPath(SpecialPath.ProgramFilesX86)
+            var previewToolPath = fixture.Environment.GetSpecialPath(SpecialPath.ProgramFiles)
                 .CombineWithFilePath($"Microsoft Visual Studio/{year}/Preview/Common7/IDE/mstest.exe");
             fixture.FileSystem.CreateFile(previewToolPath);
             fixture.Settings.AllowPreviewVersion = allowPreview;

--- a/src/Cake.Common.Tests/Unit/Tools/MSTest/MSTestRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSTest/MSTestRunnerTests.cs
@@ -291,5 +291,57 @@ namespace Cake.Common.Tests.Unit.Tools.MSTest
             // Then
             Assert.Equal(existingToolPath, result.Path.FullPath);
         }
+
+        [Theory]
+        [InlineData("2017", "Enterprise")]
+        [InlineData("2017", "Professional")]
+        [InlineData("2017", "Community")]
+        [InlineData("2019", "Enterprise")]
+        [InlineData("2019", "Professional")]
+        [InlineData("2019", "Community")]
+        [InlineData("2022", "Enterprise")]
+        [InlineData("2022", "Professional")]
+        [InlineData("2022", "Community")]
+        public void Should_Use_Tool_Path_For_YearAndEdition_Versions(string year, string edition)
+        {
+            // Given
+            var fixture = new MSTestRunnerFixture();
+            fixture.GivenDefaultToolDoNotExist();
+            var toolPath = fixture.Environment.GetSpecialPath(SpecialPath.ProgramFilesX86)
+                .CombineWithFilePath($"Microsoft Visual Studio/{year}/{edition}/Common7/IDE/mstest.exe");
+            fixture.FileSystem.CreateFile(toolPath);
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            Assert.Equal(toolPath, result.Path.FullPath);
+        }
+
+        [Theory]
+        [InlineData("2022", true)]
+        [InlineData("2022", false)]
+        public void Should_Use_Tool_Path_For_Preview_Version_Only_If_PreviewIsSet(string year, bool allowPreview)
+        {
+            // Given
+            var fixture = new MSTestRunnerFixture();
+            var previewToolPath = fixture.Environment.GetSpecialPath(SpecialPath.ProgramFilesX86)
+                .CombineWithFilePath($"Microsoft Visual Studio/{year}/Preview/Common7/IDE/mstest.exe");
+            fixture.FileSystem.CreateFile(previewToolPath);
+            fixture.Settings.AllowPreviewVersion = allowPreview;
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            if (allowPreview)
+            {
+                Assert.Equal(previewToolPath, result.Path.FullPath);
+            }
+            else
+            {
+                Assert.NotEqual(previewToolPath, result.Path.FullPath);
+            }
+        }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/VSTest/VSTestRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/VSTest/VSTestRunnerTests.cs
@@ -98,9 +98,15 @@ namespace Cake.Common.Tests.Unit.Tools.VSTest
         [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2017/Enterprise/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
         [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2017/Professional/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
         [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2017/Community/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2017/BuildTools/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
         [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2019/Enterprise/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
         [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2019/Professional/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
         [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2019/Community/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2019/BuildTools/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2022/Enterprise/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2022/Professional/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2022/Community/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2022/BuildTools/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
         public void Should_Use_Available_Tool_Path(string existingToolPath)
         {
             // Given
@@ -113,6 +119,30 @@ namespace Cake.Common.Tests.Unit.Tools.VSTest
 
             // Then
             Assert.Equal(existingToolPath, result.Path.FullPath);
+        }
+
+        [Theory]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2022/Preview/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe", true)]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2022/Preview/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe", false)]
+        public void Should_Use_Available_Preview_Tool_Path_Only_If_Preview_Is_Set(string previewToolPath, bool allowPreview)
+        {
+            // Given
+            var fixture = new VSTestRunnerFixture();
+            fixture.FileSystem.CreateFile(previewToolPath);
+            fixture.Settings.AllowPreviewVersion = allowPreview;
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            if (allowPreview)
+            {
+                Assert.Equal(previewToolPath, result.Path.FullPath);
+            }
+            else
+            {
+                Assert.NotEqual(previewToolPath, result.Path.FullPath);
+            }
         }
 
         [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/VSTest/VSTestRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/VSTest/VSTestRunnerTests.cs
@@ -91,7 +91,6 @@ namespace Cake.Common.Tests.Unit.Tools.VSTest
         }
 
         [Theory]
-        [InlineData("/ProgramFilesX86/Microsoft Visual Studio 15.0/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
         [InlineData("/ProgramFilesX86/Microsoft Visual Studio 14.0/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
         [InlineData("/ProgramFilesX86/Microsoft Visual Studio 12.0/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
         [InlineData("/ProgramFilesX86/Microsoft Visual Studio 11.0/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
@@ -103,10 +102,10 @@ namespace Cake.Common.Tests.Unit.Tools.VSTest
         [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2019/Professional/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
         [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2019/Community/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
         [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2019/BuildTools/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
-        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2022/Enterprise/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
-        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2022/Professional/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
-        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2022/Community/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
-        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2022/BuildTools/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
+        [InlineData("/ProgramFiles/Microsoft Visual Studio/2022/Enterprise/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
+        [InlineData("/ProgramFiles/Microsoft Visual Studio/2022/Professional/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
+        [InlineData("/ProgramFiles/Microsoft Visual Studio/2022/Community/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
+        [InlineData("/ProgramFiles/Microsoft Visual Studio/2022/BuildTools/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
         public void Should_Use_Available_Tool_Path(string existingToolPath)
         {
             // Given
@@ -122,8 +121,8 @@ namespace Cake.Common.Tests.Unit.Tools.VSTest
         }
 
         [Theory]
-        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2022/Preview/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe", true)]
-        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2022/Preview/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe", false)]
+        [InlineData("/ProgramFiles/Microsoft Visual Studio/2022/Preview/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe", true)]
+        [InlineData("/ProgramFiles/Microsoft Visual Studio/2022/Preview/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe", false)]
         public void Should_Use_Available_Preview_Tool_Path_Only_If_Preview_Is_Set(string previewToolPath, bool allowPreview)
         {
             // Given

--- a/src/Cake.Common/Tools/MSBuild/MSBuildResolver.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildResolver.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using Cake.Core;
 using Cake.Core.IO;
 
@@ -142,25 +141,12 @@ namespace Cake.Common.Tools.MSBuild
         private static DirectoryPath GetVisualStudio2017Path(IFileSystem fileSystem, ICakeEnvironment environment,
             MSBuildPlatform buildPlatform, bool allowPreviewVersion)
         {
-            var vsEditions = new List<string>
-            {
-                    "Enterprise",
-                    "Professional",
-                    "Community",
-                    "BuildTools"
-            };
-
-            if (allowPreviewVersion)
-            {
-                vsEditions.Insert(0, "Preview");
-            }
-
-            var visualStudio2017Path = environment.GetSpecialPath(SpecialPath.ProgramFilesX86);
-
-            foreach (var edition in vsEditions)
+            foreach (var edition in allowPreviewVersion
+                         ? VisualStudio.Editions.All
+                         : VisualStudio.Editions.Stable)
             {
                 // Get the bin path.
-                var binPath = visualStudio2017Path.Combine(string.Concat("Microsoft Visual Studio/2017/", edition, "/MSBuild/15.0/Bin"));
+                var binPath = VisualStudio.GetYearAndEditionRootPath(environment, "2017", edition).Combine("MSBuild/15.0/Bin");
                 if (fileSystem.Exist(binPath))
                 {
                     if (buildPlatform == MSBuildPlatform.Automatic)
@@ -177,31 +163,18 @@ namespace Cake.Common.Tools.MSBuild
                     return binPath;
                 }
             }
-            return visualStudio2017Path.Combine("Microsoft Visual Studio/2017/Professional/MSBuild/15.0/Bin");
+            return VisualStudio.GetYearAndEditionRootPath(environment, "2017", "Professional").Combine("MSBuild/15.0/Bin");
         }
 
         private static DirectoryPath GetVisualStudio2019Path(IFileSystem fileSystem, ICakeEnvironment environment,
             MSBuildPlatform buildPlatform, bool allowPreviewVersion)
         {
-            var vsEditions = new List<string>
-            {
-                "Enterprise",
-                "Professional",
-                "Community",
-                "BuildTools"
-            };
-
-            if (allowPreviewVersion)
-            {
-                vsEditions.Insert(0, "Preview");
-            }
-
-            var visualStudio2019Path = environment.GetSpecialPath(SpecialPath.ProgramFilesX86);
-
-            foreach (var edition in vsEditions)
+            foreach (var edition in allowPreviewVersion
+                         ? VisualStudio.Editions.All
+                         : VisualStudio.Editions.Stable)
             {
                 // Get the bin path.
-                var binPath = visualStudio2019Path.Combine(string.Concat("Microsoft Visual Studio/2019/", edition, "/MSBuild/Current/Bin")); // Change from Current to 16.0 after stable version released
+                var binPath = VisualStudio.GetYearAndEditionRootPath(environment, "2019", edition).Combine("MSBuild/Current/Bin");
                 if (fileSystem.Exist(binPath))
                 {
                     if (buildPlatform == MSBuildPlatform.Automatic)
@@ -218,58 +191,38 @@ namespace Cake.Common.Tools.MSBuild
                     return binPath;
                 }
             }
-            return visualStudio2019Path.Combine("Microsoft Visual Studio/2019/Professional/MSBuild/16.0/Bin");
+            return VisualStudio.GetYearAndEditionRootPath(environment, "2019", "Professional").Combine("MSBuild/Current/Bin");
         }
 
         private static DirectoryPath GetVisualStudio2022Path(IFileSystem fileSystem, ICakeEnvironment environment,
             MSBuildPlatform buildPlatform, bool allowPreviewVersion)
         {
-            var vsEditions = new List<string>
+            foreach (var edition in allowPreviewVersion
+                         ? VisualStudio.Editions.All
+                         : VisualStudio.Editions.Stable)
             {
-                "Enterprise",
-                "Professional",
-                "Community",
-                "BuildTools",
-            };
-
-            if (allowPreviewVersion)
-            {
-                vsEditions.Insert(0, "Preview");
-            }
-
-            var visualStudio2022Paths = new[]
-            {
-                environment.GetSpecialPath(SpecialPath.ProgramFiles),
-                environment.GetSpecialPath(SpecialPath.ProgramFilesX86),
-            };
-
-            foreach (var visualStudio2022Path in visualStudio2022Paths)
-            {
-                foreach (var edition in vsEditions)
+                // Get the bin path.
+                var binPath = VisualStudio.GetYearAndEditionRootPath(environment, "2022", edition).Combine("MSBuild/Current/Bin");
+                if (fileSystem.Exist(binPath))
                 {
-                    // Get the bin path.
-                    var binPath = visualStudio2022Path.Combine(string.Concat("Microsoft Visual Studio/2022/", edition, "/MSBuild/Current/Bin"));
-                    if (fileSystem.Exist(binPath))
+                    if (buildPlatform == MSBuildPlatform.Automatic)
                     {
-                        if (buildPlatform == MSBuildPlatform.Automatic)
-                        {
-                            if (environment.Platform.Is64Bit)
-                            {
-                                binPath = binPath.Combine("amd64");
-                            }
-                        }
-
-                        if (buildPlatform == MSBuildPlatform.x64)
+                        if (environment.Platform.Is64Bit)
                         {
                             binPath = binPath.Combine("amd64");
                         }
-
-                        return binPath;
                     }
+
+                    if (buildPlatform == MSBuildPlatform.x64)
+                    {
+                        binPath = binPath.Combine("amd64");
+                    }
+
+                    return binPath;
                 }
             }
 
-            return visualStudio2022Paths[0].Combine("Microsoft Visual Studio/2022/Professional/MSBuild/Current/Bin");
+            return VisualStudio.GetYearAndEditionRootPath(environment, "2022", "Professional").Combine("MSBuild/Current/Bin");
         }
 
         private static DirectoryPath GetFrameworkPath(ICakeEnvironment environment, MSBuildPlatform buildPlatform, string version)

--- a/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
@@ -351,7 +351,7 @@ namespace Cake.Common.Tools.MSBuild
                 }
             }
 
-            var path = MSBuildResolver.GetMSBuildPath(_fileSystem, _environment, settings.ToolVersion, buildPlatform, settings.CustomVersion);
+            var path = MSBuildResolver.GetMSBuildPath(_fileSystem, _environment, buildPlatform, settings);
             if (path != null)
             {
                 return new[] { path };

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
@@ -253,6 +253,12 @@ namespace Cake.Common.Tools.MSBuild
         public ISet<string> ConsoleLoggerParameters => _consoleLoggerParameters;
 
         /// <summary>
+        /// If set to <c>true</c>, MSBuildTools from a Preview installation
+        /// (e.g. Visual Studio 2022 Preview) will be considered to be used.
+        /// </summary>
+        public bool AllowPreviewVersion { get; set; } = false;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="MSBuildSettings"/> class.
         /// </summary>
         public MSBuildSettings()

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
@@ -253,8 +253,11 @@ namespace Cake.Common.Tools.MSBuild
         public ISet<string> ConsoleLoggerParameters => _consoleLoggerParameters;
 
         /// <summary>
-        /// If set to <c>true</c>, MSBuildTools from a Preview installation
+        /// Gets or sets a value indicating whether tools from a preview edition of Visual Studio should be used.
+        /// <para>
+        /// If set to <c>true</c>, MSBuildTools from a Preview edition
         /// (e.g. Visual Studio 2022 Preview) will be considered to be used.
+        /// </para>
         /// </summary>
         public bool AllowPreviewVersion { get; set; } = false;
 

--- a/src/Cake.Common/Tools/MSTest/MSTestRunner.cs
+++ b/src/Cake.Common/Tools/MSTest/MSTestRunner.cs
@@ -114,12 +114,31 @@ namespace Cake.Common.Tools.MSTest
         /// <returns>The default tool path.</returns>
         protected override IEnumerable<FilePath> GetAlternativeToolPaths(MSTestSettings settings)
         {
-            foreach (var yearAndEdition in new[] { "2019/Enterprise", "2019/Professional", "2019/Community", "2017/Enterprise", "2017/Professional", "2017/Community" })
+            foreach (var year in new[] { "2022", "2019", "2017" })
             {
-                var path = GetYearAndEditionToolPath(yearAndEdition);
-                if (_fileSystem.Exist(path))
+                var editions = new List<string>(
+                    new[]
+                    {
+                        "Enterprise",
+                        "Professional",
+                        "Community",
+                        "BuildTools",
+                    });
+
+                if (settings.AllowPreviewVersion)
                 {
-                    yield return path;
+                    editions.Insert(0, "Preview");
+                }
+
+                foreach (var edition in editions)
+                {
+                    var yearAndEdition = $"{year}/{edition}";
+
+                    var path = GetYearAndEditionToolPath(yearAndEdition);
+                    if (_fileSystem.Exist(path))
+                    {
+                        yield return path;
+                    }
                 }
             }
 

--- a/src/Cake.Common/Tools/MSTest/MSTestRunner.cs
+++ b/src/Cake.Common/Tools/MSTest/MSTestRunner.cs
@@ -114,27 +114,14 @@ namespace Cake.Common.Tools.MSTest
         /// <returns>The default tool path.</returns>
         protected override IEnumerable<FilePath> GetAlternativeToolPaths(MSTestSettings settings)
         {
-            foreach (var year in new[] { "2022", "2019", "2017" })
+            var vsRootRelativeToolPath = FilePath.FromString("Common7/IDE/mstest.exe");
+            foreach (var year in VisualStudio.Versions.TwentySeventeenAndLater)
             {
-                var editions = new List<string>(
-                    new[]
-                    {
-                        "Enterprise",
-                        "Professional",
-                        "Community",
-                        "BuildTools",
-                    });
-
-                if (settings.AllowPreviewVersion)
+                foreach (var edition in settings.AllowPreviewVersion
+                             ? VisualStudio.Editions.All
+                             : VisualStudio.Editions.Stable)
                 {
-                    editions.Insert(0, "Preview");
-                }
-
-                foreach (var edition in editions)
-                {
-                    var yearAndEdition = $"{year}/{edition}";
-
-                    var path = GetYearAndEditionToolPath(yearAndEdition);
+                    var path = VisualStudio.GetYearAndEditionToolPath(_environment, year, edition, vsRootRelativeToolPath);
                     if (_fileSystem.Exist(path))
                     {
                         yield return path;
@@ -142,9 +129,9 @@ namespace Cake.Common.Tools.MSTest
                 }
             }
 
-            foreach (var version in new[] { "14.0", "12.0", "11.0", "10.0" })
+            foreach (var version in VisualStudio.Versions.TenToFourteen)
             {
-                var path = GetVersionNumberToolPath(version);
+                var path = VisualStudio.GetVersionNumberToolPath(_environment, version, vsRootRelativeToolPath);
                 if (_fileSystem.Exist(path))
                 {
                     yield return path;
@@ -159,20 +146,6 @@ namespace Cake.Common.Tools.MSTest
                     yield return path;
                 }
             }
-        }
-
-        private FilePath GetVersionNumberToolPath(string version)
-        {
-            var programFiles = _environment.GetSpecialPath(SpecialPath.ProgramFilesX86);
-            var root = programFiles.Combine(string.Concat("Microsoft Visual Studio ", version, "/Common7/IDE"));
-            return root.CombineWithFilePath("mstest.exe");
-        }
-
-        private FilePath GetYearAndEditionToolPath(string yearAndEdition)
-        {
-            var programFiles = _environment.GetSpecialPath(SpecialPath.ProgramFilesX86);
-            var root = programFiles.Combine(string.Concat("Microsoft Visual Studio/", yearAndEdition, "/Common7/IDE"));
-            return root.CombineWithFilePath("mstest.exe");
         }
 
         private FilePath GetCommonToolPath(string environmentVariable)

--- a/src/Cake.Common/Tools/MSTest/MSTestSettings.cs
+++ b/src/Cake.Common/Tools/MSTest/MSTestSettings.cs
@@ -48,8 +48,11 @@ namespace Cake.Common.Tools.MSTest
         }
 
         /// <summary>
-        /// If set to <c>true</c>, MSBuildTools from a Preview installation
+        /// Gets or sets a value indicating whether tools from a preview edition of Visual Studio should be used.
+        /// <para>
+        /// If set to <c>true</c>, MSTest from a Preview edition
         /// (e.g. Visual Studio 2022 Preview) will be considered to be used.
+        /// </para>
         /// </summary>
         public bool AllowPreviewVersion { get; set; } = false;
     }

--- a/src/Cake.Common/Tools/MSTest/MSTestSettings.cs
+++ b/src/Cake.Common/Tools/MSTest/MSTestSettings.cs
@@ -46,5 +46,11 @@ namespace Cake.Common.Tools.MSTest
         {
             NoIsolation = true;
         }
+
+        /// <summary>
+        /// If set to <c>true</c>, MSBuildTools from a Preview installation
+        /// (e.g. Visual Studio 2022 Preview) will be considered to be used.
+        /// </summary>
+        public bool AllowPreviewVersion { get; set; } = false;
     }
 }

--- a/src/Cake.Common/Tools/VSTest/VSTestRunner.cs
+++ b/src/Cake.Common/Tools/VSTest/VSTestRunner.cs
@@ -152,27 +152,14 @@ namespace Cake.Common.Tools.VSTest
         /// <returns>The default tool path.</returns>
         protected override IEnumerable<FilePath> GetAlternativeToolPaths(VSTestSettings settings)
         {
-            foreach (var year in new[] { "2022", "2019", "2017" })
+            var vsRootRelativeToolPath = FilePath.FromString($"Common7/IDE/CommonExtensions/Microsoft/TestWindow/{VSTestConsoleExecutableName}");
+            foreach (var year in VisualStudio.Versions.TwentySeventeenAndLater)
             {
-                var editions = new List<string>(
-                    new[]
-                    {
-                        "Enterprise",
-                        "Professional",
-                        "Community",
-                        "BuildTools",
-                    });
-
-                if (settings.AllowPreviewVersion)
+                foreach (var edition in settings.AllowPreviewVersion
+                             ? VisualStudio.Editions.All
+                             : VisualStudio.Editions.Stable)
                 {
-                    editions.Insert(0, "Preview");
-                }
-
-                foreach (var edition in editions)
-                {
-                    var yearAndEdition = $"{year}/{edition}";
-
-                    var path = GetYearAndEditionToolPath(yearAndEdition);
+                    var path = VisualStudio.GetYearAndEditionToolPath(_environment, year, edition, vsRootRelativeToolPath);
                     if (_fileSystem.Exist(path))
                     {
                         yield return path;
@@ -180,28 +167,14 @@ namespace Cake.Common.Tools.VSTest
                 }
             }
 
-            foreach (var version in new[] { "15.0", "14.0", "12.0", "11.0" })
+            foreach (var version in VisualStudio.Versions.TenToFourteen)
             {
-                var path = GetVersionNumberToolPath(version);
+                var path = VisualStudio.GetVersionNumberToolPath(_environment, version, vsRootRelativeToolPath);
                 if (_fileSystem.Exist(path))
                 {
                     yield return path;
                 }
             }
-        }
-
-        private FilePath GetYearAndEditionToolPath(string yearAndEdition)
-        {
-            var programFiles = _environment.GetSpecialPath(SpecialPath.ProgramFilesX86);
-            var root = programFiles.Combine(string.Concat("Microsoft Visual Studio/", yearAndEdition, "/Common7/IDE/CommonExtensions/Microsoft/TestWindow"));
-            return root.CombineWithFilePath(VSTestConsoleExecutableName);
-        }
-
-        private FilePath GetVersionNumberToolPath(string version)
-        {
-            var programFiles = _environment.GetSpecialPath(SpecialPath.ProgramFilesX86);
-            var root = programFiles.Combine(string.Concat("Microsoft Visual Studio ", version, "/Common7/IDE/CommonExtensions/Microsoft/TestWindow"));
-            return root.CombineWithFilePath(VSTestConsoleExecutableName);
         }
     }
 }

--- a/src/Cake.Common/Tools/VSTest/VSTestRunner.cs
+++ b/src/Cake.Common/Tools/VSTest/VSTestRunner.cs
@@ -152,12 +152,31 @@ namespace Cake.Common.Tools.VSTest
         /// <returns>The default tool path.</returns>
         protected override IEnumerable<FilePath> GetAlternativeToolPaths(VSTestSettings settings)
         {
-            foreach (var yearAndEdition in new[] { "2019/Enterprise", "2019/Professional", "2019/Community", "2017/Enterprise", "2017/Professional", "2017/Community" })
+            foreach (var year in new[] { "2022", "2019", "2017" })
             {
-                var path = GetYearAndEditionToolPath(yearAndEdition);
-                if (_fileSystem.Exist(path))
+                var editions = new List<string>(
+                    new[]
+                    {
+                        "Enterprise",
+                        "Professional",
+                        "Community",
+                        "BuildTools",
+                    });
+
+                if (settings.AllowPreviewVersion)
                 {
-                    yield return path;
+                    editions.Insert(0, "Preview");
+                }
+
+                foreach (var edition in editions)
+                {
+                    var yearAndEdition = $"{year}/{edition}";
+
+                    var path = GetYearAndEditionToolPath(yearAndEdition);
+                    if (_fileSystem.Exist(path))
+                    {
+                        yield return path;
+                    }
                 }
             }
 

--- a/src/Cake.Common/Tools/VSTest/VSTestSettings.cs
+++ b/src/Cake.Common/Tools/VSTest/VSTestSettings.cs
@@ -88,5 +88,11 @@ namespace Cake.Common.Tools.VSTest
         /// - any custom value: the name of your custom logger.
         /// </summary>
         public string Logger { get; set; }
+
+        /// <summary>
+        /// If set to <c>true</c>, MSBuildTools from a Preview installation
+        /// (e.g. Visual Studio 2022 Preview) will be considered to be used.
+        /// </summary>
+        public bool AllowPreviewVersion { get; set; } = false;
     }
 }

--- a/src/Cake.Common/Tools/VSTest/VSTestSettings.cs
+++ b/src/Cake.Common/Tools/VSTest/VSTestSettings.cs
@@ -90,8 +90,11 @@ namespace Cake.Common.Tools.VSTest
         public string Logger { get; set; }
 
         /// <summary>
-        /// If set to <c>true</c>, MSBuildTools from a Preview installation
+        /// Gets or sets a value indicating whether tools from a preview edition of Visual Studio should be used.
+        /// <para>
+        /// If set to <c>true</c>, VSTest from a Preview edition
         /// (e.g. Visual Studio 2022 Preview) will be considered to be used.
+        /// </para>
         /// </summary>
         public bool AllowPreviewVersion { get; set; } = false;
     }

--- a/src/Cake.Common/Tools/VisualStudio.cs
+++ b/src/Cake.Common/Tools/VisualStudio.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools
+{
+    internal static class VisualStudio
+    {
+        internal static class Versions
+        {
+            internal static ICollection<string> TenToFourteen { get; } = new[] { "14.0", "12.0", "11.0", "10.0" };
+
+            internal static ICollection<string> TwentySeventeenAndLater { get; } = new[]
+            {
+                "2022",
+                "2019",
+                "2017"
+            };
+        }
+
+        internal static class Editions
+        {
+            internal static ICollection<string> Preview { get; } = new[]
+            {
+                "Preview"
+            };
+
+            internal static ICollection<string> Stable { get; } = new[]
+            {
+                "Enterprise",
+                "Professional",
+                "Community",
+                "BuildTools"
+            };
+
+            internal static ICollection<string> All { get; } = Preview
+                .Concat(Stable)
+                .ToArray();
+        }
+
+        internal static FilePath GetYearAndEditionToolPath(ICakeEnvironment environment, string year, string edition, FilePath relativeFile)
+        {
+            var root = GetYearAndEditionRootPath(environment, year, edition);
+            return root.CombineWithFilePath(relativeFile);
+        }
+
+        internal static DirectoryPath GetYearAndEditionRootPath(ICakeEnvironment environment, string year, string edition)
+        {
+            var programFiles = year == "2017" || year == "2019"
+                ? environment.GetSpecialPath(SpecialPath.ProgramFilesX86)
+                : environment.GetSpecialPath(SpecialPath.ProgramFiles);
+            return programFiles.Combine($"Microsoft Visual Studio/{year}/{edition}");
+        }
+
+        internal static FilePath GetVersionNumberToolPath(ICakeEnvironment environment, string version, FilePath relativeFile)
+        {
+            var root = GetVersionNumberRootPath(environment, version);
+            return root.CombineWithFilePath(relativeFile);
+        }
+
+        internal static DirectoryPath GetVersionNumberRootPath(ICakeEnvironment environment, string version)
+        {
+            var programFiles = environment.GetSpecialPath(SpecialPath.ProgramFilesX86);
+            return programFiles.Combine($"Microsoft Visual Studio {version}");
+        }
+    }
+}


### PR DESCRIPTION
This also synchronized the behavior between `MSTest`, `VSTest` and `MSBuild`:
* All are now searching in the VS 2022 installation
* All are now searching the *BuildTools* edition
* All have a setting `AllowPreviewVersion` that, if set to `true` enables searching the *Preview* edition.

fixes #3772 
