### PR TITLE
GH3124: Add missing asserted GitVersion info

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/GitVersion/GitVersionRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/GitVersion/GitVersionRunnerTests.cs
@@ -270,7 +270,9 @@ namespace Cake.Common.Tests.Unit.Tools.GitVersion
                         PreReleaseTag = "PreReleaseTag",
                         PreReleaseTagWithDash = "PreReleaseTagWithDash",
                         PreReleaseLabel = "PreReleaseLabel",
+                        PreReleaseLabelWithDash = "-PreReleaseLabel",
                         PreReleaseNumber = null,
+                        WeightedPreReleaseNumber = null,
                         BuildMetaData = "BuildMetaData",
                         BuildMetaDataPadded = "BuildMetaDataPadded",
                         FullBuildMetaData = "Branch.master.Sha.f2467748c78b3c8b37972ad0b30df2e15dfbf2cb",
@@ -283,12 +285,17 @@ namespace Cake.Common.Tests.Unit.Tools.GitVersion
                         FullSemVer = "0.1.1",
                         InformationalVersion = "0.1.1+Branch.master.Sha.f2467748c78b3c8b37972ad0b30df2e15dfbf2cb",
                         BranchName = "master",
+                        EscapedBranchName = "master",
                         Sha = "f2467748c78b3c8b37972ad0b30df2e15dfbf2cb",
                         ShortSha = "f2467748",
                         NuGetVersionV2 = "0.1.1",
                         NuGetVersion = "0.1.1",
+                        NuGetPreReleaseTagV2 = "tag",
+                        NuGetPreReleaseTag = "tag",
+                        VersionSourceSha = "f2467748c78b3c8b37972ad0b30df2e15dfbf2cb",
                         CommitsSinceVersionSource = null,
                         CommitsSinceVersionSourcePadded = "0002",
+                        UncommittedChanges = 0,
                         CommitDate = "2017-09-13",
                     }
                     ;
@@ -302,7 +309,9 @@ namespace Cake.Common.Tests.Unit.Tools.GitVersion
                         "  \"PreReleaseTag\":\"PreReleaseTag\",",
                         "  \"PreReleaseTagWithDash\":\"PreReleaseTagWithDash\",",
                         "  \"PreReleaseLabel\":\"PreReleaseLabel\",",
+                        "  \"PreReleaseLabelWithDash\":\"-PreReleaseLabel\",",
                         "  \"PreReleaseNumber\":\"\",",
+                        "  \"WeightedPreReleaseNumber\":\"\",",
                         "  \"BuildMetaData\":\"BuildMetaData\",",
                         "  \"BuildMetaDataPadded\":\"BuildMetaDataPadded\",",
                         "  \"FullBuildMetaData\":\"Branch.master.Sha.f2467748c78b3c8b37972ad0b30df2e15dfbf2cb\",",
@@ -315,12 +324,17 @@ namespace Cake.Common.Tests.Unit.Tools.GitVersion
                         "  \"FullSemVer\":\"0.1.1\",",
                         "  \"InformationalVersion\":\"0.1.1+Branch.master.Sha.f2467748c78b3c8b37972ad0b30df2e15dfbf2cb\",",
                         "  \"BranchName\":\"master\",",
+                        "  \"EscapedBranchName\":\"master\",",
                         "  \"Sha\":\"f2467748c78b3c8b37972ad0b30df2e15dfbf2cb\",",
                         "  \"ShortSha\":\"f2467748\",",
                         "  \"NuGetVersionV2\":\"0.1.1\",",
                         "  \"NuGetVersion\":\"0.1.1\",",
+                        "  \"NuGetPreReleaseTagV2\":\"tag\",",
+                        "  \"NuGetPreReleaseTag\":\"tag\",",
+                        "  \"VersionSourceSha\":\"f2467748c78b3c8b37972ad0b30df2e15dfbf2cb\",",
                         "  \"CommitsSinceVersionSource\":\"\",",
                         "  \"CommitsSinceVersionSourcePadded\":\"0002\",",
+                        "  \"UncommittedChanges\":\"0\",",
                         "  \"CommitDate\":\"2017-09-13\"",
                         "}"
                     });
@@ -336,7 +350,9 @@ namespace Cake.Common.Tests.Unit.Tools.GitVersion
                 Assert.Equal(expect.PreReleaseTag, result.PreReleaseTag);
                 Assert.Equal(expect.PreReleaseTagWithDash, result.PreReleaseTagWithDash);
                 Assert.Equal(expect.PreReleaseLabel, result.PreReleaseLabel);
+                Assert.Equal(expect.PreReleaseLabelWithDash, result.PreReleaseLabelWithDash);
                 Assert.Equal(expect.PreReleaseNumber, result.PreReleaseNumber);
+                Assert.Equal(expect.WeightedPreReleaseNumber, result.WeightedPreReleaseNumber);
                 Assert.Equal(expect.BuildMetaData, result.BuildMetaData);
                 Assert.Equal(expect.BuildMetaDataPadded, result.BuildMetaDataPadded);
                 Assert.Equal(expect.FullBuildMetaData, result.FullBuildMetaData);
@@ -349,12 +365,17 @@ namespace Cake.Common.Tests.Unit.Tools.GitVersion
                 Assert.Equal(expect.FullSemVer, result.FullSemVer);
                 Assert.Equal(expect.InformationalVersion, result.InformationalVersion);
                 Assert.Equal(expect.BranchName, result.BranchName);
+                Assert.Equal(expect.EscapedBranchName, result.EscapedBranchName);
                 Assert.Equal(expect.Sha, result.Sha);
                 Assert.Equal(expect.ShortSha, result.ShortSha);
                 Assert.Equal(expect.NuGetVersionV2, result.NuGetVersionV2);
                 Assert.Equal(expect.NuGetVersion, result.NuGetVersion);
+                Assert.Equal(expect.NuGetPreReleaseTagV2, result.NuGetPreReleaseTagV2);
+                Assert.Equal(expect.NuGetPreReleaseTag, result.NuGetPreReleaseTag);
+                Assert.Equal(expect.VersionSourceSha, result.VersionSourceSha);
                 Assert.Equal(expect.CommitsSinceVersionSource, result.CommitsSinceVersionSource);
                 Assert.Equal(expect.CommitsSinceVersionSourcePadded, result.CommitsSinceVersionSourcePadded);
+                Assert.Equal(expect.UncommittedChanges, result.UncommittedChanges);
                 Assert.Equal(expect.CommitDate, result.CommitDate);
             }
 

--- a/src/Cake.Common/Tools/GitVersion/GitVersion.cs
+++ b/src/Cake.Common/Tools/GitVersion/GitVersion.cs
@@ -40,9 +40,19 @@ namespace Cake.Common.Tools.GitVersion
         public string PreReleaseLabel { get; set; }
 
         /// <summary>
+        /// Gets or sets the pre-release label with dash.
+        /// </summary>
+        public string PreReleaseLabelWithDash { get; set; }
+
+        /// <summary>
         /// Gets or sets the pre-release number.
         /// </summary>
         public int? PreReleaseNumber { get; set; }
+
+        /// <summary>
+        /// Gets or sets the weighted pre-release number.
+        /// </summary>
+        public int? WeightedPreReleaseNumber { get; set; }
 
         /// <summary>
         /// Gets or sets the build metadata.
@@ -105,6 +115,11 @@ namespace Cake.Common.Tools.GitVersion
         public string BranchName { get; set; }
 
         /// <summary>
+        /// Gets or sets the escaped branch name.
+        /// </summary>
+        public string EscapedBranchName { get; set; }
+
+        /// <summary>
         /// Gets or sets the Git SHA.
         /// </summary>
         public string Sha { get; set; }
@@ -125,6 +140,21 @@ namespace Cake.Common.Tools.GitVersion
         public string NuGetVersion { get; set; }
 
         /// <summary>
+        /// Gets or sets the NuGet pre-release tag for v2.
+        /// </summary>
+        public string NuGetPreReleaseTagV2 { get; set; }
+
+        /// <summary>
+        /// Gets or sets the NuGet pre-release tag.
+        /// </summary>
+        public string NuGetPreReleaseTag { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version source sha.
+        /// </summary>
+        public string VersionSourceSha { get; set; }
+
+        /// <summary>
         /// Gets or sets the commits since version source.
         /// </summary>
         public int? CommitsSinceVersionSource { get; set; }
@@ -133,6 +163,11 @@ namespace Cake.Common.Tools.GitVersion
         /// Gets or sets the commits since version source padded.
         /// </summary>
         public string CommitsSinceVersionSourcePadded { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of uncommited changes.
+        /// </summary>
+        public int? UncommittedChanges { get; set; }
 
         /// <summary>
         /// Gets or sets the commit date.

--- a/src/Cake.Common/Tools/GitVersion/GitVersionInternal.cs
+++ b/src/Cake.Common/Tools/GitVersion/GitVersionInternal.cs
@@ -57,10 +57,24 @@ namespace Cake.Common.Tools.GitVersion
         }
 
         [DataMember]
+        public string PreReleaseLabelWithDash
+        {
+            get => GitVersion.PreReleaseLabelWithDash;
+            set => GitVersion.PreReleaseLabelWithDash = value;
+        }
+
+        [DataMember]
         public string PreReleaseNumber
         {
             get => ToString(GitVersion.PreReleaseNumber);
             set => GitVersion.PreReleaseNumber = ToNullableInt(value);
+        }
+
+        [DataMember]
+        public string WeightedPreReleaseNumber
+        {
+            get => ToString(GitVersion.WeightedPreReleaseNumber);
+            set => GitVersion.WeightedPreReleaseNumber = ToNullableInt(value);
         }
 
         [DataMember]
@@ -148,6 +162,13 @@ namespace Cake.Common.Tools.GitVersion
         }
 
         [DataMember]
+        public string EscapedBranchName
+        {
+            get => GitVersion.EscapedBranchName;
+            set => GitVersion.EscapedBranchName = value;
+        }
+
+        [DataMember]
         public string Sha
         {
             get => GitVersion.Sha;
@@ -176,6 +197,27 @@ namespace Cake.Common.Tools.GitVersion
         }
 
         [DataMember]
+        public string NuGetPreReleaseTagV2
+        {
+            get => GitVersion.NuGetPreReleaseTagV2;
+            set => GitVersion.NuGetPreReleaseTagV2 = value;
+        }
+
+        [DataMember]
+        public string NuGetPreReleaseTag
+        {
+            get => GitVersion.NuGetPreReleaseTag;
+            set => GitVersion.NuGetPreReleaseTag = value;
+        }
+
+        [DataMember]
+        public string VersionSourceSha
+        {
+            get => GitVersion.VersionSourceSha;
+            set => GitVersion.VersionSourceSha = value;
+        }
+
+        [DataMember]
         public string CommitsSinceVersionSource
         {
             get => ToString(GitVersion.CommitsSinceVersionSource);
@@ -187,6 +229,13 @@ namespace Cake.Common.Tools.GitVersion
         {
             get => GitVersion.CommitsSinceVersionSourcePadded;
             set => GitVersion.CommitsSinceVersionSourcePadded = value;
+        }
+
+        [DataMember]
+        public string UncommittedChanges
+        {
+            get => ToString(GitVersion.UncommittedChanges);
+            set => GitVersion.UncommittedChanges = ToNullableInt(value);
         }
 
         [DataMember]


### PR DESCRIPTION
Newer versions of GitVersion include a number of additional asserted pieces of information, including EscapedBranchName. All of the missing information has now been included in the GitVersion classes.

Fixes #3124 