### PR TITLE
Add entireProcessTree parameter to Process.Kill and Process.WaitForExit methods

### DIFF
--- a/src/Cake.Common/Tools/DotCover/DotCoverProcessRunner.cs
+++ b/src/Cake.Common/Tools/DotCover/DotCoverProcessRunner.cs
@@ -24,7 +24,7 @@ namespace Cake.Common.Tools.DotCover
             {
             }
 
-            public bool WaitForExit(int milliseconds , bool entireProcessTree = false)
+            public bool WaitForExit(int milliseconds, bool entireProcessTree = false)
             {
                 return true;
             }

--- a/src/Cake.Common/Tools/DotCover/DotCoverProcessRunner.cs
+++ b/src/Cake.Common/Tools/DotCover/DotCoverProcessRunner.cs
@@ -24,7 +24,7 @@ namespace Cake.Common.Tools.DotCover
             {
             }
 
-            public bool WaitForExit(int milliseconds)
+            public bool WaitForExit(int milliseconds , bool entireProcessTree = false)
             {
                 return true;
             }
@@ -44,7 +44,7 @@ namespace Cake.Common.Tools.DotCover
                 return Enumerable.Empty<string>();
             }
 
-            public void Kill()
+            public void Kill(bool entireProcessTree = false)
             {
             }
         }

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverProcessRunner.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverProcessRunner.cs
@@ -24,7 +24,7 @@ namespace Cake.Common.Tools.OpenCover
             {
             }
 
-            public bool WaitForExit(int milliseconds)
+            public bool WaitForExit(int milliseconds , bool entireProcessTree = false)
             {
                 return true;
             }
@@ -44,7 +44,7 @@ namespace Cake.Common.Tools.OpenCover
                 return Enumerable.Empty<string>();
             }
 
-            public void Kill()
+            public void Kill(bool entireProcessTree = false)
             {
             }
         }

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverProcessRunner.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverProcessRunner.cs
@@ -24,7 +24,7 @@ namespace Cake.Common.Tools.OpenCover
             {
             }
 
-            public bool WaitForExit(int milliseconds , bool entireProcessTree = false)
+            public bool WaitForExit(int milliseconds, bool entireProcessTree = false)
             {
                 return true;
             }

--- a/src/Cake.Common/Tools/SpecFlow/SpecFlowProcessRunner.cs
+++ b/src/Cake.Common/Tools/SpecFlow/SpecFlowProcessRunner.cs
@@ -24,7 +24,7 @@ namespace Cake.Common.Tools.SpecFlow
             {
             }
 
-            public bool WaitForExit(int milliseconds)
+            public bool WaitForExit(int milliseconds, bool entireProcessTree = false)
             {
                 return true;
             }
@@ -44,7 +44,7 @@ namespace Cake.Common.Tools.SpecFlow
                 return Enumerable.Empty<string>();
             }
 
-            public void Kill()
+            public void Kill(bool entireProcessTree = false)
             {
             }
         }

--- a/src/Cake.Core/IO/IProcess.cs
+++ b/src/Cake.Core/IO/IProcess.cs
@@ -21,8 +21,9 @@ namespace Cake.Core.IO
         /// Waits for the process to exit with possible timeout for command.
         /// </summary>
         /// <param name="milliseconds">The amount of time, in milliseconds, to wait for the associated process to exit. The maximum is the largest possible value of a 32-bit integer, which represents infinity to the operating system.</param>
+        /// <param name="entireProcessTree">true to kill the associated process and its descendants; false to kill only the associated process.</param>
         /// <returns>true if the associated process has exited; otherwise, false.</returns>
-        bool WaitForExit(int milliseconds);
+        bool WaitForExit(int milliseconds, bool entireProcessTree = false);
 
         /// <summary>
         /// Gets the exit code of the process.
@@ -45,6 +46,7 @@ namespace Cake.Core.IO
         /// <summary>
         /// Immediately stops the associated process.
         /// </summary>
-        void Kill();
+        /// <param name="entireProcessTree">true to kill the associated process and its descendants; false to kill only the associated process.</param>
+        void Kill(bool entireProcessTree = false);
     }
 }

--- a/src/Cake.Core/IO/ProcessWrapper.cs
+++ b/src/Cake.Core/IO/ProcessWrapper.cs
@@ -106,7 +106,7 @@ namespace Cake.Core.IO
             }
         }
 
-        public void Kill(bool entireProcessTree=false)
+        public void Kill(bool entireProcessTree = false)
         {
             _process.Kill(entireProcessTree);
             _process.WaitForExit();

--- a/src/Cake.Core/IO/ProcessWrapper.cs
+++ b/src/Cake.Core/IO/ProcessWrapper.cs
@@ -39,7 +39,7 @@ namespace Cake.Core.IO
             _process.WaitForExit();
         }
 
-        public bool WaitForExit(int milliseconds, bool entireProcessTree=false)
+        public bool WaitForExit(int milliseconds, bool entireProcessTree = false)
         {
             if (_process.WaitForExit(milliseconds))
             {

--- a/src/Cake.Core/IO/ProcessWrapper.cs
+++ b/src/Cake.Core/IO/ProcessWrapper.cs
@@ -39,7 +39,7 @@ namespace Cake.Core.IO
             _process.WaitForExit();
         }
 
-        public bool WaitForExit(int milliseconds)
+        public bool WaitForExit(int milliseconds, bool entireProcessTree=false)
         {
             if (_process.WaitForExit(milliseconds))
             {
@@ -48,7 +48,7 @@ namespace Cake.Core.IO
             _process.Refresh();
             if (!_process.HasExited)
             {
-                _process.Kill();
+                _process.Kill(entireProcessTree);
             }
             return false;
         }
@@ -106,9 +106,9 @@ namespace Cake.Core.IO
             }
         }
 
-        public void Kill()
+        public void Kill(bool entireProcessTree=false)
         {
-            _process.Kill();
+            _process.Kill(entireProcessTree);
             _process.WaitForExit();
         }
 

--- a/src/Cake.Testing/FakeProcess.cs
+++ b/src/Cake.Testing/FakeProcess.cs
@@ -29,7 +29,7 @@ namespace Cake.Testing
         }
 
         /// <inheritdoc/>
-        public bool WaitForExit(int milliseconds)
+        public bool WaitForExit(int milliseconds ,bool entireProcessTree = false)
         {
             return true;
         }
@@ -53,7 +53,7 @@ namespace Cake.Testing
         }
 
         /// <inheritdoc/>
-        public void Kill()
+        public void Kill(bool entireProcessTree = false)
         {
         }
 

--- a/src/Cake.Testing/FakeProcess.cs
+++ b/src/Cake.Testing/FakeProcess.cs
@@ -29,7 +29,7 @@ namespace Cake.Testing
         }
 
         /// <inheritdoc/>
-        public bool WaitForExit(int milliseconds ,bool entireProcessTree = false)
+        public bool WaitForExit(int milliseconds, bool entireProcessTree = false)
         {
             return true;
         }


### PR DESCRIPTION

I Use Process tools for start npm scripts 
but in some scenario i need to kill process and subprocess 
but process not kill sub process 
i want add entireProcessTree prameter to kill process and wait for exit  