### PR TITLE
Add alias for dotnet workload uninstall command

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/DotNet/Workload/Uninstall/DotNetWorkloadUninstallerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/DotNet/Workload/Uninstall/DotNetWorkloadUninstallerFixture.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Cake.Common.Tools.DotNet.Workload.Uninstall;
+
+namespace Cake.Common.Tests.Fixtures.Tools.DotNet.Workload.Uninstall
+{
+    internal sealed class DotNetWorkloadUninstallerFixture : DotNetFixture<DotNetWorkloadUninstallSettings>
+    {
+        public IEnumerable<string> WorkloadIds { get; set; }
+
+        protected override void RunTool()
+        {
+            var tool = new DotNetWorkloadUninstaller(FileSystem, Environment, ProcessRunner, Tools);
+            tool.Uninstall(WorkloadIds);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Workload/Uninstall/DotNetWorkloadUninstallTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Workload/Uninstall/DotNetWorkloadUninstallTests.cs
@@ -1,0 +1,88 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tests.Fixtures.Tools.DotNet.Workload.Uninstall;
+using Cake.Testing;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.DotNet.Workload.Uninstall
+{
+    public sealed class DotNetWorkloadUninstallTests
+    {
+        public sealed class TheWorkloadSearchMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new DotNetWorkloadUninstallerFixture();
+                fixture.WorkloadIds = new string[] { "maui" };
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, ".NET CLI: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new DotNetWorkloadUninstallerFixture();
+                fixture.WorkloadIds = new string[] { "maui" };
+                fixture.GivenProcessExitsWithCode(1);
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
+            }
+
+            [Fact]
+            public void Should_Add_WorkloadIds_Argument()
+            {
+                // Given
+                var fixture = new DotNetWorkloadUninstallerFixture();
+                fixture.WorkloadIds = new string[] { "maui-android", "maui-ios" };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("workload uninstall maui-android maui-ios", result.Args);
+            }
+
+            [Fact]
+            public void Should_Throw_If_WorkloadIds_Is_Empty()
+            {
+                // Given
+                var fixture = new DotNetWorkloadUninstallerFixture();
+                fixture.WorkloadIds = new string[] { };
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "workloadIds");
+            }
+
+            [Fact]
+            public void Should_Throw_If_WorkloadIds_Is_Null()
+            {
+                // Given
+                var fixture = new DotNetWorkloadUninstallerFixture();
+                fixture.WorkloadIds = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "workloadIds");
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
@@ -23,6 +23,7 @@ using Cake.Common.Tools.DotNet.Test;
 using Cake.Common.Tools.DotNet.Tool;
 using Cake.Common.Tools.DotNet.VSTest;
 using Cake.Common.Tools.DotNet.Workload.Search;
+using Cake.Common.Tools.DotNet.Workload.Uninstall;
 using Cake.Common.Tools.DotNetCore.Build;
 using Cake.Common.Tools.DotNetCore.BuildServer;
 using Cake.Common.Tools.DotNetCore.Clean;
@@ -1933,6 +1934,48 @@ namespace Cake.Common.Tools.DotNet
 
             var searcher = new DotNetWorkloadSearcher(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             return searcher.Search(searchString, settings);
+        }
+
+        /// <summary>
+        /// Uninstalls a specified workload.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="workloadId">The workload ID to uninstall.</param>
+        /// <example>
+        /// <code>
+        /// DotNetWorkloadUninstall("maui");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Workload")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Workload.Uninstall")]
+        public static void DotNetWorkloadUninstall(this ICakeContext context, string workloadId)
+        {
+            context.DotNetWorkloadUninstall(new string[] { workloadId });
+        }
+
+        /// <summary>
+        /// Uninstalls one or more workloads.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="workloadIds">The workload ID or multiple IDs to uninstall.</param>
+        /// <example>
+        /// <code>
+        /// DotNetWorkloadUninstall(new string[] { "maui", "maui-desktop", "maui-mobile" });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Workload")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Workload.Uninstall")]
+        public static void DotNetWorkloadUninstall(this ICakeContext context, IEnumerable<string> workloadIds)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var uninstaller = new DotNetWorkloadUninstaller(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            uninstaller.Uninstall(workloadIds);
         }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Workload/Uninstall/DotNetWorkloadUninstallSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Workload/Uninstall/DotNetWorkloadUninstallSettings.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Tools.DotNet.Workload.Uninstall
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetWorkloadUninstaller" />.
+    /// </summary>
+    public sealed class DotNetWorkloadUninstallSettings : DotNetSettings
+    {
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/Workload/Uninstall/DotNetWorkloadUninstaller.cs
+++ b/src/Cake.Common/Tools/DotNet/Workload/Uninstall/DotNetWorkloadUninstaller.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.DotNet.Workload.Uninstall
+{
+    /// <summary>
+    /// .NET workloads uninstaller.
+    /// </summary>
+    public sealed class DotNetWorkloadUninstaller : DotNetTool<DotNetWorkloadUninstallSettings>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotNetWorkloadUninstaller" /> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="tools">The tool locator.</param>
+        public DotNetWorkloadUninstaller(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IToolLocator tools) : base(fileSystem, environment, processRunner, tools)
+        {
+        }
+
+        /// <summary>
+        /// Uninstalls one or more workloads.
+        /// </summary>
+        /// <param name="workloadIds">The workload ID or multiple IDs to uninstall.</param>
+        public void Uninstall(IEnumerable<string> workloadIds)
+        {
+            if (workloadIds == null || !workloadIds.Any())
+            {
+                throw new ArgumentNullException(nameof(workloadIds));
+            }
+
+            var settings = new DotNetWorkloadUninstallSettings();
+            RunCommand(settings, GetArguments(workloadIds, settings));
+        }
+
+        private ProcessArgumentBuilder GetArguments(IEnumerable<string> workloadIds, DotNetWorkloadUninstallSettings settings)
+        {
+            var builder = CreateArgumentBuilder(settings);
+
+            builder.Append("workload uninstall");
+
+            if (workloadIds != null && workloadIds.Any())
+            {
+                builder.Append(string.Join(" ", workloadIds));
+            }
+
+            return builder;
+        }
+    }
+}


### PR DESCRIPTION
Add an alias for `dotnet workload uninstall` command

Fixes #3486

There is nothing to uninstall on the build servers, what integration test I should add here: https://github.com/cake-build/cake/blob/develop/tests/integration/Cake.Common/Tools/DotNetCore/DotNetCoreAliases.cake

- Install any workload in "Cake.Common.Tools.DotNetCore.DotNetCoreAliases.Setup"
- Add "Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetWorkloadInstall" and "Cake.Common.Tools.DotNetCore.DotNetCoreAliases.DotNetWorkloadUninstall" as dependent on the "DotNetWorkloadInstall"
- DotNetWorkloadUninstall("any") with try...catch
- Skip for now

Please review
Thank you in advance