### PR TITLE
GH1852: Incorrect escaping of semicolon in property values for msbuild

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNetCore/MSBuild/DotNetCoreMSBuildBuilderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNetCore/MSBuild/DotNetCoreMSBuildBuilderTests.cs
@@ -185,7 +185,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNetCore.MSBuild
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("msbuild /property:A=B /property:A=E /property:C=D", result.Args);
+                Assert.Equal("msbuild /property:A=B;E /property:C=D", result.Args);
             }
 
             [Theory]

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -820,7 +820,39 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/v:normal /p:A=B /p:A=E /p:C=D /target:Build " +
+                Assert.Equal("/v:normal /p:A=B;E /p:C=D /target:Build " +
+                             "\"C:/Working/src/Solution.sln\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Concatenate_Property_With_Multiple_Arguments_To_Process_Argument()
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows);
+                fixture.Settings.WithProperty("A", "B", "E");
+                fixture.Settings.WithProperty("C", "D", "F", "G");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/v:normal /p:A=B;E /p:C=D;F;G /target:Build " +
+                             "\"C:/Working/src/Solution.sln\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Escape_Semicolons_For_Specified_Property_Arguments_When_Appending_To_Process_Argument()
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows);
+                fixture.Settings.WithProperty("DefineConstants", "A;B");
+                fixture.Settings.WithProperty("A", "A;B");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/v:normal /p:DefineConstants=A;B /p:A=A%3BB /target:Build " +
                              "\"C:/Working/src/Solution.sln\"", result.Args);
             }
 

--- a/src/Cake.Common/Tools/DotNetCore/MSBuild/MSBuildArgumentBuilderExtensions.cs
+++ b/src/Cake.Common/Tools/DotNetCore/MSBuild/MSBuildArgumentBuilderExtensions.cs
@@ -46,15 +46,7 @@ namespace Cake.Common.Tools.DotNetCore.MSBuild
                     throw new ArgumentException("A property must have at least one non-empty value", nameof(settings.Properties));
                 }
 
-                foreach (var value in property.Value)
-                {
-                    if (string.IsNullOrWhiteSpace(value))
-                    {
-                        continue;
-                    }
-
-                    builder.AppendMSBuildSwitch("property", $"{property.Key}={value.EscapeMSBuildPropertySpecialCharacters()}");
-                }
+                builder.AppendMSBuildSwitch("property", $"{property.Key}={property.BuildMSBuildPropertyParameterString()}");
             }
 
             // Set the maximum number of processors?

--- a/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildRunner.cs
@@ -293,15 +293,11 @@ namespace Cake.Common.Tools.MSBuild
                     throw new ArgumentOutOfRangeException(nameof(platform), platform, "Invalid platform");
             }
         }
-
         private static IEnumerable<string> GetPropertyArguments(IDictionary<string, IList<string>> properties)
         {
-            foreach (var propertyKey in properties.Keys)
+            foreach (var property in properties)
             {
-                foreach (var propertyValue in properties[propertyKey])
-                {
-                    yield return string.Concat("/p:", propertyKey, "=", propertyValue.EscapeMSBuildPropertySpecialCharacters());
-                }
+                yield return string.Concat("/p:", property.Key, "=", property.BuildMSBuildPropertyParameterString());
             }
         }
 


### PR DESCRIPTION
**Changes:**

1.  The arguments of the properties specified in the `_propertiesNotEscapeSemicolons` HashSet will not escape semicolons.

_Example_: `WithProperty("DefineConstants", "A=a;B=b");` will generate `/p:DefineConstants=A=a;B=b`

2.  If more than one property argument is passed to `WithProperty()`, the argument parameters will be concatenated using a semicolon:

_Example_: `WithProperty("C", "A=a", "B=b");` will generate `/p:C=A=a;B=b`

**Current list of properties that will not escape semicolons:**

- `DefineConstants`
- `ExcludeFilesFromDeployment`

**Notes**
If these changes are not quite what you had in mind -- or if there are any other issues, please let me know and I will do my best to amend them.