### PR TITLE
GH3854: Update Spectre.Console to 0.44.0

### DIFF
--- a/src/Cake.Cli/Cake.Cli.csproj
+++ b/src/Cake.Cli/Cake.Cli.csproj
@@ -19,6 +19,6 @@
 
     <ItemGroup>
       <PackageReference Include="Autofac" Version="6.3.0" />
-      <PackageReference Include="Spectre.Console" Version="0.43.0" />
+      <PackageReference Include="Spectre.Console" Version="0.44.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* fixes #3854
