### PR TITLE
Make CakeTaskBuilder ctor public

### DIFF
--- a/src/Cake.Core/CakeTaskBuilder.cs
+++ b/src/Cake.Core/CakeTaskBuilder.cs
@@ -18,7 +18,12 @@ namespace Cake.Core
 
         internal CakeTask Target { get; }
 
-        internal CakeTaskBuilder(CakeTask task)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CakeTaskBuilder"/> class.
+        /// </summary>
+        /// <param name="task">The target task.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="task"/> is null.</exception>
+        public CakeTaskBuilder(CakeTask task)
         {
             Target = task ?? throw new ArgumentNullException(nameof(task));
         }


### PR DESCRIPTION
This small PR changes the constructor of CakeTaskBuilder to public in order to improve the cake extensibility.

Fixes #2591
