### PR TITLE
GH4011: Add SetStepSummary method to GH Provider

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Build/GitHubActionsCommandsFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/GitHubActionsCommandsFixture.cs
@@ -140,6 +140,12 @@ namespace Cake.Common.Tests.Fixtures.Build
             return this;
         }
 
+        public GitHubActionsCommandsFixture WithNoGitHubStepSummary()
+        {
+            Environment.GetEnvironmentVariable("GITHUB_STEP_SUMMARY").Returns(null as string);
+            return this;
+        }
+
         public GitHubActionsCommandsFixture WithNoGitHubPath()
         {
             Environment.GetEnvironmentVariable("GITHUB_PATH").Returns(null as string);

--- a/src/Cake.Common.Tests/Fixtures/Build/GitHubActionsInfoFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/GitHubActionsInfoFixture.cs
@@ -57,6 +57,7 @@ namespace Cake.Common.Tests.Fixtures.Build
             Environment.GetEnvironmentVariable("ACTIONS_RUNTIME_URL").Returns(ActionRuntimeUrl);
             Environment.GetEnvironmentVariable("GITHUB_ENV").Returns("/opt/github.env");
             Environment.GetEnvironmentVariable("GITHUB_OUTPUT").Returns("/opt/github.output");
+            Environment.GetEnvironmentVariable("GITHUB_STEP_SUMMARY").Returns("/opt/github.stepsummary");
             Environment.GetEnvironmentVariable("GITHUB_PATH").Returns("/opt/github.path");
             Environment.WorkingDirectory.Returns("/home/runner/work/cake/cake");
         }

--- a/src/Cake.Common.Tests/Unit/Build/GitHubActions/Commands/GitHubActionsCommandsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/GitHubActions/Commands/GitHubActionsCommandsTests.cs
@@ -253,6 +253,56 @@ CAKEEOF
             }
         }
 
+        public sealed class TheSetStepSummaryMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Summary_Is_Null()
+            {
+                // Given
+                var commands = new GitHubActionsCommandsFixture().CreateGitHubActionsCommands();
+
+                // When
+                var result = Record.Exception(() => commands.SetStepSummary(null));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "summary");
+            }
+
+            [Fact]
+            public void Should_Throw_If_StepSummary_Is_Null()
+            {
+                // Given
+                var commands = new GitHubActionsCommandsFixture()
+                                .WithNoGitHubStepSummary()
+                                .CreateGitHubActionsCommands();
+
+                var summary = "summary";
+
+                // When
+                var result = Record.Exception(() => commands.SetStepSummary(summary));
+
+                // Then
+                AssertEx.IsCakeException(result, "GitHub Actions Runtime StepSummary missing.");
+            }
+
+            [Fact]
+            public void Should_SetStepSummary()
+            {
+                // Given
+                var gitHubActionsCommandsFixture = new GitHubActionsCommandsFixture();
+                var commands = gitHubActionsCommandsFixture.CreateGitHubActionsCommands();
+                var summary = "## This is some markdown content :rocket:";
+
+                // When
+                commands.SetStepSummary(summary);
+
+                // Then
+                Assert.Equal(
+                    string.Concat(summary, System.Environment.NewLine).NormalizeLineEndings(),
+                    gitHubActionsCommandsFixture.FileSystem.GetFile("/opt/github.stepsummary").GetTextContent().NormalizeLineEndings());
+            }
+        }
+
         public sealed class TheUploadArtifactMethod
         {
             public sealed class File

--- a/src/Cake.Common/Build/GitHubActions/Commands/GitHubActionsCommands.cs
+++ b/src/Cake.Common/Build/GitHubActions/Commands/GitHubActionsCommands.cs
@@ -134,6 +134,28 @@ namespace Cake.Common.Build.GitHubActions.Commands
         }
 
         /// <summary>
+        /// Creates or updates the step summary for a GitHub workflow.
+        /// </summary>
+        /// <param name="summary">The step summary.</param>
+        public void SetStepSummary(string summary)
+        {
+            if (string.IsNullOrEmpty(summary))
+            {
+                throw new ArgumentNullException(nameof(summary));
+            }
+
+            if (_actionsEnvironment.Runtime.StepSummary == null)
+            {
+                throw new CakeException("GitHub Actions Runtime StepSummary missing.");
+            }
+
+            var file = _fileSystem.GetFile(_actionsEnvironment.Runtime.StepSummary);
+            using var stream = file.Open(FileMode.Append, FileAccess.Write, FileShare.None);
+            using var writer = new StreamWriter(stream);
+            writer.WriteLine(summary);
+        }
+
+        /// <summary>
         /// Upload local file into a file container folder, and create an artifact.
         /// </summary>
         /// <param name="path">Path to the local file.</param>

--- a/src/Cake.Common/Build/GitHubActions/Data/GitHubActionsRuntimeInfo.cs
+++ b/src/Cake.Common/Build/GitHubActions/Data/GitHubActionsRuntimeInfo.cs
@@ -63,6 +63,14 @@ namespace Cake.Common.Build.GitHubActions.Data
         public FilePath OutputPath => GetEnvironmentFilePath("GITHUB_OUTPUT");
 
         /// <summary>
+        /// Gets the path to output file to set the step summary.
+        /// </summary>
+        /// <value>
+        /// The path to output file to set the step summary.
+        /// </value>
+        public FilePath StepSummary => GetEnvironmentFilePath("GITHUB_STEP_SUMMARY");
+
+        /// <summary>
         /// Gets the path to path file to add a path to system path that the following steps in a job can use.
         /// </summary>
         /// <value>

--- a/tests/integration/Cake.Common/Build/GitHubActions/GitHubActionsProvider.cake
+++ b/tests/integration/Cake.Common/Build/GitHubActions/GitHubActionsProvider.cake
@@ -44,6 +44,25 @@ Task("Cake.Common.Build.GitHubActionsProvider.Commands.SetOutputParameter")
         GitHubActions.Commands.SetOutputParameter(key, value);
 });
 
+Task("Cake.Common.Build.GitHubActionsProvider.Commands.SetStepSummary")
+    .Does(() => {
+        // Given
+        string summary = $@"## Identifier
+{Context.Environment.Runtime.BuiltFramework.Identifier}
+
+## Built Framework Version
+{Context.Environment.Runtime.BuiltFramework.Version}
+
+## Cake Version
+{Context.Environment.Runtime.CakeVersion.ToString(3)}
+
+## Runner OS
+{GitHubActions.Environment.Runner.OS}";
+
+        // When
+        GitHubActions.Commands.SetStepSummary(summary);
+});
+
 Task("Cake.Common.Build.GitHubActionsProvider.Commands.UploadArtifact.File")
     .Does<GitHubActionsData>(async data => {
         // When
@@ -108,7 +127,8 @@ if (GitHubActions.IsRunningOnGitHubActions)
         .IsDependentOn("Cake.Common.Build.GitHubActionsProvider.Provider")
         .IsDependentOn("Cake.Common.Build.GitHubActionsProvider.Commands.AddPath")
         .IsDependentOn("Cake.Common.Build.GitHubActionsProvider.Commands.SetEnvironmentVariable")
-        .IsDependentOn("Cake.Common.Build.GitHubActionsProvider.Commands.SetOutputParameter");
+        .IsDependentOn("Cake.Common.Build.GitHubActionsProvider.Commands.SetOutputParameter")
+        .IsDependentOn("Cake.Common.Build.GitHubActionsProvider.Commands.SetStepSummary");
 
 }
 


### PR DESCRIPTION
This commit adds a new SetStepSummary method, which can be used to write markdown content to known location, which will then mean that the summary is shown for the overall workflow.

Fixes #4011 