### PR TITLE
GH4044: Adds overload for IsDependeeOf with CakeTaskBuilder

### DIFF
--- a/src/Cake.Core.Tests/Unit/CakeTaskBuilderExtensionsTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeTaskBuilderExtensionsTests.cs
@@ -110,6 +110,23 @@ namespace Cake.Core.Tests.Unit
                 Assert.Single(task.Dependees);
                 Assert.Equal("other", task.Dependees[0].Name);
             }
+
+            [Fact]
+            public void Should_Add_Dependee_To_Task_From_Other()
+            {
+                // Given
+                var task = new CakeTask("task");
+                var other = new CakeTask("other");
+                var builder = new CakeTaskBuilder(task);
+                var otherBuilder = new CakeTaskBuilder(other);
+
+                // When
+                builder.IsDependeeOf(otherBuilder);
+
+                // Then
+                Assert.Single(task.Dependees);
+                Assert.Equal("other", task.Dependees[0].Name);
+            }
         }
 
         public sealed class TheWithCriteriaMethod

--- a/src/Cake.Core/CakeTaskBuilder.Dependencies.cs
+++ b/src/Cake.Core/CakeTaskBuilder.Dependencies.cs
@@ -62,5 +62,26 @@ namespace Cake.Core
             builder.Target.AddDependee(name);
             return builder;
         }
+
+        /// <summary>
+        /// Makes the task a dependency of another task.
+        /// </summary>
+        /// <param name="builder">The task builder.</param>
+        /// <param name="other">The name of the dependent task.</param>
+        /// <returns>The same <see cref="CakeTaskBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static CakeTaskBuilder IsDependeeOf(this CakeTaskBuilder builder, CakeTaskBuilder other)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+            if (other == null)
+            {
+                throw new ArgumentNullException(nameof(other));
+            }
+
+            builder.Target.AddDependee(other.Target.Name);
+            return builder;
+        }
     }
 }


### PR DESCRIPTION
This PR adds a new overload for `IsDependeeOf` that accepts a `CakeTaskBuilder`, same as the overload for `IsDependentOn`

Fixes https://github.com/cake-build/cake/issues/4044
