### PR TITLE
GH4006: Add missing GitVersion CLI options

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/GitVersion/GitVersionRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/GitVersion/GitVersionRunnerTests.cs
@@ -86,18 +86,35 @@ namespace Cake.Common.Tests.Unit.Tools.GitVersion
                 Assert.Equal("/Working", result.Process.WorkingDirectory.FullPath);
             }
 
-            [Fact]
-            public void Should_Add_OutputType_To_Arguments_If_Set()
+            [Theory]
+            [InlineData(GitVersionOutput.Json, "-output json")]
+            [InlineData(GitVersionOutput.File, "-output file")]
+            public void Should_Add_OutputType_To_Arguments_If_Set(GitVersionOutput outputType, string args)
             {
                 // Given
                 var fixture = new GitVersionRunnerFixture();
-                fixture.Settings.OutputType = GitVersionOutput.Json;
+                fixture.Settings.OutputType = outputType;
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("-output json", result.Args);
+                Assert.Equal(args, result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_OutputFile_If_Set_With_OutputType_File()
+            {
+                // Given
+                var fixture = new GitVersionRunnerFixture();
+                fixture.Settings.OutputType = GitVersionOutput.File;
+                fixture.Settings.OutputFile = "GitVersion.json";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-output file -outputfile \"GitVersion.json\"", result.Args);
             }
 
             [Fact]
@@ -159,6 +176,20 @@ namespace Cake.Common.Tests.Unit.Tools.GitVersion
             }
 
             [Fact]
+            public void Should_Add_ConfigFile_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new GitVersionRunnerFixture();
+                fixture.Settings.ConfigFile = "c:/temp/gitversion.yml";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("-config \"c:/temp/gitversion.yml\"", result.Args);
+            }
+
+            [Fact]
             public void Should_Add_RepositoryPath_To_Arguments_If_Set()
             {
                 // Given
@@ -211,6 +242,102 @@ namespace Cake.Common.Tests.Unit.Tools.GitVersion
                 // Given
                 var fixture = new GitVersionRunnerFixture();
                 fixture.Settings.NoFetch = nofetch;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(args, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "-nocache")]
+            [InlineData(false, "")]
+            public void Should_Add_NoCache_To_Arguments_If_Set(bool nocache, string args)
+            {
+                // Given
+                var fixture = new GitVersionRunnerFixture();
+                fixture.Settings.NoCache = nocache;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(args, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "-nonormalize")]
+            [InlineData(false, "")]
+            public void Should_Add_NoNormalize_To_Arguments_If_Set(bool nonormalize, string args)
+            {
+                // Given
+                var fixture = new GitVersionRunnerFixture();
+                fixture.Settings.NoNormalize = nonormalize;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(args, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "-diag")]
+            [InlineData(false, "")]
+            public void Should_Add_Diag_To_Arguments_If_Set(bool diag, string args)
+            {
+                // Given
+                var fixture = new GitVersionRunnerFixture();
+                fixture.Settings.Diag = diag;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(args, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "-updateprojectfiles")]
+            [InlineData(false, "")]
+            public void Should_Add_UpdateProjectFiles_To_Arguments_If_Set(bool updateProjectFiles, string args)
+            {
+                // Given
+                var fixture = new GitVersionRunnerFixture();
+                fixture.Settings.UpdateProjectFiles = updateProjectFiles;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(args, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "-ensureassemblyinfo")]
+            [InlineData(false, "")]
+            public void Should_Add_EnsureAssemblyInfo_To_Arguments_If_Set(bool ensureAssemblyInfo, string args)
+            {
+                // Given
+                var fixture = new GitVersionRunnerFixture();
+                fixture.Settings.EnsureAssemblyInfo = ensureAssemblyInfo;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(args, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "-updatewixversionfile")]
+            [InlineData(false, "")]
+            public void Should_Add_UpdateWixVersionFile_To_Arguments_If_Set(bool updateWixVersionFile, string args)
+            {
+                // Given
+                var fixture = new GitVersionRunnerFixture();
+                fixture.Settings.UpdateWixVersionFile = updateWixVersionFile;
 
                 // When
                 var result = fixture.Run();

--- a/src/Cake.Common/Tools/GitVersion/GitVersionOutput.cs
+++ b/src/Cake.Common/Tools/GitVersion/GitVersionOutput.cs
@@ -17,6 +17,11 @@ namespace Cake.Common.Tools.GitVersion
         /// <summary>
         /// Outputs to the stdout in a way usable by a detected build server.
         /// </summary>
-        BuildServer
+        BuildServer,
+
+        /// <summary>
+        /// Outputs to a file, as specified in the OutputFile parameter.
+        /// </summary>
+        File
     }
 }

--- a/src/Cake.Common/Tools/GitVersion/GitVersionRunner.cs
+++ b/src/Cake.Common/Tools/GitVersion/GitVersionRunner.cs
@@ -88,15 +88,25 @@ namespace Cake.Common.Tools.GitVersion
 
             if (settings.OutputType.HasValue)
             {
+                builder.Append("-output");
+
                 switch (settings.OutputType.Value)
                 {
                     case GitVersionOutput.Json:
-                        builder.Append("-output");
                         builder.Append("json");
                         break;
                     case GitVersionOutput.BuildServer:
-                        builder.Append("-output");
                         builder.Append("buildserver");
+                        break;
+                    case GitVersionOutput.File:
+                        builder.Append("file");
+
+                        if (settings.OutputFile != null)
+                        {
+                            builder.Append("-outputfile");
+                            builder.AppendQuoted(settings.OutputFile.FullPath);
+                        }
+
                         break;
                 }
             }
@@ -165,9 +175,45 @@ namespace Cake.Common.Tools.GitVersion
                 builder.AppendQuoted(settings.LogFilePath.FullPath);
             }
 
+            if (settings.ConfigFile != null)
+            {
+                builder.Append("-config");
+                builder.AppendQuoted(settings.ConfigFile.FullPath);
+            }
+
             if (settings.NoFetch)
             {
                 builder.Append("-nofetch");
+            }
+
+            if (settings.NoCache)
+            {
+                builder.Append("-nocache");
+            }
+
+            if (settings.NoNormalize)
+            {
+                builder.Append("-nonormalize");
+            }
+
+            if (settings.Diag)
+            {
+                builder.Append("-diag");
+            }
+
+            if (settings.UpdateProjectFiles)
+            {
+                builder.Append("-updateprojectfiles");
+            }
+
+            if (settings.EnsureAssemblyInfo)
+            {
+                builder.Append("-ensureassemblyinfo");
+            }
+
+            if (settings.UpdateWixVersionFile)
+            {
+                builder.Append("-updatewixversionfile");
             }
 
             if (settings.Verbosity.HasValue)

--- a/src/Cake.Common/Tools/GitVersion/GitVersionSettings.cs
+++ b/src/Cake.Common/Tools/GitVersion/GitVersionSettings.cs
@@ -23,6 +23,17 @@ namespace Cake.Common.Tools.GitVersion
         public GitVersionOutput? OutputType { get; set; }
 
         /// <summary>
+        /// Gets or sets the path to a file to store the asserted GitVersion numbers in JSON format.
+        /// </summary>
+        public FilePath OutputFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to config file.
+        /// </summary>
+        /// <remarks>Defaults to GitVersion.yml.</remarks>
+        public FilePath ConfigFile { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to update all the AssemblyInfo files.
         /// </summary>
         public bool UpdateAssemblyInfo { get; set; }
@@ -31,6 +42,23 @@ namespace Cake.Common.Tools.GitVersion
         /// Gets or sets whether to update all the AssemblyInfo files.
         /// </summary>
         public FilePath UpdateAssemblyInfoFilePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to recursively search for all project files (.csproj/.vbproj/.fsproj) files in the git repo and update them.
+        /// </summary>
+        /// <remarks>This is only compatible with the newer Sdk projects.</remarks>
+        public bool UpdateProjectFiles { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether if the assembly info file specified with /updateassemblyinfo or /updateassemblyinfofilename is not found, it be created with these attributes: AssemblyFileVersion, AssemblyVersion and AssemblyInformationalVersion.
+        /// </summary>
+        /// <remarks>Supports writing version info for: C#, F#, VB.</remarks>
+        public bool EnsureAssemblyInfo { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether all the GitVersion variables are written to 'GitVersion_WixVersion.wxi'. The variables can then be referenced in other WiX project files for versioning.
+        /// </summary>
+        public bool UpdateWixVersionFile { get; set; }
 
         /// <summary>
         /// Gets or sets whether to only show a specific variable.
@@ -67,6 +95,22 @@ namespace Cake.Common.Tools.GitVersion
         /// </summary>
         /// <remarks>If your CI server clones the entire repository you can set this to 'true' to prevent GitVersion attempting any remote repository fetching.</remarks>
         public bool NoFetch { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to bypass the cached GitVersion result. Result will not be written to the cache.
+        /// </summary>
+        public bool NoCache { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to disable normalize step on a build server.
+        /// </summary>
+        public bool NoNormalize { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run GitVersion with additional diagnostic information.
+        /// </summary>
+        /// <remarks>Requires git.exe to be installed.</remarks>
+        public bool Diag { get; set; }
 
         /// <summary>
         /// Gets or sets the dynamic repository path. Defaults to %TEMP%.


### PR DESCRIPTION
Since the initial implementation in Cake, there are a number of new command line options for GitVersion. While it is possible to set these using ArgumentCustomization, these should be supported directly within the Cake settings class.

Fixes #4006 