### PR TITLE
Add null check in InfoFeature

### DIFF
--- a/src/Cake.Cli/Features/InfoFeature.cs
+++ b/src/Cake.Cli/Features/InfoFeature.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Cake.Core;
+using System;
 
 namespace Cake.Cli
 {
@@ -37,6 +38,11 @@ namespace Cake.Cli
         /// <inheritdoc/>
         public void Run(IConsole console)
         {
+            if (console is null)
+            {
+                throw new ArgumentNullException(nameof(console));
+            }
+
             var version = _resolver.GetVersion();
             var product = _resolver.GetProductVersion();
 

--- a/src/Cake.Cli/Features/InfoFeature.cs
+++ b/src/Cake.Cli/Features/InfoFeature.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Core;
 using System;
+using Cake.Core;
 
 namespace Cake.Cli
 {

--- a/src/Cake.Tests/Unit/Features/InfoFeatureTests.cs
+++ b/src/Cake.Tests/Unit/Features/InfoFeatureTests.cs
@@ -22,5 +22,21 @@ namespace Cake.Tests.Unit.Features
             Assert.Contains("Version: 1.2.3", console.Messages);
             Assert.Contains("Details: 3.2.1", console.Messages);
         }
+
+
+        [Fact]
+        public void Should_Throw_If_Console_Is_Null()
+        {
+            // Given
+            var resolver = new FakeVersionResolver("1.2.3", "3.2.1");
+            var feature = new InfoFeature(resolver);
+
+            // When
+            var result = Record.Exception(() =>
+                     feature.Run(null));
+
+            // Then
+            AssertEx.IsArgumentNullException(result, "console");
+        }
     }
 }

--- a/src/Cake.Tests/Unit/Features/InfoFeatureTests.cs
+++ b/src/Cake.Tests/Unit/Features/InfoFeatureTests.cs
@@ -23,7 +23,6 @@ namespace Cake.Tests.Unit.Features
             Assert.Contains("Details: 3.2.1", console.Messages);
         }
 
-
         [Fact]
         public void Should_Throw_If_Console_Is_Null()
         {

--- a/src/Cake.Tests/Unit/Features/VersionFeatureTests.cs
+++ b/src/Cake.Tests/Unit/Features/VersionFeatureTests.cs
@@ -21,5 +21,20 @@ namespace Cake.Tests.Unit.Features
             // Then
             Assert.Contains("1.2.3", console.Messages);
         }
+
+        [Fact]
+        public void Should_Throw_If_Console_Is_Null()
+        {
+            // Given
+            var resolver = new FakeVersionResolver("1.2.3", "3.2.1");
+            var feature = new VersionFeature(resolver);
+
+            // When
+            var result = Record.Exception(() =>
+                     feature.Run(null));
+
+            // Then
+            AssertEx.IsArgumentNullException(result, "console");
+        }
     }
 }


### PR DESCRIPTION
Just noticed that one of the features had a null check but no tests associated. And that there was another feature that did not have that null check so added that with an associated check.

Closes #3894