### PR TITLE
GH3878: Adds support for case sensitive OpenCover filters

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/OpenCover/OpenCoverTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/OpenCover/OpenCoverTests.cs
@@ -145,6 +145,24 @@ namespace Cake.Common.Tests.Unit.Tools.OpenCover
             }
 
             [Fact]
+            public void Should_Append_CaseSensitive_Filters()
+            {
+                // Given
+                var fixture = new OpenCoverFixture();
+                fixture.Settings.Filters.Add("Value");
+                fixture.Settings.Filters.Add("value");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-target:\"/Working/tools/Test.exe\" " +
+                             "-targetargs:\"-argument\" " +
+                             "-filter:\"Value value\" " +
+                             "-register:user -output:\"/Working/result.xml\"", result.Args);
+            }
+
+            [Fact]
             public void Should_Append_Attribute_Filters()
             {
                 // Given

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverSettings.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverSettings.cs
@@ -115,7 +115,7 @@ namespace Cake.Common.Tools.OpenCover
         /// </summary>
         public OpenCoverSettings()
         {
-            _filters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _filters = new HashSet<string>(StringComparer.Ordinal);
             _excludedAttributeFilters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             _excludedFileFilters = new HashSet<string>(StringComparer.Ordinal);
             Register = new OpenCoverRegisterOptionUser();


### PR DESCRIPTION
Currently, if you try to apply multiple (case-sensitive) filters (with same-ish values) in your cake script like this:

```cake
var coverageInclusionFilters = new List<string>
{
   "+[ModuleName*]*",
   "+[moduleName*]*"
};

var openCoverSettings = new OpenCoverSettings();
//rest of the code omitted for clarity

for(var inclusionFilter in coverageInclusionFilters)
{
   openCoverSettings.WithFilter(inclusionFilter);
}
```
It produces this kind of a filter argument value:
```ps
-filter:"+[ModuleName*]*" 
```
containing only the first one from the coverageInclusionFilters list from the code above.

As per https://github.com/opencover/opencover/wiki/Usage#understanding-filters
OpenCover filters are case-sensitive. 

This change enables you to apply those kind of filter values.
