### PR TITLE
GH2953: Feature addition target initializer msbuildsettings

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -777,12 +777,170 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             }
 
             [Fact]
-            public void Should_Append_Targets_To_Process_Arguments()
+            public void Should_Add_Single_Target_With_AddTarget()
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows);
+                fixture.Settings.WithTarget("A");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/v:normal /target:A " +
+                             "\"C:/Working/src/Solution.sln\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Multiple_Targets_With_AddTarget()
             {
                 // Given
                 var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows);
                 fixture.Settings.WithTarget("A");
                 fixture.Settings.WithTarget("B");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/v:normal /target:A;B " +
+                             "\"C:/Working/src/Solution.sln\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Add_Duplicate_Target_With_AddTarget()
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows);
+                fixture.Settings.WithTarget("A");
+                fixture.Settings.WithTarget("A");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/v:normal /target:A " +
+                             "\"C:/Working/src/Solution.sln\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Single_Target_With_Initializer()
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows)
+                {
+                    Settings = new MSBuildSettings
+                    {
+                        Target = "A",
+                    }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/v:normal /target:A " +
+                             "\"C:/Working/src/Solution.sln\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Remove_Existing_Targets_When_Set_After_Initializer()
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows)
+                {
+                    Settings = new MSBuildSettings
+                    {
+                        Target = "A",
+                    }
+                };
+
+                fixture.Settings.Target = "B";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/v:normal /target:B " +
+                             "\"C:/Working/src/Solution.sln\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Multiple_Targets_With_Initializer()
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows)
+                {
+                    Settings = new MSBuildSettings
+                    {
+                        Target = "A;B",
+                    }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/v:normal /target:A;B " +
+                             "\"C:/Working/src/Solution.sln\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Multiple_Targets_With_Initializer_And_AddTarget()
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows)
+                {
+                    Settings = new MSBuildSettings
+                    {
+                        Target = "A;B",
+                    }
+                };
+
+                fixture.Settings.WithTarget("C");
+                fixture.Settings.WithTarget("D");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/v:normal /target:A;B;C;D " +
+                             "\"C:/Working/src/Solution.sln\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Add_Duplicate_Target_With_Initializer()
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows)
+                {
+                    Settings = new MSBuildSettings
+                    {
+                        Target = "A",
+                    }
+                };
+
+                fixture.Settings.Target = "A";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/v:normal /target:A " +
+                             "\"C:/Working/src/Solution.sln\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Remove_Whitespace_From_Targets_With_Initializer()
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows)
+                {
+                    Settings = new MSBuildSettings
+                    {
+                        Target = " A ; B   ;;",
+                    }
+                };
 
                 // When
                 var result = fixture.Run();

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Cake.Core.Diagnostics;
 using Cake.Core.Tooling;
 
@@ -46,6 +47,32 @@ namespace Cake.Common.Tools.MSBuild
         /// </summary>
         /// <value>The MSBuild platform.</value>
         public MSBuildPlatform MSBuildPlatform { get; set; }
+
+        /// <summary>
+        /// Gets or sets the MSBuild target.
+        /// </summary>
+        /// <value>The MSBuild target.</value>
+        public string Target
+        {
+            get => string.Join(";", Targets);
+            set
+            {
+                Targets.Clear();
+
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    return;
+                }
+
+                foreach (var target in value
+                                            .Split(';')
+                                            .Select(target => target.Trim())
+                                            .Where(target => !string.IsNullOrEmpty(target)))
+                {
+                    Targets.Add(target);
+                }
+            }
+        }
 
         /// <summary>
         /// Gets or sets the tool version.


### PR DESCRIPTION
Regarding the following (incomplete) PR which is now over 6 months old, https://github.com/cake-build/cake/pull/3721, I have rebased @sbwaggoner's original changes on to an up-to-date `develop` branch and made the change recommended by @devlead on 15 December 2021 during the PR review. Several unit tests have also been added to increase the code coverage of this area too.

Regarding the conditional StringSplitOptions approach recommended in the review, I tried implementing it as suggested but given .Net Core 3.1 StringSplitOptions enum doesn't include the StringSplitOptions.TrimEntries option, trimming still needed to be implemented manually in the code for that target framework. So the conditional compile logic didn't end up offering any benefit imho.
