### PR TITLE
GH3997: Remove obsolete DotNetTestSettings Logger property

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Test/DotNetTesterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Test/DotNetTesterTests.cs
@@ -132,9 +132,6 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Test
                 fixture.Settings.Settings = "./demo.runsettings";
                 fixture.Settings.Filter = "Priority = 1";
                 fixture.Settings.TestAdapterPath = @"/Working/custom-test-adapter";
-#pragma warning disable CS0618
-                fixture.Settings.Logger = "trx;LogFileName=/Working/logfile.trx";
-#pragma warning restore CS0618
                 fixture.Settings.Loggers = new[] { "html;LogFileName=/Working/logfile.html" };
                 fixture.Settings.DiagnosticFile = "./artifacts/logging/diagnostics.txt";
                 fixture.Settings.ResultsDirectory = "./tests/";
@@ -147,7 +144,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Test
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("test --settings \"/Working/demo.runsettings\" --filter \"Priority = 1\" --test-adapter-path \"/Working/custom-test-adapter\" --logger \"trx;LogFileName=/Working/logfile.trx\" --logger \"html;LogFileName=/Working/logfile.html\" --output \"/Working/artifacts\" --framework dnxcore50 --configuration Release --collect \"XPlat Code Coverage\" --diag \"/Working/artifacts/logging/diagnostics.txt\" --no-build --no-restore --nologo --results-directory \"/Working/tests\" --logger trx;LogFileName=\"/Working/tests/TestResults.xml\" --runtime win-x64 --source \"https://api.nuget.org/v3/index.json\" --blame", result.Args);
+                Assert.Equal("test --settings \"/Working/demo.runsettings\" --filter \"Priority = 1\" --test-adapter-path \"/Working/custom-test-adapter\" --logger \"html;LogFileName=/Working/logfile.html\" --output \"/Working/artifacts\" --framework dnxcore50 --configuration Release --collect \"XPlat Code Coverage\" --diag \"/Working/artifacts/logging/diagnostics.txt\" --no-build --no-restore --nologo --results-directory \"/Working/tests\" --logger trx;LogFileName=\"/Working/tests/TestResults.xml\" --runtime win-x64 --source \"https://api.nuget.org/v3/index.json\" --blame", result.Args);
             }
 
             [Fact]

--- a/src/Cake.Common/Tools/DotNet/Test/DotNetTestSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Test/DotNetTestSettings.cs
@@ -32,12 +32,6 @@ namespace Cake.Common.Tools.DotNet.Test
         public DirectoryPath TestAdapterPath { get; set; }
 
         /// <summary>
-        /// Gets or sets a logger for test results.
-        /// </summary>
-        [Obsolete("Please use Loggers instead.")]
-        public string Logger { get; set; }
-
-        /// <summary>
         /// Gets or sets the loggers for test results.
         /// </summary>
         public ICollection<string> Loggers { get; set; } = new List<string>();

--- a/src/Cake.Common/Tools/DotNet/Test/DotNetTester.cs
+++ b/src/Cake.Common/Tools/DotNet/Test/DotNetTester.cs
@@ -81,15 +81,6 @@ namespace Cake.Common.Tools.DotNet.Test
                 builder.AppendQuoted(settings.TestAdapterPath.MakeAbsolute(_environment).FullPath);
             }
 
-            // Logger
-#pragma warning disable CS0618
-            if (!string.IsNullOrWhiteSpace(settings.Logger))
-            {
-                builder.Append("--logger");
-                builder.AppendQuoted(settings.Logger);
-            }
-#pragma warning restore CS0618
-
             // Loggers
             if (settings.Loggers != null)
             {


### PR DESCRIPTION
* fixes #3997