### PR TITLE
(#3794) fix detection of VS2022 BuildTools

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -175,8 +175,8 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             }
 
             [Theory]
-            [InlineData(MSBuildToolVersion.VS2022, PlatformTarget.x64, PlatformFamily.Windows, false, "/Program/Microsoft Visual Studio/2022/BuildTools/MSBuild/Current/Bin/amd64/MSBuild.exe")]
-            [InlineData(MSBuildToolVersion.VS2022, PlatformTarget.x86, PlatformFamily.Windows, false, "/Program/Microsoft Visual Studio/2022/BuildTools/MSBuild/Current/Bin/MSBuild.exe")]
+            [InlineData(MSBuildToolVersion.VS2022, PlatformTarget.x64, PlatformFamily.Windows, false, "/Program86/Microsoft Visual Studio/2022/BuildTools/MSBuild/Current/Bin/amd64/MSBuild.exe")]
+            [InlineData(MSBuildToolVersion.VS2022, PlatformTarget.x86, PlatformFamily.Windows, false, "/Program86/Microsoft Visual Studio/2022/BuildTools/MSBuild/Current/Bin/MSBuild.exe")]
             public void Should_Get_Correct_Path_To_MSBuild_Version_17_When_Only_Build_Tools_Are_Installed(MSBuildToolVersion version, PlatformTarget target, PlatformFamily family, bool is64BitOperativeSystem, string expected)
             {
                 // Given
@@ -186,8 +186,8 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
 
                 fixture.GivenDefaultToolDoNotExist();
                 fixture.GivenMSBuildIsNotInstalled();
-                fixture.FileSystem.CreateFile("/Program/Microsoft Visual Studio/2022/BuildTools/MSBuild/Current/Bin/amd64/MSBuild.exe");
-                fixture.FileSystem.CreateFile("/Program/Microsoft Visual Studio/2022/BuildTools/MSBuild/Current/Bin/MSBuild.exe");
+                fixture.FileSystem.CreateFile("/Program86/Microsoft Visual Studio/2022/BuildTools/MSBuild/Current/Bin/amd64/MSBuild.exe");
+                fixture.FileSystem.CreateFile("/Program86/Microsoft Visual Studio/2022/BuildTools/MSBuild/Current/Bin/MSBuild.exe");
 
                 // When
                 var result = fixture.Run();

--- a/src/Cake.Common.Tests/Unit/Tools/VSTest/VSTestRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/VSTest/VSTestRunnerTests.cs
@@ -105,7 +105,7 @@ namespace Cake.Common.Tests.Unit.Tools.VSTest
         [InlineData("/ProgramFiles/Microsoft Visual Studio/2022/Enterprise/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
         [InlineData("/ProgramFiles/Microsoft Visual Studio/2022/Professional/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
         [InlineData("/ProgramFiles/Microsoft Visual Studio/2022/Community/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
-        [InlineData("/ProgramFiles/Microsoft Visual Studio/2022/BuildTools/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
+        [InlineData("/ProgramFilesX86/Microsoft Visual Studio/2022/BuildTools/Common7/IDE/CommonExtensions/Microsoft/TestWindow/vstest.console.exe")]
         public void Should_Use_Available_Tool_Path(string existingToolPath)
         {
             // Given

--- a/src/Cake.Common/Tools/VisualStudio.cs
+++ b/src/Cake.Common/Tools/VisualStudio.cs
@@ -47,9 +47,13 @@ namespace Cake.Common.Tools
 
         internal static DirectoryPath GetYearAndEditionRootPath(ICakeEnvironment environment, string year, string edition)
         {
-            var programFiles = year == "2017" || year == "2019"
-                ? environment.GetSpecialPath(SpecialPath.ProgramFilesX86)
-                : environment.GetSpecialPath(SpecialPath.ProgramFiles);
+            var programFiles = (year, edition) switch
+            {
+                ("2022", "BuildTools") => environment.GetSpecialPath(SpecialPath.ProgramFilesX86),
+                ("2022", _) => environment.GetSpecialPath(SpecialPath.ProgramFiles),
+                (_, _) => environment.GetSpecialPath(SpecialPath.ProgramFilesX86),
+            };
+
             return programFiles.Combine($"Microsoft Visual Studio/{year}/{edition}");
         }
 


### PR DESCRIPTION
Contrary to all other VS2022 editions, VS2022 *BuildTools* is installed under `ProgramFiles (x86)`.

fixes #3794 