### PR TITLE
GH4032: Add missing ILMergeSettings

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/ILMerge/ILMergeRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/ILMerge/ILMergeRunnerTests.cs
@@ -180,6 +180,132 @@ namespace Cake.Common.Tests.Unit.Tools.ILMerge
             }
 
             [Fact]
+            public void Should_Add_SearchDirectories_If_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.SearchDirectories = new DirectoryPath[] { "/Working/DirectoryA", "/Working/DirectoryB" };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/lib:\"/Working/DirectoryA\" " +
+                             "/lib:\"/Working/DirectoryB\" " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Log_If_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.Log = true;
+                fixture.Settings.LogFile = null;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/log " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_LogFile_If_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.Log = false;
+                fixture.Settings.LogFile = "/Working/output.log";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/log:\"/Working/output.log\" " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_KeyFile_If_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.KeyFile = "/Working/input.key";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/keyfile:\"/Working/input.key\" " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_KeyFile_And_DelaySign_If_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.KeyFile = "/Working/input.key";
+                fixture.Settings.DelaySign = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/keyfile:\"/Working/input.key\" " +
+                             "/delaysign " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_KeyContainer_If_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.KeyContainer = "myContainer";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/keycontainer:\"myContainer\" " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_KeyContainer_And_DelaySign_If_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.KeyContainer = "myContainer";
+                fixture.Settings.DelaySign = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/keycontainer:\"myContainer\" " +
+                             "/delaysign " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Add_DelaySign_If_KeyFile_Or_KeyContainer_Not_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.DelaySign = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
             public void Should_Internalize_If_Enabled_In_Settings()
             {
                 // Given
@@ -190,14 +316,14 @@ namespace Cake.Common.Tests.Unit.Tools.ILMerge
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/out:\"/Working/output.exe\" " +
-                             "/internalize \"/Working/input.exe\"", result.Args);
+                Assert.Equal("/internalize " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
             }
 
             [Theory]
-            [InlineData(TargetKind.Dll, "/out:\"/Working/output.exe\" /target:\"dll\" \"/Working/input.exe\"")]
-            [InlineData(TargetKind.Exe, "/out:\"/Working/output.exe\" /target:\"exe\" \"/Working/input.exe\"")]
-            [InlineData(TargetKind.WinExe, "/out:\"/Working/output.exe\" /target:\"winexe\" \"/Working/input.exe\"")]
+            [InlineData(TargetKind.Dll, "/target:\"dll\" /out:\"/Working/output.exe\" \"/Working/input.exe\"")]
+            [InlineData(TargetKind.Exe, "/target:\"exe\" /out:\"/Working/output.exe\" \"/Working/input.exe\"")]
+            [InlineData(TargetKind.WinExe, "/target:\"winexe\" /out:\"/Working/output.exe\" \"/Working/input.exe\"")]
             [InlineData(TargetKind.Default, "/out:\"/Working/output.exe\" \"/Working/input.exe\"")]
             public void Should_Set_Target_Kind_If_Enabled_In_Settings(TargetKind kind, string expected)
             {
@@ -213,6 +339,160 @@ namespace Cake.Common.Tests.Unit.Tools.ILMerge
             }
 
             [Fact]
+            public void Should_Add_Closed_If_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.Closed = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/closed " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_NDebug_If_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.NDebug = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/ndebug " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Version_If_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.Version = "1.2.3.4";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/ver:1.2.3.4 " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_CopyAttributes_If_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.CopyAttributes = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/copyattrs " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_CopyAttributes_And_AllowMultiple_If_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.CopyAttributes = true;
+                fixture.Settings.AllowMultiple = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/copyattrs /allowMultiple " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_CopyAttributes_And_KeepFirst_If_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.CopyAttributes = true;
+                fixture.Settings.KeepFirst = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/copyattrs /keepFirst " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_CopyAttributes_And_AllowMultiple_And_KeepFirst_If_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.CopyAttributes = true;
+                fixture.Settings.AllowMultiple = true;
+                fixture.Settings.KeepFirst = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/copyattrs /allowMultiple /keepFirst " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Add_AllowMultiple_And_KeepFirst_If_CopyAttributes_Not_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.AllowMultiple = true;
+                fixture.Settings.KeepFirst = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_XmlDocumentation_If_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.XmlDocumentation = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/xmldocs " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_AttributeFile_If_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.AttributeFile = "/Working/input.attributes";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/attr:\"/Working/input.attributes\" " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
             public void Should_Set_Target_Platform_If_Enabled_In_Settings()
             {
                 // Given
@@ -225,8 +505,8 @@ namespace Cake.Common.Tests.Unit.Tools.ILMerge
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/out:\"/Working/output.exe\" " +
-                             "/targetPlatform:v4,\"/NetFramework\" " +
+                Assert.Equal("/targetPlatform:v4,\"/NetFramework\" " +
+                             "/out:\"/Working/output.exe\" " +
                              "\"/Working/input.exe\"", result.Args);
             }
 
@@ -241,8 +521,8 @@ namespace Cake.Common.Tests.Unit.Tools.ILMerge
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/out:\"/Working/output.exe\" " +
-                             "/targetPlatform:v4 \"/Working/input.exe\"", result.Args);
+                Assert.Equal("/targetPlatform:v4 " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
             }
 
             [Fact]
@@ -257,6 +537,113 @@ namespace Cake.Common.Tests.Unit.Tools.ILMerge
                 // Then
                 Assert.Equal("/out:\"/Working/output.exe\" " +
                              "\"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_UseFullPublicKeyForReferences_If_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.UseFullPublicKeyForReferences = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/useFullPublicKeyForReferences " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_WildCards_If_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.Wildcards = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/wildcards " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_ZeroPeKind_If_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.ZeroPeKind = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/zeroPeKind " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_AllowDuplicates_If_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.AllowDuplicateTypes = true;
+                fixture.Settings.DuplicateTypes = null;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/allowDup " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_DuplicateType_If_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.AllowDuplicateTypes = false;
+                fixture.Settings.DuplicateTypes = new string[] { "typeA", "typeB" };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/allowDup:typeA /allowDup:typeB " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Union_If_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.Union = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/union " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Align_If_Enabled_In_Settings()
+            {
+                // Given
+                var fixture = new ILMergeRunnerFixture();
+                fixture.Settings.Align = 13;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/align:13 " +
+                             "/out:\"/Working/output.exe\" \"/Working/input.exe\"", result.Args);
             }
         }
     }

--- a/src/Cake.Common/Tools/ILMerge/ILMergeSettings.cs
+++ b/src/Cake.Common/Tools/ILMerge/ILMergeSettings.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Core.IO;
 using Cake.Core.Tooling;
 
 namespace Cake.Common.Tools.ILMerge
@@ -32,6 +33,190 @@ namespace Cake.Common.Tools.ILMerge
         /// </summary>
         /// <value>The target platform.</value>
         public TargetPlatform TargetPlatform { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the target assembly will be
+        /// delay signed.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if target assembly will be delay signed; otherwise, <c>false</c>.
+        /// </value>
+        /// <remark>This can be set only in conjunction with the <see cref="KeyFile"/> option.</remark>
+        public bool DelaySign { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the "transitive closure" of the
+        /// input assemblies is computed and added to the list of input assemblies.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the "transitive closure" of the input assemblies is computed
+        /// and added to the list of input assemblies; otherwise, <c>false</c>.
+        /// </value>
+        /// <remark>
+        /// An assembly is considered part of the transitive closure if it is
+        /// referenced, either directly or indirectly, from one of the originally
+        /// specified input assemblies and it has an external reference to one of
+        /// the input assemblies, or one of the assemblies that has such a reference.
+        /// </remark>
+        public bool Closed { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether a .pdb file for the output assembly
+        /// is generated and merges into it any .pdb files found for input assemblies.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if pdb file is generated for output assembly; otherwise, <c>false</c>.
+        /// </value>
+        public bool NDebug { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the assembly level attributes of
+        /// each input assembly are copied over into the target assembly.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the assembly level attributes are copied to target
+        /// assembly; otherwise, <c>false</c>.
+        /// </value>
+        public bool CopyAttributes { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether you want to allow duplicates (for
+        /// those attributes whose type specifies "AllowMultiple" in their definition).
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if duplicates are allowed; otherwise, <c>false</c>.
+        /// </value>
+        /// <remark>This can be set only in conjunction with the <see cref="CopyAttributes"/> option.</remark>
+        public bool AllowMultiple { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the first attribute that is found is kept.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the first attribute that is found is kept; otherwise, <c>false</c>.
+        /// </value>
+        /// <remark>This can be set only in conjunction with the <see cref="CopyAttributes"/> option.</remark>
+        public bool KeepFirst { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether XML documentation files are merged
+        /// to produce an XML documentation file for the target assembly.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if XML documentation files are merged; otherwise, <c>false</c>.
+        /// </value>
+        public bool XmlDocumentation { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether external assembly references
+        /// in the manifest of the target assembly will use full public keys or
+        /// public key tokens.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> when full public keys should be used; otherwise, <c>false</c>.
+        /// </value>
+        public bool UseFullPublicKeyForReferences { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether any wild cards in file names
+        /// are expanded and all matching files will be used as input.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if wildcards in file names are expanded; otherwise, <c>false</c>.
+        /// </value>
+        public bool Wildcards { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether an assembly's PeKind flag (this
+        /// is the value of the field listed as .corflags in the Manifest) is zero
+        /// it will be treated as if it was ILonly.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> when assembly's PeKind flag is zero; otherwise, <c>false</c>.
+        /// </value>
+        public bool ZeroPeKind { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether types with the same name are all
+        /// merged into a single type in the target assembly.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if types with the same name are merged into a single type in
+        /// the target assembly; otherwise, <c>false</c>.
+        /// </value>
+        /// <remark>Cannot be specified at the same time as <see cref="AllowDuplicateTypes"/>.</remark>
+        public bool Union { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that controls the file alignment used for the target assembly.
+        /// </summary>
+        public int? Align { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path and filename to an attribute assembly, an assembly that
+        /// will be used to get all of the assembly-level attributes such as Culture,
+        /// Version, etc.
+        /// </summary>
+        public FilePath AttributeFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version. When this has a non-null value, then the target assembly will be given its
+        /// value as the version number of the assembly.
+        /// </summary>
+        /// <remark>
+        /// The version must be a valid assembly version as defined by the attribute
+        /// AssemblyVersion in the System.Reflection namespace.
+        /// </remark>
+        public string Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether log messages are written.
+        /// </summary>
+        /// <remark>
+        /// If Log is true, but <see cref="LogFile"/> is null, then log messages are written to
+        /// Console.Out.
+        /// </remark>
+        public bool Log { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the file where log messages should be written to.
+        /// </summary>
+        public FilePath LogFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to a .snk file. The target assembly will be signed with
+        /// its contents and will then have a strong name.
+        /// </summary>
+        public FilePath KeyFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the container to use when signing the target assembly.
+        /// </summary>
+        public string KeyContainer { get; set; }
+
+        /// <summary>
+        /// Gets or sets the directories to be used to search for input assemblies.
+        /// </summary>
+        public DirectoryPath[] SearchDirectories { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow the user to allow all
+        /// public types to be renamed when they are duplicates.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if all public types should be allowed to be renamed; otherwise <c>false</c>.
+        /// </value>
+        /// <remark>
+        /// Use <see cref="DuplicateTypes"/> to allow fine grain control over exactly
+        /// which types are allowed to be renamed.
+        /// </remark>
+        public bool AllowDuplicateTypes { get; set; }
+
+        /// <summary>
+        /// Gets or sets a list of public types which are allowed to be renamed when duplicates
+        /// exist.
+        /// </summary>
+        public string[] DuplicateTypes { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ILMergeSettings"/> class.


### PR DESCRIPTION
Using the documentation available here:

https://github.com/dotnet/ILMerge/blob/master/ilmerge-manual.md

added the missing settings that can be set when calling ilmerge.exe

Fixes #4032 