### PR TITLE
Make CakeEngineActions public

### DIFF
--- a/src/Cake.Core/CakeEngineActions.cs
+++ b/src/Cake.Core/CakeEngineActions.cs
@@ -7,17 +7,40 @@ using System.Collections.Generic;
 
 namespace Cake.Core
 {
-    internal sealed class CakeEngineActions
+    /// <summary>
+    /// Container for actions required by the engine.
+    /// </summary>
+    public sealed class CakeEngineActions
     {
         private readonly ICakeDataService _data;
         private readonly HashSet<Type> _dataTypes;
         private readonly List<Action> _validations;
 
+        /// <summary>
+        /// Gets all registerd setup actions.
+        /// </summary>
         public List<Action<ISetupContext>> Setups { get; }
+
+        /// <summary>
+        /// Gets all registered teardown actions.
+        /// </summary>
         public List<Action<ITeardownContext>> Teardowns { get; }
+
+        /// <summary>
+        /// Gets the registered task setup action.
+        /// </summary>
         public Action<ITaskSetupContext> TaskSetup { get; private set; }
+
+        /// <summary>
+        /// Gets the registered task teardown action.
+        /// </summary>
         public Action<ITaskTeardownContext> TaskTeardown { get; private set; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CakeEngineActions"/> class.
+        /// </summary>
+        /// <param name="data">The data context.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="data"/> is null.</exception>
         public CakeEngineActions(ICakeDataService data)
         {
             _data = data ?? throw new ArgumentNullException(nameof(data));
@@ -28,11 +51,21 @@ namespace Cake.Core
             Teardowns = new List<Action<ITeardownContext>>();
         }
 
+        /// <summary>
+        /// Register a setup action.
+        /// </summary>
+        /// <param name="action">The setup action.</param>
         public void RegisterSetup(Action<ISetupContext> action)
         {
             Setups.Add(action);
         }
 
+        /// <summary>
+        /// Registers a setup action.
+        /// </summary>
+        /// <typeparam name="TData">Type of the data for the setup action.</typeparam>
+        /// <param name="action">The setup action.</param>
+        /// <exception cref="CakeException"><typeparamref name="TData"/> was already registered.</exception>
         public void RegisterSetup<TData>(Func<ISetupContext, TData> action)
             where TData : class
         {
@@ -50,11 +83,20 @@ namespace Cake.Core
             });
         }
 
+        /// <summary>
+        /// Registers a teardown action.
+        /// </summary>
+        /// <param name="action">The teardown action.</param>
         public void RegisterTeardown(Action<ITeardownContext> action)
         {
             Teardowns.Add(action);
         }
 
+        /// <summary>
+        /// Registers a teardown action.
+        /// </summary>
+        /// <typeparam name="TData">Type of the data for the teardown action.</typeparam>
+        /// <param name="action">The teardown action.</param>
         public void RegisterTeardown<TData>(Action<ITeardownContext, TData> action)
             where TData : class
         {
@@ -65,12 +107,21 @@ namespace Cake.Core
             });
         }
 
+        /// <summary>
+        /// Registers the task setup action.
+        /// </summary>
+        /// <param name="action">The task setup action.</param>
         public void RegisterTaskSetup(Action<ITaskSetupContext> action)
         {
             EnsureNotRegistered(TaskSetup, "Task Setup");
             TaskSetup = action;
         }
 
+        /// <summary>
+        /// Registers the task setup action.
+        /// </summary>
+        /// <typeparam name="TData">Type of the data for the task setup action.</typeparam>
+        /// <param name="action">The task setup action.</param>
         public void RegisterTaskSetup<TData>(Action<ITaskSetupContext, TData> action)
             where TData : class
         {
@@ -82,12 +133,21 @@ namespace Cake.Core
             };
         }
 
+        /// <summary>
+        /// Registers the task teardown action.
+        /// </summary>
+        /// <param name="action">The task teardown action.</param>
         public void RegisterTaskTeardown(Action<ITaskTeardownContext> action)
         {
             EnsureNotRegistered(TaskTeardown, "Task Teardown");
             TaskTeardown = action;
         }
 
+        /// <summary>
+        /// Registers the task teardown action.
+        /// </summary>
+        /// <typeparam name="TData">Type of the data for the task teardown action.</typeparam>
+        /// <param name="action">The task teardown action.</param>
         public void RegisterTaskTeardown<TData>(Action<ITaskTeardownContext, TData> action)
             where TData : class
         {
@@ -99,6 +159,9 @@ namespace Cake.Core
             };
         }
 
+        /// <summary>
+        /// Executed all validations.
+        /// </summary>
         public void Validate()
         {
             foreach (var validation in _validations)


### PR DESCRIPTION
This small PR makes the CakeEngineActions public in order to use it in a custom engine.

Fixes #3956 