### PR TITLE
GH3819: Update GitReleaseManager comment template to remove Cake NuGet package and Chocolatey portable

### DIFF
--- a/GitReleaseManager.yaml
+++ b/GitReleaseManager.yaml
@@ -22,8 +22,6 @@ close:
     The release is available on:
 
     - [GitHub Release](https://github.com/{owner}/{repository}/releases/tag/{milestone})
-    - [NuGet Package](https://www.nuget.org/packages/Cake/{milestone})
-    - [Chocolatey Package](https://chocolatey.org/packages/cake.portable/{milestone})
-    - [.Net Global Tool](https://www.nuget.org/packages/Cake.Tool/{milestone})
-    
+    - [.NET Tool](https://www.nuget.org/packages/Cake.Tool/{milestone})
+
     Your **[GitReleaseManager](https://github.com/GitTools/GitReleaseManager)** bot :package::rocket:


### PR DESCRIPTION
Closes https://github.com/cake-build/cake/issues/3819

ps: Frosting was never included in the automated comments, but can take the opportunity to also include it if some of you think it's a good idea.
