### PR TITLE
GH3969: Update Spectre.Console to 0.45.0

### DIFF
--- a/src/Cake.Cli/Cake.Cli.csproj
+++ b/src/Cake.Cli/Cake.Cli.csproj
@@ -19,6 +19,7 @@
 
     <ItemGroup>
       <PackageReference Include="Autofac" Version="6.4.0" />
-      <PackageReference Include="Spectre.Console" Version="0.44.0" />
+      <PackageReference Include="Spectre.Console" Version="0.45.0" />
+      <PackageReference Include="Spectre.Console.Cli" Version="0.45.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* fixes #3969
