### PR TITLE
(#3858, #3859) Made PathCollapser aware of different formats

### DIFF
--- a/src/Cake.Core.Tests/Unit/IO/DirectoryPathTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/DirectoryPathTests.cs
@@ -359,7 +359,6 @@ namespace Cake.Core.Tests.Unit.IO
                 [InlineData("/C/Data/Work", "/C/Data")]
                 [InlineData("/C/Data/Work/file.txt", "/C/Data/Work")]
                 [InlineData("/folder/foo/..", "/")]
-                [InlineData("/..", ".")] // a bit unexpected, but due to the way "Collapse" works.
                 public void Should_Return_Parent_Directory(string directoryPath, string parentPath)
                 {
                     // Given
@@ -374,6 +373,7 @@ namespace Cake.Core.Tests.Unit.IO
 
                 [NonWindowsTheory]
                 [InlineData("/")]
+                [InlineData("/..")]
                 public void Should_Return_Null_If_No_Parent(string directoryPath)
                 {
                     // Given

--- a/src/Cake.Core.Tests/Unit/IO/PathCollapserTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/PathCollapserTests.cs
@@ -22,103 +22,177 @@ namespace Cake.Core.Tests.Unit.IO
                 AssertEx.IsArgumentNullException(result, "path");
             }
 
-            [Fact]
-            public void Should_Collapse_Relative_Path()
+            public sealed class WithPathsInRelativeFormat
             {
-                // Given, When
-                var path = PathCollapser.Collapse(new DirectoryPath("hello/temp/test/../../world"));
+                [Fact]
+                public void Should_Collapse_Relative_Path()
+                {
+                    // Given, When
+                    var path = PathCollapser.Collapse(new DirectoryPath("hello/temp/test/../../world"));
 
-                // Then
-                Assert.Equal("hello/world", path);
+                    // Then
+                    Assert.Equal("hello/world", path);
+                }
+
+                [Fact]
+                public void Should_Collapse_Path_With_Separated_Ellipsis()
+                {
+                    // Given, When
+                    var path = PathCollapser.Collapse(new DirectoryPath("hello/temp/../temp2/../world"));
+
+                    // Then
+                    Assert.Equal("hello/world", path);
+                }
+
+                [Theory]
+                [InlineData("./foo/..", ".")]
+                [InlineData("foo/..", ".")]
+                public void Should_Collapse_To_Dot_When_Only_One_Folder_Is_Followed_By_Ellipsis(string input,
+                    string expected)
+                {
+                    // Given, When
+                    var path = PathCollapser.Collapse(new DirectoryPath(input));
+
+                    // Then
+                    Assert.Equal(expected, path);
+                }
+
+                [Theory]
+                [InlineData(".")]
+                [InlineData("./")]
+                [InlineData("")]
+                public void Should_Collapse_Single_Dot_To_Single_Dot(string uncollapsedPath)
+                {
+                    // Given, When
+                    var path = PathCollapser.Collapse(new DirectoryPath(uncollapsedPath));
+
+                    // Then
+                    Assert.Equal(".", path);
+                }
+
+                [Fact]
+                public void Should_Collapse_Single_Dot_With_Ellipsis()
+                {
+                    // Given, When
+                    var path = PathCollapser.Collapse(new DirectoryPath("./.."));
+
+                    // Then
+                    Assert.Equal(".", path);
+                }
+
+                [Theory]
+                [InlineData("./a", "a")]
+                [InlineData("a/./b", "a/b")]
+                [InlineData("a/b/.", "a/b")]
+                public void Should_Collapse_Single_Dot(string uncollapsedPath, string collapsedPath)
+                {
+                    // Given, When
+                    var path = PathCollapser.Collapse(new DirectoryPath(uncollapsedPath));
+
+                    // Then
+                    Assert.Equal(collapsedPath, path);
+                }
             }
 
-            [Fact]
-            public void Should_Collapse_Path_With_Separated_Ellipsis()
+            public sealed class WithPathsInUncFormat
             {
-                // Given, When
-                var path = PathCollapser.Collapse(new DirectoryPath("hello/temp/../temp2/../world"));
+                [Theory]
+                [InlineData(@"\\server\share\folder\..", @"\\server\share")]
+                [InlineData(@"\\server\share\folder\..\..\..\..", @"\\server")]
+                [InlineData(@"\\server\share\folder\..\..\..\..\foo", @"\\server\foo")]
+                public void Should_Collapse_Ellipsis(string input,
+                    string expected)
+                {
+                    // Given, When
+                    var path = PathCollapser.Collapse(new DirectoryPath(input));
 
-                // Then
-                Assert.Equal("hello/world", path);
+                    // Then
+                    Assert.Equal(expected, path);
+                }
             }
 
-            [WindowsFact]
-            public void Should_Collapse_Path_With_Windows_Root()
+            public sealed class WithPathsInNonWindowsFormat
             {
-                // Given, When
-                var path = PathCollapser.Collapse(new DirectoryPath("c:/hello/temp/test/../../world"));
+                [Fact]
+                public void Should_Collapse_Path_With_Non_Windows_Root()
+                {
+                    // Given, When
+                    var path = PathCollapser.Collapse(new DirectoryPath("/hello/temp/test/../../world"));
 
-                // Then
-                Assert.Equal("c:/hello/world", path);
+                    // Then
+                    Assert.Equal("/hello/world", path);
+                }
+
+                [NonWindowsFact]
+                public void Should_Stop_Collapsing_When_Root_Is_Reached()
+                {
+                    // Given, When
+                    var path = PathCollapser.Collapse(new DirectoryPath("/hello/../../../../../../temp"));
+
+                    // Then
+                    Assert.Equal("/temp", path);
+                }
+
+                [NonWindowsTheory]
+                [InlineData("/foo/..", "/")]
+                [InlineData("/..", "/")]
+                public void Should_Collapse_To_Root_When_Only_One_Folder_Is_Followed_By_Ellipsis(string input,
+                    string expected)
+                {
+                    // Given, When
+                    var path = PathCollapser.Collapse(new DirectoryPath(input));
+
+                    // Then
+                    Assert.Equal(expected, path);
+                }
+
+                [Theory]
+                [InlineData("/a/./b", "/a/b")]
+                [InlineData("/a/b/.", "/a/b")]
+                [InlineData("/./a/b", "/a/b")]
+                public void Should_Collapse_Single_Dot(string uncollapsedPath, string collapsedPath)
+                {
+                    // Given, When
+                    var path = PathCollapser.Collapse(new DirectoryPath(uncollapsedPath));
+
+                    // Then
+                    Assert.Equal(collapsedPath, path);
+                }
             }
 
-            [Fact]
-            public void Should_Collapse_Path_With_Non_Windows_Root()
+            public sealed class WithPathsInWindowsFormat
             {
-                // Given, When
-                var path = PathCollapser.Collapse(new DirectoryPath("/hello/temp/test/../../world"));
+                [Fact]
+                public void Should_Collapse_Path_With_Windows_Root()
+                {
+                    // Given, When
+                    var path = PathCollapser.Collapse(new DirectoryPath("c:/hello/temp/test/../../world"));
 
-                // Then
-                Assert.Equal("/hello/world", path);
-            }
+                    // Then
+                    Assert.Equal("c:/hello/world", path);
+                }
 
-            [WindowsFact]
-            public void Should_Stop_Collapsing_When_Windows_Root_Is_Reached()
-            {
-                // Given, When
-                var path = PathCollapser.Collapse(new DirectoryPath("c:/../../../../../../temp"));
+                [WindowsFact]
+                public void Should_Stop_Collapsing_When_Windows_Root_Is_Reached()
+                {
+                    // Given, When
+                    var path = PathCollapser.Collapse(new DirectoryPath("c:/../../../../../../temp"));
 
-                // Then
-                Assert.Equal("c:/temp", path);
-            }
+                    // Then
+                    Assert.Equal("c:/temp", path);
+                }
 
-            [Fact]
-            public void Should_Stop_Collapsing_When_Root_Is_Reached()
-            {
-                // Given, When
-                var path = PathCollapser.Collapse(new DirectoryPath("/hello/../../../../../../temp"));
+                [Theory]
+                [InlineData("C:/foo/..", "C:")]
+                public void Should_Collapse_To_Root_When_Only_One_Folder_Is_Followed_By_Ellipsis(string input,
+                    string expected)
+                {
+                    // Given, When
+                    var path = PathCollapser.Collapse(new DirectoryPath(input));
 
-                // Then
-                Assert.Equal("/temp", path);
-            }
-
-            [Theory]
-            [InlineData(".")]
-            [InlineData("./")]
-            [InlineData("/.")]
-            public void Should_Collapse_Single_Dot_To_Single_Dot(string uncollapsedPath)
-            {
-                // Given, When
-                var path = PathCollapser.Collapse(new DirectoryPath(uncollapsedPath));
-
-                // Then
-                Assert.Equal(".", path);
-            }
-
-            [Fact]
-            public void Should_Collapse_Single_Dot_With_Ellipsis()
-            {
-                // Given, When
-                var path = PathCollapser.Collapse(new DirectoryPath("./.."));
-
-                // Then
-                Assert.Equal(".", path);
-            }
-
-            [Theory]
-            [InlineData("./a", "a")]
-            [InlineData("a/./b", "a/b")]
-            [InlineData("/a/./b", "/a/b")]
-            [InlineData("a/b/.", "a/b")]
-            [InlineData("/a/b/.", "/a/b")]
-            [InlineData("/./a/b", "/a/b")]
-            public void Should_Collapse_Single_Dot(string uncollapsedPath, string collapsedPath)
-            {
-                // Given, When
-                var path = PathCollapser.Collapse(new DirectoryPath(uncollapsedPath));
-
-                // Then
-                Assert.Equal(collapsedPath, path);
+                    // Then
+                    Assert.Equal(expected, path);
+                }
             }
         }
     }

--- a/src/Cake.Core/IO/DirectoryPath.cs
+++ b/src/Cake.Core/IO/DirectoryPath.cs
@@ -69,12 +69,6 @@ namespace Cake.Core.IO
                 return null;
             }
 
-            if (IsUNC && collapsed.FullPath.StartsWith("//"))
-            {
-                // workaround for GH-3859
-                collapsed = new DirectoryPath(collapsed.FullPath.Replace("/", "\\"));
-            }
-
             if (collapsed.IsUNC && collapsed.Segments.Length < 4)
             {
                 // UNC is special: \\server\share makes 3 (!) Segments

--- a/src/Cake.Testing.Xunit/NonWindowsFactAttribute.cs
+++ b/src/Cake.Testing.Xunit/NonWindowsFactAttribute.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Core;
+
+namespace Cake.Testing.Xunit
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public sealed class NonWindowsFactAttribute : PlatformRestrictedFactAttribute
+    {
+        public NonWindowsFactAttribute(string reason = null)
+            : base(PlatformFamily.Windows, true, reason)
+        {
+        }
+    }
+}

--- a/src/Cake.Testing.Xunit/PlatformRestrictedFactAttribute.cs
+++ b/src/Cake.Testing.Xunit/PlatformRestrictedFactAttribute.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Core;
+using Cake.Core.Polyfill;
+using Xunit;
+
+namespace Cake.Testing.Xunit
+{
+    public abstract class PlatformRestrictedFactAttribute : FactAttribute
+    {
+        private static readonly PlatformFamily _family;
+        private string _skip;
+
+        static PlatformRestrictedFactAttribute()
+        {
+            _family = EnvironmentHelper.GetPlatformFamily();
+        }
+
+        protected PlatformRestrictedFactAttribute(
+            PlatformFamily requiredFamily,
+            bool invert,
+            string reason = null)
+        {
+            if ((requiredFamily != _family) ^ invert)
+            {
+                if (string.IsNullOrEmpty(reason))
+                {
+                    var platformName = Enum.GetName(typeof(PlatformFamily), requiredFamily);
+                    if (invert)
+                    {
+                        platformName = $"Non-{platformName}";
+                    }
+
+                    reason = $"{platformName} test.";
+                }
+
+                Reason = reason;
+            }
+        }
+
+        private string Reason { get; }
+
+        public override string Skip
+        {
+            get => _skip ?? Reason;
+            set => _skip = value;
+        }
+    }
+}


### PR DESCRIPTION
Especially different calculations of the root of a path
for windows, non-windows and UNC like paths.

To this end, I re-structured the unit test. There were no test
removed that previously existed, but only new tests added.

Also, instead of joining together the path with one specific
separator ('/'), I re-used the existing separator of the original
path. (This was the main-fix for #3859.)

