### PR TITLE
(build) Set next version to 3.0.0

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-next-version: 2.0.0
+next-version: 3.0.0
 branches:
   master:
     regex: main

--- a/src/Cake.Core/Constants.cs
+++ b/src/Cake.Core/Constants.cs
@@ -11,7 +11,7 @@ namespace Cake.Core
         public const ConsoleColor DefaultConsoleColor = (ConsoleColor)(-1);
 
         public static readonly Version LatestBreakingChange = new Version(0, 26, 0);
-        public static readonly Version LatestPotentialBreakingChange = new Version(2, 0, 0);
+        public static readonly Version LatestPotentialBreakingChange = new Version(3, 0, 0);
 
         public static class Settings
         {


### PR DESCRIPTION
There are upcoming breaking changes in Cake, so we need to start building version 3.0.0, rather than 2.4.0.