### PR TITLE
GH4050 GH1146: Overhaul Chocolatey Cake Aliases

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/ApiKey/ChocolateyApiKeySetterFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/ApiKey/ChocolateyApiKeySetterFixture.cs
@@ -8,19 +8,17 @@ namespace Cake.Common.Tests.Fixtures.Tools.Chocolatey.ApiKey
 {
     internal sealed class ChocolateyApiKeySetterFixture : ChocolateyFixture<ChocolateyApiKeySettings>
     {
-        public string ApiKey { get; set; }
         public string Source { get; set; }
 
         public ChocolateyApiKeySetterFixture()
         {
             Source = "source1";
-            ApiKey = "apikey1";
         }
 
         protected override void RunTool()
         {
             var tool = new ChocolateyApiKeySetter(FileSystem, Environment, ProcessRunner, Tools, Resolver);
-            tool.Set(ApiKey, Source, Settings);
+            tool.Set(Source, Settings);
         }
     }
 }

--- a/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/Packer/ChocolateyPackerFixtureResult.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/Chocolatey/Packer/ChocolateyPackerFixtureResult.cs
@@ -25,8 +25,8 @@ namespace Cake.Common.Tests.Fixtures.Tools.Chocolatey.Packer
         {
             var args = process.Arguments.Render();
             var parts = args.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-            var last = parts.Last();
-            var file = fileSystem.GetFile(last.UnQuote());
+            var nuspecFilePath = parts[1];
+            var file = fileSystem.GetFile(nuspecFilePath.UnQuote());
             return file.Exists ? file.GetTextContent() : null;
         }
     }

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/ApiKey/ChocolateyApiKeySetterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/ApiKey/ChocolateyApiKeySetterTests.cs
@@ -143,12 +143,12 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.ApiKey
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("apikey -s \"source1\" -k \"apikey1\" -y", result.Args);
+                Assert.Equal("apikey --source=\"source1\" --confirm", result.Args);
             }
 
             [Theory]
-            [InlineData(true, "apikey -s \"source1\" -k \"apikey1\" -d -y")]
-            [InlineData(false, "apikey -s \"source1\" -k \"apikey1\" -y")]
+            [InlineData(true, "apikey --source=\"source1\" --debug --confirm")]
+            [InlineData(false, "apikey --source=\"source1\" --confirm")]
             public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
             {
                 // Given
@@ -163,8 +163,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.ApiKey
             }
 
             [Theory]
-            [InlineData(true, "apikey -s \"source1\" -k \"apikey1\" -v -y")]
-            [InlineData(false, "apikey -s \"source1\" -k \"apikey1\" -y")]
+            [InlineData(true, "apikey --source=\"source1\" --verbose --confirm")]
+            [InlineData(false, "apikey --source=\"source1\" --confirm")]
             public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
             {
                 // Given
@@ -179,8 +179,56 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.ApiKey
             }
 
             [Theory]
-            [InlineData(true, "apikey -s \"source1\" -k \"apikey1\" -y -f")]
-            [InlineData(false, "apikey -s \"source1\" -k \"apikey1\" -y")]
+            [InlineData(true, "apikey --source=\"source1\" --trace --confirm")]
+            [InlineData(false, "apikey --source=\"source1\" --confirm")]
+            public void Should_Add_Trace_Flag_To_Arguments_If_Set(bool trace, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.Settings.Trace = trace;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "apikey --source=\"source1\" --no-color --confirm")]
+            [InlineData(false, "apikey --source=\"source1\" --confirm")]
+            public void Should_Add_NoColor_Flag_To_Arguments_If_Set(bool noColor, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.Settings.NoColor = noColor;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "apikey --source=\"source1\" --accept-license --confirm")]
+            [InlineData(false, "apikey --source=\"source1\" --confirm")]
+            public void Should_Add_AcceptLicense_Flag_To_Arguments_If_Set(bool acceptLicense, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.Settings.AcceptLicense = acceptLicense;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "apikey --source=\"source1\" --confirm --force")]
+            [InlineData(false, "apikey --source=\"source1\" --confirm")]
             public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
             {
                 // Given
@@ -195,8 +243,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.ApiKey
             }
 
             [Theory]
-            [InlineData(true, "apikey -s \"source1\" -k \"apikey1\" -y --noop")]
-            [InlineData(false, "apikey -s \"source1\" -k \"apikey1\" -y")]
+            [InlineData(true, "apikey --source=\"source1\" --confirm --what-if")]
+            [InlineData(false, "apikey --source=\"source1\" --confirm")]
             public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
             {
                 // Given
@@ -211,8 +259,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.ApiKey
             }
 
             [Theory]
-            [InlineData(true, "apikey -s \"source1\" -k \"apikey1\" -y -r")]
-            [InlineData(false, "apikey -s \"source1\" -k \"apikey1\" -y")]
+            [InlineData(true, "apikey --source=\"source1\" --confirm --limit-output")]
+            [InlineData(false, "apikey --source=\"source1\" --confirm")]
             public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
             {
                 // Given
@@ -227,8 +275,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.ApiKey
             }
 
             [Theory]
-            [InlineData(5, "apikey -s \"source1\" -k \"apikey1\" -y --execution-timeout \"5\"")]
-            [InlineData(0, "apikey -s \"source1\" -k \"apikey1\" -y")]
+            [InlineData(5, "apikey --source=\"source1\" --confirm --execution-timeout=\"5\"")]
+            [InlineData(0, "apikey --source=\"source1\" --confirm")]
             public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
             {
                 // Given
@@ -243,8 +291,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.ApiKey
             }
 
             [Theory]
-            [InlineData(@"c:\temp", "apikey -s \"source1\" -k \"apikey1\" -y -c \"c:\\temp\"")]
-            [InlineData("", "apikey -s \"source1\" -k \"apikey1\" -y")]
+            [InlineData(@"c:\temp", "apikey --source=\"source1\" --confirm --cache-location=\"c:\\temp\"")]
+            [InlineData("", "apikey --source=\"source1\" --confirm")]
             public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
             {
                 // Given
@@ -259,13 +307,205 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.ApiKey
             }
 
             [Theory]
-            [InlineData(true, "apikey -s \"source1\" -k \"apikey1\" -y --allowunofficial")]
-            [InlineData(false, "apikey -s \"source1\" -k \"apikey1\" -y")]
+            [InlineData(true, "apikey --source=\"source1\" --confirm --allow-unofficial")]
+            [InlineData(false, "apikey --source=\"source1\" --confirm")]
             public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
             {
                 // Given
                 var fixture = new ChocolateyApiKeySetterFixture();
                 fixture.Settings.AllowUnofficial = allowUnofficial;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "apikey --source=\"source1\" --confirm --fail-on-error-output")]
+            [InlineData(false, "apikey --source=\"source1\" --confirm")]
+            public void Should_Add_FailOnErrorOutput_Flag_To_Arguments_If_Set(bool failOnErrorOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.Settings.FailOnErrorOutput = failOnErrorOutput;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "apikey --source=\"source1\" --confirm --use-system-powershell")]
+            [InlineData(false, "apikey --source=\"source1\" --confirm")]
+            public void Should_Add_UseSystemPowerShell_Flag_To_Arguments_If_Set(bool useSystemPowerShell, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.Settings.UseSystemPowerShell = useSystemPowerShell;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "apikey --source=\"source1\" --confirm --no-progress")]
+            [InlineData(false, "apikey --source=\"source1\" --confirm")]
+            public void Should_Add_NoProgress_Flag_To_Arguments_If_Set(bool noProgress, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.Settings.NoProgress = noProgress;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy", "apikey --source=\"source1\" --confirm --proxy=\"proxy\"")]
+            [InlineData(null, "apikey --source=\"source1\" --confirm")]
+            public void Should_Add_Proxy_Flag_To_Arguments_If_Set(string proxy, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.Settings.Proxy = proxy;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-user", "apikey --source=\"source1\" --confirm --proxy-user=\"proxy-user\"")]
+            [InlineData(null, "apikey --source=\"source1\" --confirm")]
+            public void Should_Add_ProxyUser_Flag_To_Arguments_If_Set(string proxyUser, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.Settings.ProxyUser = proxyUser;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-password", "apikey --source=\"source1\" --confirm --proxy-password=\"proxy-password\"")]
+            [InlineData(null, "apikey --source=\"source1\" --confirm")]
+            public void Should_Add_ProxyPassword_Flag_To_Arguments_If_Set(string proxyPassword, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.Settings.ProxyPassword = proxyPassword;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy1,proxy2", "apikey --source=\"source1\" --confirm --proxy-bypass-list=\"proxy1,proxy2\"")]
+            [InlineData(null, "apikey --source=\"source1\" --confirm")]
+            public void Should_Add_ProxyByPassList_Flag_To_Arguments_If_Set(string proxyByPassList, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.Settings.ProxyByPassList = proxyByPassList;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "apikey --source=\"source1\" --confirm --proxy-bypass-on-local")]
+            [InlineData(false, "apikey --source=\"source1\" --confirm")]
+            public void Should_Add_ProxyByPassOnLocal_Flag_To_Arguments_If_Set(bool proxyBypassOnLocal, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.Settings.ProxyBypassOnLocal = proxyBypassOnLocal;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./output.log", "apikey --source=\"source1\" --confirm --log-file=\"/Working/output.log\"")]
+            [InlineData(null, "apikey --source=\"source1\" --confirm")]
+            public void Should_Add_Log_File_Flag_To_Arguments_If_Set(string logFilePath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.Settings.LogFile = logFilePath;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "apikey --source=\"source1\" --confirm --skip-compatibility-checks")]
+            [InlineData(false, "apikey --source=\"source1\" --confirm")]
+            public void Should_Add_Skip_Compatibility_Flag_To_Arguments_If_Set(bool skipCompatibiity, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.Settings.SkipCompatibilityChecks = skipCompatibiity;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("key1", "apikey --source=\"source1\" --confirm --api-key=\"key1\"")]
+            [InlineData(null, "apikey --source=\"source1\" --confirm")]
+            public void Should_Add_ApiKey_Flag_To_Arguments_If_Set(string apiKey, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.Settings.ApiKey = apiKey;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "apikey --source=\"source1\" --confirm --remove")]
+            [InlineData(false, "apikey --source=\"source1\" --confirm")]
+            public void Should_Add_Remove_Flag_To_Arguments_If_Set(bool remove, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyApiKeySetterFixture();
+                fixture.Settings.Remove = remove;
 
                 // When
                 var result = fixture.Run();

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Config/ChocolateyConfigSetterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Config/ChocolateyConfigSetterTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Common.Tests.Fixtures.Tools.Chocolatey.ApiKey;
 using Cake.Common.Tests.Fixtures.Tools.Chocolatey.Config;
 using Cake.Testing;
 using Cake.Testing.Xunit;
@@ -125,13 +126,13 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Config
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("config set --name \"cacheLocation\" " +
-                             "--value \"c:\\temp\" -y", result.Args);
+                Assert.Equal("config set --name=\"cacheLocation\" " +
+                             "--value=\"c:\\temp\" --confirm", result.Args);
             }
 
             [Theory]
-            [InlineData(true, "config set --name \"cacheLocation\" --value \"c:\\temp\" -d -y")]
-            [InlineData(false, "config set --name \"cacheLocation\" --value \"c:\\temp\" -y")]
+            [InlineData(true, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --debug --confirm")]
+            [InlineData(false, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm")]
             public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
             {
                 // Given
@@ -146,8 +147,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Config
             }
 
             [Theory]
-            [InlineData(true, "config set --name \"cacheLocation\" --value \"c:\\temp\" -v -y")]
-            [InlineData(false, "config set --name \"cacheLocation\" --value \"c:\\temp\" -y")]
+            [InlineData(true, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --verbose --confirm")]
+            [InlineData(false, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm")]
             public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
             {
                 // Given
@@ -162,8 +163,56 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Config
             }
 
             [Theory]
-            [InlineData(true, "config set --name \"cacheLocation\" --value \"c:\\temp\" -y -f")]
-            [InlineData(false, "config set --name \"cacheLocation\" --value \"c:\\temp\" -y")]
+            [InlineData(true, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --trace --confirm")]
+            [InlineData(false, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm")]
+            public void Should_Add_Trace_Flag_To_Arguments_If_Set(bool trace, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.Settings.Trace = trace;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --no-color --confirm")]
+            [InlineData(false, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm")]
+            public void Should_Add_NoColor_Flag_To_Arguments_If_Set(bool noColor, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.Settings.NoColor = noColor;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --accept-license --confirm")]
+            [InlineData(false, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm")]
+            public void Should_Add_AcceptLicense_Flag_To_Arguments_If_Set(bool acceptLicense, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.Settings.AcceptLicense = acceptLicense;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm --force")]
+            [InlineData(false, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm")]
             public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
             {
                 // Given
@@ -178,8 +227,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Config
             }
 
             [Theory]
-            [InlineData(true, "config set --name \"cacheLocation\" --value \"c:\\temp\" -y --noop")]
-            [InlineData(false, "config set --name \"cacheLocation\" --value \"c:\\temp\" -y")]
+            [InlineData(true, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm --what-if")]
+            [InlineData(false, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm")]
             public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
             {
                 // Given
@@ -194,8 +243,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Config
             }
 
             [Theory]
-            [InlineData(true, "config set --name \"cacheLocation\" --value \"c:\\temp\" -y -r")]
-            [InlineData(false, "config set --name \"cacheLocation\" --value \"c:\\temp\" -y")]
+            [InlineData(true, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm --limit-output")]
+            [InlineData(false, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm")]
             public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
             {
                 // Given
@@ -210,8 +259,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Config
             }
 
             [Theory]
-            [InlineData(5, "config set --name \"cacheLocation\" --value \"c:\\temp\" -y --execution-timeout \"5\"")]
-            [InlineData(0, "config set --name \"cacheLocation\" --value \"c:\\temp\" -y")]
+            [InlineData(5, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm --execution-timeout=\"5\"")]
+            [InlineData(0, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm")]
             public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
             {
                 // Given
@@ -226,8 +275,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Config
             }
 
             [Theory]
-            [InlineData(@"c:\temp", "config set --name \"cacheLocation\" --value \"c:\\temp\" -y -c \"c:\\temp\"")]
-            [InlineData("", "config set --name \"cacheLocation\" --value \"c:\\temp\" -y")]
+            [InlineData(@"c:\temp", "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm --cache-location=\"c:\\temp\"")]
+            [InlineData("", "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm")]
             public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
             {
                 // Given
@@ -242,13 +291,173 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Config
             }
 
             [Theory]
-            [InlineData(true, "config set --name \"cacheLocation\" --value \"c:\\temp\" -y --allowunofficial")]
-            [InlineData(false, "config set --name \"cacheLocation\" --value \"c:\\temp\" -y")]
+            [InlineData(true, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm --allow-unofficial")]
+            [InlineData(false, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm")]
             public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
             {
                 // Given
                 var fixture = new ChocolateyConfigSetterFixture();
                 fixture.Settings.AllowUnofficial = allowUnofficial;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm --fail-on-error-output")]
+            [InlineData(false, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm")]
+            public void Should_Add_FailOnErrorOutput_Flag_To_Arguments_If_Set(bool failOnErrorOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.Settings.FailOnErrorOutput = failOnErrorOutput;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm --use-system-powershell")]
+            [InlineData(false, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm")]
+            public void Should_Add_UseSystemPowerShell_Flag_To_Arguments_If_Set(bool useSystemPowerShell, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.Settings.UseSystemPowerShell = useSystemPowerShell;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm --no-progress")]
+            [InlineData(false, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm")]
+            public void Should_Add_NoProgress_Flag_To_Arguments_If_Set(bool noProgress, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.Settings.NoProgress = noProgress;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy", "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm --proxy=\"proxy\"")]
+            [InlineData(null, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm")]
+            public void Should_Add_Proxy_Flag_To_Arguments_If_Set(string proxy, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.Settings.Proxy = proxy;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-user", "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm --proxy-user=\"proxy-user\"")]
+            [InlineData(null, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm")]
+            public void Should_Add_ProxyUser_Flag_To_Arguments_If_Set(string proxyUser, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.Settings.ProxyUser = proxyUser;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-password", "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm --proxy-password=\"proxy-password\"")]
+            [InlineData(null, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm")]
+            public void Should_Add_ProxyPassword_Flag_To_Arguments_If_Set(string proxyPassword, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.Settings.ProxyPassword = proxyPassword;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy1,proxy2", "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm --proxy-bypass-list=\"proxy1,proxy2\"")]
+            [InlineData(null, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm")]
+            public void Should_Add_ProxyByPassList_Flag_To_Arguments_If_Set(string proxyByPassList, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.Settings.ProxyByPassList = proxyByPassList;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm --proxy-bypass-on-local")]
+            [InlineData(false, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm")]
+            public void Should_Add_ProxyByPassOnLocal_Flag_To_Arguments_If_Set(bool proxyBypassOnLocal, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.Settings.ProxyBypassOnLocal = proxyBypassOnLocal;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./output.log", "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm --log-file=\"/Working/output.log\"")]
+            [InlineData(null, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm")]
+            public void Should_Add_Log_File_Flag_To_Arguments_If_Set(string logFilePath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.Settings.LogFile = logFilePath;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm --skip-compatibility-checks")]
+            [InlineData(false, "config set --name=\"cacheLocation\" --value=\"c:\\temp\" --confirm")]
+            public void Should_Add_Skip_Compatibility_Flag_To_Arguments_If_Set(bool skipCompatibiity, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyConfigSetterFixture();
+                fixture.Settings.SkipCompatibilityChecks = skipCompatibiity;
 
                 // When
                 var result = fixture.Run();

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Download/ChocolateyDownloadTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Download/ChocolateyDownloadTests.cs
@@ -139,12 +139,12 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Download
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("download \"MyPackage\" -y", result.Args);
+                Assert.Equal("download \"MyPackage\" --confirm", result.Args);
             }
 
             [Theory]
-            [InlineData(true, "download \"MyPackage\" -d -y")]
-            [InlineData(false, "download \"MyPackage\" -y")]
+            [InlineData(true, "download \"MyPackage\" --debug --confirm")]
+            [InlineData(false, "download \"MyPackage\" --confirm")]
             public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
             {
                 // Given
@@ -159,8 +159,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Download
             }
 
             [Theory]
-            [InlineData(true, "download \"MyPackage\" -v -y")]
-            [InlineData(false, "download \"MyPackage\" -y")]
+            [InlineData(true, "download \"MyPackage\" --verbose --confirm")]
+            [InlineData(false, "download \"MyPackage\" --confirm")]
             public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
             {
                 // Given
@@ -175,8 +175,40 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Download
             }
 
             [Theory]
-            [InlineData(true, "download \"MyPackage\" --acceptLicense -y")]
-            [InlineData(false, "download \"MyPackage\" -y")]
+            [InlineData(true, "download \"MyPackage\" --trace --confirm")]
+            [InlineData(false, "download \"MyPackage\" --confirm")]
+            public void Should_Add_Trace_Flag_To_Arguments_If_Set(bool trace, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.Trace = trace;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "download \"MyPackage\" --no-color --confirm")]
+            [InlineData(false, "download \"MyPackage\" --confirm")]
+            public void Should_Add_NoColor_Flag_To_Arguments_If_Set(bool noColor, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.NoColor = noColor;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "download \"MyPackage\" --accept-license --confirm")]
+            [InlineData(false, "download \"MyPackage\" --confirm")]
             public void Should_Add_AcceptLicense_Flag_To_Arguments_If_Set(bool acceptLicense, string expected)
             {
                 // Given
@@ -191,8 +223,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Download
             }
 
             [Theory]
-            [InlineData(true, "download \"MyPackage\" -y -f")]
-            [InlineData(false, "download \"MyPackage\" -y")]
+            [InlineData(true, "download \"MyPackage\" --confirm --force")]
+            [InlineData(false, "download \"MyPackage\" --confirm")]
             public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
             {
                 // Given
@@ -207,8 +239,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Download
             }
 
             [Theory]
-            [InlineData(true, "download \"MyPackage\" -y --noop")]
-            [InlineData(false, "download \"MyPackage\" -y")]
+            [InlineData(true, "download \"MyPackage\" --confirm --what-if")]
+            [InlineData(false, "download \"MyPackage\" --confirm")]
             public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
             {
                 // Given
@@ -223,8 +255,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Download
             }
 
             [Theory]
-            [InlineData(true, "download \"MyPackage\" -y -r")]
-            [InlineData(false, "download \"MyPackage\" -y")]
+            [InlineData(true, "download \"MyPackage\" --confirm --limit-output")]
+            [InlineData(false, "download \"MyPackage\" --confirm")]
             public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
             {
                 // Given
@@ -239,8 +271,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Download
             }
 
             [Theory]
-            [InlineData(5, "download \"MyPackage\" -y --execution-timeout \"5\"")]
-            [InlineData(0, "download \"MyPackage\" -y")]
+            [InlineData(5, "download \"MyPackage\" --confirm --execution-timeout=\"5\"")]
+            [InlineData(0, "download \"MyPackage\" --confirm")]
             public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
             {
                 // Given
@@ -255,8 +287,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Download
             }
 
             [Theory]
-            [InlineData(@"c:\temp", "download \"MyPackage\" -y -c \"c:\\temp\"")]
-            [InlineData("", "download \"MyPackage\" -y")]
+            [InlineData(@"c:\temp", "download \"MyPackage\" --confirm --cache-location=\"c:\\temp\"")]
+            [InlineData("", "download \"MyPackage\" --confirm")]
             public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
             {
                 // Given
@@ -271,13 +303,173 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Download
             }
 
             [Theory]
-            [InlineData(true, "download \"MyPackage\" -y --allowunofficial")]
-            [InlineData(false, "download \"MyPackage\" -y")]
+            [InlineData(true, "download \"MyPackage\" --confirm --allow-unofficial")]
+            [InlineData(false, "download \"MyPackage\" --confirm")]
             public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
             {
                 // Given
                 var fixture = new ChocolateyDownloadFixture();
                 fixture.Settings.AllowUnofficial = allowUnofficial;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "download \"MyPackage\" --confirm --fail-on-error-output")]
+            [InlineData(false, "download \"MyPackage\" --confirm")]
+            public void Should_Add_FailOnErrorOutput_Flag_To_Arguments_If_Set(bool failOnErrorOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.FailOnErrorOutput = failOnErrorOutput;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "download \"MyPackage\" --confirm --use-system-powershell")]
+            [InlineData(false, "download \"MyPackage\" --confirm")]
+            public void Should_Add_UseSystemPowerShell_Flag_To_Arguments_If_Set(bool useSystemPowerShell, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.UseSystemPowerShell = useSystemPowerShell;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "download \"MyPackage\" --confirm --no-progress")]
+            [InlineData(false, "download \"MyPackage\" --confirm")]
+            public void Should_Add_NoProgress_Flag_To_Arguments_If_Set(bool noProgress, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.NoProgress = noProgress;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy", "download \"MyPackage\" --confirm --proxy=\"proxy\"")]
+            [InlineData(null, "download \"MyPackage\" --confirm")]
+            public void Should_Add_Proxy_Flag_To_Arguments_If_Set(string proxy, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.Proxy = proxy;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-user", "download \"MyPackage\" --confirm --proxy-user=\"proxy-user\"")]
+            [InlineData(null, "download \"MyPackage\" --confirm")]
+            public void Should_Add_ProxyUser_Flag_To_Arguments_If_Set(string proxyUser, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.ProxyUser = proxyUser;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-password", "download \"MyPackage\" --confirm --proxy-password=\"proxy-password\"")]
+            [InlineData(null, "download \"MyPackage\" --confirm")]
+            public void Should_Add_ProxyPassword_Flag_To_Arguments_If_Set(string proxyPassword, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.ProxyPassword = proxyPassword;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy1,proxy2", "download \"MyPackage\" --confirm --proxy-bypass-list=\"proxy1,proxy2\"")]
+            [InlineData(null, "download \"MyPackage\" --confirm")]
+            public void Should_Add_ProxyByPassList_Flag_To_Arguments_If_Set(string proxyByPassList, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.ProxyByPassList = proxyByPassList;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "download \"MyPackage\" --confirm --proxy-bypass-on-local")]
+            [InlineData(false, "download \"MyPackage\" --confirm")]
+            public void Should_Add_ProxyByPassOnLocal_Flag_To_Arguments_If_Set(bool proxyBypassOnLocal, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.ProxyBypassOnLocal = proxyBypassOnLocal;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./output.log", "download \"MyPackage\" --confirm --log-file=\"/Working/output.log\"")]
+            [InlineData(null, "download \"MyPackage\" --confirm")]
+            public void Should_Add_Log_File_Flag_To_Arguments_If_Set(string logFilePath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.LogFile = logFilePath;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "download \"MyPackage\" --confirm --skip-compatibility-checks")]
+            [InlineData(false, "download \"MyPackage\" --confirm")]
+            public void Should_Add_Skip_Compatibility_Flag_To_Arguments_If_Set(bool skipCompatibiity, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.SkipCompatibilityChecks = skipCompatibiity;
 
                 // When
                 var result = fixture.Run();
@@ -297,7 +489,7 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Download
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("download \"MyPackage\" -y -s \"A\"", result.Args);
+                Assert.Equal("download \"MyPackage\" --confirm --source=\"A\"", result.Args);
             }
 
             [Fact]
@@ -311,17 +503,81 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Download
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("download \"MyPackage\" -y --version \"1.0.0\"", result.Args);
+                Assert.Equal("download \"MyPackage\" --confirm --version=\"1.0.0\"", result.Args);
             }
 
             [Theory]
-            [InlineData(true, "download \"MyPackage\" -y --pre")]
-            [InlineData(false, "download \"MyPackage\" -y")]
+            [InlineData(true, "download \"MyPackage\" --confirm --pre")]
+            [InlineData(false, "download \"MyPackage\" --confirm")]
             public void Should_Add_Prerelease_Flag_To_Arguments_If_Set(bool prerelease, string expected)
             {
                 // Given
                 var fixture = new ChocolateyDownloadFixture();
                 fixture.Settings.Prerelease = prerelease;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("user1", "download \"MyPackage\" --confirm --user=\"user1\"")]
+            [InlineData("", "download \"MyPackage\" --confirm")]
+            public void Should_Add_User_To_Arguments_If_Set(string user, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.User = user;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("password1", "download \"MyPackage\" --confirm --password=\"password1\"")]
+            [InlineData("", "download \"MyPackage\" --confirm")]
+            public void Should_Add_Password_To_Arguments_If_Set(string password, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.Password = password;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./mycert.pfx", "download \"MyPackage\" --confirm --cert=\"/Working/mycert.pfx\"")]
+            [InlineData(null, "download \"MyPackage\" --confirm")]
+            public void Should_Add_Cert_To_Arguments_If_Set(string certificate, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.Certificate = certificate;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("certpassword", "download \"MyPackage\" --confirm --certpassword=\"certpassword\"")]
+            [InlineData("", "download \"MyPackage\" --confirm")]
+            public void Should_Add_CertPassword_To_Arguments_If_Set(string certificatePassword, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.CertificatePassword = certificatePassword;
 
                 // When
                 var result = fixture.Run();
@@ -341,12 +597,12 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Download
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("download \"MyPackage\" -y --outputdirectory \"/Working/Foo\"", result.Args);
+                Assert.Equal("download \"MyPackage\" --confirm --output-directory=\"/Working/Foo\"", result.Args);
             }
 
             [Theory]
-            [InlineData(true, "download \"MyPackage\" -y -i")]
-            [InlineData(false, "download \"MyPackage\" -y")]
+            [InlineData(true, "download \"MyPackage\" --confirm --ignore-dependencies")]
+            [InlineData(false, "download \"MyPackage\" --confirm")]
             public void Should_Add_IgnoreDependencies_Flag_To_Arguments_If_Set(bool ignoreDependencies, string expected)
             {
                 // Given
@@ -361,8 +617,56 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Download
             }
 
             [Theory]
-            [InlineData(true, "download \"MyPackage\" -y --internalize")]
-            [InlineData(false, "download \"MyPackage\" -y")]
+            [InlineData(true, "download \"MyPackage\" --confirm --installed-packages")]
+            [InlineData(false, "download \"MyPackage\" --confirm")]
+            public void Should_Add_Installed_Flag_To_Arguments_If_Set(bool installed, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.Installed = installed;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "download \"MyPackage\" --confirm --ignore-unfound")]
+            [InlineData(false, "download \"MyPackage\" --confirm")]
+            public void Should_Add_IgnoreUnfound_Flag_To_Arguments_If_Set(bool ignoreUnfound, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.IgnoreUnfound = ignoreUnfound;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "download \"MyPackage\" --confirm --disable-repository-optimizations")]
+            [InlineData(false, "download \"MyPackage\" --confirm")]
+            public void Should_Add_DisableRepositoryOptimizations_Flag_To_Arguments_If_Set(bool disableRepositoryOptimizations, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.DisableRepositoryOptimizations = disableRepositoryOptimizations;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "download \"MyPackage\" --confirm --internalize")]
+            [InlineData(false, "download \"MyPackage\" --confirm")]
             public void Should_Add_Internalize_Flag_To_Arguments_If_Set(bool internalize, string expected)
             {
                 // Given
@@ -377,8 +681,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Download
             }
 
             [Theory]
-            [InlineData(true, "download \"MyPackage\" -y --internalize --internalize-all-urls")]
-            [InlineData(false, "download \"MyPackage\" -y --internalize")]
+            [InlineData(true, "download \"MyPackage\" --confirm --internalize --internalize-all-urls")]
+            [InlineData(false, "download \"MyPackage\" --confirm --internalize")]
             public void Should_Add_InternalizeAllUrls_Flag_To_Arguments_If_Set(bool internalizeAllUrls, string expected)
             {
                 // Given
@@ -407,14 +711,14 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Download
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("download \"MyPackage\" -y", result.Args);
+                Assert.Equal("download \"MyPackage\" --confirm", result.Args);
             }
 
             [Theory]
-            [InlineData(@"\\foo", "download \"MyPackage\" -y --internalize --resources-location=\"\\\\foo\"")]
-            [InlineData("https://foo.local", "download \"MyPackage\" -y --internalize --resources-location=\"https://foo.local\"")]
-            [InlineData(null, "download \"MyPackage\" -y --internalize")]
-            [InlineData("", "download \"MyPackage\" -y --internalize")]
+            [InlineData(@"\\foo", "download \"MyPackage\" --confirm --internalize --resources-location=\"\\\\foo\"")]
+            [InlineData("https://foo.local", "download \"MyPackage\" --confirm --internalize --resources-location=\"https://foo.local\"")]
+            [InlineData(null, "download \"MyPackage\" --confirm --internalize")]
+            [InlineData("", "download \"MyPackage\" --confirm --internalize")]
             public void Should_Add_ResourceLocation_To_Arguments_If_Set(string resourcesLocation, string expected)
             {
                 // Given
@@ -445,14 +749,14 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Download
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("download \"MyPackage\" -y", result.Args);
+                Assert.Equal("download \"MyPackage\" --confirm", result.Args);
             }
 
             [Theory]
-            [InlineData(@"\\foo", "download \"MyPackage\" -y --internalize --resources-location=\"\\\\resources\" --download-location=\"\\\\foo\"")]
-            [InlineData("https://foo.local", "download \"MyPackage\" -y --internalize --resources-location=\"\\\\resources\" --download-location=\"https://foo.local\"")]
-            [InlineData(null, "download \"MyPackage\" -y --internalize --resources-location=\"\\\\resources\"")]
-            [InlineData("", "download \"MyPackage\" -y --internalize --resources-location=\"\\\\resources\"")]
+            [InlineData(@"\\foo", "download \"MyPackage\" --confirm --internalize --resources-location=\"\\\\resources\" --download-location=\"\\\\foo\"")]
+            [InlineData("https://foo.local", "download \"MyPackage\" --confirm --internalize --resources-location=\"\\\\resources\" --download-location=\"https://foo.local\"")]
+            [InlineData(null, "download \"MyPackage\" --confirm --internalize --resources-location=\"\\\\resources\"")]
+            [InlineData("", "download \"MyPackage\" --confirm --internalize --resources-location=\"\\\\resources\"")]
             public void Should_Add_DownloadLocation_To_Arguments_If_Set(string downloadLocation, string expected)
             {
                 // Given
@@ -485,7 +789,7 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Download
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("download \"MyPackage\" -y", result.Args);
+                Assert.Equal("download \"MyPackage\" --confirm", result.Args);
             }
 
             [Theory]
@@ -505,12 +809,12 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Download
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("download \"MyPackage\" -y --internalize", result.Args);
+                Assert.Equal("download \"MyPackage\" --confirm --internalize", result.Args);
             }
 
             [Theory]
-            [InlineData(true, "download \"MyPackage\" -y --internalize --append-useoriginallocation")]
-            [InlineData(false, "download \"MyPackage\" -y --internalize")]
+            [InlineData(true, "download \"MyPackage\" --confirm --internalize --append-use-original-location")]
+            [InlineData(false, "download \"MyPackage\" --confirm --internalize")]
             public void Should_Add_AppendUseOriginalLocation_Flag_To_Arguments_If_Set(bool appendUseOriginalLocation, string expected)
             {
                 // Given
@@ -539,17 +843,17 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Download
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("download \"MyPackage\" -y", result.Args);
+                Assert.Equal("download \"MyPackage\" --confirm", result.Args);
             }
 
             [Theory]
-            [InlineData("user1", "download \"MyPackage\" -y -u \"user1\"")]
-            [InlineData("", "download \"MyPackage\" -y")]
-            public void Should_Add_User_To_Arguments_If_Set(string user, string expected)
+            [InlineData(true, "download \"MyPackage\" --confirm --skip-download-cache")]
+            [InlineData(false, "download \"MyPackage\" --confirm")]
+            public void Should_Add_SkipDownloadCache_Flag_To_Arguments_If_Set(bool skipDownloadCache, string expected)
             {
                 // Given
                 var fixture = new ChocolateyDownloadFixture();
-                fixture.Settings.User = user;
+                fixture.Settings.SkipDownloadCache = skipDownloadCache;
 
                 // When
                 var result = fixture.Run();
@@ -559,13 +863,61 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Download
             }
 
             [Theory]
-            [InlineData("password1", "download \"MyPackage\" -y -p \"password1\"")]
-            [InlineData("", "download \"MyPackage\" -y")]
-            public void Should_Add_Password_To_Arguments_If_Set(string password, string expected)
+            [InlineData(true, "download \"MyPackage\" --confirm --use-download-cache")]
+            [InlineData(false, "download \"MyPackage\" --confirm")]
+            public void Should_Add_UseDownloadCache_Flag_To_Arguments_If_Set(bool useDownloadCache, string expected)
             {
                 // Given
                 var fixture = new ChocolateyDownloadFixture();
-                fixture.Settings.Password = password;
+                fixture.Settings.UseDownloadCache = useDownloadCache;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "download \"MyPackage\" --confirm --skip-virus-check")]
+            [InlineData(false, "download \"MyPackage\" --confirm")]
+            public void Should_Add_SkipVirusCheck_Flag_To_Arguments_If_Set(bool skipVirusCheck, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.SkipVirusCheck = skipVirusCheck;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "download \"MyPackage\" --confirm --virus-check")]
+            [InlineData(false, "download \"MyPackage\" --confirm")]
+            public void Should_Add_VirusCheck_Flag_To_Arguments_If_Set(bool virusCheck, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.VirusCheck = virusCheck;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(5, "download \"MyPackage\" --confirm --virus-positives-minimum=\"5\"")]
+            [InlineData(0, "download \"MyPackage\" --confirm")]
+            public void Should_Add_VirusPositivesMinimum_To_Arguments_If_Set(int virusPositivesMinimum, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDownloadFixture();
+                fixture.Settings.VirusPositivesMinimum = virusPositivesMinimum;
 
                 // When
                 var result = fixture.Run();

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Export/ChocolateyExporterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Export/ChocolateyExporterTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Common.Tests.Fixtures.Tools.Chocolatey.ApiKey;
 using Cake.Common.Tests.Fixtures.Tools.Chocolatey.Export;
 using Cake.Testing;
 using Cake.Testing.Xunit;
@@ -125,12 +126,12 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Export
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("export -y", result.Args);
+                Assert.Equal("export --confirm", result.Args);
             }
 
             [Theory]
-            [InlineData(true, "export -d -y")]
-            [InlineData(false, "export -y")]
+            [InlineData(true, "export --debug --confirm")]
+            [InlineData(false, "export --confirm")]
             public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
             {
                 // Given
@@ -145,8 +146,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Export
             }
 
             [Theory]
-            [InlineData(true, "export -v -y")]
-            [InlineData(false, "export -y")]
+            [InlineData(true, "export --verbose --confirm")]
+            [InlineData(false, "export --confirm")]
             public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
             {
                 // Given
@@ -161,8 +162,56 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Export
             }
 
             [Theory]
-            [InlineData(true, "export -y -f")]
-            [InlineData(false, "export -y")]
+            [InlineData(true, "export --trace --confirm")]
+            [InlineData(false, "export --confirm")]
+            public void Should_Add_Trace_Flag_To_Arguments_If_Set(bool trace, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.Trace = trace;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "export --no-color --confirm")]
+            [InlineData(false, "export --confirm")]
+            public void Should_Add_NoColor_Flag_To_Arguments_If_Set(bool noColor, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.NoColor = noColor;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "export --accept-license --confirm")]
+            [InlineData(false, "export --confirm")]
+            public void Should_Add_AcceptLicense_Flag_To_Arguments_If_Set(bool acceptLicense, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.AcceptLicense = acceptLicense;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "export --confirm --force")]
+            [InlineData(false, "export --confirm")]
             public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
             {
                 // Given
@@ -177,8 +226,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Export
             }
 
             [Theory]
-            [InlineData(true, "export -y --noop")]
-            [InlineData(false, "export -y")]
+            [InlineData(true, "export --confirm --what-if")]
+            [InlineData(false, "export --confirm")]
             public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
             {
                 // Given
@@ -193,8 +242,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Export
             }
 
             [Theory]
-            [InlineData(true, "export -y -r")]
-            [InlineData(false, "export -y")]
+            [InlineData(true, "export --confirm --limit-output")]
+            [InlineData(false, "export --confirm")]
             public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
             {
                 // Given
@@ -209,8 +258,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Export
             }
 
             [Theory]
-            [InlineData(5, "export -y --execution-timeout \"5\"")]
-            [InlineData(0, "export -y")]
+            [InlineData(5, "export --confirm --execution-timeout=\"5\"")]
+            [InlineData(0, "export --confirm")]
             public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
             {
                 // Given
@@ -225,8 +274,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Export
             }
 
             [Theory]
-            [InlineData(@"c:\temp", "export -y -c \"c:\\temp\"")]
-            [InlineData("", "export -y")]
+            [InlineData(@"c:\temp", "export --confirm --cache-location=\"c:\\temp\"")]
+            [InlineData("", "export --confirm")]
             public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
             {
                 // Given
@@ -241,8 +290,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Export
             }
 
             [Theory]
-            [InlineData(true, "export -y --allowunofficial")]
-            [InlineData(false, "export -y")]
+            [InlineData(true, "export --confirm --allow-unofficial")]
+            [InlineData(false, "export --confirm")]
             public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
             {
                 // Given
@@ -257,8 +306,168 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Export
             }
 
             [Theory]
-            [InlineData(@"c:\temp", "export -y --output-file-path \"c:/temp\"")]
-            [InlineData(null, "export -y")]
+            [InlineData(true, "export --confirm --fail-on-error-output")]
+            [InlineData(false, "export --confirm")]
+            public void Should_Add_FailOnErrorOutput_Flag_To_Arguments_If_Set(bool failOnErrorOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.FailOnErrorOutput = failOnErrorOutput;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "export --confirm --use-system-powershell")]
+            [InlineData(false, "export --confirm")]
+            public void Should_Add_UseSystemPowerShell_Flag_To_Arguments_If_Set(bool useSystemPowerShell, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.UseSystemPowerShell = useSystemPowerShell;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "export --confirm --no-progress")]
+            [InlineData(false, "export --confirm")]
+            public void Should_Add_NoProgress_Flag_To_Arguments_If_Set(bool noProgress, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.NoProgress = noProgress;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy", "export --confirm --proxy=\"proxy\"")]
+            [InlineData(null, "export --confirm")]
+            public void Should_Add_Proxy_Flag_To_Arguments_If_Set(string proxy, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.Proxy = proxy;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-user", "export --confirm --proxy-user=\"proxy-user\"")]
+            [InlineData(null, "export --confirm")]
+            public void Should_Add_ProxyUser_Flag_To_Arguments_If_Set(string proxyUser, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.ProxyUser = proxyUser;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-password", "export --confirm --proxy-password=\"proxy-password\"")]
+            [InlineData(null, "export --confirm")]
+            public void Should_Add_ProxyPassword_Flag_To_Arguments_If_Set(string proxyPassword, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.ProxyPassword = proxyPassword;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy1,proxy2", "export --confirm --proxy-bypass-list=\"proxy1,proxy2\"")]
+            [InlineData(null, "export --confirm")]
+            public void Should_Add_ProxyByPassList_Flag_To_Arguments_If_Set(string proxyByPassList, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.ProxyByPassList = proxyByPassList;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "export --confirm --proxy-bypass-on-local")]
+            [InlineData(false, "export --confirm")]
+            public void Should_Add_ProxyByPassOnLocal_Flag_To_Arguments_If_Set(bool proxyBypassOnLocal, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.ProxyBypassOnLocal = proxyBypassOnLocal;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./output.log", "export --confirm --log-file=\"/Working/output.log\"")]
+            [InlineData(null, "export --confirm")]
+            public void Should_Add_Log_File_Flag_To_Arguments_If_Set(string logFilePath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.LogFile = logFilePath;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "export --confirm --skip-compatibility-checks")]
+            [InlineData(false, "export --confirm")]
+            public void Should_Add_Skip_Compatibility_Flag_To_Arguments_If_Set(bool skipCompatibiity, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyExportFixture();
+                fixture.Settings.SkipCompatibilityChecks = skipCompatibiity;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(@"c:\temp", "export --confirm --output-file-path=\"c:/temp\"")]
+            [InlineData(null, "export --confirm")]
             public void Should_Add_OutputFilePath_To_Arguments_If_Set(string outputFilePath, string expected)
             {
                 // Given
@@ -273,8 +482,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Export
             }
 
             [Theory]
-            [InlineData(true, "export -y --include-version-numbers")]
-            [InlineData(false, "export -y")]
+            [InlineData(true, "export --confirm --include-version-numbers")]
+            [InlineData(false, "export --confirm")]
             public void Should_Add_IncludeVersionNumbers_Flag_To_Arguments_If_Set(bool includeVersionNumbers, string expected)
             {
                 // Given

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Features/ChocolateyFeatureTogglerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Features/ChocolateyFeatureTogglerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Common.Tests.Fixtures.Tools.Chocolatey.ApiKey;
 using Cake.Common.Tests.Fixtures.Tools.Chocolatey.Features;
 using Cake.Testing;
 using Cake.Testing.Xunit;
@@ -125,12 +126,12 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Features
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("feature enable -n \"checkSumFiles\" -y", result.Args);
+                Assert.Equal("feature enable --name=\"checkSumFiles\" --confirm", result.Args);
             }
 
             [Theory]
-            [InlineData(true, "feature enable -n \"checkSumFiles\" -d -y")]
-            [InlineData(false, "feature enable -n \"checkSumFiles\" -y")]
+            [InlineData(true, "feature enable --name=\"checkSumFiles\" --debug --confirm")]
+            [InlineData(false, "feature enable --name=\"checkSumFiles\" --confirm")]
             public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
             {
                 // Given
@@ -145,8 +146,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Features
             }
 
             [Theory]
-            [InlineData(true, "feature enable -n \"checkSumFiles\" -v -y")]
-            [InlineData(false, "feature enable -n \"checkSumFiles\" -y")]
+            [InlineData(true, "feature enable --name=\"checkSumFiles\" --verbose --confirm")]
+            [InlineData(false, "feature enable --name=\"checkSumFiles\" --confirm")]
             public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
             {
                 // Given
@@ -161,8 +162,56 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Features
             }
 
             [Theory]
-            [InlineData(true, "feature enable -n \"checkSumFiles\" -y -f")]
-            [InlineData(false, "feature enable -n \"checkSumFiles\" -y")]
+            [InlineData(true, "feature enable --name=\"checkSumFiles\" --trace --confirm")]
+            [InlineData(false, "feature enable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_Trace_Flag_To_Arguments_If_Set(bool trace, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableFeatureFixture();
+                fixture.Settings.Trace = trace;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "feature enable --name=\"checkSumFiles\" --no-color --confirm")]
+            [InlineData(false, "feature enable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_NoColor_Flag_To_Arguments_If_Set(bool noColor, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableFeatureFixture();
+                fixture.Settings.NoColor = noColor;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "feature enable --name=\"checkSumFiles\" --accept-license --confirm")]
+            [InlineData(false, "feature enable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_AcceptLicense_Flag_To_Arguments_If_Set(bool acceptLicense, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableFeatureFixture();
+                fixture.Settings.AcceptLicense = acceptLicense;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "feature enable --name=\"checkSumFiles\" --confirm --force")]
+            [InlineData(false, "feature enable --name=\"checkSumFiles\" --confirm")]
             public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
             {
                 // Given
@@ -177,8 +226,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Features
             }
 
             [Theory]
-            [InlineData(true, "feature enable -n \"checkSumFiles\" -y --noop")]
-            [InlineData(false, "feature enable -n \"checkSumFiles\" -y")]
+            [InlineData(true, "feature enable --name=\"checkSumFiles\" --confirm --what-if")]
+            [InlineData(false, "feature enable --name=\"checkSumFiles\" --confirm")]
             public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
             {
                 // Given
@@ -193,8 +242,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Features
             }
 
             [Theory]
-            [InlineData(true, "feature enable -n \"checkSumFiles\" -y -r")]
-            [InlineData(false, "feature enable -n \"checkSumFiles\" -y")]
+            [InlineData(true, "feature enable --name=\"checkSumFiles\" --confirm --limit-output")]
+            [InlineData(false, "feature enable --name=\"checkSumFiles\" --confirm")]
             public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
             {
                 // Given
@@ -209,8 +258,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Features
             }
 
             [Theory]
-            [InlineData(5, "feature enable -n \"checkSumFiles\" -y --execution-timeout \"5\"")]
-            [InlineData(0, "feature enable -n \"checkSumFiles\" -y")]
+            [InlineData(5, "feature enable --name=\"checkSumFiles\" --confirm --execution-timeout=\"5\"")]
+            [InlineData(0, "feature enable --name=\"checkSumFiles\" --confirm")]
             public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
             {
                 // Given
@@ -225,8 +274,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Features
             }
 
             [Theory]
-            [InlineData(@"c:\temp", "feature enable -n \"checkSumFiles\" -y -c \"c:\\temp\"")]
-            [InlineData("", "feature enable -n \"checkSumFiles\" -y")]
+            [InlineData(@"c:\temp", "feature enable --name=\"checkSumFiles\" --confirm --cache-location=\"c:\\temp\"")]
+            [InlineData("", "feature enable --name=\"checkSumFiles\" --confirm")]
             public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
             {
                 // Given
@@ -241,13 +290,173 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Features
             }
 
             [Theory]
-            [InlineData(true, "feature enable -n \"checkSumFiles\" -y --allowunofficial")]
-            [InlineData(false, "feature enable -n \"checkSumFiles\" -y")]
+            [InlineData(true, "feature enable --name=\"checkSumFiles\" --confirm --allow-unofficial")]
+            [InlineData(false, "feature enable --name=\"checkSumFiles\" --confirm")]
             public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
             {
                 // Given
                 var fixture = new ChocolateyEnableFeatureFixture();
                 fixture.Settings.AllowUnofficial = allowUnofficial;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "feature enable --name=\"checkSumFiles\" --confirm --fail-on-error-output")]
+            [InlineData(false, "feature enable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_FailOnErrorOutput_Flag_To_Arguments_If_Set(bool failOnErrorOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableFeatureFixture();
+                fixture.Settings.FailOnErrorOutput = failOnErrorOutput;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "feature enable --name=\"checkSumFiles\" --confirm --use-system-powershell")]
+            [InlineData(false, "feature enable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_UseSystemPowerShell_Flag_To_Arguments_If_Set(bool useSystemPowerShell, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableFeatureFixture();
+                fixture.Settings.UseSystemPowerShell = useSystemPowerShell;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "feature enable --name=\"checkSumFiles\" --confirm --no-progress")]
+            [InlineData(false, "feature enable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_NoProgress_Flag_To_Arguments_If_Set(bool noProgress, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableFeatureFixture();
+                fixture.Settings.NoProgress = noProgress;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy", "feature enable --name=\"checkSumFiles\" --confirm --proxy=\"proxy\"")]
+            [InlineData(null, "feature enable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_Proxy_Flag_To_Arguments_If_Set(string proxy, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableFeatureFixture();
+                fixture.Settings.Proxy = proxy;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-user", "feature enable --name=\"checkSumFiles\" --confirm --proxy-user=\"proxy-user\"")]
+            [InlineData(null, "feature enable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_ProxyUser_Flag_To_Arguments_If_Set(string proxyUser, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableFeatureFixture();
+                fixture.Settings.ProxyUser = proxyUser;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-password", "feature enable --name=\"checkSumFiles\" --confirm --proxy-password=\"proxy-password\"")]
+            [InlineData(null, "feature enable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_ProxyPassword_Flag_To_Arguments_If_Set(string proxyPassword, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableFeatureFixture();
+                fixture.Settings.ProxyPassword = proxyPassword;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy1,proxy2", "feature enable --name=\"checkSumFiles\" --confirm --proxy-bypass-list=\"proxy1,proxy2\"")]
+            [InlineData(null, "feature enable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_ProxyByPassList_Flag_To_Arguments_If_Set(string proxyByPassList, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableFeatureFixture();
+                fixture.Settings.ProxyByPassList = proxyByPassList;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "feature enable --name=\"checkSumFiles\" --confirm --proxy-bypass-on-local")]
+            [InlineData(false, "feature enable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_ProxyByPassOnLocal_Flag_To_Arguments_If_Set(bool proxyBypassOnLocal, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableFeatureFixture();
+                fixture.Settings.ProxyBypassOnLocal = proxyBypassOnLocal;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./output.log", "feature enable --name=\"checkSumFiles\" --confirm --log-file=\"/Working/output.log\"")]
+            [InlineData(null, "feature enable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_Log_File_Flag_To_Arguments_If_Set(string logFilePath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableFeatureFixture();
+                fixture.Settings.LogFile = logFilePath;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "feature enable --name=\"checkSumFiles\" --confirm --skip-compatibility-checks")]
+            [InlineData(false, "feature enable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_Skip_Compatibility_Flag_To_Arguments_If_Set(bool skipCompatibiity, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableFeatureFixture();
+                fixture.Settings.SkipCompatibilityChecks = skipCompatibiity;
 
                 // When
                 var result = fixture.Run();
@@ -371,12 +580,12 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Features
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("feature disable -n \"checkSumFiles\" -y", result.Args);
+                Assert.Equal("feature disable --name=\"checkSumFiles\" --confirm", result.Args);
             }
 
             [Theory]
-            [InlineData(true, "feature disable -n \"checkSumFiles\" -d -y")]
-            [InlineData(false, "feature disable -n \"checkSumFiles\" -y")]
+            [InlineData(true, "feature disable --name=\"checkSumFiles\" --debug --confirm")]
+            [InlineData(false, "feature disable --name=\"checkSumFiles\" --confirm")]
             public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
             {
                 // Given
@@ -391,8 +600,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Features
             }
 
             [Theory]
-            [InlineData(true, "feature disable -n \"checkSumFiles\" -v -y")]
-            [InlineData(false, "feature disable -n \"checkSumFiles\" -y")]
+            [InlineData(true, "feature disable --name=\"checkSumFiles\" --verbose --confirm")]
+            [InlineData(false, "feature disable --name=\"checkSumFiles\" --confirm")]
             public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
             {
                 // Given
@@ -407,8 +616,56 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Features
             }
 
             [Theory]
-            [InlineData(true, "feature disable -n \"checkSumFiles\" -y -f")]
-            [InlineData(false, "feature disable -n \"checkSumFiles\" -y")]
+            [InlineData(true, "feature disable --name=\"checkSumFiles\" --trace --confirm")]
+            [InlineData(false, "feature disable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_Trace_Flag_To_Arguments_If_Set(bool trace, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableFeatureFixture();
+                fixture.Settings.Trace = trace;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "feature disable --name=\"checkSumFiles\" --no-color --confirm")]
+            [InlineData(false, "feature disable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_NoColor_Flag_To_Arguments_If_Set(bool noColor, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableFeatureFixture();
+                fixture.Settings.NoColor = noColor;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "feature disable --name=\"checkSumFiles\" --accept-license --confirm")]
+            [InlineData(false, "feature disable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_AcceptLicense_Flag_To_Arguments_If_Set(bool acceptLicense, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableFeatureFixture();
+                fixture.Settings.AcceptLicense = acceptLicense;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "feature disable --name=\"checkSumFiles\" --confirm --force")]
+            [InlineData(false, "feature disable --name=\"checkSumFiles\" --confirm")]
             public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
             {
                 // Given
@@ -423,8 +680,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Features
             }
 
             [Theory]
-            [InlineData(true, "feature disable -n \"checkSumFiles\" -y --noop")]
-            [InlineData(false, "feature disable -n \"checkSumFiles\" -y")]
+            [InlineData(true, "feature disable --name=\"checkSumFiles\" --confirm --what-if")]
+            [InlineData(false, "feature disable --name=\"checkSumFiles\" --confirm")]
             public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
             {
                 // Given
@@ -439,8 +696,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Features
             }
 
             [Theory]
-            [InlineData(true, "feature disable -n \"checkSumFiles\" -y -r")]
-            [InlineData(false, "feature disable -n \"checkSumFiles\" -y")]
+            [InlineData(true, "feature disable --name=\"checkSumFiles\" --confirm --limit-output")]
+            [InlineData(false, "feature disable --name=\"checkSumFiles\" --confirm")]
             public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
             {
                 // Given
@@ -455,8 +712,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Features
             }
 
             [Theory]
-            [InlineData(5, "feature disable -n \"checkSumFiles\" -y --execution-timeout \"5\"")]
-            [InlineData(0, "feature disable -n \"checkSumFiles\" -y")]
+            [InlineData(5, "feature disable --name=\"checkSumFiles\" --confirm --execution-timeout=\"5\"")]
+            [InlineData(0, "feature disable --name=\"checkSumFiles\" --confirm")]
             public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
             {
                 // Given
@@ -471,8 +728,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Features
             }
 
             [Theory]
-            [InlineData(@"c:\temp", "feature disable -n \"checkSumFiles\" -y -c \"c:\\temp\"")]
-            [InlineData("", "feature disable -n \"checkSumFiles\" -y")]
+            [InlineData(@"c:\temp", "feature disable --name=\"checkSumFiles\" --confirm --cache-location=\"c:\\temp\"")]
+            [InlineData("", "feature disable --name=\"checkSumFiles\" --confirm")]
             public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
             {
                 // Given
@@ -487,13 +744,172 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Features
             }
 
             [Theory]
-            [InlineData(true, "feature disable -n \"checkSumFiles\" -y --allowunofficial")]
-            [InlineData(false, "feature disable -n \"checkSumFiles\" -y")]
+            [InlineData(true, "feature disable --name=\"checkSumFiles\" --confirm --allow-unofficial")]
+            [InlineData(false, "feature disable --name=\"checkSumFiles\" --confirm")]
             public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
             {
                 // Given
                 var fixture = new ChocolateyDisableFeatureFixture();
                 fixture.Settings.AllowUnofficial = allowUnofficial;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+            [Theory]
+            [InlineData(true, "feature disable --name=\"checkSumFiles\" --confirm --fail-on-error-output")]
+            [InlineData(false, "feature disable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_FailOnErrorOutput_Flag_To_Arguments_If_Set(bool failOnErrorOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableFeatureFixture();
+                fixture.Settings.FailOnErrorOutput = failOnErrorOutput;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "feature disable --name=\"checkSumFiles\" --confirm --use-system-powershell")]
+            [InlineData(false, "feature disable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_UseSystemPowerShell_Flag_To_Arguments_If_Set(bool useSystemPowerShell, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableFeatureFixture();
+                fixture.Settings.UseSystemPowerShell = useSystemPowerShell;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "feature disable --name=\"checkSumFiles\" --confirm --no-progress")]
+            [InlineData(false, "feature disable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_NoProgress_Flag_To_Arguments_If_Set(bool noProgress, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableFeatureFixture();
+                fixture.Settings.NoProgress = noProgress;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy", "feature disable --name=\"checkSumFiles\" --confirm --proxy=\"proxy\"")]
+            [InlineData(null, "feature disable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_Proxy_Flag_To_Arguments_If_Set(string proxy, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableFeatureFixture();
+                fixture.Settings.Proxy = proxy;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-user", "feature disable --name=\"checkSumFiles\" --confirm --proxy-user=\"proxy-user\"")]
+            [InlineData(null, "feature disable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_ProxyUser_Flag_To_Arguments_If_Set(string proxyUser, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableFeatureFixture();
+                fixture.Settings.ProxyUser = proxyUser;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-password", "feature disable --name=\"checkSumFiles\" --confirm --proxy-password=\"proxy-password\"")]
+            [InlineData(null, "feature disable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_ProxyPassword_Flag_To_Arguments_If_Set(string proxyPassword, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableFeatureFixture();
+                fixture.Settings.ProxyPassword = proxyPassword;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy1,proxy2", "feature disable --name=\"checkSumFiles\" --confirm --proxy-bypass-list=\"proxy1,proxy2\"")]
+            [InlineData(null, "feature disable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_ProxyByPassList_Flag_To_Arguments_If_Set(string proxyByPassList, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableFeatureFixture();
+                fixture.Settings.ProxyByPassList = proxyByPassList;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "feature disable --name=\"checkSumFiles\" --confirm --proxy-bypass-on-local")]
+            [InlineData(false, "feature disable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_ProxyByPassOnLocal_Flag_To_Arguments_If_Set(bool proxyBypassOnLocal, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableFeatureFixture();
+                fixture.Settings.ProxyBypassOnLocal = proxyBypassOnLocal;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./output.log", "feature disable --name=\"checkSumFiles\" --confirm --log-file=\"/Working/output.log\"")]
+            [InlineData(null, "feature disable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_Log_File_Flag_To_Arguments_If_Set(string logFilePath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableFeatureFixture();
+                fixture.Settings.LogFile = logFilePath;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "feature disable --name=\"checkSumFiles\" --confirm --skip-compatibility-checks")]
+            [InlineData(false, "feature disable --name=\"checkSumFiles\" --confirm")]
+            public void Should_Add_Skip_Compatibility_Flag_To_Arguments_If_Set(bool skipCompatibiity, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableFeatureFixture();
+                fixture.Settings.SkipCompatibilityChecks = skipCompatibiity;
 
                 // When
                 var result = fixture.Run();

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Install/ChocolateyInstallerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Install/ChocolateyInstallerTests.cs
@@ -139,12 +139,12 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("install \"Cake\" -y", result.Args);
+                Assert.Equal("install \"Cake\" --confirm", result.Args);
             }
 
             [Theory]
-            [InlineData(true, "install \"Cake\" -d -y")]
-            [InlineData(false, "install \"Cake\" -y")]
+            [InlineData(true, "install \"Cake\" --debug --confirm")]
+            [InlineData(false, "install \"Cake\" --confirm")]
             public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
             {
                 // Given
@@ -159,8 +159,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData(true, "install \"Cake\" -v -y")]
-            [InlineData(false, "install \"Cake\" -y")]
+            [InlineData(true, "install \"Cake\" --verbose --confirm")]
+            [InlineData(false, "install \"Cake\" --confirm")]
             public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
             {
                 // Given
@@ -175,8 +175,40 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData(true, "install \"Cake\" --acceptLicense -y")]
-            [InlineData(false, "install \"Cake\" -y")]
+            [InlineData(true, "install \"Cake\" --trace --confirm")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_Trace_Flag_To_Arguments_If_Set(bool trace, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.Trace = trace;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --no-color --confirm")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_NoColor_Flag_To_Arguments_If_Set(bool noColor, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.NoColor = noColor;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --accept-license --confirm")]
+            [InlineData(false, "install \"Cake\" --confirm")]
             public void Should_Add_AcceptLicense_Flag_To_Arguments_If_Set(bool acceptLicense, string expected)
             {
                 // Given
@@ -191,8 +223,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData(true, "install \"Cake\" -y -f")]
-            [InlineData(false, "install \"Cake\" -y")]
+            [InlineData(true, "install \"Cake\" --confirm --force")]
+            [InlineData(false, "install \"Cake\" --confirm")]
             public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
             {
                 // Given
@@ -207,8 +239,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData(true, "install \"Cake\" -y --noop")]
-            [InlineData(false, "install \"Cake\" -y")]
+            [InlineData(true, "install \"Cake\" --confirm --what-if")]
+            [InlineData(false, "install \"Cake\" --confirm")]
             public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
             {
                 // Given
@@ -223,8 +255,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData(true, "install \"Cake\" -y -r")]
-            [InlineData(false, "install \"Cake\" -y")]
+            [InlineData(true, "install \"Cake\" --confirm --limit-output")]
+            [InlineData(false, "install \"Cake\" --confirm")]
             public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
             {
                 // Given
@@ -239,8 +271,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData(5, "install \"Cake\" -y --execution-timeout \"5\"")]
-            [InlineData(0, "install \"Cake\" -y")]
+            [InlineData(5, "install \"Cake\" --confirm --execution-timeout=\"5\"")]
+            [InlineData(0, "install \"Cake\" --confirm")]
             public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
             {
                 // Given
@@ -255,8 +287,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData(@"c:\temp", "install \"Cake\" -y -c \"c:\\temp\"")]
-            [InlineData("", "install \"Cake\" -y")]
+            [InlineData(@"c:\temp", "install \"Cake\" --confirm --cache-location=\"c:\\temp\"")]
+            [InlineData("", "install \"Cake\" --confirm")]
             public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
             {
                 // Given
@@ -271,13 +303,173 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData(true, "install \"Cake\" -y --allowunofficial")]
-            [InlineData(false, "install \"Cake\" -y")]
+            [InlineData(true, "install \"Cake\" --confirm --allow-unofficial")]
+            [InlineData(false, "install \"Cake\" --confirm")]
             public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
             {
                 // Given
                 var fixture = new ChocolateyInstallFixture();
                 fixture.Settings.AllowUnofficial = allowUnofficial;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --fail-on-error-output")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_FailOnErrorOutput_Flag_To_Arguments_If_Set(bool failOnErrorOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.FailOnErrorOutput = failOnErrorOutput;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --use-system-powershell")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_UseSystemPowerShell_Flag_To_Arguments_If_Set(bool useSystemPowerShell, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.UseSystemPowerShell = useSystemPowerShell;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --no-progress")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_NoProgress_Flag_To_Arguments_If_Set(bool noProgress, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.NoProgress = noProgress;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy", "install \"Cake\" --confirm --proxy=\"proxy\"")]
+            [InlineData(null, "install \"Cake\" --confirm")]
+            public void Should_Add_Proxy_Flag_To_Arguments_If_Set(string proxy, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.Proxy = proxy;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-user", "install \"Cake\" --confirm --proxy-user=\"proxy-user\"")]
+            [InlineData(null, "install \"Cake\" --confirm")]
+            public void Should_Add_ProxyUser_Flag_To_Arguments_If_Set(string proxyUser, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.ProxyUser = proxyUser;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-password", "install \"Cake\" --confirm --proxy-password=\"proxy-password\"")]
+            [InlineData(null, "install \"Cake\" --confirm")]
+            public void Should_Add_ProxyPassword_Flag_To_Arguments_If_Set(string proxyPassword, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.ProxyPassword = proxyPassword;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy1,proxy2", "install \"Cake\" --confirm --proxy-bypass-list=\"proxy1,proxy2\"")]
+            [InlineData(null, "install \"Cake\" --confirm")]
+            public void Should_Add_ProxyByPassList_Flag_To_Arguments_If_Set(string proxyByPassList, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.ProxyByPassList = proxyByPassList;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --proxy-bypass-on-local")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_ProxyByPassOnLocal_Flag_To_Arguments_If_Set(bool proxyBypassOnLocal, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.ProxyBypassOnLocal = proxyBypassOnLocal;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./output.log", "install \"Cake\" --confirm --log-file=\"/Working/output.log\"")]
+            [InlineData(null, "install \"Cake\" --confirm")]
+            public void Should_Add_Log_File_Flag_To_Arguments_If_Set(string logFilePath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.LogFile = logFilePath;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --skip-compatibility-checks")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_Skip_Compatibility_Flag_To_Arguments_If_Set(bool skipCompatibiity, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.SkipCompatibilityChecks = skipCompatibiity;
 
                 // When
                 var result = fixture.Run();
@@ -297,7 +489,7 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("install \"Cake\" -y -s \"A\"", result.Args);
+                Assert.Equal("install \"Cake\" --confirm --source=\"A\"", result.Args);
             }
 
             [Fact]
@@ -311,12 +503,12 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("install \"Cake\" -y --version \"1.0.0\"", result.Args);
+                Assert.Equal("install \"Cake\" --confirm --version=\"1.0.0\"", result.Args);
             }
 
             [Theory]
-            [InlineData(true, "install \"Cake\" -y --pre")]
-            [InlineData(false, "install \"Cake\" -y")]
+            [InlineData(true, "install \"Cake\" --confirm --pre")]
+            [InlineData(false, "install \"Cake\" --confirm")]
             public void Should_Add_Prerelease_Flag_To_Arguments_If_Set(bool prerelease, string expected)
             {
                 // Given
@@ -331,8 +523,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData(true, "install \"Cake\" -y --x86")]
-            [InlineData(false, "install \"Cake\" -y")]
+            [InlineData(true, "install \"Cake\" --confirm --forcex86")]
+            [InlineData(false, "install \"Cake\" --confirm")]
             public void Should_Add_Forcex86_Flag_To_Arguments_If_Set(bool forcex86, string expected)
             {
                 // Given
@@ -347,8 +539,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData("args1", "install \"Cake\" -y --ia \"args1\"")]
-            [InlineData("", "install \"Cake\" -y")]
+            [InlineData("args1", "install \"Cake\" --confirm --install-arguments=\"args1\"")]
+            [InlineData("", "install \"Cake\" --confirm")]
             public void Should_Add_InstallArguments_To_Arguments_If_Set(string installArgs, string expected)
             {
                 // Given
@@ -363,8 +555,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData(true, "install \"Cake\" -y -o")]
-            [InlineData(false, "install \"Cake\" -y")]
+            [InlineData(true, "install \"Cake\" --confirm --override-arguments")]
+            [InlineData(false, "install \"Cake\" --confirm")]
             public void Should_Add_OverrideArguments_Flag_To_Arguments_If_Set(bool overrideArguments, string expected)
             {
                 // Given
@@ -379,8 +571,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData(true, "install \"Cake\" -y --notSilent")]
-            [InlineData(false, "install \"Cake\" -y")]
+            [InlineData(true, "install \"Cake\" --confirm --not-silent")]
+            [InlineData(false, "install \"Cake\" --confirm")]
             public void Should_Add_NotSilent_Flag_To_Arguments_If_Set(bool notSilent, string expected)
             {
                 // Given
@@ -395,8 +587,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData("param1", "install \"Cake\" -y --params \"param1\"")]
-            [InlineData("", "install \"Cake\" -y")]
+            [InlineData("param1", "install \"Cake\" --confirm --package-parameters=\"param1\"")]
+            [InlineData("", "install \"Cake\" --confirm")]
             public void Should_Add_PackageParameters_To_Arguments_If_Set(string packageParameters, string expected)
             {
                 // Given
@@ -411,8 +603,40 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData(true, "install \"Cake\" -y --allowdowngrade")]
-            [InlineData(false, "install \"Cake\" -y")]
+            [InlineData(true, "install \"Cake\" --confirm --apply-install-arguments-to-dependencies")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_ApplyInstallArgumentsToDependencies_To_Arguments_If_Set(bool applyInstallArgumentsToDependencies, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.ApplyInstallArgumentsToDependencies = applyInstallArgumentsToDependencies;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --apply-package-parameters-to-dependencies")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_ApplyPackageParametersToDependencies_To_Arguments_If_Set(bool applyPackageParametersToDependencies, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.ApplyPackageParametersToDependencies = applyPackageParametersToDependencies;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --allow-downgrade")]
+            [InlineData(false, "install \"Cake\" --confirm")]
             public void Should_Add_AllowDowngrade_Flag_To_Arguments_If_Set(bool allowDowngrade, string expected)
             {
                 // Given
@@ -427,8 +651,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData(true, "install \"Cake\" -y -m")]
-            [InlineData(false, "install \"Cake\" -y")]
+            [InlineData(true, "install \"Cake\" --confirm --side-by-side")]
+            [InlineData(false, "install \"Cake\" --confirm")]
             public void Should_Add_SideBySide_Flag_To_Arguments_If_Set(bool sideBySide, string expected)
             {
                 // Given
@@ -443,8 +667,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData(true, "install \"Cake\" -y -i")]
-            [InlineData(false, "install \"Cake\" -y")]
+            [InlineData(true, "install \"Cake\" --confirm --ignore-dependencies")]
+            [InlineData(false, "install \"Cake\" --confirm")]
             public void Should_Add_IgnoreDependencies_Flag_To_Arguments_If_Set(bool ignoreDependencies, string expected)
             {
                 // Given
@@ -459,8 +683,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData(true, "install \"Cake\" -y -x")]
-            [InlineData(false, "install \"Cake\" -y")]
+            [InlineData(true, "install \"Cake\" --confirm --force-dependencies")]
+            [InlineData(false, "install \"Cake\" --confirm")]
             public void Should_Add_ForceDependencies_Flag_To_Arguments_If_Set(bool forceDependencies, string expected)
             {
                 // Given
@@ -475,8 +699,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData(true, "install \"Cake\" -y -n")]
-            [InlineData(false, "install \"Cake\" -y")]
+            [InlineData(true, "install \"Cake\" --confirm --skip-automation-scripts")]
+            [InlineData(false, "install \"Cake\" --confirm")]
             public void Should_Add_SkipPowerShell_Flag_To_Arguments_If_Set(bool skipPowerShell, string expected)
             {
                 // Given
@@ -491,8 +715,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData("user1", "install \"Cake\" -y -u \"user1\"")]
-            [InlineData("", "install \"Cake\" -y")]
+            [InlineData("user1", "install \"Cake\" --confirm --user=\"user1\"")]
+            [InlineData("", "install \"Cake\" --confirm")]
             public void Should_Add_User_To_Arguments_If_Set(string user, string expected)
             {
                 // Given
@@ -507,8 +731,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData("password1", "install \"Cake\" -y -p \"password1\"")]
-            [InlineData("", "install \"Cake\" -y")]
+            [InlineData("password1", "install \"Cake\" --confirm --password=\"password1\"")]
+            [InlineData("", "install \"Cake\" --confirm")]
             public void Should_Add_Password_To_Arguments_If_Set(string password, string expected)
             {
                 // Given
@@ -523,13 +747,493 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData(true, "install \"Cake\" -y --ignorechecksums")]
-            [InlineData(false, "install \"Cake\" -y")]
+            [InlineData("./mycert.pfx", "install \"Cake\" --confirm --cert=\"/Working/mycert.pfx\"")]
+            [InlineData(null, "install \"Cake\" --confirm")]
+            public void Should_Add_Cert_To_Arguments_If_Set(string certificate, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.Certificate = certificate;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("certpassword", "install \"Cake\" --confirm --certpassword=\"certpassword\"")]
+            [InlineData("", "install \"Cake\" --confirm")]
+            public void Should_Add_CertPassword_To_Arguments_If_Set(string certificatePassword, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.CertificatePassword = certificatePassword;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --ignore-checksums")]
+            [InlineData(false, "install \"Cake\" --confirm")]
             public void Should_Add_IgnoreChecksums_Flag_To_Arguments_If_Set(bool ignoreChecksums, string expected)
             {
                 // Given
                 var fixture = new ChocolateyInstallFixture();
                 fixture.Settings.IgnoreChecksums = ignoreChecksums;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --allow-empty-checksums")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_AllowEmptyChecksums_Flag_To_Arguments_If_Set(bool allowEmptyChecksums, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.AllowEmptyChecksums = allowEmptyChecksums;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --allow-empty-checksums-secure")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_AllowEmptyChecksumsSecure_Flag_To_Arguments_If_Set(bool allowEmptyChecksumsSecure, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.AllowEmptyChecksumsSecure = allowEmptyChecksumsSecure;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --require-checksums")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_RequireChecksums_Flag_To_Arguments_If_Set(bool requireChecksums, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.RequireChecksums = requireChecksums;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("abcdef", "install \"Cake\" --confirm --download-checksum=\"abcdef\"")]
+            [InlineData(null, "install \"Cake\" --confirm")]
+            public void Should_Add_Checksum_Flag_To_Arguments_If_Set(string checksum, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.Checksum = checksum;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("abcdef", "install \"Cake\" --confirm --download-checksum-x64=\"abcdef\"")]
+            [InlineData(null, "install \"Cake\" --confirm")]
+            public void Should_Add_Checksum64_Flag_To_Arguments_If_Set(string checksum64, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.Checksum64 = checksum64;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("md5", "install \"Cake\" --confirm --download-checksum-type=\"md5\"")]
+            [InlineData(null, "install \"Cake\" --confirm")]
+            public void Should_Add_ChecksumType_Flag_To_Arguments_If_Set(string checkSumType, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.ChecksumType = checkSumType;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("md5", "install \"Cake\" --confirm --download-checksum-type-x64=\"md5\"")]
+            [InlineData(null, "install \"Cake\" --confirm")]
+            public void Should_Add_ChecksumType64_Flag_To_Arguments_If_Set(string checkSumType64, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.ChecksumType64 = checkSumType64;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --ignore-package-exit-codes")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_IgnorePackageExitCodes_Flag_To_Arguments_If_Set(bool ignorePackageExitCodes, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.IgnorePackageExitCodes = ignorePackageExitCodes;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --use-package-exit-codes")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_UsePackageExitCodes_Flag_To_Arguments_If_Set(bool usePackageExitCodes, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.UsePackageExitCodes = usePackageExitCodes;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --stop-on-first-package-failure")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_StopOnFirstFailure_Flag_To_Arguments_If_Set(bool stopOnFirstFailure, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.StopOnFirstFailure = stopOnFirstFailure;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --exit-when-reboot-detected")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_ExitWhenRebootDetected_Flag_To_Arguments_If_Set(bool exitWhenRebootDetected, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.ExitWhenRebootDetected = exitWhenRebootDetected;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --ignore-detected-reboot")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_IgnoreDetectedReboot_Flag_To_Arguments_If_Set(bool ignoreDetectedReboot, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.IgnoreDetectedReboot = ignoreDetectedReboot;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --disable-repository-optimizations")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_DisableRepositoryOptimizations_Flag_To_Arguments_If_Set(bool disableRepositoryOptimizations, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.DisableRepositoryOptimizations = disableRepositoryOptimizations;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --pin-package")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_Pin_Flag_To_Arguments_If_Set(bool pin, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.Pin = pin;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --skip-hooks")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_SkipHooks_Flag_To_Arguments_If_Set(bool skipHooks, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.SkipHooks = skipHooks;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --skip-download-cache")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_SkipDownloadCache_Flag_To_Arguments_If_Set(bool skipDownloadCache, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.SkipDownloadCache = skipDownloadCache;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --use-download-cache")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_UseDownloadCache_Flag_To_Arguments_If_Set(bool useDownloadCache, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.UseDownloadCache = useDownloadCache;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --skip-virus-check")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_SkipVirusCheck_Flag_To_Arguments_If_Set(bool skipVirusCheck, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.SkipVirusCheck = skipVirusCheck;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --virus-check")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_VirusCheck_Flag_To_Arguments_If_Set(bool virusCheck, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.VirusCheck = virusCheck;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(5, "install \"Cake\" --confirm --virus-positives-minimum=\"5\"")]
+            [InlineData(0, "install \"Cake\" --confirm")]
+            public void Should_Add_VirusPositivesMinimum_To_Arguments_If_Set(int virusPositivesMinimum, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.VirusPositivesMinimum = virusPositivesMinimum;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("super-secret", "install \"Cake\" --confirm --install-arguments-sensitive=\"super-secret\"")]
+            [InlineData(null, "install \"Cake\" --confirm")]
+            public void Should_Add_InstallArgumentsSensitive_Flag_To_Arguments_If_Set(string installArgumentsSensitive, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.InstallArgumentsSensitive = installArgumentsSensitive;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("super-secret", "install \"Cake\" --confirm --package-parameters-sensitive=\"super-secret\"")]
+            [InlineData(null, "install \"Cake\" --confirm")]
+            public void Should_Add_PackageParametersSensitive_Flag_To_Arguments_If_Set(string packageParametersSensitive, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.PackageParametersSensitive = packageParametersSensitive;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./install", "install \"Cake\" --confirm --install-directory=\"/Working/install\"")]
+            [InlineData(null, "install \"Cake\" --confirm")]
+            public void Should_Add_InstallDirectory_Flag_To_Arguments_If_Set(string installDirectory, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.InstallDirectory = installDirectory;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(5, "install \"Cake\" --confirm --maximum-download-bits-per-second=\"5\"")]
+            [InlineData(0, "install \"Cake\" --confirm")]
+            public void Should_Add_MaximumDownloadBitsPerSecond_Flag_To_Arguments_If_Set(int maximumDownloadBitsPerSecond, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.MaximumDownloadBitsPerSecond = maximumDownloadBitsPerSecond;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --reduce-package-size")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_ReducePackageSize_Flag_To_Arguments_If_Set(bool reducePackageSize, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.ReducePackageSize = reducePackageSize;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --no-reduce-package-size")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_NoReducePackageSize_Flag_To_Arguments_If_Set(bool noReducePackageSize, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.NoReducePackageSize = noReducePackageSize;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"Cake\" --confirm --reduce-nupkg-only")]
+            [InlineData(false, "install \"Cake\" --confirm")]
+            public void Should_Add_ReduceNupkgOnly_Flag_To_Arguments_If_Set(bool reduceNupkgOnly, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.ReduceNupkgOnly = reduceNupkgOnly;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("Just because", "install \"Cake\" --confirm --pin-reason=\"Just because\"")]
+            [InlineData(null, "install \"Cake\" --confirm")]
+            public void Should_Add_PinReason_Flag_To_Arguments_If_Set(string pinReason, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFixture();
+                fixture.Settings.PinReason = pinReason;
 
                 // When
                 var result = fixture.Run();
@@ -667,12 +1371,12 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("install \"/Working/packages.config\" -y", result.Args);
+                Assert.Equal("install \"/Working/packages.config\" --confirm", result.Args);
             }
 
             [Theory]
-            [InlineData(true, "install \"/Working/packages.config\" -d -y")]
-            [InlineData(false, "install \"/Working/packages.config\" -y")]
+            [InlineData(true, "install \"/Working/packages.config\" --debug --confirm")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
             public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
             {
                 // Given
@@ -687,8 +1391,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData(true, "install \"/Working/packages.config\" -v -y")]
-            [InlineData(false, "install \"/Working/packages.config\" -y")]
+            [InlineData(true, "install \"/Working/packages.config\" --verbose --confirm")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
             public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
             {
                 // Given
@@ -703,8 +1407,56 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData(true, "install \"/Working/packages.config\" -y -f")]
-            [InlineData(false, "install \"/Working/packages.config\" -y")]
+            [InlineData(true, "install \"/Working/packages.config\" --trace --confirm")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_Trace_Flag_To_Arguments_If_Set(bool trace, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.Trace = trace;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --no-color --confirm")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_NoColor_Flag_To_Arguments_If_Set(bool noColor, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.NoColor = noColor;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --accept-license --confirm")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_AcceptLicense_Flag_To_Arguments_If_Set(bool acceptLicense, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.AcceptLicense = acceptLicense;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --force")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
             public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
             {
                 // Given
@@ -719,8 +1471,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData(true, "install \"/Working/packages.config\" -y --noop")]
-            [InlineData(false, "install \"/Working/packages.config\" -y")]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --what-if")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
             public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
             {
                 // Given
@@ -735,8 +1487,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData(true, "install \"/Working/packages.config\" -y -r")]
-            [InlineData(false, "install \"/Working/packages.config\" -y")]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --limit-output")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
             public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
             {
                 // Given
@@ -751,8 +1503,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData(5, "install \"/Working/packages.config\" -y --execution-timeout \"5\"")]
-            [InlineData(0, "install \"/Working/packages.config\" -y")]
+            [InlineData(5, "install \"/Working/packages.config\" --confirm --execution-timeout=\"5\"")]
+            [InlineData(0, "install \"/Working/packages.config\" --confirm")]
             public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
             {
                 // Given
@@ -767,8 +1519,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData(@"c:\temp", "install \"/Working/packages.config\" -y -c \"c:\\temp\"")]
-            [InlineData("", "install \"/Working/packages.config\" -y")]
+            [InlineData(@"c:\temp", "install \"/Working/packages.config\" --confirm --cache-location=\"c:\\temp\"")]
+            [InlineData("", "install \"/Working/packages.config\" --confirm")]
             public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
             {
                 // Given
@@ -783,13 +1535,173 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
             }
 
             [Theory]
-            [InlineData(true, "install \"/Working/packages.config\" -y --allowunofficial")]
-            [InlineData(false, "install \"/Working/packages.config\" -y")]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --allow-unofficial")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
             public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
             {
                 // Given
                 var fixture = new ChocolateyInstallFromConfigFixture();
                 fixture.Settings.AllowUnofficial = allowUnofficial;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --fail-on-error-output")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_FailOnErrorOutput_Flag_To_Arguments_If_Set(bool failOnErrorOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.FailOnErrorOutput = failOnErrorOutput;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --use-system-powershell")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_UseSystemPowerShell_Flag_To_Arguments_If_Set(bool useSystemPowerShell, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.UseSystemPowerShell = useSystemPowerShell;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --no-progress")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_NoProgress_Flag_To_Arguments_If_Set(bool noProgress, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.NoProgress = noProgress;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy", "install \"/Working/packages.config\" --confirm --proxy=\"proxy\"")]
+            [InlineData(null, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_Proxy_Flag_To_Arguments_If_Set(string proxy, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.Proxy = proxy;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-user", "install \"/Working/packages.config\" --confirm --proxy-user=\"proxy-user\"")]
+            [InlineData(null, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_ProxyUser_Flag_To_Arguments_If_Set(string proxyUser, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.ProxyUser = proxyUser;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-password", "install \"/Working/packages.config\" --confirm --proxy-password=\"proxy-password\"")]
+            [InlineData(null, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_ProxyPassword_Flag_To_Arguments_If_Set(string proxyPassword, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.ProxyPassword = proxyPassword;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy1,proxy2", "install \"/Working/packages.config\" --confirm --proxy-bypass-list=\"proxy1,proxy2\"")]
+            [InlineData(null, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_ProxyByPassList_Flag_To_Arguments_If_Set(string proxyByPassList, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.ProxyByPassList = proxyByPassList;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --proxy-bypass-on-local")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_ProxyByPassOnLocal_Flag_To_Arguments_If_Set(bool proxyBypassOnLocal, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.ProxyBypassOnLocal = proxyBypassOnLocal;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./output.log", "install \"/Working/packages.config\" --confirm --log-file=\"/Working/output.log\"")]
+            [InlineData(null, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_Log_File_Flag_To_Arguments_If_Set(string logFilePath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.LogFile = logFilePath;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --skip-compatibility-checks")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_Skip_Compatibility_Flag_To_Arguments_If_Set(bool skipCompatibiity, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.SkipCompatibilityChecks = skipCompatibiity;
 
                 // When
                 var result = fixture.Run();
@@ -809,7 +1721,743 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Install
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("install \"/Working/packages.config\" -y -s \"A\"", result.Args);
+                Assert.Equal("install \"/Working/packages.config\" --confirm --source=\"A\"", result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --pre")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_Prerelease_Flag_To_Arguments_If_Set(bool prerelease, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.Prerelease = prerelease;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --forcex86")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_Forcex86_Flag_To_Arguments_If_Set(bool forcex86, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.Forcex86 = forcex86;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("args1", "install \"/Working/packages.config\" --confirm --install-arguments=\"args1\"")]
+            [InlineData("", "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_InstallArguments_To_Arguments_If_Set(string installArgs, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.InstallArguments = installArgs;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --override-arguments")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_OverrideArguments_Flag_To_Arguments_If_Set(bool overrideArguments, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.OverrideArguments = overrideArguments;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --not-silent")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_NotSilent_Flag_To_Arguments_If_Set(bool notSilent, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.NotSilent = notSilent;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("param1", "install \"/Working/packages.config\" --confirm --package-parameters=\"param1\"")]
+            [InlineData("", "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_PackageParameters_To_Arguments_If_Set(string packageParameters, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.PackageParameters = packageParameters;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --apply-install-arguments-to-dependencies")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_ApplyInstallArgumentsToDependencies_To_Arguments_If_Set(bool applyInstallArgumentsToDependencies, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.ApplyInstallArgumentsToDependencies = applyInstallArgumentsToDependencies;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --apply-package-parameters-to-dependencies")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_ApplyPackageParametersToDependencies_To_Arguments_If_Set(bool applyPackageParametersToDependencies, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.ApplyPackageParametersToDependencies = applyPackageParametersToDependencies;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --allow-downgrade")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_AllowDowngrade_Flag_To_Arguments_If_Set(bool allowDowngrade, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.AllowDowngrade = allowDowngrade;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --side-by-side")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_SideBySide_Flag_To_Arguments_If_Set(bool sideBySide, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.SideBySide = sideBySide;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --ignore-dependencies")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_IgnoreDependencies_Flag_To_Arguments_If_Set(bool ignoreDependencies, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.IgnoreDependencies = ignoreDependencies;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --force-dependencies")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_ForceDependencies_Flag_To_Arguments_If_Set(bool forceDependencies, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.ForceDependencies = forceDependencies;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --skip-automation-scripts")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_SkipPowerShell_Flag_To_Arguments_If_Set(bool skipPowerShell, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.SkipPowerShell = skipPowerShell;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("user1", "install \"/Working/packages.config\" --confirm --user=\"user1\"")]
+            [InlineData("", "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_User_To_Arguments_If_Set(string user, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.User = user;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("password1", "install \"/Working/packages.config\" --confirm --password=\"password1\"")]
+            [InlineData("", "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_Password_To_Arguments_If_Set(string password, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.Password = password;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./mycert.pfx", "install \"/Working/packages.config\" --confirm --cert=\"/Working/mycert.pfx\"")]
+            [InlineData(null, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_Cert_To_Arguments_If_Set(string certificate, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.Certificate = certificate;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("certpassword", "install \"/Working/packages.config\" --confirm --certpassword=\"certpassword\"")]
+            [InlineData("", "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_CertPassword_To_Arguments_If_Set(string certificatePassword, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.CertificatePassword = certificatePassword;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --ignore-checksums")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_IgnoreChecksums_Flag_To_Arguments_If_Set(bool ignoreChecksums, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.IgnoreChecksums = ignoreChecksums;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --allow-empty-checksums")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_AllowEmptyChecksums_Flag_To_Arguments_If_Set(bool allowEmptyChecksums, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.AllowEmptyChecksums = allowEmptyChecksums;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --allow-empty-checksums-secure")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_AllowEmptyChecksumsSecure_Flag_To_Arguments_If_Set(bool allowEmptyChecksumsSecure, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.AllowEmptyChecksumsSecure = allowEmptyChecksumsSecure;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --require-checksums")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_RequireChecksums_Flag_To_Arguments_If_Set(bool requireChecksums, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.RequireChecksums = requireChecksums;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("abcdef", "install \"/Working/packages.config\" --confirm --download-checksum=\"abcdef\"")]
+            [InlineData(null, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_Checksum_Flag_To_Arguments_If_Set(string checksum, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.Checksum = checksum;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("abcdef", "install \"/Working/packages.config\" --confirm --download-checksum-x64=\"abcdef\"")]
+            [InlineData(null, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_Checksum64_Flag_To_Arguments_If_Set(string checksum64, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.Checksum64 = checksum64;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("md5", "install \"/Working/packages.config\" --confirm --download-checksum-type=\"md5\"")]
+            [InlineData(null, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_ChecksumType_Flag_To_Arguments_If_Set(string checkSumType, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.ChecksumType = checkSumType;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("md5", "install \"/Working/packages.config\" --confirm --download-checksum-type-x64=\"md5\"")]
+            [InlineData(null, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_ChecksumType64_Flag_To_Arguments_If_Set(string checkSumType64, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.ChecksumType64 = checkSumType64;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --ignore-package-exit-codes")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_IgnorePackageExitCodes_Flag_To_Arguments_If_Set(bool ignorePackageExitCodes, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.IgnorePackageExitCodes = ignorePackageExitCodes;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --use-package-exit-codes")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_UsePackageExitCodes_Flag_To_Arguments_If_Set(bool usePackageExitCodes, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.UsePackageExitCodes = usePackageExitCodes;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --stop-on-first-package-failure")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_StopOnFirstFailure_Flag_To_Arguments_If_Set(bool stopOnFirstFailure, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.StopOnFirstFailure = stopOnFirstFailure;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --exit-when-reboot-detected")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_ExitWhenRebootDetected_Flag_To_Arguments_If_Set(bool exitWhenRebootDetected, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.ExitWhenRebootDetected = exitWhenRebootDetected;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --ignore-detected-reboot")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_IgnoreDetectedReboot_Flag_To_Arguments_If_Set(bool ignoreDetectedReboot, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.IgnoreDetectedReboot = ignoreDetectedReboot;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --disable-repository-optimizations")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_DisableRepositoryOptimizations_Flag_To_Arguments_If_Set(bool disableRepositoryOptimizations, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.DisableRepositoryOptimizations = disableRepositoryOptimizations;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --pin-package")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_Pin_Flag_To_Arguments_If_Set(bool pin, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.Pin = pin;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --skip-hooks")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_SkipHooks_Flag_To_Arguments_If_Set(bool skipHooks, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.SkipHooks = skipHooks;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --skip-download-cache")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_SkipDownloadCache_Flag_To_Arguments_If_Set(bool skipDownloadCache, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.SkipDownloadCache = skipDownloadCache;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --use-download-cache")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_UseDownloadCache_Flag_To_Arguments_If_Set(bool useDownloadCache, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.UseDownloadCache = useDownloadCache;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --skip-virus-check")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_SkipVirusCheck_Flag_To_Arguments_If_Set(bool skipVirusCheck, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.SkipVirusCheck = skipVirusCheck;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --virus-check")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_VirusCheck_Flag_To_Arguments_If_Set(bool virusCheck, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.VirusCheck = virusCheck;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(5, "install \"/Working/packages.config\" --confirm --virus-positives-minimum=\"5\"")]
+            [InlineData(0, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_VirusPositivesMinimum_To_Arguments_If_Set(int virusPositivesMinimum, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.VirusPositivesMinimum = virusPositivesMinimum;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("super-secret", "install \"/Working/packages.config\" --confirm --install-arguments-sensitive=\"super-secret\"")]
+            [InlineData(null, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_InstallArgumentsSensitive_Flag_To_Arguments_If_Set(string installArgumentsSensitive, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.InstallArgumentsSensitive = installArgumentsSensitive;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("super-secret", "install \"/Working/packages.config\" --confirm --package-parameters-sensitive=\"super-secret\"")]
+            [InlineData(null, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_PackageParametersSensitive_Flag_To_Arguments_If_Set(string packageParametersSensitive, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.PackageParametersSensitive = packageParametersSensitive;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./install", "install \"/Working/packages.config\" --confirm --install-directory=\"/Working/install\"")]
+            [InlineData(null, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_InstallDirectory_Flag_To_Arguments_If_Set(string installDirectory, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.InstallDirectory = installDirectory;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(5, "install \"/Working/packages.config\" --confirm --maximum-download-bits-per-second=\"5\"")]
+            [InlineData(0, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_MaximumDownloadBitsPerSecond_Flag_To_Arguments_If_Set(int maximumDownloadBitsPerSecond, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.MaximumDownloadBitsPerSecond = maximumDownloadBitsPerSecond;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --reduce-package-size")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_ReducePackageSize_Flag_To_Arguments_If_Set(bool reducePackageSize, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.ReducePackageSize = reducePackageSize;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --no-reduce-package-size")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_NoReducePackageSize_Flag_To_Arguments_If_Set(bool noReducePackageSize, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.NoReducePackageSize = noReducePackageSize;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "install \"/Working/packages.config\" --confirm --reduce-nupkg-only")]
+            [InlineData(false, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_ReduceNupkgOnly_Flag_To_Arguments_If_Set(bool reduceNupkgOnly, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.ReduceNupkgOnly = reduceNupkgOnly;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("Just because", "install \"/Working/packages.config\" --confirm --pin-reason=\"Just because\"")]
+            [InlineData(null, "install \"/Working/packages.config\" --confirm")]
+            public void Should_Add_PinReason_Flag_To_Arguments_If_Set(string pinReason, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyInstallFromConfigFixture();
+                fixture.Settings.PinReason = pinReason;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
             }
         }
     }

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/New/ChocolateyNewTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/New/ChocolateyNewTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Cake.Common.Tests.Fixtures.Tools.Chocolatey.ApiKey;
 using Cake.Common.Tests.Fixtures.Tools.Chocolatey.New;
 using Cake.Common.Tests.Properties;
 using Cake.Common.Tools.Chocolatey.New;
@@ -144,7 +145,375 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.New
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("new \"MyPackage\" -y", result.Args);
+                Assert.Equal("new \"MyPackage\" --confirm", result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "new \"MyPackage\" --debug --confirm")]
+            [InlineData(false, "new \"MyPackage\" --confirm")]
+            public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.Debug = debug;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "new \"MyPackage\" --verbose --confirm")]
+            [InlineData(false, "new \"MyPackage\" --confirm")]
+            public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.Verbose = verbose;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "new \"MyPackage\" --trace --confirm")]
+            [InlineData(false, "new \"MyPackage\" --confirm")]
+            public void Should_Add_Trace_Flag_To_Arguments_If_Set(bool trace, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.Trace = trace;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "new \"MyPackage\" --no-color --confirm")]
+            [InlineData(false, "new \"MyPackage\" --confirm")]
+            public void Should_Add_NoColor_Flag_To_Arguments_If_Set(bool noColor, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.NoColor = noColor;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "new \"MyPackage\" --accept-license --confirm")]
+            [InlineData(false, "new \"MyPackage\" --confirm")]
+            public void Should_Add_AcceptLicense_Flag_To_Arguments_If_Set(bool acceptLicense, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.AcceptLicense = acceptLicense;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "new \"MyPackage\" --confirm --force")]
+            [InlineData(false, "new \"MyPackage\" --confirm")]
+            public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.Force = force;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "new \"MyPackage\" --confirm --what-if")]
+            [InlineData(false, "new \"MyPackage\" --confirm")]
+            public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.Noop = noop;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "new \"MyPackage\" --confirm --limit-output")]
+            [InlineData(false, "new \"MyPackage\" --confirm")]
+            public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.LimitOutput = limitOutput;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(5, "new \"MyPackage\" --confirm --execution-timeout=\"5\"")]
+            [InlineData(0, "new \"MyPackage\" --confirm")]
+            public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.ExecutionTimeout = executionTimeout;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(@"c:\temp", "new \"MyPackage\" --confirm --cache-location=\"c:\\temp\"")]
+            [InlineData("", "new \"MyPackage\" --confirm")]
+            public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.CacheLocation = cacheLocation;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "new \"MyPackage\" --confirm --allow-unofficial")]
+            [InlineData(false, "new \"MyPackage\" --confirm")]
+            public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.AllowUnofficial = allowUnofficial;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "new \"MyPackage\" --confirm --fail-on-error-output")]
+            [InlineData(false, "new \"MyPackage\" --confirm")]
+            public void Should_Add_FailOnErrorOutput_Flag_To_Arguments_If_Set(bool failOnErrorOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.FailOnErrorOutput = failOnErrorOutput;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "new \"MyPackage\" --confirm --use-system-powershell")]
+            [InlineData(false, "new \"MyPackage\" --confirm")]
+            public void Should_Add_UseSystemPowerShell_Flag_To_Arguments_If_Set(bool useSystemPowerShell, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.UseSystemPowerShell = useSystemPowerShell;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "new \"MyPackage\" --confirm --no-progress")]
+            [InlineData(false, "new \"MyPackage\" --confirm")]
+            public void Should_Add_NoProgress_Flag_To_Arguments_If_Set(bool noProgress, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.NoProgress = noProgress;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy", "new \"MyPackage\" --confirm --proxy=\"proxy\"")]
+            [InlineData(null, "new \"MyPackage\" --confirm")]
+            public void Should_Add_Proxy_Flag_To_Arguments_If_Set(string proxy, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.Proxy = proxy;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-user", "new \"MyPackage\" --confirm --proxy-user=\"proxy-user\"")]
+            [InlineData(null, "new \"MyPackage\" --confirm")]
+            public void Should_Add_ProxyUser_Flag_To_Arguments_If_Set(string proxyUser, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.ProxyUser = proxyUser;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-password", "new \"MyPackage\" --confirm --proxy-password=\"proxy-password\"")]
+            [InlineData(null, "new \"MyPackage\" --confirm")]
+            public void Should_Add_ProxyPassword_Flag_To_Arguments_If_Set(string proxyPassword, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.ProxyPassword = proxyPassword;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy1,proxy2", "new \"MyPackage\" --confirm --proxy-bypass-list=\"proxy1,proxy2\"")]
+            [InlineData(null, "new \"MyPackage\" --confirm")]
+            public void Should_Add_ProxyByPassList_Flag_To_Arguments_If_Set(string proxyByPassList, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.ProxyByPassList = proxyByPassList;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "new \"MyPackage\" --confirm --proxy-bypass-on-local")]
+            [InlineData(false, "new \"MyPackage\" --confirm")]
+            public void Should_Add_ProxyByPassOnLocal_Flag_To_Arguments_If_Set(bool proxyBypassOnLocal, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.ProxyBypassOnLocal = proxyBypassOnLocal;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./output.log", "new \"MyPackage\" --confirm --log-file=\"/Working/output.log\"")]
+            [InlineData(null, "new \"MyPackage\" --confirm")]
+            public void Should_Add_Log_File_Flag_To_Arguments_If_Set(string logFilePath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.LogFile = logFilePath;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "new \"MyPackage\" --confirm --skip-compatibility-checks")]
+            [InlineData(false, "new \"MyPackage\" --confirm")]
+            public void Should_Add_Skip_Compatibility_Flag_To_Arguments_If_Set(bool skipCompatibiity, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.SkipCompatibilityChecks = skipCompatibiity;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "new \"MyPackage\" --confirm --automaticpackage")]
+            [InlineData(false, "new \"MyPackage\" --confirm")]
+            public void Should_Add_AutomaticPackage_Flag_To_Arguments_If_Set(bool automaticPackage, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.AutomaticPackage = automaticPackage;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("templateA", "new \"MyPackage\" --confirm --template-name=\"templateA\"")]
+            [InlineData(null, "new \"MyPackage\" --confirm")]
+            public void Should_Add_TemplateName_Flag_To_Arguments_If_Set(string templateName, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.TemplateName = templateName;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
             }
 
             [Fact]
@@ -158,7 +527,7 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.New
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("new \"MyPackage\" -y packageversion=\"1.2.3\"", result.Args);
+                Assert.Equal("new \"MyPackage\" --confirm packageversion=\"1.2.3\"", result.Args);
             }
 
             [Fact]
@@ -172,7 +541,7 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.New
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("new \"MyPackage\" -y maintainername=\"John Doe\"", result.Args);
+                Assert.Equal("new \"MyPackage\" --confirm maintainername=\"John Doe\"", result.Args);
             }
 
             [Fact]
@@ -186,7 +555,7 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.New
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("new \"MyPackage\" -y maintainerrepo=\"johndoe\"", result.Args);
+                Assert.Equal("new \"MyPackage\" --confirm maintainerrepo=\"johndoe\"", result.Args);
             }
 
             [Fact]
@@ -200,7 +569,7 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.New
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("new \"MyPackage\" -y installertype=\"msi\"", result.Args);
+                Assert.Equal("new \"MyPackage\" --confirm installertype=\"msi\"", result.Args);
             }
 
             [Fact]
@@ -214,7 +583,7 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.New
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("new \"MyPackage\" -y url=\"https://example.com\"", result.Args);
+                Assert.Equal("new \"MyPackage\" --confirm url=\"https://example.com\"", result.Args);
             }
 
             [Fact]
@@ -228,15 +597,15 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.New
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("new \"MyPackage\" -y url64=\"https://example.com\"", result.Args);
+                Assert.Equal("new \"MyPackage\" --confirm url64=\"https://example.com\"", result.Args);
             }
 
             [Theory]
-            [InlineData("-Foo", "new \"MyPackage\" -y silentargs=\"-Foo\"")]
-            [InlineData("--Foo", "new \"MyPackage\" -y silentargs=\"--Foo\"")]
-            [InlineData("/Foo", "new \"MyPackage\" -y silentargs=\"/Foo\"")]
-            [InlineData("-Foo=Bar", "new \"MyPackage\" -y silentargs=\"-Foo=Bar\"")]
-            [InlineData("-Foo --Foo /Foo -Foo=Bar", "new \"MyPackage\" -y silentargs=\"-Foo --Foo /Foo -Foo=Bar\"")]
+            [InlineData("-Foo", "new \"MyPackage\" --confirm silentargs=\"-Foo\"")]
+            [InlineData("--Foo", "new \"MyPackage\" --confirm silentargs=\"--Foo\"")]
+            [InlineData("/Foo", "new \"MyPackage\" --confirm silentargs=\"/Foo\"")]
+            [InlineData("-Foo=Bar", "new \"MyPackage\" --confirm silentargs=\"-Foo=Bar\"")]
+            [InlineData("-Foo --Foo /Foo -Foo=Bar", "new \"MyPackage\" --confirm silentargs=\"-Foo --Foo /Foo -Foo=Bar\"")]
             public void Should_Add_Silent_Args_To_Arguments_If_Set(string silentArgs, string expected)
             {
                 // Given
@@ -251,8 +620,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.New
             }
 
             [Theory]
-            [InlineData("Foo", "Bar", "new \"MyPackage\" -y Foo=\"Bar\"")]
-            [InlineData("Foo", "Foo Bar", "new \"MyPackage\" -y Foo=\"Foo Bar\"")]
+            [InlineData("Foo", "Bar", "new \"MyPackage\" --confirm Foo=\"Bar\"")]
+            [InlineData("Foo", "Foo Bar", "new \"MyPackage\" --confirm Foo=\"Foo Bar\"")]
             public void Should_Add_Additional_Property_Value_To_Arguments_If_Set(string additionalPropertyName, string additionalPropertyValue, string expected)
             {
                 // Given
@@ -278,7 +647,7 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.New
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("new \"MyPackage\" -y Foo1=\"Bar1\" Foo2=\"Bar2\"", result.Args);
+                Assert.Equal("new \"MyPackage\" --confirm Foo1=\"Bar1\" Foo2=\"Bar2\"", result.Args);
             }
 
             [Fact]
@@ -292,7 +661,199 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.New
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("new \"MyPackage\" -y --outputdirectory \"/Working/Foo\"", result.Args);
+                Assert.Equal("new \"MyPackage\" --confirm --output-directory=\"/Working/Foo\"", result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "new \"MyPackage\" --confirm --built-in-template")]
+            [InlineData(false, "new \"MyPackage\" --confirm")]
+            public void Should_Add_BuiltInTemplate_Flag_To_Arguments_If_Set(bool builtIn, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.BuiltInTemplate = builtIn;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./input/install.exe", "new \"MyPackage\" --confirm --file=\"./input/install.exe\"")]
+            [InlineData(null, "new \"MyPackage\" --confirm")]
+            public void Should_Add_File_Flag_To_Arguments_If_Set(string fileName, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.File = fileName;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./input/install.exe", "new \"MyPackage\" --confirm --file64=\"./input/install.exe\"")]
+            [InlineData(null, "new \"MyPackage\" --confirm")]
+            public void Should_Add_File64_Flag_To_Arguments_If_Set(string file64Name, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.File64 = file64Name;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "new \"MyPackage\" --confirm --use-original-files-location")]
+            [InlineData(false, "new \"MyPackage\" --confirm")]
+            public void Should_Add_UseOriginalFilesLocation_Flag_To_Arguments_If_Set(bool useOriginalFilesLocation, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.UseOriginalFilesLocation = useOriginalFilesLocation;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("abcdef", "new \"MyPackage\" --confirm --download-checksum=\"abcdef\"")]
+            [InlineData(null, "new \"MyPackage\" --confirm")]
+            public void Should_Add_Checksum_Flag_To_Arguments_If_Set(string checksum, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.Checksum = checksum;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("abcdef", "new \"MyPackage\" --confirm --download-checksum-x64=\"abcdef\"")]
+            [InlineData(null, "new \"MyPackage\" --confirm")]
+            public void Should_Add_Checksum64_Flag_To_Arguments_If_Set(string checksum64, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.Checksum64 = checksum64;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("md5", "new \"MyPackage\" --confirm --download-checksum-type=\"md5\"")]
+            [InlineData(null, "new \"MyPackage\" --confirm")]
+            public void Should_Add_ChecksumType_Flag_To_Arguments_If_Set(string checkSumType, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.ChecksumType = checkSumType;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "new \"MyPackage\" --confirm --pause-on-error")]
+            [InlineData(false, "new \"MyPackage\" --confirm")]
+            public void Should_Add_PauseOnError_Flag_To_Arguments_If_Set(bool pauseOnError, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.PauseOnError = pauseOnError;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "new \"MyPackage\" --confirm --build-package")]
+            [InlineData(false, "new \"MyPackage\" --confirm")]
+            public void Should_Add_BuildPackage_Flag_To_Arguments_If_Set(bool buildPackage, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.BuildPackage = buildPackage;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "new \"MyPackage\" --confirm --from-programs-and-features")]
+            [InlineData(false, "new \"MyPackage\" --confirm")]
+            public void Should_Add_GeneratePackagesFromInstalledSoftware_Flag_To_Arguments_If_Set(bool generatePackagesFromInstalledSoftware, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.GeneratePackagesFromInstalledSoftware = generatePackagesFromInstalledSoftware;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "new \"MyPackage\" --confirm --remove-architecture-from-name")]
+            [InlineData(false, "new \"MyPackage\" --confirm")]
+            public void Should_Add_RemoveArchitectureFromName_Flag_To_Arguments_If_Set(bool removeArchitectureFromName, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.RemoveArchitectureFromName = removeArchitectureFromName;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "new \"MyPackage\" --confirm --include-architecture-in-name")]
+            [InlineData(false, "new \"MyPackage\" --confirm")]
+            public void Should_Add_IncludeArchitectureInPackageName_Flag_To_Arguments_If_Set(bool includeArchitectureInPackageName, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyNewFixture();
+                fixture.Settings.IncludeArchitectureInPackageName = includeArchitectureInPackageName;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
             }
         }
     }

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Pack/ChocolateyPackerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Pack/ChocolateyPackerTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Cake.Common.Tests.Fixtures.Tools.Chocolatey.ApiKey;
 using Cake.Common.Tests.Fixtures.Tools.Chocolatey.Packer;
 using Cake.Common.Tests.Properties;
 using Cake.Common.Tools.Chocolatey.Pack;
@@ -176,8 +177,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pack
             }
 
             [Theory]
-            [InlineData(true, "pack -d -y \"/Working/existing.temp.nuspec\"")]
-            [InlineData(false, "pack -y \"/Working/existing.temp.nuspec\"")]
+            [InlineData(true, "pack \"/Working/existing.temp.nuspec\" --debug --confirm")]
+            [InlineData(false, "pack \"/Working/existing.temp.nuspec\" --confirm")]
             public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
             {
                 // Given
@@ -192,8 +193,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pack
             }
 
             [Theory]
-            [InlineData(true, "pack -v -y \"/Working/existing.temp.nuspec\"")]
-            [InlineData(false, "pack -y \"/Working/existing.temp.nuspec\"")]
+            [InlineData(true, "pack \"/Working/existing.temp.nuspec\" --verbose --confirm")]
+            [InlineData(false, "pack \"/Working/existing.temp.nuspec\" --confirm")]
             public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
             {
                 // Given
@@ -208,8 +209,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pack
             }
 
             [Theory]
-            [InlineData(true, "pack -y -f \"/Working/existing.temp.nuspec\"")]
-            [InlineData(false, "pack -y \"/Working/existing.temp.nuspec\"")]
+            [InlineData(true, "pack \"/Working/existing.temp.nuspec\" --confirm --force")]
+            [InlineData(false, "pack \"/Working/existing.temp.nuspec\" --confirm")]
             public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
             {
                 // Given
@@ -224,8 +225,56 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pack
             }
 
             [Theory]
-            [InlineData(true, "pack -y --noop \"/Working/existing.temp.nuspec\"")]
-            [InlineData(false, "pack -y \"/Working/existing.temp.nuspec\"")]
+            [InlineData(true, "pack \"/Working/existing.temp.nuspec\" --trace --confirm")]
+            [InlineData(false, "pack \"/Working/existing.temp.nuspec\" --confirm")]
+            public void Should_Add_Trace_Flag_To_Arguments_If_Set(bool trace, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPackerWithNuSpecFixture();
+                fixture.Settings.Trace = trace;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "pack \"/Working/existing.temp.nuspec\" --no-color --confirm")]
+            [InlineData(false, "pack \"/Working/existing.temp.nuspec\" --confirm")]
+            public void Should_Add_NoColor_Flag_To_Arguments_If_Set(bool noColor, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPackerWithNuSpecFixture();
+                fixture.Settings.NoColor = noColor;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "pack \"/Working/existing.temp.nuspec\" --accept-license --confirm")]
+            [InlineData(false, "pack \"/Working/existing.temp.nuspec\" --confirm")]
+            public void Should_Add_AcceptLicense_Flag_To_Arguments_If_Set(bool acceptLicense, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPackerWithNuSpecFixture();
+                fixture.Settings.AcceptLicense = acceptLicense;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "pack \"/Working/existing.temp.nuspec\" --confirm --what-if")]
+            [InlineData(false, "pack \"/Working/existing.temp.nuspec\" --confirm")]
             public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
             {
                 // Given
@@ -240,8 +289,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pack
             }
 
             [Theory]
-            [InlineData(true, "pack -y -r \"/Working/existing.temp.nuspec\"")]
-            [InlineData(false, "pack -y \"/Working/existing.temp.nuspec\"")]
+            [InlineData(true, "pack \"/Working/existing.temp.nuspec\" --confirm --limit-output")]
+            [InlineData(false, "pack \"/Working/existing.temp.nuspec\" --confirm")]
             public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
             {
                 // Given
@@ -256,8 +305,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pack
             }
 
             [Theory]
-            [InlineData(5, "pack -y --execution-timeout \"5\" \"/Working/existing.temp.nuspec\"")]
-            [InlineData(0, "pack -y \"/Working/existing.temp.nuspec\"")]
+            [InlineData(5, "pack \"/Working/existing.temp.nuspec\" --confirm --execution-timeout=\"5\"")]
+            [InlineData(0, "pack \"/Working/existing.temp.nuspec\" --confirm")]
             public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
             {
                 // Given
@@ -272,8 +321,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pack
             }
 
             [Theory]
-            [InlineData(@"c:\temp", "pack -y -c \"c:\\temp\" \"/Working/existing.temp.nuspec\"")]
-            [InlineData("", "pack -y \"/Working/existing.temp.nuspec\"")]
+            [InlineData(@"c:\temp", "pack \"/Working/existing.temp.nuspec\" --confirm --cache-location=\"c:\\temp\"")]
+            [InlineData("", "pack \"/Working/existing.temp.nuspec\" --confirm")]
             public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
             {
                 // Given
@@ -288,13 +337,173 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pack
             }
 
             [Theory]
-            [InlineData(true, "pack -y --allowunofficial \"/Working/existing.temp.nuspec\"")]
-            [InlineData(false, "pack -y \"/Working/existing.temp.nuspec\"")]
+            [InlineData(true, "pack \"/Working/existing.temp.nuspec\" --confirm --allow-unofficial")]
+            [InlineData(false, "pack \"/Working/existing.temp.nuspec\" --confirm")]
             public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
             {
                 // Given
                 var fixture = new ChocolateyPackerWithNuSpecFixture();
                 fixture.Settings.AllowUnofficial = allowUnofficial;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "pack \"/Working/existing.temp.nuspec\" --confirm --fail-on-error-output")]
+            [InlineData(false, "pack \"/Working/existing.temp.nuspec\" --confirm")]
+            public void Should_Add_FailOnErrorOutput_Flag_To_Arguments_If_Set(bool failOnErrorOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPackerWithNuSpecFixture();
+                fixture.Settings.FailOnErrorOutput = failOnErrorOutput;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "pack \"/Working/existing.temp.nuspec\" --confirm --use-system-powershell")]
+            [InlineData(false, "pack \"/Working/existing.temp.nuspec\" --confirm")]
+            public void Should_Add_UseSystemPowerShell_Flag_To_Arguments_If_Set(bool useSystemPowerShell, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPackerWithNuSpecFixture();
+                fixture.Settings.UseSystemPowerShell = useSystemPowerShell;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "pack \"/Working/existing.temp.nuspec\" --confirm --no-progress")]
+            [InlineData(false, "pack \"/Working/existing.temp.nuspec\" --confirm")]
+            public void Should_Add_NoProgress_Flag_To_Arguments_If_Set(bool noProgress, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPackerWithNuSpecFixture();
+                fixture.Settings.NoProgress = noProgress;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy", "pack \"/Working/existing.temp.nuspec\" --confirm --proxy=\"proxy\"")]
+            [InlineData(null, "pack \"/Working/existing.temp.nuspec\" --confirm")]
+            public void Should_Add_Proxy_Flag_To_Arguments_If_Set(string proxy, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPackerWithNuSpecFixture();
+                fixture.Settings.Proxy = proxy;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-user", "pack \"/Working/existing.temp.nuspec\" --confirm --proxy-user=\"proxy-user\"")]
+            [InlineData(null, "pack \"/Working/existing.temp.nuspec\" --confirm")]
+            public void Should_Add_ProxyUser_Flag_To_Arguments_If_Set(string proxyUser, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPackerWithNuSpecFixture();
+                fixture.Settings.ProxyUser = proxyUser;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-password", "pack \"/Working/existing.temp.nuspec\" --confirm --proxy-password=\"proxy-password\"")]
+            [InlineData(null, "pack \"/Working/existing.temp.nuspec\" --confirm")]
+            public void Should_Add_ProxyPassword_Flag_To_Arguments_If_Set(string proxyPassword, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPackerWithNuSpecFixture();
+                fixture.Settings.ProxyPassword = proxyPassword;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy1,proxy2", "pack \"/Working/existing.temp.nuspec\" --confirm --proxy-bypass-list=\"proxy1,proxy2\"")]
+            [InlineData(null, "pack \"/Working/existing.temp.nuspec\" --confirm")]
+            public void Should_Add_ProxyByPassList_Flag_To_Arguments_If_Set(string proxyByPassList, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPackerWithNuSpecFixture();
+                fixture.Settings.ProxyByPassList = proxyByPassList;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "pack \"/Working/existing.temp.nuspec\" --confirm --proxy-bypass-on-local")]
+            [InlineData(false, "pack \"/Working/existing.temp.nuspec\" --confirm")]
+            public void Should_Add_ProxyByPassOnLocal_Flag_To_Arguments_If_Set(bool proxyBypassOnLocal, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPackerWithNuSpecFixture();
+                fixture.Settings.ProxyBypassOnLocal = proxyBypassOnLocal;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./output.log", "pack \"/Working/existing.temp.nuspec\" --confirm --log-file=\"/Working/output.log\"")]
+            [InlineData(null, "pack \"/Working/existing.temp.nuspec\" --confirm")]
+            public void Should_Add_Log_File_Flag_To_Arguments_If_Set(string logFilePath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPackerWithNuSpecFixture();
+                fixture.Settings.LogFile = logFilePath;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "pack \"/Working/existing.temp.nuspec\" --confirm --skip-compatibility-checks")]
+            [InlineData(false, "pack \"/Working/existing.temp.nuspec\" --confirm")]
+            public void Should_Add_Skip_Compatibility_Flag_To_Arguments_If_Set(bool skipCompatibiity, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPackerWithNuSpecFixture();
+                fixture.Settings.SkipCompatibilityChecks = skipCompatibiity;
 
                 // When
                 var result = fixture.Run();
@@ -314,8 +523,23 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pack
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("pack -y --version \"1.0.0\" " +
-                             "\"/Working/existing.temp.nuspec\"", result.Args);
+                Assert.Equal("pack \"/Working/existing.temp.nuspec\" --confirm --version=\"1.0.0\"", result.Args);
+            }
+
+            [Theory]
+            [InlineData("./output", "pack \"/Working/existing.temp.nuspec\" --confirm --output-directory=\"/Working/output\"")]
+            [InlineData(null, "pack \"/Working/existing.temp.nuspec\" --confirm")]
+            public void Should_Add_OutputDirectory_Flag_To_Arguments_If_Set(string outputDirectory, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPackerWithNuSpecFixture();
+                fixture.Settings.OutputDirectory = outputDirectory;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
             }
 
             [Fact]
@@ -547,8 +771,7 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pack
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("pack -y --version \"1.0.0\" " +
-                             "\"/Working/nonexisting.temp.nuspec\"", result.Args);
+                Assert.Equal("pack \"/Working/nonexisting.temp.nuspec\" --confirm --version=\"1.0.0\"", result.Args);
             }
 
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Pin/ChocolateyPinnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Pin/ChocolateyPinnerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Common.Tests.Fixtures.Tools.Chocolatey.ApiKey;
 using Cake.Common.Tests.Fixtures.Tools.Chocolatey.Pin;
 using Cake.Testing;
 using Cake.Testing.Xunit;
@@ -125,12 +126,12 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pin
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("pin add -n \"Cake\" -y", result.Args);
+                Assert.Equal("pin add --name=\"Cake\" --confirm", result.Args);
             }
 
             [Theory]
-            [InlineData(true, "pin add -n \"Cake\" -d -y")]
-            [InlineData(false, "pin add -n \"Cake\" -y")]
+            [InlineData(true, "pin add --name=\"Cake\" --debug --confirm")]
+            [InlineData(false, "pin add --name=\"Cake\" --confirm")]
             public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
             {
                 // Given
@@ -145,8 +146,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pin
             }
 
             [Theory]
-            [InlineData(true, "pin add -n \"Cake\" -v -y")]
-            [InlineData(false, "pin add -n \"Cake\" -y")]
+            [InlineData(true, "pin add --name=\"Cake\" --verbose --confirm")]
+            [InlineData(false, "pin add --name=\"Cake\" --confirm")]
             public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
             {
                 // Given
@@ -161,8 +162,56 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pin
             }
 
             [Theory]
-            [InlineData(true, "pin add -n \"Cake\" -y -f")]
-            [InlineData(false, "pin add -n \"Cake\" -y")]
+            [InlineData(true, "pin add --name=\"Cake\" --trace --confirm")]
+            [InlineData(false, "pin add --name=\"Cake\" --confirm")]
+            public void Should_Add_Trace_Flag_To_Arguments_If_Set(bool trace, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.Settings.Trace = trace;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "pin add --name=\"Cake\" --no-color --confirm")]
+            [InlineData(false, "pin add --name=\"Cake\" --confirm")]
+            public void Should_Add_NoColor_Flag_To_Arguments_If_Set(bool noColor, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.Settings.NoColor = noColor;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "pin add --name=\"Cake\" --accept-license --confirm")]
+            [InlineData(false, "pin add --name=\"Cake\" --confirm")]
+            public void Should_Add_AcceptLicense_Flag_To_Arguments_If_Set(bool acceptLicense, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.Settings.AcceptLicense = acceptLicense;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "pin add --name=\"Cake\" --confirm --force")]
+            [InlineData(false, "pin add --name=\"Cake\" --confirm")]
             public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
             {
                 // Given
@@ -177,8 +226,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pin
             }
 
             [Theory]
-            [InlineData(true, "pin add -n \"Cake\" -y --noop")]
-            [InlineData(false, "pin add -n \"Cake\" -y")]
+            [InlineData(true, "pin add --name=\"Cake\" --confirm --what-if")]
+            [InlineData(false, "pin add --name=\"Cake\" --confirm")]
             public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
             {
                 // Given
@@ -193,8 +242,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pin
             }
 
             [Theory]
-            [InlineData(true, "pin add -n \"Cake\" -y -r")]
-            [InlineData(false, "pin add -n \"Cake\" -y")]
+            [InlineData(true, "pin add --name=\"Cake\" --confirm --limit-output")]
+            [InlineData(false, "pin add --name=\"Cake\" --confirm")]
             public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
             {
                 // Given
@@ -209,8 +258,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pin
             }
 
             [Theory]
-            [InlineData(5, "pin add -n \"Cake\" -y --execution-timeout \"5\"")]
-            [InlineData(0, "pin add -n \"Cake\" -y")]
+            [InlineData(5, "pin add --name=\"Cake\" --confirm --execution-timeout=\"5\"")]
+            [InlineData(0, "pin add --name=\"Cake\" --confirm")]
             public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
             {
                 // Given
@@ -225,8 +274,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pin
             }
 
             [Theory]
-            [InlineData(@"c:\temp", "pin add -n \"Cake\" -y -c \"c:\\temp\"")]
-            [InlineData("", "pin add -n \"Cake\" -y")]
+            [InlineData(@"c:\temp", "pin add --name=\"Cake\" --confirm --cache-location=\"c:\\temp\"")]
+            [InlineData("", "pin add --name=\"Cake\" --confirm")]
             public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
             {
                 // Given
@@ -241,13 +290,173 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pin
             }
 
             [Theory]
-            [InlineData(true, "pin add -n \"Cake\" -y --allowunofficial")]
-            [InlineData(false, "pin add -n \"Cake\" -y")]
+            [InlineData(true, "pin add --name=\"Cake\" --confirm --allow-unofficial")]
+            [InlineData(false, "pin add --name=\"Cake\" --confirm")]
             public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
             {
                 // Given
                 var fixture = new ChocolateyPinnerFixture();
                 fixture.Settings.AllowUnofficial = allowUnofficial;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "pin add --name=\"Cake\" --confirm --fail-on-error-output")]
+            [InlineData(false, "pin add --name=\"Cake\" --confirm")]
+            public void Should_Add_FailOnErrorOutput_Flag_To_Arguments_If_Set(bool failOnErrorOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.Settings.FailOnErrorOutput = failOnErrorOutput;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "pin add --name=\"Cake\" --confirm --use-system-powershell")]
+            [InlineData(false, "pin add --name=\"Cake\" --confirm")]
+            public void Should_Add_UseSystemPowerShell_Flag_To_Arguments_If_Set(bool useSystemPowerShell, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.Settings.UseSystemPowerShell = useSystemPowerShell;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "pin add --name=\"Cake\" --confirm --no-progress")]
+            [InlineData(false, "pin add --name=\"Cake\" --confirm")]
+            public void Should_Add_NoProgress_Flag_To_Arguments_If_Set(bool noProgress, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.Settings.NoProgress = noProgress;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy", "pin add --name=\"Cake\" --confirm --proxy=\"proxy\"")]
+            [InlineData(null, "pin add --name=\"Cake\" --confirm")]
+            public void Should_Add_Proxy_Flag_To_Arguments_If_Set(string proxy, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.Settings.Proxy = proxy;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-user", "pin add --name=\"Cake\" --confirm --proxy-user=\"proxy-user\"")]
+            [InlineData(null, "pin add --name=\"Cake\" --confirm")]
+            public void Should_Add_ProxyUser_Flag_To_Arguments_If_Set(string proxyUser, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.Settings.ProxyUser = proxyUser;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-password", "pin add --name=\"Cake\" --confirm --proxy-password=\"proxy-password\"")]
+            [InlineData(null, "pin add --name=\"Cake\" --confirm")]
+            public void Should_Add_ProxyPassword_Flag_To_Arguments_If_Set(string proxyPassword, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.Settings.ProxyPassword = proxyPassword;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy1,proxy2", "pin add --name=\"Cake\" --confirm --proxy-bypass-list=\"proxy1,proxy2\"")]
+            [InlineData(null, "pin add --name=\"Cake\" --confirm")]
+            public void Should_Add_ProxyByPassList_Flag_To_Arguments_If_Set(string proxyByPassList, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.Settings.ProxyByPassList = proxyByPassList;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "pin add --name=\"Cake\" --confirm --proxy-bypass-on-local")]
+            [InlineData(false, "pin add --name=\"Cake\" --confirm")]
+            public void Should_Add_ProxyByPassOnLocal_Flag_To_Arguments_If_Set(bool proxyBypassOnLocal, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.Settings.ProxyBypassOnLocal = proxyBypassOnLocal;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./output.log", "pin add --name=\"Cake\" --confirm --log-file=\"/Working/output.log\"")]
+            [InlineData(null, "pin add --name=\"Cake\" --confirm")]
+            public void Should_Add_Log_File_Flag_To_Arguments_If_Set(string logFilePath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.Settings.LogFile = logFilePath;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "pin add --name=\"Cake\" --confirm --skip-compatibility-checks")]
+            [InlineData(false, "pin add --name=\"Cake\" --confirm")]
+            public void Should_Add_Skip_Compatibility_Flag_To_Arguments_If_Set(bool skipCompatibiity, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.Settings.SkipCompatibilityChecks = skipCompatibiity;
 
                 // When
                 var result = fixture.Run();
@@ -267,7 +476,23 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Pin
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("pin add -n \"Cake\" --version \"1.0.0\" -y", result.Args);
+                Assert.Equal("pin add --name=\"Cake\" --confirm --version=\"1.0.0\"", result.Args);
+            }
+
+            [Theory]
+            [InlineData("Just because", "pin add --name=\"Cake\" --confirm --pin-reason=\"Just because\"")]
+            [InlineData(null, "pin add --name=\"Cake\" --confirm")]
+            public void Should_Add_PinReason_Flag_To_Arguments_If_Set(string pinReason, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPinnerFixture();
+                fixture.Settings.PinReason = pinReason;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
             }
         }
     }

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Push/ChocolateyPusherTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Push/ChocolateyPusherTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Cake.Common.Tests.Fixtures.Tools.Chocolatey.ApiKey;
 using Cake.Common.Tests.Fixtures.Tools.Chocolatey.Push;
 using Cake.Testing;
 using Cake.Testing.Xunit;
@@ -126,55 +127,12 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Push
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("push \"/Working/existing.nupkg\" -y", result.Args);
-            }
-
-            [Fact]
-            public void Should_Add_Api_Key_To_Arguments_If_Not_Null()
-            {
-                // Given
-                var fixture = new ChocolateyPusherFixture();
-                fixture.Settings.ApiKey = "1234";
-
-                // When
-                var result = fixture.Run();
-
-                // Then
-                Assert.Equal("push \"/Working/existing.nupkg\" -k 1234 -y", result.Args);
-            }
-
-            [Fact]
-            public void Should_Add_Source_To_Arguments_If_Not_Null()
-            {
-                // Given
-                var fixture = new ChocolateyPusherFixture();
-                fixture.Settings.Source = "http://customsource/";
-
-                // When
-                var result = fixture.Run();
-
-                // Then
-                Assert.Equal("push \"/Working/existing.nupkg\" " +
-                             "-s \"http://customsource/\" -y", result.Args);
-            }
-
-            [Fact]
-            public void Should_Add_Timeout_To_Arguments_If_Not_Null()
-            {
-                // Given
-                var fixture = new ChocolateyPusherFixture();
-                fixture.Settings.Timeout = TimeSpan.FromSeconds(987);
-
-                // When
-                var result = fixture.Run();
-
-                // Then
-                Assert.Equal("push \"/Working/existing.nupkg\" -t 987 -y", result.Args);
+                Assert.Equal("push \"/Working/existing.nupkg\" --confirm", result.Args);
             }
 
             [Theory]
-            [InlineData(true, "push \"/Working/existing.nupkg\" -d -y")]
-            [InlineData(false, "push \"/Working/existing.nupkg\" -y")]
+            [InlineData(true, "push \"/Working/existing.nupkg\" --debug --confirm")]
+            [InlineData(false, "push \"/Working/existing.nupkg\" --confirm")]
             public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
             {
                 // Given
@@ -189,8 +147,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Push
             }
 
             [Theory]
-            [InlineData(true, "push \"/Working/existing.nupkg\" -v -y")]
-            [InlineData(false, "push \"/Working/existing.nupkg\" -y")]
+            [InlineData(true, "push \"/Working/existing.nupkg\" --verbose --confirm")]
+            [InlineData(false, "push \"/Working/existing.nupkg\" --confirm")]
             public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
             {
                 // Given
@@ -205,8 +163,56 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Push
             }
 
             [Theory]
-            [InlineData(true, "push \"/Working/existing.nupkg\" -y -f")]
-            [InlineData(false, "push \"/Working/existing.nupkg\" -y")]
+            [InlineData(true, "push \"/Working/existing.nupkg\" --trace --confirm")]
+            [InlineData(false, "push \"/Working/existing.nupkg\" --confirm")]
+            public void Should_Add_Trace_Flag_To_Arguments_If_Set(bool trace, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPusherFixture();
+                fixture.Settings.Trace = trace;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "push \"/Working/existing.nupkg\" --no-color --confirm")]
+            [InlineData(false, "push \"/Working/existing.nupkg\" --confirm")]
+            public void Should_Add_NoColor_Flag_To_Arguments_If_Set(bool noColor, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPusherFixture();
+                fixture.Settings.NoColor = noColor;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "push \"/Working/existing.nupkg\" --accept-license --confirm")]
+            [InlineData(false, "push \"/Working/existing.nupkg\" --confirm")]
+            public void Should_Add_AcceptLicense_Flag_To_Arguments_If_Set(bool acceptLicense, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPusherFixture();
+                fixture.Settings.AcceptLicense = acceptLicense;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "push \"/Working/existing.nupkg\" --confirm --force")]
+            [InlineData(false, "push \"/Working/existing.nupkg\" --confirm")]
             public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
             {
                 // Given
@@ -221,8 +227,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Push
             }
 
             [Theory]
-            [InlineData(true, "push \"/Working/existing.nupkg\" -y --noop")]
-            [InlineData(false, "push \"/Working/existing.nupkg\" -y")]
+            [InlineData(true, "push \"/Working/existing.nupkg\" --confirm --what-if")]
+            [InlineData(false, "push \"/Working/existing.nupkg\" --confirm")]
             public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
             {
                 // Given
@@ -237,8 +243,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Push
             }
 
             [Theory]
-            [InlineData(true, "push \"/Working/existing.nupkg\" -y -r")]
-            [InlineData(false, "push \"/Working/existing.nupkg\" -y")]
+            [InlineData(true, "push \"/Working/existing.nupkg\" --confirm --limit-output")]
+            [InlineData(false, "push \"/Working/existing.nupkg\" --confirm")]
             public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
             {
                 // Given
@@ -253,8 +259,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Push
             }
 
             [Theory]
-            [InlineData(5, "push \"/Working/existing.nupkg\" -y --execution-timeout \"5\"")]
-            [InlineData(0, "push \"/Working/existing.nupkg\" -y")]
+            [InlineData(5, "push \"/Working/existing.nupkg\" --confirm --execution-timeout=\"5\"")]
+            [InlineData(0, "push \"/Working/existing.nupkg\" --confirm")]
             public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
             {
                 // Given
@@ -269,8 +275,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Push
             }
 
             [Theory]
-            [InlineData(@"c:\temp", "push \"/Working/existing.nupkg\" -y -c \"c:\\temp\"")]
-            [InlineData("", "push \"/Working/existing.nupkg\" -y")]
+            [InlineData(@"c:\temp", "push \"/Working/existing.nupkg\" --confirm --cache-location=\"c:\\temp\"")]
+            [InlineData("", "push \"/Working/existing.nupkg\" --confirm")]
             public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
             {
                 // Given
@@ -285,13 +291,265 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Push
             }
 
             [Theory]
-            [InlineData(true, "push \"/Working/existing.nupkg\" -y --allowunofficial")]
-            [InlineData(false, "push \"/Working/existing.nupkg\" -y")]
+            [InlineData(true, "push \"/Working/existing.nupkg\" --confirm --allow-unofficial")]
+            [InlineData(false, "push \"/Working/existing.nupkg\" --confirm")]
             public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
             {
                 // Given
                 var fixture = new ChocolateyPusherFixture();
                 fixture.Settings.AllowUnofficial = allowUnofficial;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+            [Theory]
+            [InlineData(true, "push \"/Working/existing.nupkg\" --confirm --fail-on-error-output")]
+            [InlineData(false, "push \"/Working/existing.nupkg\" --confirm")]
+            public void Should_Add_FailOnErrorOutput_Flag_To_Arguments_If_Set(bool failOnErrorOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPusherFixture();
+                fixture.Settings.FailOnErrorOutput = failOnErrorOutput;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "push \"/Working/existing.nupkg\" --confirm --use-system-powershell")]
+            [InlineData(false, "push \"/Working/existing.nupkg\" --confirm")]
+            public void Should_Add_UseSystemPowerShell_Flag_To_Arguments_If_Set(bool useSystemPowerShell, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPusherFixture();
+                fixture.Settings.UseSystemPowerShell = useSystemPowerShell;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "push \"/Working/existing.nupkg\" --confirm --no-progress")]
+            [InlineData(false, "push \"/Working/existing.nupkg\" --confirm")]
+            public void Should_Add_NoProgress_Flag_To_Arguments_If_Set(bool noProgress, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPusherFixture();
+                fixture.Settings.NoProgress = noProgress;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy", "push \"/Working/existing.nupkg\" --confirm --proxy=\"proxy\"")]
+            [InlineData(null, "push \"/Working/existing.nupkg\" --confirm")]
+            public void Should_Add_Proxy_Flag_To_Arguments_If_Set(string proxy, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPusherFixture();
+                fixture.Settings.Proxy = proxy;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-user", "push \"/Working/existing.nupkg\" --confirm --proxy-user=\"proxy-user\"")]
+            [InlineData(null, "push \"/Working/existing.nupkg\" --confirm")]
+            public void Should_Add_ProxyUser_Flag_To_Arguments_If_Set(string proxyUser, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPusherFixture();
+                fixture.Settings.ProxyUser = proxyUser;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-password", "push \"/Working/existing.nupkg\" --confirm --proxy-password=\"proxy-password\"")]
+            [InlineData(null, "push \"/Working/existing.nupkg\" --confirm")]
+            public void Should_Add_ProxyPassword_Flag_To_Arguments_If_Set(string proxyPassword, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPusherFixture();
+                fixture.Settings.ProxyPassword = proxyPassword;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy1,proxy2", "push \"/Working/existing.nupkg\" --confirm --proxy-bypass-list=\"proxy1,proxy2\"")]
+            [InlineData(null, "push \"/Working/existing.nupkg\" --confirm")]
+            public void Should_Add_ProxyByPassList_Flag_To_Arguments_If_Set(string proxyByPassList, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPusherFixture();
+                fixture.Settings.ProxyByPassList = proxyByPassList;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "push \"/Working/existing.nupkg\" --confirm --proxy-bypass-on-local")]
+            [InlineData(false, "push \"/Working/existing.nupkg\" --confirm")]
+            public void Should_Add_ProxyByPassOnLocal_Flag_To_Arguments_If_Set(bool proxyBypassOnLocal, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPusherFixture();
+                fixture.Settings.ProxyBypassOnLocal = proxyBypassOnLocal;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./output.log", "push \"/Working/existing.nupkg\" --confirm --log-file=\"/Working/output.log\"")]
+            [InlineData(null, "push \"/Working/existing.nupkg\" --confirm")]
+            public void Should_Add_Log_File_Flag_To_Arguments_If_Set(string logFilePath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPusherFixture();
+                fixture.Settings.LogFile = logFilePath;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "push \"/Working/existing.nupkg\" --confirm --skip-compatibility-checks")]
+            [InlineData(false, "push \"/Working/existing.nupkg\" --confirm")]
+            public void Should_Add_Skip_Compatibility_Flag_To_Arguments_If_Set(bool skipCompatibiity, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPusherFixture();
+                fixture.Settings.SkipCompatibilityChecks = skipCompatibiity;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Source_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new ChocolateyPusherFixture();
+                fixture.Settings.Source = "http://customsource/";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("push \"/Working/existing.nupkg\" " +
+                             "--confirm --source=\"http://customsource/\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Api_Key_To_Arguments_If_Not_Null()
+            {
+                // Given
+                var fixture = new ChocolateyPusherFixture();
+                fixture.Settings.ApiKey = "1234";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("push \"/Working/existing.nupkg\" --confirm --api-key=\"1234\"", result.Args);
+            }
+
+            [Theory]
+            [InlineData("abcdef", "push \"/Working/existing.nupkg\" --confirm --client-code=\"abcdef\"")]
+            [InlineData(null, "push \"/Working/existing.nupkg\" --confirm")]
+            public void Should_Add_ClientCode_Flag_To_Arguments_If_Set(string clientCode, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPusherFixture();
+                fixture.Settings.ClientCode = clientCode;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("https://test.com", "push \"/Working/existing.nupkg\" --confirm --redirect-url=\"https://test.com\"")]
+            [InlineData(null, "push \"/Working/existing.nupkg\" --confirm")]
+            public void Should_Add_RedirectUrl_Flag_To_Arguments_If_Set(string redirectUrl, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPusherFixture();
+                fixture.Settings.RedirectUrl = redirectUrl;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("IntuneA", "push \"/Working/existing.nupkg\" --confirm --endpoint=\"IntuneA\"")]
+            [InlineData(null, "push \"/Working/existing.nupkg\" --confirm")]
+            public void Should_Add_Endpoint_Flag_To_Arguments_If_Set(string endPoint, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPusherFixture();
+                fixture.Settings.EndPoint = endPoint;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "push \"/Working/existing.nupkg\" --confirm --skip-cleanup")]
+            [InlineData(false, "push \"/Working/existing.nupkg\" --confirm")]
+            public void Should_Add_SkipCleanup_Flag_To_Arguments_If_Set(bool skipCleanup, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyPusherFixture();
+                fixture.Settings.SkipCleanup = skipCleanup;
 
                 // When
                 var result = fixture.Run();

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Sources/ChocolateySourcesTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Sources/ChocolateySourcesTests.cs
@@ -125,12 +125,12 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("source add -n \"name\" -s \"source\" -y", result.Args);
+                Assert.Equal("source add --name=\"name\" --source=\"source\" --confirm", result.Args);
             }
 
             [Theory]
-            [InlineData(true, "source add -n \"name\" -s \"source\" -d -y")]
-            [InlineData(false, "source add -n \"name\" -s \"source\" -y")]
+            [InlineData(true, "source add --name=\"name\" --source=\"source\" --debug --confirm")]
+            [InlineData(false, "source add --name=\"name\" --source=\"source\" --confirm")]
             public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
             {
                 // Given
@@ -145,8 +145,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(true, "source add -n \"name\" -s \"source\" -v -y")]
-            [InlineData(false, "source add -n \"name\" -s \"source\" -y")]
+            [InlineData(true, "source add --name=\"name\" --source=\"source\" --verbose --confirm")]
+            [InlineData(false, "source add --name=\"name\" --source=\"source\" --confirm")]
             public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
             {
                 // Given
@@ -161,8 +161,56 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(true, "source add -n \"name\" -s \"source\" -y -f")]
-            [InlineData(false, "source add -n \"name\" -s \"source\" -y")]
+            [InlineData(true, "source add --name=\"name\" --source=\"source\" --trace --confirm")]
+            [InlineData(false, "source add --name=\"name\" --source=\"source\" --confirm")]
+            public void Should_Add_Trace_Flag_To_Arguments_If_Set(bool trace, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyAddSourceFixture();
+                fixture.Settings.Trace = trace;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source add --name=\"name\" --source=\"source\" --no-color --confirm")]
+            [InlineData(false, "source add --name=\"name\" --source=\"source\" --confirm")]
+            public void Should_Add_NoColor_Flag_To_Arguments_If_Set(bool noColor, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyAddSourceFixture();
+                fixture.Settings.NoColor = noColor;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source add --name=\"name\" --source=\"source\" --accept-license --confirm")]
+            [InlineData(false, "source add --name=\"name\" --source=\"source\" --confirm")]
+            public void Should_Add_AcceptLicense_Flag_To_Arguments_If_Set(bool acceptLicense, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyAddSourceFixture();
+                fixture.Settings.AcceptLicense = acceptLicense;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source add --name=\"name\" --source=\"source\" --confirm --force")]
+            [InlineData(false, "source add --name=\"name\" --source=\"source\" --confirm")]
             public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
             {
                 // Given
@@ -177,8 +225,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(true, "source add -n \"name\" -s \"source\" -y --noop")]
-            [InlineData(false, "source add -n \"name\" -s \"source\" -y")]
+            [InlineData(true, "source add --name=\"name\" --source=\"source\" --confirm --what-if")]
+            [InlineData(false, "source add --name=\"name\" --source=\"source\" --confirm")]
             public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
             {
                 // Given
@@ -193,8 +241,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(true, "source add -n \"name\" -s \"source\" -y -r")]
-            [InlineData(false, "source add -n \"name\" -s \"source\" -y")]
+            [InlineData(true, "source add --name=\"name\" --source=\"source\" --confirm --limit-output")]
+            [InlineData(false, "source add --name=\"name\" --source=\"source\" --confirm")]
             public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
             {
                 // Given
@@ -209,8 +257,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(5, "source add -n \"name\" -s \"source\" -y --execution-timeout \"5\"")]
-            [InlineData(0, "source add -n \"name\" -s \"source\" -y")]
+            [InlineData(5, "source add --name=\"name\" --source=\"source\" --confirm --execution-timeout=\"5\"")]
+            [InlineData(0, "source add --name=\"name\" --source=\"source\" --confirm")]
             public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
             {
                 // Given
@@ -225,8 +273,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(@"c:\temp", "source add -n \"name\" -s \"source\" -y -c \"c:\\temp\"")]
-            [InlineData("", "source add -n \"name\" -s \"source\" -y")]
+            [InlineData(@"c:\temp", "source add --name=\"name\" --source=\"source\" --confirm --cache-location=\"c:\\temp\"")]
+            [InlineData("", "source add --name=\"name\" --source=\"source\" --confirm")]
             public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
             {
                 // Given
@@ -241,8 +289,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(true, "source add -n \"name\" -s \"source\" -y --allowunofficial")]
-            [InlineData(false, "source add -n \"name\" -s \"source\" -y")]
+            [InlineData(true, "source add --name=\"name\" --source=\"source\" --confirm --allow-unofficial")]
+            [InlineData(false, "source add --name=\"name\" --source=\"source\" --confirm")]
             public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
             {
                 // Given
@@ -257,13 +305,285 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(2, "source add -n \"name\" -s \"source\" -y --priority \"2\"")]
-            [InlineData(0, "source add -n \"name\" -s \"source\" -y")]
+            [InlineData(true, "source add --name=\"name\" --source=\"source\" --confirm --fail-on-error-output")]
+            [InlineData(false, "source add --name=\"name\" --source=\"source\" --confirm")]
+            public void Should_Add_FailOnErrorOutput_Flag_To_Arguments_If_Set(bool failOnErrorOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyAddSourceFixture();
+                fixture.Settings.FailOnErrorOutput = failOnErrorOutput;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source add --name=\"name\" --source=\"source\" --confirm --use-system-powershell")]
+            [InlineData(false, "source add --name=\"name\" --source=\"source\" --confirm")]
+            public void Should_Add_UseSystemPowerShell_Flag_To_Arguments_If_Set(bool useSystemPowerShell, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyAddSourceFixture();
+                fixture.Settings.UseSystemPowerShell = useSystemPowerShell;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source add --name=\"name\" --source=\"source\" --confirm --no-progress")]
+            [InlineData(false, "source add --name=\"name\" --source=\"source\" --confirm")]
+            public void Should_Add_NoProgress_Flag_To_Arguments_If_Set(bool noProgress, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyAddSourceFixture();
+                fixture.Settings.NoProgress = noProgress;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy", "source add --name=\"name\" --source=\"source\" --confirm --proxy=\"proxy\"")]
+            [InlineData(null, "source add --name=\"name\" --source=\"source\" --confirm")]
+            public void Should_Add_Proxy_Flag_To_Arguments_If_Set(string proxy, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyAddSourceFixture();
+                fixture.Settings.Proxy = proxy;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-user", "source add --name=\"name\" --source=\"source\" --confirm --proxy-user=\"proxy-user\"")]
+            [InlineData(null, "source add --name=\"name\" --source=\"source\" --confirm")]
+            public void Should_Add_ProxyUser_Flag_To_Arguments_If_Set(string proxyUser, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyAddSourceFixture();
+                fixture.Settings.ProxyUser = proxyUser;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-password", "source add --name=\"name\" --source=\"source\" --confirm --proxy-password=\"proxy-password\"")]
+            [InlineData(null, "source add --name=\"name\" --source=\"source\" --confirm")]
+            public void Should_Add_ProxyPassword_Flag_To_Arguments_If_Set(string proxyPassword, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyAddSourceFixture();
+                fixture.Settings.ProxyPassword = proxyPassword;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy1,proxy2", "source add --name=\"name\" --source=\"source\" --confirm --proxy-bypass-list=\"proxy1,proxy2\"")]
+            [InlineData(null, "source add --name=\"name\" --source=\"source\" --confirm")]
+            public void Should_Add_ProxyByPassList_Flag_To_Arguments_If_Set(string proxyByPassList, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyAddSourceFixture();
+                fixture.Settings.ProxyByPassList = proxyByPassList;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source add --name=\"name\" --source=\"source\" --confirm --proxy-bypass-on-local")]
+            [InlineData(false, "source add --name=\"name\" --source=\"source\" --confirm")]
+            public void Should_Add_ProxyByPassOnLocal_Flag_To_Arguments_If_Set(bool proxyBypassOnLocal, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyAddSourceFixture();
+                fixture.Settings.ProxyBypassOnLocal = proxyBypassOnLocal;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./output.log", "source add --name=\"name\" --source=\"source\" --confirm --log-file=\"/Working/output.log\"")]
+            [InlineData(null, "source add --name=\"name\" --source=\"source\" --confirm")]
+            public void Should_Add_Log_File_Flag_To_Arguments_If_Set(string logFilePath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyAddSourceFixture();
+                fixture.Settings.LogFile = logFilePath;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source add --name=\"name\" --source=\"source\" --confirm --skip-compatibility-checks")]
+            [InlineData(false, "source add --name=\"name\" --source=\"source\" --confirm")]
+            public void Should_Add_Skip_Compatibility_Flag_To_Arguments_If_Set(bool skipCompatibiity, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyAddSourceFixture();
+                fixture.Settings.SkipCompatibilityChecks = skipCompatibiity;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("user1", "source add --name=\"name\" --source=\"source\" --confirm --user=\"user1\"")]
+            [InlineData("", "source add --name=\"name\" --source=\"source\" --confirm")]
+            public void Should_Add_User_To_Arguments_If_Set(string user, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyAddSourceFixture();
+                fixture.Settings.UserName = user;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("password1", "source add --name=\"name\" --source=\"source\" --confirm --password=\"password1\"")]
+            [InlineData("", "source add --name=\"name\" --source=\"source\" --confirm")]
+            public void Should_Add_Password_To_Arguments_If_Set(string password, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyAddSourceFixture();
+                fixture.Settings.Password = password;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./mycert.pfx", "source add --name=\"name\" --source=\"source\" --confirm --cert=\"/Working/mycert.pfx\"")]
+            [InlineData(null, "source add --name=\"name\" --source=\"source\" --confirm")]
+            public void Should_Add_Cert_To_Arguments_If_Set(string certificate, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyAddSourceFixture();
+                fixture.Settings.Certificate = certificate;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("certpassword", "source add --name=\"name\" --source=\"source\" --confirm --certpassword=\"certpassword\"")]
+            [InlineData("", "source add --name=\"name\" --source=\"source\" --confirm")]
+            public void Should_Add_CertPassword_To_Arguments_If_Set(string certificatePassword, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyAddSourceFixture();
+                fixture.Settings.CertificatePassword = certificatePassword;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(2, "source add --name=\"name\" --source=\"source\" --confirm --priority=\"2\"")]
+            [InlineData(0, "source add --name=\"name\" --source=\"source\" --confirm")]
             public void Should_Add_Priority_To_Arguments_If_Set(int priority, string expected)
             {
                 // Given
                 var fixture = new ChocolateyAddSourceFixture();
                 fixture.Settings.Priority = priority;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source add --name=\"name\" --source=\"source\" --confirm --bypass-proxy")]
+            [InlineData(false, "source add --name=\"name\" --source=\"source\" --confirm")]
+            public void Should_Add_ByPassProxy_Flag_To_Arguments_If_Set(bool byPassProxy, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyAddSourceFixture();
+                fixture.Settings.ByPassProxy = byPassProxy;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source add --name=\"name\" --source=\"source\" --confirm --allow-self-service")]
+            [InlineData(false, "source add --name=\"name\" --source=\"source\" --confirm")]
+            public void Should_Add_AllowSelfService_Flag_To_Arguments_If_Set(bool allowSelfService, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyAddSourceFixture();
+                fixture.Settings.AllowSelfService = allowSelfService;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source add --name=\"name\" --source=\"source\" --confirm --admin-only")]
+            [InlineData(false, "source add --name=\"name\" --source=\"source\" --confirm")]
+            public void Should_Add_AdminOnly_Flag_To_Arguments_If_Set(bool adminOnly, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyAddSourceFixture();
+                fixture.Settings.AdminOnly = adminOnly;
 
                 // When
                 var result = fixture.Run();
@@ -387,12 +707,12 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("source remove -n \"name\" -y", result.Args);
+                Assert.Equal("source remove --name=\"name\" --confirm", result.Args);
             }
 
             [Theory]
-            [InlineData(true, "source remove -n \"name\" -d -y")]
-            [InlineData(false, "source remove -n \"name\" -y")]
+            [InlineData(true, "source remove --name=\"name\" --debug --confirm")]
+            [InlineData(false, "source remove --name=\"name\" --confirm")]
             public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
             {
                 // Given
@@ -407,8 +727,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(true, "source remove -n \"name\" -v -y")]
-            [InlineData(false, "source remove -n \"name\" -y")]
+            [InlineData(true, "source remove --name=\"name\" --verbose --confirm")]
+            [InlineData(false, "source remove --name=\"name\" --confirm")]
             public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
             {
                 // Given
@@ -423,8 +743,56 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(true, "source remove -n \"name\" -y -f")]
-            [InlineData(false, "source remove -n \"name\" -y")]
+            [InlineData(true, "source remove --name=\"name\" --trace --confirm")]
+            [InlineData(false, "source remove --name=\"name\" --confirm")]
+            public void Should_Add_Trace_Flag_To_Arguments_If_Set(bool trace, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyRemoveSourceFixture();
+                fixture.Settings.Trace = trace;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source remove --name=\"name\" --no-color --confirm")]
+            [InlineData(false, "source remove --name=\"name\" --confirm")]
+            public void Should_Add_NoColor_Flag_To_Arguments_If_Set(bool noColor, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyRemoveSourceFixture();
+                fixture.Settings.NoColor = noColor;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source remove --name=\"name\" --accept-license --confirm")]
+            [InlineData(false, "source remove --name=\"name\" --confirm")]
+            public void Should_Add_AcceptLicense_Flag_To_Arguments_If_Set(bool acceptLicense, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyRemoveSourceFixture();
+                fixture.Settings.AcceptLicense = acceptLicense;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source remove --name=\"name\" --confirm --force")]
+            [InlineData(false, "source remove --name=\"name\" --confirm")]
             public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
             {
                 // Given
@@ -439,8 +807,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(true, "source remove -n \"name\" -y --noop")]
-            [InlineData(false, "source remove -n \"name\" -y")]
+            [InlineData(true, "source remove --name=\"name\" --confirm --what-if")]
+            [InlineData(false, "source remove --name=\"name\" --confirm")]
             public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
             {
                 // Given
@@ -455,8 +823,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(true, "source remove -n \"name\" -y -r")]
-            [InlineData(false, "source remove -n \"name\" -y")]
+            [InlineData(true, "source remove --name=\"name\" --confirm --limit-output")]
+            [InlineData(false, "source remove --name=\"name\" --confirm")]
             public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
             {
                 // Given
@@ -471,8 +839,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(5, "source remove -n \"name\" -y --execution-timeout \"5\"")]
-            [InlineData(0, "source remove -n \"name\" -y")]
+            [InlineData(5, "source remove --name=\"name\" --confirm --execution-timeout=\"5\"")]
+            [InlineData(0, "source remove --name=\"name\" --confirm")]
             public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
             {
                 // Given
@@ -487,8 +855,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(@"c:\temp", "source remove -n \"name\" -y -c \"c:\\temp\"")]
-            [InlineData("", "source remove -n \"name\" -y")]
+            [InlineData(@"c:\temp", "source remove --name=\"name\" --confirm --cache-location=\"c:\\temp\"")]
+            [InlineData("", "source remove --name=\"name\" --confirm")]
             public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
             {
                 // Given
@@ -503,13 +871,173 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(true, "source remove -n \"name\" -y --allowunofficial")]
-            [InlineData(false, "source remove -n \"name\" -y")]
+            [InlineData(true, "source remove --name=\"name\" --confirm --allow-unofficial")]
+            [InlineData(false, "source remove --name=\"name\" --confirm")]
             public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
             {
                 // Given
                 var fixture = new ChocolateyRemoveSourceFixture();
                 fixture.Settings.AllowUnofficial = allowUnofficial;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source remove --name=\"name\" --confirm --fail-on-error-output")]
+            [InlineData(false, "source remove --name=\"name\" --confirm")]
+            public void Should_Add_FailOnErrorOutput_Flag_To_Arguments_If_Set(bool failOnErrorOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyRemoveSourceFixture();
+                fixture.Settings.FailOnErrorOutput = failOnErrorOutput;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source remove --name=\"name\" --confirm --use-system-powershell")]
+            [InlineData(false, "source remove --name=\"name\" --confirm")]
+            public void Should_Add_UseSystemPowerShell_Flag_To_Arguments_If_Set(bool useSystemPowerShell, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyRemoveSourceFixture();
+                fixture.Settings.UseSystemPowerShell = useSystemPowerShell;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source remove --name=\"name\" --confirm --no-progress")]
+            [InlineData(false, "source remove --name=\"name\" --confirm")]
+            public void Should_Add_NoProgress_Flag_To_Arguments_If_Set(bool noProgress, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyRemoveSourceFixture();
+                fixture.Settings.NoProgress = noProgress;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy", "source remove --name=\"name\" --confirm --proxy=\"proxy\"")]
+            [InlineData(null, "source remove --name=\"name\" --confirm")]
+            public void Should_Add_Proxy_Flag_To_Arguments_If_Set(string proxy, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyRemoveSourceFixture();
+                fixture.Settings.Proxy = proxy;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-user", "source remove --name=\"name\" --confirm --proxy-user=\"proxy-user\"")]
+            [InlineData(null, "source remove --name=\"name\" --confirm")]
+            public void Should_Add_ProxyUser_Flag_To_Arguments_If_Set(string proxyUser, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyRemoveSourceFixture();
+                fixture.Settings.ProxyUser = proxyUser;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-password", "source remove --name=\"name\" --confirm --proxy-password=\"proxy-password\"")]
+            [InlineData(null, "source remove --name=\"name\" --confirm")]
+            public void Should_Add_ProxyPassword_Flag_To_Arguments_If_Set(string proxyPassword, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyRemoveSourceFixture();
+                fixture.Settings.ProxyPassword = proxyPassword;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy1,proxy2", "source remove --name=\"name\" --confirm --proxy-bypass-list=\"proxy1,proxy2\"")]
+            [InlineData(null, "source remove --name=\"name\" --confirm")]
+            public void Should_Add_ProxyByPassList_Flag_To_Arguments_If_Set(string proxyByPassList, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyRemoveSourceFixture();
+                fixture.Settings.ProxyByPassList = proxyByPassList;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source remove --name=\"name\" --confirm --proxy-bypass-on-local")]
+            [InlineData(false, "source remove --name=\"name\" --confirm")]
+            public void Should_Add_ProxyByPassOnLocal_Flag_To_Arguments_If_Set(bool proxyBypassOnLocal, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyRemoveSourceFixture();
+                fixture.Settings.ProxyBypassOnLocal = proxyBypassOnLocal;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./output.log", "source remove --name=\"name\" --confirm --log-file=\"/Working/output.log\"")]
+            [InlineData(null, "source remove --name=\"name\" --confirm")]
+            public void Should_Add_Log_File_Flag_To_Arguments_If_Set(string logFilePath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyRemoveSourceFixture();
+                fixture.Settings.LogFile = logFilePath;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source remove --name=\"name\" --confirm --skip-compatibility-checks")]
+            [InlineData(false, "source remove --name=\"name\" --confirm")]
+            public void Should_Add_Skip_Compatibility_Flag_To_Arguments_If_Set(bool skipCompatibiity, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyRemoveSourceFixture();
+                fixture.Settings.SkipCompatibilityChecks = skipCompatibiity;
 
                 // When
                 var result = fixture.Run();
@@ -633,12 +1161,12 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("source enable -n \"name\" -y", result.Args);
+                Assert.Equal("source enable --name=\"name\" --confirm", result.Args);
             }
 
             [Theory]
-            [InlineData(true, "source enable -n \"name\" -d -y")]
-            [InlineData(false, "source enable -n \"name\" -y")]
+            [InlineData(true, "source enable --name=\"name\" --debug --confirm")]
+            [InlineData(false, "source enable --name=\"name\" --confirm")]
             public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
             {
                 // Given
@@ -653,8 +1181,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(true, "source enable -n \"name\" -v -y")]
-            [InlineData(false, "source enable -n \"name\" -y")]
+            [InlineData(true, "source enable --name=\"name\" --verbose --confirm")]
+            [InlineData(false, "source enable --name=\"name\" --confirm")]
             public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
             {
                 // Given
@@ -669,8 +1197,56 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(true, "source enable -n \"name\" -y -f")]
-            [InlineData(false, "source enable -n \"name\" -y")]
+            [InlineData(true, "source enable --name=\"name\" --trace --confirm")]
+            [InlineData(false, "source enable --name=\"name\" --confirm")]
+            public void Should_Add_Trace_Flag_To_Arguments_If_Set(bool trace, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableSourceFixture();
+                fixture.Settings.Trace = trace;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source enable --name=\"name\" --no-color --confirm")]
+            [InlineData(false, "source enable --name=\"name\" --confirm")]
+            public void Should_Add_NoColor_Flag_To_Arguments_If_Set(bool noColor, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableSourceFixture();
+                fixture.Settings.NoColor = noColor;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source enable --name=\"name\" --accept-license --confirm")]
+            [InlineData(false, "source enable --name=\"name\" --confirm")]
+            public void Should_Add_AcceptLicense_Flag_To_Arguments_If_Set(bool acceptLicense, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableSourceFixture();
+                fixture.Settings.AcceptLicense = acceptLicense;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source enable --name=\"name\" --confirm --force")]
+            [InlineData(false, "source enable --name=\"name\" --confirm")]
             public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
             {
                 // Given
@@ -685,8 +1261,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(true, "source enable -n \"name\" -y --noop")]
-            [InlineData(false, "source enable -n \"name\" -y")]
+            [InlineData(true, "source enable --name=\"name\" --confirm --what-if")]
+            [InlineData(false, "source enable --name=\"name\" --confirm")]
             public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
             {
                 // Given
@@ -701,8 +1277,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(true, "source enable -n \"name\" -y -r")]
-            [InlineData(false, "source enable -n \"name\" -y")]
+            [InlineData(true, "source enable --name=\"name\" --confirm --limit-output")]
+            [InlineData(false, "source enable --name=\"name\" --confirm")]
             public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
             {
                 // Given
@@ -717,8 +1293,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(5, "source enable -n \"name\" -y --execution-timeout \"5\"")]
-            [InlineData(0, "source enable -n \"name\" -y")]
+            [InlineData(5, "source enable --name=\"name\" --confirm --execution-timeout=\"5\"")]
+            [InlineData(0, "source enable --name=\"name\" --confirm")]
             public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
             {
                 // Given
@@ -733,8 +1309,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(@"c:\temp", "source enable -n \"name\" -y -c \"c:\\temp\"")]
-            [InlineData("", "source enable -n \"name\" -y")]
+            [InlineData(@"c:\temp", "source enable --name=\"name\" --confirm --cache-location=\"c:\\temp\"")]
+            [InlineData("", "source enable --name=\"name\" --confirm")]
             public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
             {
                 // Given
@@ -749,13 +1325,173 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(true, "source enable -n \"name\" -y --allowunofficial")]
-            [InlineData(false, "source enable -n \"name\" -y")]
+            [InlineData(true, "source enable --name=\"name\" --confirm --allow-unofficial")]
+            [InlineData(false, "source enable --name=\"name\" --confirm")]
             public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
             {
                 // Given
                 var fixture = new ChocolateyEnableSourceFixture();
                 fixture.Settings.AllowUnofficial = allowUnofficial;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source enable --name=\"name\" --confirm --fail-on-error-output")]
+            [InlineData(false, "source enable --name=\"name\" --confirm")]
+            public void Should_Add_FailOnErrorOutput_Flag_To_Arguments_If_Set(bool failOnErrorOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableSourceFixture();
+                fixture.Settings.FailOnErrorOutput = failOnErrorOutput;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source enable --name=\"name\" --confirm --use-system-powershell")]
+            [InlineData(false, "source enable --name=\"name\" --confirm")]
+            public void Should_Add_UseSystemPowerShell_Flag_To_Arguments_If_Set(bool useSystemPowerShell, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableSourceFixture();
+                fixture.Settings.UseSystemPowerShell = useSystemPowerShell;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source enable --name=\"name\" --confirm --no-progress")]
+            [InlineData(false, "source enable --name=\"name\" --confirm")]
+            public void Should_Add_NoProgress_Flag_To_Arguments_If_Set(bool noProgress, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableSourceFixture();
+                fixture.Settings.NoProgress = noProgress;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy", "source enable --name=\"name\" --confirm --proxy=\"proxy\"")]
+            [InlineData(null, "source enable --name=\"name\" --confirm")]
+            public void Should_Add_Proxy_Flag_To_Arguments_If_Set(string proxy, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableSourceFixture();
+                fixture.Settings.Proxy = proxy;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-user", "source enable --name=\"name\" --confirm --proxy-user=\"proxy-user\"")]
+            [InlineData(null, "source enable --name=\"name\" --confirm")]
+            public void Should_Add_ProxyUser_Flag_To_Arguments_If_Set(string proxyUser, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableSourceFixture();
+                fixture.Settings.ProxyUser = proxyUser;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-password", "source enable --name=\"name\" --confirm --proxy-password=\"proxy-password\"")]
+            [InlineData(null, "source enable --name=\"name\" --confirm")]
+            public void Should_Add_ProxyPassword_Flag_To_Arguments_If_Set(string proxyPassword, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableSourceFixture();
+                fixture.Settings.ProxyPassword = proxyPassword;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy1,proxy2", "source enable --name=\"name\" --confirm --proxy-bypass-list=\"proxy1,proxy2\"")]
+            [InlineData(null, "source enable --name=\"name\" --confirm")]
+            public void Should_Add_ProxyByPassList_Flag_To_Arguments_If_Set(string proxyByPassList, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableSourceFixture();
+                fixture.Settings.ProxyByPassList = proxyByPassList;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source enable --name=\"name\" --confirm --proxy-bypass-on-local")]
+            [InlineData(false, "source enable --name=\"name\" --confirm")]
+            public void Should_Add_ProxyByPassOnLocal_Flag_To_Arguments_If_Set(bool proxyBypassOnLocal, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableSourceFixture();
+                fixture.Settings.ProxyBypassOnLocal = proxyBypassOnLocal;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./output.log", "source enable --name=\"name\" --confirm --log-file=\"/Working/output.log\"")]
+            [InlineData(null, "source enable --name=\"name\" --confirm")]
+            public void Should_Add_Log_File_Flag_To_Arguments_If_Set(string logFilePath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableSourceFixture();
+                fixture.Settings.LogFile = logFilePath;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source enable --name=\"name\" --confirm --skip-compatibility-checks")]
+            [InlineData(false, "source enable --name=\"name\" --confirm")]
+            public void Should_Add_Skip_Compatibility_Flag_To_Arguments_If_Set(bool skipCompatibiity, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyEnableSourceFixture();
+                fixture.Settings.SkipCompatibilityChecks = skipCompatibiity;
 
                 // When
                 var result = fixture.Run();
@@ -879,12 +1615,12 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("source disable -n \"name\" -y", result.Args);
+                Assert.Equal("source disable --name=\"name\" --confirm", result.Args);
             }
 
             [Theory]
-            [InlineData(true, "source disable -n \"name\" -d -y")]
-            [InlineData(false, "source disable -n \"name\" -y")]
+            [InlineData(true, "source disable --name=\"name\" --debug --confirm")]
+            [InlineData(false, "source disable --name=\"name\" --confirm")]
             public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
             {
                 // Given
@@ -899,8 +1635,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(true, "source disable -n \"name\" -v -y")]
-            [InlineData(false, "source disable -n \"name\" -y")]
+            [InlineData(true, "source disable --name=\"name\" --verbose --confirm")]
+            [InlineData(false, "source disable --name=\"name\" --confirm")]
             public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
             {
                 // Given
@@ -915,8 +1651,56 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(true, "source disable -n \"name\" -y -f")]
-            [InlineData(false, "source disable -n \"name\" -y")]
+            [InlineData(true, "source disable --name=\"name\" --trace --confirm")]
+            [InlineData(false, "source disable --name=\"name\" --confirm")]
+            public void Should_Add_Trace_Flag_To_Arguments_If_Set(bool trace, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableSourceFixture();
+                fixture.Settings.Trace = trace;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source disable --name=\"name\" --no-color --confirm")]
+            [InlineData(false, "source disable --name=\"name\" --confirm")]
+            public void Should_Add_NoColor_Flag_To_Arguments_If_Set(bool noColor, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableSourceFixture();
+                fixture.Settings.NoColor = noColor;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source disable --name=\"name\" --accept-license --confirm")]
+            [InlineData(false, "source disable --name=\"name\" --confirm")]
+            public void Should_Add_AcceptLicense_Flag_To_Arguments_If_Set(bool acceptLicense, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableSourceFixture();
+                fixture.Settings.AcceptLicense = acceptLicense;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source disable --name=\"name\" --confirm --force")]
+            [InlineData(false, "source disable --name=\"name\" --confirm")]
             public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
             {
                 // Given
@@ -931,8 +1715,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(true, "source disable -n \"name\" -y --noop")]
-            [InlineData(false, "source disable -n \"name\" -y")]
+            [InlineData(true, "source disable --name=\"name\" --confirm --what-if")]
+            [InlineData(false, "source disable --name=\"name\" --confirm")]
             public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
             {
                 // Given
@@ -947,8 +1731,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(true, "source disable -n \"name\" -y -r")]
-            [InlineData(false, "source disable -n \"name\" -y")]
+            [InlineData(true, "source disable --name=\"name\" --confirm --limit-output")]
+            [InlineData(false, "source disable --name=\"name\" --confirm")]
             public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
             {
                 // Given
@@ -963,8 +1747,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(5, "source disable -n \"name\" -y --execution-timeout \"5\"")]
-            [InlineData(0, "source disable -n \"name\" -y")]
+            [InlineData(5, "source disable --name=\"name\" --confirm --execution-timeout=\"5\"")]
+            [InlineData(0, "source disable --name=\"name\" --confirm")]
             public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
             {
                 // Given
@@ -979,8 +1763,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(@"c:\temp", "source disable -n \"name\" -y -c \"c:\\temp\"")]
-            [InlineData("", "source disable -n \"name\" -y")]
+            [InlineData(@"c:\temp", "source disable --name=\"name\" --confirm --cache-location=\"c:\\temp\"")]
+            [InlineData("", "source disable --name=\"name\" --confirm")]
             public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
             {
                 // Given
@@ -995,13 +1779,173 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Sources
             }
 
             [Theory]
-            [InlineData(true, "source disable -n \"name\" -y --allowunofficial")]
-            [InlineData(false, "source disable -n \"name\" -y")]
+            [InlineData(true, "source disable --name=\"name\" --confirm --allow-unofficial")]
+            [InlineData(false, "source disable --name=\"name\" --confirm")]
             public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
             {
                 // Given
                 var fixture = new ChocolateyDisableSourceFixture();
                 fixture.Settings.AllowUnofficial = allowUnofficial;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source disable --name=\"name\" --confirm --fail-on-error-output")]
+            [InlineData(false, "source disable --name=\"name\" --confirm")]
+            public void Should_Add_FailOnErrorOutput_Flag_To_Arguments_If_Set(bool failOnErrorOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableSourceFixture();
+                fixture.Settings.FailOnErrorOutput = failOnErrorOutput;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source disable --name=\"name\" --confirm --use-system-powershell")]
+            [InlineData(false, "source disable --name=\"name\" --confirm")]
+            public void Should_Add_UseSystemPowerShell_Flag_To_Arguments_If_Set(bool useSystemPowerShell, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableSourceFixture();
+                fixture.Settings.UseSystemPowerShell = useSystemPowerShell;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source disable --name=\"name\" --confirm --no-progress")]
+            [InlineData(false, "source disable --name=\"name\" --confirm")]
+            public void Should_Add_NoProgress_Flag_To_Arguments_If_Set(bool noProgress, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableSourceFixture();
+                fixture.Settings.NoProgress = noProgress;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy", "source disable --name=\"name\" --confirm --proxy=\"proxy\"")]
+            [InlineData(null, "source disable --name=\"name\" --confirm")]
+            public void Should_Add_Proxy_Flag_To_Arguments_If_Set(string proxy, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableSourceFixture();
+                fixture.Settings.Proxy = proxy;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-user", "source disable --name=\"name\" --confirm --proxy-user=\"proxy-user\"")]
+            [InlineData(null, "source disable --name=\"name\" --confirm")]
+            public void Should_Add_ProxyUser_Flag_To_Arguments_If_Set(string proxyUser, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableSourceFixture();
+                fixture.Settings.ProxyUser = proxyUser;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-password", "source disable --name=\"name\" --confirm --proxy-password=\"proxy-password\"")]
+            [InlineData(null, "source disable --name=\"name\" --confirm")]
+            public void Should_Add_ProxyPassword_Flag_To_Arguments_If_Set(string proxyPassword, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableSourceFixture();
+                fixture.Settings.ProxyPassword = proxyPassword;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy1,proxy2", "source disable --name=\"name\" --confirm --proxy-bypass-list=\"proxy1,proxy2\"")]
+            [InlineData(null, "source disable --name=\"name\" --confirm")]
+            public void Should_Add_ProxyByPassList_Flag_To_Arguments_If_Set(string proxyByPassList, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableSourceFixture();
+                fixture.Settings.ProxyByPassList = proxyByPassList;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source disable --name=\"name\" --confirm --proxy-bypass-on-local")]
+            [InlineData(false, "source disable --name=\"name\" --confirm")]
+            public void Should_Add_ProxyByPassOnLocal_Flag_To_Arguments_If_Set(bool proxyBypassOnLocal, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableSourceFixture();
+                fixture.Settings.ProxyBypassOnLocal = proxyBypassOnLocal;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./output.log", "source disable --name=\"name\" --confirm --log-file=\"/Working/output.log\"")]
+            [InlineData(null, "source disable --name=\"name\" --confirm")]
+            public void Should_Add_Log_File_Flag_To_Arguments_If_Set(string logFilePath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableSourceFixture();
+                fixture.Settings.LogFile = logFilePath;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "source disable --name=\"name\" --confirm --skip-compatibility-checks")]
+            [InlineData(false, "source disable --name=\"name\" --confirm")]
+            public void Should_Add_Skip_Compatibility_Flag_To_Arguments_If_Set(bool skipCompatibiity, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyDisableSourceFixture();
+                fixture.Settings.SkipCompatibilityChecks = skipCompatibiity;
 
                 // When
                 var result = fixture.Run();

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Uninstall/ChocolateyUninstallerSettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Uninstall/ChocolateyUninstallerSettingsTests.cs
@@ -16,7 +16,7 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             var settings = new ChocolateyUninstallSettings();
 
             // Then
-            Assert.False(settings.GlobalArguments);
+            Assert.False(settings.ApplyInstallArgumentsToDependencies);
         }
 
         [Fact]
@@ -26,7 +26,7 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             var settings = new ChocolateyUninstallSettings();
 
             // Then
-            Assert.False(settings.GlobalPackageParameters);
+            Assert.False(settings.ApplyPackageParametersToDependencies);
         }
 
         [Fact]
@@ -96,7 +96,7 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             var settings = new ChocolateyUninstallSettings();
 
             // Then
-            Assert.False(settings.IgnoreAutoUninstaller);
+            Assert.False(settings.IgnoreAutoUninstallerFailure);
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Uninstall/ChocolateyUninstallerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Uninstall/ChocolateyUninstallerTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Common.Tests.Fixtures.Tools.Chocolatey.ApiKey;
+using Cake.Common.Tests.Fixtures.Tools.Chocolatey.Installer;
 using Cake.Common.Tests.Fixtures.Tools.Chocolatey.Uninstaller;
 using Cake.Testing;
 using Cake.Testing.Xunit;
@@ -139,12 +141,12 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("uninstall \"Cake\" -y", result.Args);
+                Assert.Equal("uninstall \"Cake\" --confirm", result.Args);
             }
 
             [Theory]
-            [InlineData(true, "uninstall \"Cake\" -d -y")]
-            [InlineData(false, "uninstall \"Cake\" -y")]
+            [InlineData(true, "uninstall \"Cake\" --debug --confirm")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
             public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
             {
                 // Given
@@ -159,8 +161,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             }
 
             [Theory]
-            [InlineData(true, "uninstall \"Cake\" -v -y")]
-            [InlineData(false, "uninstall \"Cake\" -y")]
+            [InlineData(true, "uninstall \"Cake\" --verbose --confirm")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
             public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
             {
                 // Given
@@ -175,8 +177,40 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             }
 
             [Theory]
-            [InlineData(true, "uninstall \"Cake\" --acceptLicense -y")]
-            [InlineData(false, "uninstall \"Cake\" -y")]
+            [InlineData(true, "uninstall \"Cake\" --trace --confirm")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
+            public void Should_Add_Trace_Flag_To_Arguments_If_Set(bool trace, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUninstallerFixture();
+                fixture.Settings.Trace = trace;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "uninstall \"Cake\" --no-color --confirm")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
+            public void Should_Add_NoColor_Flag_To_Arguments_If_Set(bool noColor, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUninstallerFixture();
+                fixture.Settings.NoColor = noColor;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "uninstall \"Cake\" --accept-license --confirm")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
             public void Should_Add_AcceptLicense_Flag_To_Arguments_If_Set(bool acceptLicense, string expected)
             {
                 // Given
@@ -191,8 +225,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             }
 
             [Theory]
-            [InlineData(true, "uninstall \"Cake\" -y -f")]
-            [InlineData(false, "uninstall \"Cake\" -y")]
+            [InlineData(true, "uninstall \"Cake\" --confirm --force")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
             public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
             {
                 // Given
@@ -207,8 +241,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             }
 
             [Theory]
-            [InlineData(true, "uninstall \"Cake\" -y --noop")]
-            [InlineData(false, "uninstall \"Cake\" -y")]
+            [InlineData(true, "uninstall \"Cake\" --confirm --what-if")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
             public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
             {
                 // Given
@@ -223,8 +257,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             }
 
             [Theory]
-            [InlineData(true, "uninstall \"Cake\" -y -r")]
-            [InlineData(false, "uninstall \"Cake\" -y")]
+            [InlineData(true, "uninstall \"Cake\" --confirm --limit-output")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
             public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
             {
                 // Given
@@ -239,8 +273,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             }
 
             [Theory]
-            [InlineData(5, "uninstall \"Cake\" -y --execution-timeout \"5\"")]
-            [InlineData(0, "uninstall \"Cake\" -y")]
+            [InlineData(5, "uninstall \"Cake\" --confirm --execution-timeout=\"5\"")]
+            [InlineData(0, "uninstall \"Cake\" --confirm")]
             public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
             {
                 // Given
@@ -255,8 +289,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             }
 
             [Theory]
-            [InlineData(@"c:\temp", "uninstall \"Cake\" -y -c \"c:\\temp\"")]
-            [InlineData("", "uninstall \"Cake\" -y")]
+            [InlineData(@"c:\temp", "uninstall \"Cake\" --confirm --cache-location=\"c:\\temp\"")]
+            [InlineData("", "uninstall \"Cake\" --confirm")]
             public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
             {
                 // Given
@@ -271,8 +305,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             }
 
             [Theory]
-            [InlineData(true, "uninstall \"Cake\" -y --allowunofficial")]
-            [InlineData(false, "uninstall \"Cake\" -y")]
+            [InlineData(true, "uninstall \"Cake\" --confirm --allow-unofficial")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
             public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
             {
                 // Given
@@ -287,13 +321,13 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             }
 
             [Theory]
-            [InlineData(true, "uninstall \"Cake\" -y --failstderr")]
-            [InlineData(false, "uninstall \"Cake\" -y")]
-            public void Should_Add_FailOnStandardError_To_Arguments_If_Set(bool failOnStandardError, string expected)
+            [InlineData(true, "uninstall \"Cake\" --confirm --fail-on-error-output")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
+            public void Should_Add_FailOnErrorOutput_Flag_To_Arguments_If_Set(bool failOnErrorOutput, string expected)
             {
                 // Given
                 var fixture = new ChocolateyUninstallerFixture();
-                fixture.Settings.FailOnStandardError = failOnStandardError;
+                fixture.Settings.FailOnErrorOutput = failOnErrorOutput;
 
                 // When
                 var result = fixture.Run();
@@ -303,13 +337,141 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             }
 
             [Theory]
-            [InlineData(true, "uninstall \"Cake\" -y --use-system-powershell")]
-            [InlineData(false, "uninstall \"Cake\" -y")]
-            public void Should_Add_UseSystemPowershell_To_Arguments_If_Set(bool useSystemPowershell, string expected)
+            [InlineData(true, "uninstall \"Cake\" --confirm --use-system-powershell")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
+            public void Should_Add_UseSystemPowerShell_Flag_To_Arguments_If_Set(bool useSystemPowerShell, string expected)
             {
                 // Given
                 var fixture = new ChocolateyUninstallerFixture();
-                fixture.Settings.UseSystemPowershell = useSystemPowershell;
+                fixture.Settings.UseSystemPowerShell = useSystemPowerShell;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "uninstall \"Cake\" --confirm --no-progress")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
+            public void Should_Add_NoProgress_Flag_To_Arguments_If_Set(bool noProgress, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUninstallerFixture();
+                fixture.Settings.NoProgress = noProgress;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy", "uninstall \"Cake\" --confirm --proxy=\"proxy\"")]
+            [InlineData(null, "uninstall \"Cake\" --confirm")]
+            public void Should_Add_Proxy_Flag_To_Arguments_If_Set(string proxy, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUninstallerFixture();
+                fixture.Settings.Proxy = proxy;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-user", "uninstall \"Cake\" --confirm --proxy-user=\"proxy-user\"")]
+            [InlineData(null, "uninstall \"Cake\" --confirm")]
+            public void Should_Add_ProxyUser_Flag_To_Arguments_If_Set(string proxyUser, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUninstallerFixture();
+                fixture.Settings.ProxyUser = proxyUser;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-password", "uninstall \"Cake\" --confirm --proxy-password=\"proxy-password\"")]
+            [InlineData(null, "uninstall \"Cake\" --confirm")]
+            public void Should_Add_ProxyPassword_Flag_To_Arguments_If_Set(string proxyPassword, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUninstallerFixture();
+                fixture.Settings.ProxyPassword = proxyPassword;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy1,proxy2", "uninstall \"Cake\" --confirm --proxy-bypass-list=\"proxy1,proxy2\"")]
+            [InlineData(null, "uninstall \"Cake\" --confirm")]
+            public void Should_Add_ProxyByPassList_Flag_To_Arguments_If_Set(string proxyByPassList, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUninstallerFixture();
+                fixture.Settings.ProxyByPassList = proxyByPassList;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "uninstall \"Cake\" --confirm --proxy-bypass-on-local")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
+            public void Should_Add_ProxyByPassOnLocal_Flag_To_Arguments_If_Set(bool proxyBypassOnLocal, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUninstallerFixture();
+                fixture.Settings.ProxyBypassOnLocal = proxyBypassOnLocal;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./output.log", "uninstall \"Cake\" --confirm --log-file=\"/Working/output.log\"")]
+            [InlineData(null, "uninstall \"Cake\" --confirm")]
+            public void Should_Add_Log_File_Flag_To_Arguments_If_Set(string logFilePath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUninstallerFixture();
+                fixture.Settings.LogFile = logFilePath;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "uninstall \"Cake\" --confirm --skip-compatibility-checks")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
+            public void Should_Add_Skip_Compatibility_Flag_To_Arguments_If_Set(bool skipCompatibiity, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUninstallerFixture();
+                fixture.Settings.SkipCompatibilityChecks = skipCompatibiity;
 
                 // When
                 var result = fixture.Run();
@@ -329,7 +491,7 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("uninstall \"Cake\" -y -s \"A\"", result.Args);
+                Assert.Equal("uninstall \"Cake\" --confirm --source=\"A\"", result.Args);
             }
 
             [Fact]
@@ -343,12 +505,12 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("uninstall \"Cake\" -y --version \"1.0.0\"", result.Args);
+                Assert.Equal("uninstall \"Cake\" --confirm --version=\"1.0.0\"", result.Args);
             }
 
             [Theory]
-            [InlineData(true, "uninstall \"Cake\" -y --allversions")]
-            [InlineData(false, "uninstall \"Cake\" -y")]
+            [InlineData(true, "uninstall \"Cake\" --confirm --all-versions")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
             public void Should_Add_AllVersions_To_Arguments_If_Set(bool allVersions, string expected)
             {
                 // Given
@@ -363,8 +525,24 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             }
 
             [Theory]
-            [InlineData(true, "uninstall \"Cake\" -y -o")]
-            [InlineData(false, "uninstall \"Cake\" -y")]
+            [InlineData("arg1, arg2", "uninstall \"Cake\" --confirm --uninstall-arguments=\"arg1, arg2\"")]
+            [InlineData("", "uninstall \"Cake\" --confirm")]
+            public void Should_Add_UninstallArguments_Flag_To_Arguments_If_Set(string uninstallArguments, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUninstallerFixture();
+                fixture.Settings.UninstallArguments = uninstallArguments;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "uninstall \"Cake\" --confirm --override-arguments")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
             public void Should_Add_OverrideArguments_Flag_To_Arguments_If_Set(bool overrideArguments, string expected)
             {
                 // Given
@@ -379,8 +557,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             }
 
             [Theory]
-            [InlineData(true, "uninstall \"Cake\" -y --notSilent")]
-            [InlineData(false, "uninstall \"Cake\" -y")]
+            [InlineData(true, "uninstall \"Cake\" --confirm --not-silent")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
             public void Should_Add_NotSilent_Flag_To_Arguments_If_Set(bool notSilent, string expected)
             {
                 // Given
@@ -395,8 +573,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             }
 
             [Theory]
-            [InlineData("param1", "uninstall \"Cake\" -y --params \"param1\"")]
-            [InlineData("", "uninstall \"Cake\" -y")]
+            [InlineData("param1", "uninstall \"Cake\" --confirm --package-parameters=\"param1\"")]
+            [InlineData("", "uninstall \"Cake\" --confirm")]
             public void Should_Add_PackageParameters_To_Arguments_If_Set(string packageParameters, string expected)
             {
                 // Given
@@ -411,13 +589,13 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             }
 
             [Theory]
-            [InlineData(true, "uninstall \"Cake\" -y --argsglobal")]
-            [InlineData(false, "uninstall \"Cake\" -y")]
-            public void Should_Add_GlobalArguments_To_Arguments_If_Set(bool globalArguments, string expected)
+            [InlineData(true, "uninstall \"Cake\" --confirm --apply-install-arguments-to-dependencies")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
+            public void Should_Add_ApplyInstallArgumentsToDependencies_To_Arguments_If_Set(bool applyInstallArgumentsToDependencies, string expected)
             {
                 // Given
                 var fixture = new ChocolateyUninstallerFixture();
-                fixture.Settings.GlobalArguments = globalArguments;
+                fixture.Settings.ApplyInstallArgumentsToDependencies = applyInstallArgumentsToDependencies;
 
                 // When
                 var result = fixture.Run();
@@ -427,13 +605,13 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             }
 
             [Theory]
-            [InlineData(true, "uninstall \"Cake\" -y --paramsglobal")]
-            [InlineData(false, "uninstall \"Cake\" -y")]
-            public void Should_Add_GlobalPackageParameters_To_Arguments_If_Set(bool globalPackageParameters, string expected)
+            [InlineData(true, "uninstall \"Cake\" --confirm --apply-package-parameters-to-dependencies")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
+            public void Should_Add_ApplyPackageParametersToDependencies_To_Arguments_If_Set(bool applyPackageParametersToDependencies, string expected)
             {
                 // Given
                 var fixture = new ChocolateyUninstallerFixture();
-                fixture.Settings.GlobalPackageParameters = globalPackageParameters;
+                fixture.Settings.ApplyPackageParametersToDependencies = applyPackageParametersToDependencies;
 
                 // When
                 var result = fixture.Run();
@@ -443,8 +621,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             }
 
             [Theory]
-            [InlineData(true, "uninstall \"Cake\" -y -m")]
-            [InlineData(false, "uninstall \"Cake\" -y")]
+            [InlineData(true, "uninstall \"Cake\" --confirm --side-by-side")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
             public void Should_Add_SideBySide_Flag_To_Arguments_If_Set(bool sideBySide, string expected)
             {
                 // Given
@@ -459,8 +637,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             }
 
             [Theory]
-            [InlineData(true, "uninstall \"Cake\" -y -x")]
-            [InlineData(false, "uninstall \"Cake\" -y")]
+            [InlineData(true, "uninstall \"Cake\" --confirm --force-dependencies")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
             public void Should_Add_ForceDependencies_Flag_To_Arguments_If_Set(bool forceDependencies, string expected)
             {
                 // Given
@@ -475,8 +653,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             }
 
             [Theory]
-            [InlineData(true, "uninstall \"Cake\" -y -n")]
-            [InlineData(false, "uninstall \"Cake\" -y")]
+            [InlineData(true, "uninstall \"Cake\" --confirm --skip-automation-scripts")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
             public void Should_Add_SkipPowerShell_Flag_To_Arguments_If_Set(bool skipPowerShell, string expected)
             {
                 // Given
@@ -491,8 +669,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             }
 
             [Theory]
-            [InlineData(true, "uninstall \"Cake\" -y --ignorepackageexitcodes")]
-            [InlineData(false, "uninstall \"Cake\" -y")]
+            [InlineData(true, "uninstall \"Cake\" --confirm --ignore-package-exit-codes")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
             public void Should_Add_IgnorePackageExitCoedes_To_Arguments_If_Set(bool ignorePackageExitCodes, string expected)
             {
                 // Given
@@ -507,8 +685,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             }
 
             [Theory]
-            [InlineData(true, "uninstall \"Cake\" -y --usepackageexitcodes")]
-            [InlineData(false, "uninstall \"Cake\" -y")]
+            [InlineData(true, "uninstall \"Cake\" --confirm --use-package-exit-codes")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
             public void Should_Add_UsePackageExitCodes_To_Arguments_If_Set(bool usePackageExitCodes, string expected)
             {
                 // Given
@@ -523,8 +701,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             }
 
             [Theory]
-            [InlineData(true, "uninstall \"Cake\" -y --use-autouninstaller")]
-            [InlineData(false, "uninstall \"Cake\" -y")]
+            [InlineData(true, "uninstall \"Cake\" --confirm --use-autouninstaller")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
             public void Should_Add_UseAutoUninstaller_To_Arguments_If_Set(bool useAutoUninstaller, string expected)
             {
                 // Given
@@ -539,8 +717,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             }
 
             [Theory]
-            [InlineData(true, "uninstall \"Cake\" -y --skipautouninstaller")]
-            [InlineData(false, "uninstall \"Cake\" -y")]
+            [InlineData(true, "uninstall \"Cake\" --confirm --skip-autouninstaller")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
             public void Should_Add_SkipAutoUninstaller_To_Arguments_If_Set(bool skipAutoUninstaller, string expected)
             {
                 // Given
@@ -555,8 +733,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             }
 
             [Theory]
-            [InlineData(true, "uninstall \"Cake\" -y --failonautouninstaller")]
-            [InlineData(false, "uninstall \"Cake\" -y")]
+            [InlineData(true, "uninstall \"Cake\" --confirm --fail-on-autouninstaller")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
             public void Should_Add_FailOnAutoUninstaller_To_Arguments_If_Set(bool failOnAutoUninstaller, string expected)
             {
                 // Given
@@ -571,13 +749,93 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Uninstall
             }
 
             [Theory]
-            [InlineData(true, "uninstall \"Cake\" -y --ignoreautouninstallerfailure")]
-            [InlineData(false, "uninstall \"Cake\" -y")]
+            [InlineData(true, "uninstall \"Cake\" --confirm --ignore-autouninstaller-failure")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
             public void Should_Add_IgnoreAutoUninstallerFailure_To_Arguments_If_Set(bool ignoreAutoUninstaller, string expected)
             {
                 // Given
                 var fixture = new ChocolateyUninstallerFixture();
-                fixture.Settings.IgnoreAutoUninstaller = ignoreAutoUninstaller;
+                fixture.Settings.IgnoreAutoUninstallerFailure = ignoreAutoUninstaller;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "uninstall \"Cake\" --confirm --stop-on-first-package-failure")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
+            public void Should_Add_StopOnFirstFailure_Flag_To_Arguments_If_Set(bool stopOnFirstFailure, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUninstallerFixture();
+                fixture.Settings.StopOnFirstFailure = stopOnFirstFailure;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "uninstall \"Cake\" --confirm --exit-when-reboot-detected")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
+            public void Should_Add_ExitWhenRebootDetected_Flag_To_Arguments_If_Set(bool exitWhenRebootDetected, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUninstallerFixture();
+                fixture.Settings.ExitWhenRebootDetected = exitWhenRebootDetected;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "uninstall \"Cake\" --confirm --ignore-detected-reboot")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
+            public void Should_Add_IgnoreDetectedReboot_Flag_To_Arguments_If_Set(bool ignoreDetectedReboot, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUninstallerFixture();
+                fixture.Settings.IgnoreDetectedReboot = ignoreDetectedReboot;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "uninstall \"Cake\" --confirm --skip-hooks")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
+            public void Should_Add_SkipHooks_Flag_To_Arguments_If_Set(bool skipHooks, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUninstallerFixture();
+                fixture.Settings.SkipHooks = skipHooks;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "uninstall \"Cake\" --confirm --from-programs-and-features")]
+            [InlineData(false, "uninstall \"Cake\" --confirm")]
+            public void Should_Add_FromProgramsAndFeatures_Flag_To_Arguments_If_Set(bool fromProgramsAndFeatures, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUninstallerFixture();
+                fixture.Settings.FromProgramsAndFeatures = fromProgramsAndFeatures;
 
                 // When
                 var result = fixture.Run();

--- a/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Upgrade/ChocolateyUpgraderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Chocolatey/Upgrade/ChocolateyUpgraderTests.cs
@@ -139,12 +139,12 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("upgrade \"Cake\" -y", result.Args);
+                Assert.Equal("upgrade \"Cake\" --confirm", result.Args);
             }
 
             [Theory]
-            [InlineData(true, "upgrade \"Cake\" -d -y")]
-            [InlineData(false, "upgrade \"Cake\" -y")]
+            [InlineData(true, "upgrade \"Cake\" --debug --confirm")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
             public void Should_Add_Debug_Flag_To_Arguments_If_Set(bool debug, string expected)
             {
                 // Given
@@ -159,8 +159,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
             }
 
             [Theory]
-            [InlineData(true, "upgrade \"Cake\" -v -y")]
-            [InlineData(false, "upgrade \"Cake\" -y")]
+            [InlineData(true, "upgrade \"Cake\" --verbose --confirm")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
             public void Should_Add_Verbose_Flag_To_Arguments_If_Set(bool verbose, string expected)
             {
                 // Given
@@ -175,8 +175,40 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
             }
 
             [Theory]
-            [InlineData(true, "upgrade \"Cake\" --acceptLicense -y")]
-            [InlineData(false, "upgrade \"Cake\" -y")]
+            [InlineData(true, "upgrade \"Cake\" --trace --confirm")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_Trace_Flag_To_Arguments_If_Set(bool trace, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.Trace = trace;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --no-color --confirm")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_NoColor_Flag_To_Arguments_If_Set(bool noColor, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.NoColor = noColor;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --accept-license --confirm")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
             public void Should_Add_AcceptLicense_Flag_To_Arguments_If_Set(bool acceptLicense, string expected)
             {
                 // Given
@@ -191,8 +223,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
             }
 
             [Theory]
-            [InlineData(true, "upgrade \"Cake\" -y -f")]
-            [InlineData(false, "upgrade \"Cake\" -y")]
+            [InlineData(true, "upgrade \"Cake\" --confirm --force")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
             public void Should_Add_Force_Flag_To_Arguments_If_Set(bool force, string expected)
             {
                 // Given
@@ -207,8 +239,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
             }
 
             [Theory]
-            [InlineData(true, "upgrade \"Cake\" -y --noop")]
-            [InlineData(false, "upgrade \"Cake\" -y")]
+            [InlineData(true, "upgrade \"Cake\" --confirm --what-if")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
             public void Should_Add_Noop_Flag_To_Arguments_If_Set(bool noop, string expected)
             {
                 // Given
@@ -223,8 +255,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
             }
 
             [Theory]
-            [InlineData(true, "upgrade \"Cake\" -y -r")]
-            [InlineData(false, "upgrade \"Cake\" -y")]
+            [InlineData(true, "upgrade \"Cake\" --confirm --limit-output")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
             public void Should_Add_LimitOutput_Flag_To_Arguments_If_Set(bool limitOutput, string expected)
             {
                 // Given
@@ -239,8 +271,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
             }
 
             [Theory]
-            [InlineData(5, "upgrade \"Cake\" -y --execution-timeout \"5\"")]
-            [InlineData(0, "upgrade \"Cake\" -y")]
+            [InlineData(5, "upgrade \"Cake\" --confirm --execution-timeout=\"5\"")]
+            [InlineData(0, "upgrade \"Cake\" --confirm")]
             public void Should_Add_ExecutionTimeout_To_Arguments_If_Set(int executionTimeout, string expected)
             {
                 // Given
@@ -255,8 +287,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
             }
 
             [Theory]
-            [InlineData(@"c:\temp", "upgrade \"Cake\" -y -c \"c:\\temp\"")]
-            [InlineData("", "upgrade \"Cake\" -y")]
+            [InlineData(@"c:\temp", "upgrade \"Cake\" --confirm --cache-location=\"c:\\temp\"")]
+            [InlineData("", "upgrade \"Cake\" --confirm")]
             public void Should_Add_CacheLocation_Flag_To_Arguments_If_Set(string cacheLocation, string expected)
             {
                 // Given
@@ -271,13 +303,173 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
             }
 
             [Theory]
-            [InlineData(true, "upgrade \"Cake\" -y --allowunofficial")]
-            [InlineData(false, "upgrade \"Cake\" -y")]
+            [InlineData(true, "upgrade \"Cake\" --confirm --allow-unofficial")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
             public void Should_Add_AllowUnofficial_Flag_To_Arguments_If_Set(bool allowUnofficial, string expected)
             {
                 // Given
                 var fixture = new ChocolateyUpgraderFixture();
                 fixture.Settings.AllowUnofficial = allowUnofficial;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --fail-on-error-output")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_FailOnErrorOutput_Flag_To_Arguments_If_Set(bool failOnErrorOutput, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.FailOnErrorOutput = failOnErrorOutput;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --use-system-powershell")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_UseSystemPowerShell_Flag_To_Arguments_If_Set(bool useSystemPowerShell, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.UseSystemPowerShell = useSystemPowerShell;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --no-progress")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_NoProgress_Flag_To_Arguments_If_Set(bool noProgress, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.NoProgress = noProgress;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy", "upgrade \"Cake\" --confirm --proxy=\"proxy\"")]
+            [InlineData(null, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_Proxy_Flag_To_Arguments_If_Set(string proxy, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.Proxy = proxy;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-user", "upgrade \"Cake\" --confirm --proxy-user=\"proxy-user\"")]
+            [InlineData(null, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_ProxyUser_Flag_To_Arguments_If_Set(string proxyUser, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.ProxyUser = proxyUser;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy-password", "upgrade \"Cake\" --confirm --proxy-password=\"proxy-password\"")]
+            [InlineData(null, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_ProxyPassword_Flag_To_Arguments_If_Set(string proxyPassword, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.ProxyPassword = proxyPassword;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("proxy1,proxy2", "upgrade \"Cake\" --confirm --proxy-bypass-list=\"proxy1,proxy2\"")]
+            [InlineData(null, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_ProxyByPassList_Flag_To_Arguments_If_Set(string proxyByPassList, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.ProxyByPassList = proxyByPassList;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --proxy-bypass-on-local")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_ProxyByPassOnLocal_Flag_To_Arguments_If_Set(bool proxyBypassOnLocal, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.ProxyBypassOnLocal = proxyBypassOnLocal;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./output.log", "upgrade \"Cake\" --confirm --log-file=\"/Working/output.log\"")]
+            [InlineData(null, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_Log_File_Flag_To_Arguments_If_Set(string logFilePath, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.LogFile = logFilePath;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --skip-compatibility-checks")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_Skip_Compatibility_Flag_To_Arguments_If_Set(bool skipCompatibiity, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.SkipCompatibilityChecks = skipCompatibiity;
 
                 // When
                 var result = fixture.Run();
@@ -297,7 +489,7 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("upgrade \"Cake\" -y -s \"A\"", result.Args);
+                Assert.Equal("upgrade \"Cake\" --confirm --source=\"A\"", result.Args);
             }
 
             [Fact]
@@ -311,12 +503,12 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("upgrade \"Cake\" -y --version \"1.0.0\"", result.Args);
+                Assert.Equal("upgrade \"Cake\" --confirm --version=\"1.0.0\"", result.Args);
             }
 
             [Theory]
-            [InlineData(true, "upgrade \"Cake\" -y --pre")]
-            [InlineData(false, "upgrade \"Cake\" -y")]
+            [InlineData(true, "upgrade \"Cake\" --confirm --pre")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
             public void Should_Add_Prerelease_Flag_To_Arguments_If_Set(bool prerelease, string expected)
             {
                 // Given
@@ -331,8 +523,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
             }
 
             [Theory]
-            [InlineData(true, "upgrade \"Cake\" -y --x86")]
-            [InlineData(false, "upgrade \"Cake\" -y")]
+            [InlineData(true, "upgrade \"Cake\" --confirm --forcex86")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
             public void Should_Add_Forcex86_Flag_To_Arguments_If_Set(bool forcex86, string expected)
             {
                 // Given
@@ -347,8 +539,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
             }
 
             [Theory]
-            [InlineData("args1", "upgrade \"Cake\" -y --ia \"args1\"")]
-            [InlineData("", "upgrade \"Cake\" -y")]
+            [InlineData("args1", "upgrade \"Cake\" --confirm --install-arguments=\"args1\"")]
+            [InlineData("", "upgrade \"Cake\" --confirm")]
             public void Should_Add_InstallArguments_To_Arguments_If_Set(string installArgs, string expected)
             {
                 // Given
@@ -363,8 +555,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
             }
 
             [Theory]
-            [InlineData(true, "upgrade \"Cake\" -y -o")]
-            [InlineData(false, "upgrade \"Cake\" -y")]
+            [InlineData(true, "upgrade \"Cake\" --confirm --override-arguments")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
             public void Should_Add_OverrideArguments_Flag_To_Arguments_If_Set(bool overrideArguments, string expected)
             {
                 // Given
@@ -379,8 +571,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
             }
 
             [Theory]
-            [InlineData(true, "upgrade \"Cake\" -y --notSilent")]
-            [InlineData(false, "upgrade \"Cake\" -y")]
+            [InlineData(true, "upgrade \"Cake\" --confirm --not-silent")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
             public void Should_Add_NotSilent_Flag_To_Arguments_If_Set(bool notSilent, string expected)
             {
                 // Given
@@ -395,8 +587,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
             }
 
             [Theory]
-            [InlineData("param1", "upgrade \"Cake\" -y --params \"param1\"")]
-            [InlineData("", "upgrade \"Cake\" -y")]
+            [InlineData("param1", "upgrade \"Cake\" --confirm --package-parameters=\"param1\"")]
+            [InlineData("", "upgrade \"Cake\" --confirm")]
             public void Should_Add_PackageParameters_To_Arguments_If_Set(string packageParameters, string expected)
             {
                 // Given
@@ -411,8 +603,40 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
             }
 
             [Theory]
-            [InlineData(true, "upgrade \"Cake\" -y --allowdowngrade")]
-            [InlineData(false, "upgrade \"Cake\" -y")]
+            [InlineData(true, "upgrade \"Cake\" --confirm --apply-install-arguments-to-dependencies")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_ApplyInstallArgumentsToDependencies_To_Arguments_If_Set(bool applyInstallArgumentsToDependencies, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.ApplyInstallArgumentsToDependencies = applyInstallArgumentsToDependencies;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --apply-package-parameters-to-dependencies")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_ApplyPackageParametersToDependencies_To_Arguments_If_Set(bool applyPackageParametersToDependencies, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.ApplyPackageParametersToDependencies = applyPackageParametersToDependencies;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --allow-downgrade")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
             public void Should_Add_AllowDowngrade_Flag_To_Arguments_If_Set(bool allowDowngrade, string expected)
             {
                 // Given
@@ -427,8 +651,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
             }
 
             [Theory]
-            [InlineData(true, "upgrade \"Cake\" -y -m")]
-            [InlineData(false, "upgrade \"Cake\" -y")]
+            [InlineData(true, "upgrade \"Cake\" --confirm --side-by-side")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
             public void Should_Add_SideBySide_Flag_To_Arguments_If_Set(bool sideBySide, string expected)
             {
                 // Given
@@ -443,8 +667,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
             }
 
             [Theory]
-            [InlineData(true, "upgrade \"Cake\" -y -i")]
-            [InlineData(false, "upgrade \"Cake\" -y")]
+            [InlineData(true, "upgrade \"Cake\" --confirm --ignore-dependencies")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
             public void Should_Add_IgnoreDependencies_Flag_To_Arguments_If_Set(bool ignoreDependencies, string expected)
             {
                 // Given
@@ -459,8 +683,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
             }
 
             [Theory]
-            [InlineData(true, "upgrade \"Cake\" -y -n")]
-            [InlineData(false, "upgrade \"Cake\" -y")]
+            [InlineData(true, "upgrade \"Cake\" --confirm --skip-automation-scripts")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
             public void Should_Add_SkipPowerShell_Flag_To_Arguments_If_Set(bool skipPowerShell, string expected)
             {
                 // Given
@@ -475,8 +699,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
             }
 
             [Theory]
-            [InlineData(true, "upgrade \"Cake\" -y --failonunfound")]
-            [InlineData(false, "upgrade \"Cake\" -y")]
+            [InlineData(true, "upgrade \"Cake\" --confirm --fail-on-unfound")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
             public void Should_Add_FailOnUnfound_Flag_To_Arguments_If_Set(bool failOnUnfound, string expected)
             {
                 // Given
@@ -491,8 +715,24 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
             }
 
             [Theory]
-            [InlineData(true, "upgrade \"Cake\" -y --failonnotinstalled")]
-            [InlineData(false, "upgrade \"Cake\" -y")]
+            [InlineData(true, "upgrade \"Cake\" --confirm --ignore-unfound")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_IgnoreUnfound_Flag_To_Arguments_If_Set(bool ignoreUnfound, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.IgnoreUnfound = ignoreUnfound;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --fail-on-not-installed")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
             public void Should_Add_FailOnNotInstalled_Flag_To_Arguments_If_Set(bool failOnNotInstalled, string expected)
             {
                 // Given
@@ -507,8 +747,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
             }
 
             [Theory]
-            [InlineData("user1", "upgrade \"Cake\" -y -u \"user1\"")]
-            [InlineData("", "upgrade \"Cake\" -y")]
+            [InlineData("user1", "upgrade \"Cake\" --confirm --user=\"user1\"")]
+            [InlineData("", "upgrade \"Cake\" --confirm")]
             public void Should_Add_User_To_Arguments_If_Set(string user, string expected)
             {
                 // Given
@@ -523,8 +763,8 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
             }
 
             [Theory]
-            [InlineData("password1", "upgrade \"Cake\" -y -p \"password1\"")]
-            [InlineData("", "upgrade \"Cake\" -y")]
+            [InlineData("password1", "upgrade \"Cake\" --confirm --password=\"password1\"")]
+            [InlineData("", "upgrade \"Cake\" --confirm")]
             public void Should_Add_Password_To_Arguments_If_Set(string password, string expected)
             {
                 // Given
@@ -539,13 +779,621 @@ namespace Cake.Common.Tests.Unit.Tools.Chocolatey.Upgrade
             }
 
             [Theory]
-            [InlineData(true, "upgrade \"Cake\" -y --ignorechecksums")]
-            [InlineData(false, "upgrade \"Cake\" -y")]
+            [InlineData("./mycert.pfx", "upgrade \"Cake\" --confirm --cert=\"/Working/mycert.pfx\"")]
+            [InlineData(null, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_Cert_To_Arguments_If_Set(string certificate, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.Certificate = certificate;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("certpassword", "upgrade \"Cake\" --confirm --certpassword=\"certpassword\"")]
+            [InlineData("", "upgrade \"Cake\" --confirm")]
+            public void Should_Add_CertPassword_To_Arguments_If_Set(string certificatePassword, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.CertificatePassword = certificatePassword;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --ignore-checksums")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
             public void Should_Add_IgnoreChecksums_Flag_To_Arguments_If_Set(bool ignoreChecksums, string expected)
             {
                 // Given
                 var fixture = new ChocolateyUpgraderFixture();
                 fixture.Settings.IgnoreChecksums = ignoreChecksums;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --allow-empty-checksums")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_AllowEmptyChecksums_Flag_To_Arguments_If_Set(bool allowEmptyChecksums, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.AllowEmptyChecksums = allowEmptyChecksums;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --allow-empty-checksums-secure")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_AllowEmptyChecksumsSecure_Flag_To_Arguments_If_Set(bool allowEmptyChecksumsSecure, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.AllowEmptyChecksumsSecure = allowEmptyChecksumsSecure;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --require-checksums")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_RequireChecksums_Flag_To_Arguments_If_Set(bool requireChecksums, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.RequireChecksums = requireChecksums;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("abcdef", "upgrade \"Cake\" --confirm --download-checksum=\"abcdef\"")]
+            [InlineData(null, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_Checksum_Flag_To_Arguments_If_Set(string checksum, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.Checksum = checksum;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("abcdef", "upgrade \"Cake\" --confirm --download-checksum-x64=\"abcdef\"")]
+            [InlineData(null, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_Checksum64_Flag_To_Arguments_If_Set(string checksum64, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.Checksum64 = checksum64;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("md5", "upgrade \"Cake\" --confirm --download-checksum-type=\"md5\"")]
+            [InlineData(null, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_ChecksumType_Flag_To_Arguments_If_Set(string checkSumType, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.ChecksumType = checkSumType;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("md5", "upgrade \"Cake\" --confirm --download-checksum-type-x64=\"md5\"")]
+            [InlineData(null, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_ChecksumType64_Flag_To_Arguments_If_Set(string checkSumType64, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.ChecksumType64 = checkSumType64;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --ignore-package-exit-codes")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_IgnorePackageExitCodes_Flag_To_Arguments_If_Set(bool ignorePackageExitCodes, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.IgnorePackageExitCodes = ignorePackageExitCodes;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --use-package-exit-codes")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_UsePackageExitCodes_Flag_To_Arguments_If_Set(bool usePackageExitCodes, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.UsePackageExitCodes = usePackageExitCodes;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("packageA,packageB", "upgrade \"Cake\" --confirm --except=\"packageA,packageB\"")]
+            [InlineData(null, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_Except_Flag_To_Arguments_If_Set(string except, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.Except = except;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --stop-on-first-package-failure")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_StopOnFirstFailure_Flag_To_Arguments_If_Set(bool stopOnFirstFailure, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.StopOnFirstFailure = stopOnFirstFailure;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --skip-if-not-installed")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_SkipIfNotInstalled_Flag_To_Arguments_If_Set(bool skipIfNotInstalled, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.SkipIfNotInstalled = skipIfNotInstalled;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --install-if-not-installed")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_InstallIfNotInstalled_Flag_To_Arguments_If_Set(bool installIfNotInstalled, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.InstallIfNotInstalled = installIfNotInstalled;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --exclude-prerelease")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_ExcludePrerelease_Flag_To_Arguments_If_Set(bool excludePrerelease, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.ExcludePrerelease = excludePrerelease;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --use-remembered-arguments")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_UseRememberedArguments_Flag_To_Arguments_If_Set(bool useRememberedArguments, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.UseRememberedArguments = useRememberedArguments;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --ignore-remembered-arguments")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_IgnoreRememeredArguments_Flag_To_Arguments_If_Set(bool ignoreRememeredArguments, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.IgnoreRememeredArguments = ignoreRememeredArguments;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --exit-when-reboot-detected")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_ExitWhenRebootDetected_Flag_To_Arguments_If_Set(bool exitWhenRebootDetected, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.ExitWhenRebootDetected = exitWhenRebootDetected;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --ignore-detected-reboot")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_IgnoreDetectedReboot_Flag_To_Arguments_If_Set(bool ignoreDetectedReboot, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.IgnoreDetectedReboot = ignoreDetectedReboot;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --disable-repository-optimizations")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_DisableRepositoryOptimizations_Flag_To_Arguments_If_Set(bool disableRepositoryOptimizations, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.DisableRepositoryOptimizations = disableRepositoryOptimizations;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --pin-package")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_Pin_Flag_To_Arguments_If_Set(bool pin, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.Pin = pin;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --skip-hooks")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_SkipHooks_Flag_To_Arguments_If_Set(bool skipHooks, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.SkipHooks = skipHooks;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --skip-download-cache")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_SkipDownloadCache_Flag_To_Arguments_If_Set(bool skipDownloadCache, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.SkipDownloadCache = skipDownloadCache;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --use-download-cache")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_UseDownloadCache_Flag_To_Arguments_If_Set(bool useDownloadCache, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.UseDownloadCache = useDownloadCache;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --skip-virus-check")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_SkipVirusCheck_Flag_To_Arguments_If_Set(bool skipVirusCheck, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.SkipVirusCheck = skipVirusCheck;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --virus-check")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_VirusCheck_Flag_To_Arguments_If_Set(bool virusCheck, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.VirusCheck = virusCheck;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(5, "upgrade \"Cake\" --confirm --virus-positives-minimum=\"5\"")]
+            [InlineData(0, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_VirusPositivesMinimum_To_Arguments_If_Set(int virusPositivesMinimum, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.VirusPositivesMinimum = virusPositivesMinimum;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("super-secret", "upgrade \"Cake\" --confirm --install-arguments-sensitive=\"super-secret\"")]
+            [InlineData(null, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_InstallArgumentsSensitive_Flag_To_Arguments_If_Set(string installArgumentsSensitive, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.InstallArgumentsSensitive = installArgumentsSensitive;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("super-secret", "upgrade \"Cake\" --confirm --package-parameters-sensitive=\"super-secret\"")]
+            [InlineData(null, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_PackageParametersSensitive_Flag_To_Arguments_If_Set(string packageParametersSensitive, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.PackageParametersSensitive = packageParametersSensitive;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("./install", "upgrade \"Cake\" --confirm --install-directory=\"/Working/install\"")]
+            [InlineData(null, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_InstallDirectory_Flag_To_Arguments_If_Set(string installDirectory, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.InstallDirectory = installDirectory;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(5, "upgrade \"Cake\" --confirm --maximum-download-bits-per-second=\"5\"")]
+            [InlineData(0, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_MaximumDownloadBitsPerSecond_Flag_To_Arguments_If_Set(int maximumDownloadBitsPerSecond, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.MaximumDownloadBitsPerSecond = maximumDownloadBitsPerSecond;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --reduce-package-size")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_ReducePackageSize_Flag_To_Arguments_If_Set(bool reducePackageSize, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.ReducePackageSize = reducePackageSize;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --no-reduce-package-size")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_NoReducePackageSize_Flag_To_Arguments_If_Set(bool noReducePackageSize, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.NoReducePackageSize = noReducePackageSize;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --reduce-nupkg-only")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_ReduceNupkgOnly_Flag_To_Arguments_If_Set(bool reduceNupkgOnly, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.ReduceNupkgOnly = reduceNupkgOnly;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --exclude-chocolatey-packages-during-upgrade-all")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_ExcludeChocolateyPackagesDuringUpgradeAll_Flag_To_Arguments_If_Set(bool excludeChocolateyPackagesDuringUpgradeAll, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.ExcludeChocolateyPackagesDuringUpgradeAll = excludeChocolateyPackagesDuringUpgradeAll;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData(true, "upgrade \"Cake\" --confirm --include-chocolatey-packages-during-upgrade-all")]
+            [InlineData(false, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_IncludeChocolateyPackagesDuringUpgradeAll_Flag_To_Arguments_If_Set(bool includeChocolateyPackagesDuringUpgradeAll, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.IncludeChocolateyPackagesDuringUpgradeAll = includeChocolateyPackagesDuringUpgradeAll;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Theory]
+            [InlineData("Just because", "upgrade \"Cake\" --confirm --pin-reason=\"Just because\"")]
+            [InlineData(null, "upgrade \"Cake\" --confirm")]
+            public void Should_Add_PinReason_Flag_To_Arguments_If_Set(string pinReason, string expected)
+            {
+                // Given
+                var fixture = new ChocolateyUpgraderFixture();
+                fixture.Settings.PinReason = pinReason;
 
                 // When
                 var result = fixture.Run();

--- a/src/Cake.Common/Tools/Chocolatey/ApiKey/ChocolateyApiKeySetter.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ApiKey/ChocolateyApiKeySetter.cs
@@ -35,19 +35,13 @@ namespace Cake.Common.Tools.Chocolatey.ApiKey
         /// <summary>
         /// Pins Chocolatey packages using the specified package id and settings.
         /// </summary>
-        /// <param name="apiKey">The API key.</param>
         /// <param name="source">The Server URL where the API key is valid.</param>
         /// <param name="settings">The settings.</param>
-        public void Set(string apiKey, string source, ChocolateyApiKeySettings settings)
+        public void Set(string source, ChocolateyApiKeySettings settings)
         {
             if (settings == null)
             {
                 throw new ArgumentNullException(nameof(settings));
-            }
-
-            if (string.IsNullOrWhiteSpace(apiKey))
-            {
-                throw new ArgumentNullException(nameof(apiKey));
             }
 
             if (string.IsNullOrWhiteSpace(source))
@@ -55,72 +49,29 @@ namespace Cake.Common.Tools.Chocolatey.ApiKey
                 throw new ArgumentNullException(nameof(source));
             }
 
-            Run(settings, GetArguments(apiKey, source, settings));
+            Run(settings, GetArguments(source, settings));
         }
 
-        private ProcessArgumentBuilder GetArguments(string apiKey, string source, ChocolateyApiKeySettings settings)
+        private ProcessArgumentBuilder GetArguments(string source, ChocolateyApiKeySettings settings)
         {
+            const string separator = "=";
             var builder = new ProcessArgumentBuilder();
 
             builder.Append("apikey");
 
-            builder.Append("-s");
-            builder.AppendQuoted(source);
+            builder.AppendSwitchQuoted("--source", separator, source);
 
-            builder.Append("-k");
-            builder.AppendQuotedSecret(apiKey);
+            // Add common arguments using the inherited method
+            AddGlobalArguments(settings, builder);
 
-            // Debug
-            if (settings.Debug)
+            if (!string.IsNullOrEmpty(settings.ApiKey))
             {
-                builder.Append("-d");
+                builder.AppendSwitchQuoted("--api-key", separator, settings.ApiKey);
             }
 
-            // Verbose
-            if (settings.Verbose)
+            if (settings.Remove)
             {
-                builder.Append("-v");
-            }
-
-            // Always say yes, so as to not show interactive prompt
-            builder.Append("-y");
-
-            // Force
-            if (settings.Force)
-            {
-                builder.Append("-f");
-            }
-
-            // Noop
-            if (settings.Noop)
-            {
-                builder.Append("--noop");
-            }
-
-            // Limit Output
-            if (settings.LimitOutput)
-            {
-                builder.Append("-r");
-            }
-
-            // Execution Timeout
-            if (settings.ExecutionTimeout != 0)
-            {
-                builder.Append("--execution-timeout");
-                builder.AppendQuoted(settings.ExecutionTimeout.ToString(CultureInfo.InvariantCulture));
-            }
-
-            // Cache Location
-            if (!string.IsNullOrWhiteSpace(settings.CacheLocation))
-            {
-                builder.Append("-c");
-                builder.AppendQuoted(settings.CacheLocation);
-            }
-
-            // Allow Unofficial
-            if (settings.AllowUnofficial)
-            {
-                builder.Append("--allowunofficial");
+                builder.Append("--remove");
             }
 
             return builder;

--- a/src/Cake.Common/Tools/Chocolatey/ApiKey/ChocolateyApiKeySettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ApiKey/ChocolateyApiKeySettings.cs
@@ -2,62 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Core.Tooling;
-
 namespace Cake.Common.Tools.Chocolatey.ApiKey
 {
     /// <summary>
     /// Contains settings used by <see cref="ChocolateyApiKeySetter"/>.
     /// </summary>
-    public sealed class ChocolateyApiKeySettings : ToolSettings
+    public sealed class ChocolateyApiKeySettings : ChocolateySettings
     {
         /// <summary>
-        /// Gets or sets a value indicating whether to run in debug mode.
+        /// Gets or sets the API key for the server.
         /// </summary>
-        /// <value>The debug flag.</value>
-        public bool Debug { get; set; }
+        /// <value>The API key for the server.</value>
+        public string ApiKey { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to run in verbose mode.
+        /// Gets or sets a value indicating whether to remove the selected source.
         /// </summary>
-        /// <value>The verbose flag.</value>
-        public bool Verbose { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in forced mode.
-        /// </summary>
-        /// <value>The force flag.</value>
-        public bool Force { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in noop mode.
-        /// </summary>
-        /// <value>The noop flag.</value>
-        public bool Noop { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in limited output mode.
-        /// </summary>
-        /// <value>The limit output flag.</value>
-        public bool LimitOutput { get; set; }
-
-        /// <summary>
-        /// Gets or sets the execution timeout value.
-        /// </summary>
-        /// <value>The execution timeout.</value>
-        /// <remarks>Default is 2700 seconds.</remarks>
-        public int ExecutionTimeout { get; set; }
-
-        /// <summary>
-        /// Gets or sets the location of the download cache.
-        /// </summary>
-        /// <value>The download cache location.</value>
-        public string CacheLocation { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in allow unofficial mode.
-        /// </summary>
-        /// <value>The allow unofficial flag.</value>
-        public bool AllowUnofficial { get; set; }
+        public bool Remove { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ChocolateyAliases.cs
@@ -535,12 +535,12 @@ namespace Cake.Common.Tools.Chocolatey
         /// Sets the Api Key for a Chocolatey Source using the specified settings.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="apiKey">The API Key.</param>
         /// <param name="source">The source.</param>
         /// <param name="settings">The settings.</param>
         /// <example>
         /// <code>
-        /// ChocolateyApiKey("myApiKey", "http://www.mysource.com", new ChocolateyApiKeySettings {
+        /// ChocolateyApiKey("http://www.mysource.com", new ChocolateyApiKeySettings {
+        ///     ApiKey                = "myApiKey",
         ///     Debug                 = false,
         ///     Verbose               = false,
         ///     Force                 = false,
@@ -555,7 +555,7 @@ namespace Cake.Common.Tools.Chocolatey
         [CakeMethodAlias]
         [CakeAliasCategory("ApiKey")]
         [CakeNamespaceImport("Cake.Common.Tools.Chocolatey.ApiKey")]
-        public static void ChocolateyApiKey(this ICakeContext context, string apiKey, string source, ChocolateyApiKeySettings settings)
+        public static void ChocolateyApiKey(this ICakeContext context, string source, ChocolateyApiKeySettings settings)
         {
             if (context == null)
             {
@@ -564,7 +564,7 @@ namespace Cake.Common.Tools.Chocolatey
 
             var resolver = new ChocolateyToolResolver(context.FileSystem, context.Environment);
             var packer = new ChocolateyApiKeySetter(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools, resolver);
-            packer.Set(apiKey, source, settings);
+            packer.Set(source, settings);
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/Chocolatey/ChocolateySettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ChocolateySettings.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Core.IO;
 using Cake.Core.Tooling;
 
 namespace Cake.Common.Tools.Chocolatey
@@ -24,9 +25,21 @@ namespace Cake.Common.Tools.Chocolatey
         public bool Verbose { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to run in trace mode.
+        /// </summary>
+        /// <value>The trace flag.</value>
+        public bool Trace { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run in no color mode.
+        /// </summary>
+        /// <value>The no-color flag.</value>
+        public bool NoColor { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to accept license for package.
         /// </summary>
-        /// <value>The accept license flag.</value>
+        /// <value>The accept-license flag.</value>
         public bool AcceptLicense { get; set; }
 
         /// <summary>
@@ -44,7 +57,7 @@ namespace Cake.Common.Tools.Chocolatey
         /// <summary>
         /// Gets or sets a value indicating whether to run in limited output mode.
         /// </summary>
-        /// <value>The limit output flag.</value>
+        /// <value>The limit-output flag.</value>
         public bool LimitOutput { get; set; }
 
         /// <summary>
@@ -63,48 +76,66 @@ namespace Cake.Common.Tools.Chocolatey
         /// <summary>
         /// Gets or sets a value indicating whether to run in allow unofficial mode.
         /// </summary>
-        /// <value>The allow unofficial flag.</value>
+        /// <value>The allow-unofficial flag.</value>
         public bool AllowUnofficial { get; set; }
 
         /// <summary>
-        /// Gets or sets a package sources to use for this command.
+        /// Gets or sets a value indicating whether to faile when error output is detected.
         /// </summary>
-        /// <value>The package source to use for this command.</value>
-        public string Source { get; set; }
+        /// <value>The fail-on-error-output flag.</value>
+        public bool FailOnErrorOutput { get; set; }
 
         /// <summary>
-        /// Gets or sets the version of the package to install.
-        /// If none specified, the latest will be used.
+        /// Gets or sets a value indicating whether to run using system installed version of PowerShell.
         /// </summary>
-        public string Version { get; set; }
+        /// <value>The use-system-powershell flag.</value>
+        public bool UseSystemPowerShell { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to override the passed arguments.
+        /// Gets or sets a value indicating whether to run while not showing download progress.
         /// </summary>
-        /// <value>The override arguments flag.</value>
-        public bool OverrideArguments { get; set; }
+        /// <value>The no-progress flag.</value>
+        public bool NoProgress { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether or not to install silently.
+        /// Gets or sets the explicit proxy location.
         /// </summary>
-        /// <value>The not silent flag.</value>
-        public bool NotSilent { get; set; }
+        /// <value>The proxy location.</value>
+        public string Proxy { get; set; }
 
         /// <summary>
-        /// Gets or sets the parameters to pass to the package.
+        /// Gets or sets the explicit proxy user.
         /// </summary>
-        public string PackageParameters { get; set; }
+        /// <value>The proxy user.</value>
+        public string ProxyUser { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to allow side by side installation.
+        /// Gets or sets the explicit proxy password.
         /// </summary>
-        /// <value>The side by side installation flag.</value>
-        public bool SideBySide { get; set; }
+        /// <value>The proxy password.</value>
+        public string ProxyPassword { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to skip the PowerShell installation of package.
+        /// Gets or sets the comma separated list of regex location to bypass on proxy.
         /// </summary>
-        /// <value>The skip powershell flag.</value>
-        public bool SkipPowerShell { get; set; }
+        /// <value>The bypass proxy list.</value>
+        public string ProxyByPassList { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to bypass proxy for local connections.
+        /// </summary>
+        /// <value>The proxy-bypass-on-local flag.</value>
+        public bool ProxyBypassOnLocal { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the file where all log entries will be sent.
+        /// </summary>
+        public FilePath LogFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to skip all compatibility checks.
+        /// </summary>
+        /// <value>The skip-compatibility-checks flag.</value>
+        public bool SkipCompatibilityChecks { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/Chocolatey/ChocolateySharedSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ChocolateySharedSettings.cs
@@ -1,0 +1,95 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Tools.Chocolatey
+{
+    /// <summary>
+    /// Contains settings used by <see cref="ChocolateySharedSettings"/>.
+    /// </summary>
+    public class ChocolateySharedSettings : ChocolateySettings
+    {
+        /// <summary>
+        /// Gets or sets the source to find the package(s).
+        /// </summary>
+        /// <value>The URL or source name.</value>
+        public string Source { get; set; }
+
+        /// <summary>
+        /// Gets or sets the specific version of the package.
+        /// </summary>
+        public string Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether install arguments be used exclusively without appending to current package passed arguments.
+        /// </summary>
+        public bool OverrideArguments { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to process package silently.
+        /// </summary>
+        public bool NotSilent { get; set; }
+
+        /// <summary>
+        /// Gets or sets parameters to pass to the package.
+        /// </summary>
+        public string PackageParameters { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether install arguments be applied to dependent packages.
+        /// </summary>
+        public bool ApplyInstallArgumentsToDependencies { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether package parameters be applied to dependent packages.
+        /// </summary>
+        public bool ApplyPackageParametersToDependencies { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether multiple versions of a package be installed.
+        /// </summary>
+        public bool SideBySide { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to run chocolateyInstall.ps1.
+        /// </summary>
+        public bool SkipPowerShell { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to Exit with a 0 for success and 1 for non-success
+        /// no matter what package scripts provide for exit codes.
+        /// </summary>
+        /// <value>The ignore package exit codes flag.</value>
+        public bool IgnorePackageExitCodes { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use package exit codes.
+        /// </summary>
+        /// <value>The use package exit codes flag.</value>
+        public bool UsePackageExitCodes { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to stop of the first failure of a package.
+        /// </summary>
+        /// <value>The stop of first failure flag.</value>
+        public bool StopOnFirstFailure { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to exit when a reboot is detected.
+        /// </summary>
+        /// <value>The exit when reboot detected flag.</value>
+        public bool ExitWhenRebootDetected { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to ignore detected reboots.
+        /// </summary>
+        /// <value>The ignore detected reboots flag.</value>
+        public bool IgnoreDetectedReboot { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to skip the running of package hook scripts.
+        /// </summary>
+        /// <value>The skip hooks flag.</value>
+        public bool SkipHooks { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/Chocolatey/Config/ChocolateyConfigSetter.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Config/ChocolateyConfigSetter.cs
@@ -60,69 +60,18 @@ namespace Cake.Common.Tools.Chocolatey.Config
 
         private ProcessArgumentBuilder GetArguments(string name, string value, ChocolateyConfigSettings settings)
         {
+            const string separator = "=";
             var builder = new ProcessArgumentBuilder();
 
             builder.Append("config");
             builder.Append("set");
 
-            builder.Append("--name");
-            builder.AppendQuoted(name);
+            builder.AppendSwitchQuoted("--name", separator, name);
 
-            builder.Append("--value");
-            builder.AppendQuoted(value);
+            builder.AppendSwitchQuoted("--value", separator, value);
 
-            // Debug
-            if (settings.Debug)
-            {
-                builder.Append("-d");
-            }
-
-            // Verbose
-            if (settings.Verbose)
-            {
-                builder.Append("-v");
-            }
-
-            // Always say yes, so as to not show interactive prompt
-            builder.Append("-y");
-
-            // Force
-            if (settings.Force)
-            {
-                builder.Append("-f");
-            }
-
-            // Noop
-            if (settings.Noop)
-            {
-                builder.Append("--noop");
-            }
-
-            // Limit Output
-            if (settings.LimitOutput)
-            {
-                builder.Append("-r");
-            }
-
-            // Execution Timeout
-            if (settings.ExecutionTimeout != 0)
-            {
-                builder.Append("--execution-timeout");
-                builder.AppendQuoted(settings.ExecutionTimeout.ToString(CultureInfo.InvariantCulture));
-            }
-
-            // Cache Location
-            if (!string.IsNullOrWhiteSpace(settings.CacheLocation))
-            {
-                builder.Append("-c");
-                builder.AppendQuoted(settings.CacheLocation);
-            }
-
-            // Allow Unofficial
-            if (settings.AllowUnofficial)
-            {
-                builder.Append("--allowunofficial");
-            }
+            // Add common arguments using the inherited method
+            AddGlobalArguments(settings, builder);
 
             return builder;
         }

--- a/src/Cake.Common/Tools/Chocolatey/Config/ChocolateyConfigSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Config/ChocolateyConfigSettings.cs
@@ -2,62 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Core.Tooling;
-
 namespace Cake.Common.Tools.Chocolatey.Config
 {
     /// <summary>
     /// Contains settings used by <see cref="ChocolateyConfigSetter"/>.
     /// </summary>
-    public sealed class ChocolateyConfigSettings : ToolSettings
+    public sealed class ChocolateyConfigSettings : ChocolateySettings
     {
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in debug mode.
-        /// </summary>
-        /// <value>The debug flag.</value>
-        public bool Debug { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in verbose mode.
-        /// </summary>
-        /// <value>The verbose flag.</value>
-        public bool Verbose { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in forced mode.
-        /// </summary>
-        /// <value>The force flag.</value>
-        public bool Force { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in noop mode.
-        /// </summary>
-        /// <value>The noop flag.</value>
-        public bool Noop { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in limited output mode.
-        /// </summary>
-        /// <value>The limit output flag.</value>
-        public bool LimitOutput { get; set; }
-
-        /// <summary>
-        /// Gets or sets the execution timeout value.
-        /// </summary>
-        /// <value>The execution timeout.</value>
-        /// <remarks>Default is 2700 seconds.</remarks>
-        public int ExecutionTimeout { get; set; }
-
-        /// <summary>
-        /// Gets or sets the location of the download cache.
-        /// </summary>
-        /// <value>The download cache location.</value>
-        public string CacheLocation { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in allow unofficial mode.
-        /// </summary>
-        /// <value>The allow unofficial flag.</value>
-        public bool AllowUnofficial { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/Chocolatey/Download/ChocolateyDownloadSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Download/ChocolateyDownloadSettings.cs
@@ -12,9 +12,41 @@ namespace Cake.Common.Tools.Chocolatey.Download
     public sealed class ChocolateyDownloadSettings : ChocolateySettings
     {
         /// <summary>
+        /// Gets or sets the source to find the package(s) to download. Defaults to default feeds.
+        /// </summary>
+        /// <value>The server URL.</value>
+        public string Source { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version of the package to download.
+        /// If none specified, the latest will be used.
+        /// </summary>
+        public string Version { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to allow downloading of prerelease packages.
         /// </summary>
         public bool Prerelease { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user for authenticated feeds.
+        /// </summary>
+        public string User { get; set; }
+
+        /// <summary>
+        /// Gets or sets the password for authenticated feeds.
+        /// </summary>
+        public string Password { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to a PFX certificate for use with x509 authenticated feeds.
+        /// </summary>
+        public FilePath Certificate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the password for the <see cref="Certificate"/>.
+        /// </summary>
+        public string CertificatePassword { get; set; }
 
         /// <summary>
         /// Gets or sets the directory for the downloaded Chocolatey packages.
@@ -29,17 +61,26 @@ namespace Cake.Common.Tools.Chocolatey.Download
         public bool IgnoreDependencies { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to download all currently installed Chocolatey packages.
+        /// </summary>
+        public bool Installed { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to ignore unfound packages if downloading more than one at a time.
+        /// </summary>
+        public bool IgnoreUnfound { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use optimizations for reducing bandwidth when communicating with repositories.
+        /// </summary>
+        public bool DisableRepositoryOptimizations { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether all external resources should be downloaded
         /// and the package be recompiled to use the local resources instead.
         /// Requires Chocolatey business edition.
         /// </summary>
         public bool Internalize { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether all URLs, not only from known helpers, should be internalized.
-        /// Requires Chocolatey business edition (Licensed version 1.11.1+).
-        /// </summary>
-        public bool InternalizeAllUrls { get; set; }
 
         /// <summary>
         /// Gets or sets the location for downloaded resource when <see cref="Internalize"/> is set.
@@ -62,6 +103,12 @@ namespace Cake.Common.Tools.Chocolatey.Download
         public string DownloadLocation { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether all URLs, not only from known helpers, should be internalized.
+        /// Requires Chocolatey business edition (Licensed version 1.11.1+).
+        /// </summary>
+        public bool InternalizeAllUrls { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether the <c>-useOriginalLocation</c> parameter will be passed to any
         /// <c>Install-ChocolateyPackage</c> call in the package and avoiding downloading of resources when
         /// <see cref="Internalize"/> is set.
@@ -72,13 +119,28 @@ namespace Cake.Common.Tools.Chocolatey.Download
         public bool AppendUseOriginalLocation { get; set; }
 
         /// <summary>
-        /// Gets or sets the user for authenticated feeds.
+        /// Gets or sets a value indicating whether to skip the package download cache.
         /// </summary>
-        public string User { get; set; }
+        public bool SkipDownloadCache { get; set; }
 
         /// <summary>
-        /// Gets or sets the password for authenticated feeds.
+        /// Gets or sets a value indicating whether to use the package download cache.
         /// </summary>
-        public string Password { get; set; }
+        public bool UseDownloadCache { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether skip the virus checking for a package.
+        /// </summary>
+        public bool SkipVirusCheck { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to force virus checking for a package.
+        /// </summary>
+        public bool VirusCheck { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum allowed number of virus positives.
+        /// </summary>
+        public int VirusPositivesMinimum { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/Chocolatey/Export/ChocolateyExporter.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Export/ChocolateyExporter.cs
@@ -48,68 +48,18 @@ namespace Cake.Common.Tools.Chocolatey.Export
 
         private ProcessArgumentBuilder GetArguments(ChocolateyExportSettings settings)
         {
+            const string separator = "=";
             var builder = new ProcessArgumentBuilder();
 
             builder.Append("export");
 
-            // Debug
-            if (settings.Debug)
-            {
-                builder.Append("-d");
-            }
-
-            // Verbose
-            if (settings.Verbose)
-            {
-                builder.Append("-v");
-            }
-
-            // Always say yes, so as to not show interactive prompt
-            builder.Append("-y");
-
-            // Force
-            if (settings.Force)
-            {
-                builder.Append("-f");
-            }
-
-            // Noop
-            if (settings.Noop)
-            {
-                builder.Append("--noop");
-            }
-
-            // Limit Output
-            if (settings.LimitOutput)
-            {
-                builder.Append("-r");
-            }
-
-            // Execution Timeout
-            if (settings.ExecutionTimeout != 0)
-            {
-                builder.Append("--execution-timeout");
-                builder.AppendQuoted(settings.ExecutionTimeout.ToString(CultureInfo.InvariantCulture));
-            }
-
-            // Cache Location
-            if (!string.IsNullOrWhiteSpace(settings.CacheLocation))
-            {
-                builder.Append("-c");
-                builder.AppendQuoted(settings.CacheLocation);
-            }
-
-            // Allow Unofficial
-            if (settings.AllowUnofficial)
-            {
-                builder.Append("--allowunofficial");
-            }
+            // Add common arguments using the inherited method
+            AddGlobalArguments(settings, builder);
 
             // Output File Path
             if (settings.OutputFilePath != null)
             {
-                builder.Append("--output-file-path");
-                builder.AppendQuoted(settings.OutputFilePath.FullPath);
+                builder.AppendSwitchQuoted("--output-file-path", separator, settings.OutputFilePath.FullPath);
             }
 
             // Include Version Numbers

--- a/src/Cake.Common/Tools/Chocolatey/Export/ChocolateyExporterSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Export/ChocolateyExporterSettings.cs
@@ -3,64 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using Cake.Core.IO;
-using Cake.Core.Tooling;
 
 namespace Cake.Common.Tools.Chocolatey.Export
 {
     /// <summary>
     /// Contains settings used by <see cref="ChocolateyExporter"/>.
     /// </summary>
-    public sealed class ChocolateyExportSettings : ToolSettings
+    public sealed class ChocolateyExportSettings : ChocolateySettings
     {
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in debug mode.
-        /// </summary>
-        /// <value>The debug flag.</value>
-        public bool Debug { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in verbose mode.
-        /// </summary>
-        /// <value>The verbose flag.</value>
-        public bool Verbose { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in forced mode.
-        /// </summary>
-        /// <value>The force flag.</value>
-        public bool Force { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in noop mode.
-        /// </summary>
-        /// <value>The noop flag.</value>
-        public bool Noop { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in limited output mode.
-        /// </summary>
-        /// <value>The limit output flag.</value>
-        public bool LimitOutput { get; set; }
-
-        /// <summary>
-        /// Gets or sets the execution timeout value.
-        /// </summary>
-        /// <value>The execution timeout.</value>
-        /// <remarks>Default is 2700 seconds.</remarks>
-        public int ExecutionTimeout { get; set; }
-
-        /// <summary>
-        /// Gets or sets the location of the download cache.
-        /// </summary>
-        /// <value>The download cache location.</value>
-        public string CacheLocation { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in allow unofficial mode.
-        /// </summary>
-        /// <value>The allow unofficial flag.</value>
-        public bool AllowUnofficial { get; set; }
-
         /// <summary>
         /// Gets or sets the path to the file that will be generated.
         /// </summary>

--- a/src/Cake.Common/Tools/Chocolatey/Features/ChocolateyFeatureSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Features/ChocolateyFeatureSettings.cs
@@ -2,62 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Core.Tooling;
-
 namespace Cake.Common.Tools.Chocolatey.Features
 {
     /// <summary>
     /// Contains settings used by <see cref="ChocolateyFeatureToggler"/>.
     /// </summary>
-    public sealed class ChocolateyFeatureSettings : ToolSettings
+    public sealed class ChocolateyFeatureSettings : ChocolateySettings
     {
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in debug mode.
-        /// </summary>
-        /// <value>The debug flag.</value>
-        public bool Debug { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in verbose mode.
-        /// </summary>
-        /// <value>The verbose flag.</value>
-        public bool Verbose { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in forced mode.
-        /// </summary>
-        /// <value>The force flag.</value>
-        public bool Force { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in noop mode.
-        /// </summary>
-        /// <value>The noop flag.</value>
-        public bool Noop { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in limited output mode.
-        /// </summary>
-        /// <value>The limit output flag.</value>
-        public bool LimitOutput { get; set; }
-
-        /// <summary>
-        /// Gets or sets the execution timeout value.
-        /// </summary>
-        /// <value>The execution timeout.</value>
-        /// <remarks>Default is 2700 seconds.</remarks>
-        public int ExecutionTimeout { get; set; }
-
-        /// <summary>
-        /// Gets or sets the location of the download cache.
-        /// </summary>
-        /// <value>The download cache location.</value>
-        public string CacheLocation { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in allow unofficial mode.
-        /// </summary>
-        /// <value>The allow unofficial flag.</value>
-        public bool AllowUnofficial { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/Chocolatey/Features/ChocolateyFeatureToggler.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Features/ChocolateyFeatureToggler.cs
@@ -74,67 +74,17 @@ namespace Cake.Common.Tools.Chocolatey.Features
 
         private ProcessArgumentBuilder GetArguments(bool enableDisableToggle, string name, ChocolateyFeatureSettings settings)
         {
+            const string separator = "=";
             var builder = new ProcessArgumentBuilder();
 
             builder.Append("feature");
 
             builder.Append(enableDisableToggle ? "enable" : "disable");
 
-            builder.Append("-n");
-            builder.AppendQuoted(name);
+            builder.AppendSwitchQuoted("--name", separator, name);
 
-            // Debug
-            if (settings.Debug)
-            {
-                builder.Append("-d");
-            }
-
-            // Verbose
-            if (settings.Verbose)
-            {
-                builder.Append("-v");
-            }
-
-            // Always say yes, so as to not show interactive prompt
-            builder.Append("-y");
-
-            // Force
-            if (settings.Force)
-            {
-                builder.Append("-f");
-            }
-
-            // Noop
-            if (settings.Noop)
-            {
-                builder.Append("--noop");
-            }
-
-            // Limit Output
-            if (settings.LimitOutput)
-            {
-                builder.Append("-r");
-            }
-
-            // Execution Timeout
-            if (settings.ExecutionTimeout != 0)
-            {
-                builder.Append("--execution-timeout");
-                builder.AppendQuoted(settings.ExecutionTimeout.ToString(CultureInfo.InvariantCulture));
-            }
-
-            // Cache Location
-            if (!string.IsNullOrWhiteSpace(settings.CacheLocation))
-            {
-                builder.Append("-c");
-                builder.AppendQuoted(settings.CacheLocation);
-            }
-
-            // Allow Unofficial
-            if (settings.AllowUnofficial)
-            {
-                builder.Append("--allowunofficial");
-            }
+            // Add common arguments using the inherited method
+            AddGlobalArguments(settings, builder);
 
             return builder;
         }

--- a/src/Cake.Common/Tools/Chocolatey/Install/ChocolateyInstallSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Install/ChocolateyInstallSettings.cs
@@ -4,10 +4,12 @@
 
 namespace Cake.Common.Tools.Chocolatey.Install
 {
+    using global::Cake.Core.IO;
+
     /// <summary>
     /// Contains settings used by <see cref="ChocolateyInstaller"/>.
     /// </summary>
-    public sealed class ChocolateyInstallSettings : ChocolateySettings
+    public sealed class ChocolateyInstallSettings : ChocolateySharedSettings
     {
         /// <summary>
         /// Gets or sets a value indicating whether to allow installation of prerelease packages.
@@ -58,9 +60,129 @@ namespace Cake.Common.Tools.Chocolatey.Install
         public string Password { get; set; }
 
         /// <summary>
+        /// Gets or sets the path to a PFX certificate for use with x509 authenticated feeds.
+        /// </summary>
+        public FilePath Certificate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the password for the <see cref="Certificate"/>.
+        /// </summary>
+        public string CertificatePassword { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to ignore checksums.
         /// </summary>
         /// <value>The ignore checksums flag.</value>
         public bool IgnoreChecksums { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow empty checksums for bare HTTP URLs during package installation.
+        /// </summary>
+        public bool AllowEmptyChecksums { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow empty checksums for HTTPS URLs during package installation.
+        /// </summary>
+        public bool AllowEmptyChecksumsSecure { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether checksums are required during package installation.
+        /// </summary>
+        public bool RequireChecksums { get; set; }
+
+        /// <summary>
+        /// Gets or sets the checksum for 32 bit installation.
+        /// </summary>
+        public string Checksum { get; set; }
+
+        /// <summary>
+        /// Gets or sets the checksum for 64 bit installation.
+        /// </summary>
+        public string Checksum64 { get; set; }
+
+        /// <summary>
+        /// Gets or sets the checksum type to use for 32 bit installation.
+        /// </summary>
+        public string ChecksumType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the checksum type to use for 64 bit installation.
+        /// </summary>
+        public string ChecksumType64 { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use optimizations for reducing bandwidth when communicating with repositories.
+        /// </summary>
+        public bool DisableRepositoryOptimizations { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to pin the package once installed.
+        /// </summary>
+        public bool Pin { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to skip the package download cache.
+        /// </summary>
+        public bool SkipDownloadCache { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use the package download cache.
+        /// </summary>
+        public bool UseDownloadCache { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether skip the virus checking for a package.
+        /// </summary>
+        public bool SkipVirusCheck { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to force virus checking for a package.
+        /// </summary>
+        public bool VirusCheck { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum allowed number of virus positives.
+        /// </summary>
+        public int VirusPositivesMinimum { get; set; }
+
+        /// <summary>
+        /// Gets or sets the install arguments sensitive to pass to native installer.
+        /// </summary>
+        public string InstallArgumentsSensitive { get; set; }
+
+        /// <summary>
+        /// Gets or sets sensitive parameters to pass to the package.
+        /// </summary>
+        public string PackageParametersSensitive { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default application installation directory.
+        /// </summary>
+        public DirectoryPath InstallDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum download bits per second when downloading a package.
+        /// </summary>
+        public int MaximumDownloadBitsPerSecond { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether package size should be reduced on installation.
+        /// </summary>
+        public bool ReducePackageSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether there should be no reduction in package size on installation.
+        /// </summary>
+        public bool NoReducePackageSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether only the nupkg file size should be reduced.
+        /// </summary>
+        public bool ReduceNupkgOnly { get; set; }
+
+        /// <summary>
+        /// Gets or sets a reason for pinning a package during installation.
+        /// </summary>
+        public string PinReason { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/Chocolatey/Install/ChocolateyInstaller.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Install/ChocolateyInstaller.cs
@@ -46,6 +46,7 @@ namespace Cake.Common.Tools.Chocolatey.Install
             {
                 throw new ArgumentNullException(nameof(packageConfigPath));
             }
+
             if (settings == null)
             {
                 throw new ArgumentNullException(nameof(settings));
@@ -67,6 +68,7 @@ namespace Cake.Common.Tools.Chocolatey.Install
             {
                 throw new ArgumentNullException(nameof(packageId));
             }
+
             if (settings == null)
             {
                 throw new ArgumentNullException(nameof(settings));
@@ -77,12 +79,17 @@ namespace Cake.Common.Tools.Chocolatey.Install
 
         private ProcessArgumentBuilder GetArguments(string packageId, ChocolateyInstallSettings settings)
         {
+            const string separator = "=";
             var builder = new ProcessArgumentBuilder();
 
             builder.Append("install");
             builder.AppendQuoted(packageId);
 
-            AddCommonArguments(settings, builder);
+            // Add common arguments using the inherited method
+            AddGlobalArguments(settings, builder);
+
+            // Add shared arguments using the inherited method
+            AddSharedArguments(settings, builder);
 
             // Prerelease
             if (settings.Prerelease)
@@ -93,52 +100,193 @@ namespace Cake.Common.Tools.Chocolatey.Install
             // Forcex86
             if (settings.Forcex86)
             {
-                builder.Append("--x86");
+                builder.Append("--forcex86");
             }
 
             // Install Arguments
             if (!string.IsNullOrWhiteSpace(settings.InstallArguments))
             {
-                builder.Append("--ia");
-                builder.AppendQuoted(settings.InstallArguments);
+                builder.AppendSwitchQuoted("--install-arguments", separator, settings.InstallArguments);
             }
 
             // Allow Downgrade
             if (settings.AllowDowngrade)
             {
-                builder.Append("--allowdowngrade");
+                builder.Append("--allow-downgrade");
             }
 
             // Ignore Dependencies
             if (settings.IgnoreDependencies)
             {
-                builder.Append("-i");
+                builder.Append("--ignore-dependencies");
             }
 
             // Force Dependencies
             if (settings.ForceDependencies)
             {
-                builder.Append("-x");
+                builder.Append("--force-dependencies");
             }
 
             // User
             if (!string.IsNullOrWhiteSpace(settings.User))
             {
-                builder.Append("-u");
-                builder.AppendQuoted(settings.User);
+                builder.AppendSwitchQuoted("--user", separator, settings.User);
             }
 
             // Password
             if (!string.IsNullOrWhiteSpace(settings.Password))
             {
-                builder.Append("-p");
-                builder.AppendQuoted(settings.Password);
+                builder.AppendSwitchQuoted("--password", separator, settings.Password);
+            }
+
+            // Certificate
+            if (settings.Certificate != null)
+            {
+                builder.AppendSwitchQuoted("--cert", separator, settings.Certificate.MakeAbsolute(_environment).FullPath);
+            }
+
+            // Certificate Password
+            if (!string.IsNullOrEmpty(settings.CertificatePassword))
+            {
+                builder.AppendSwitchQuoted("--certpassword", separator, settings.CertificatePassword);
             }
 
             // Ignore Checksums
             if (settings.IgnoreChecksums)
             {
-                builder.Append("--ignorechecksums");
+                builder.Append("--ignore-checksums");
+            }
+
+            // Allow Empty Checksums
+            if (settings.AllowEmptyChecksums)
+            {
+                builder.Append("--allow-empty-checksums");
+            }
+
+            // Allow Empty Checksums Secure
+            if (settings.AllowEmptyChecksumsSecure)
+            {
+                builder.Append("--allow-empty-checksums-secure");
+            }
+
+            // Require Checksums
+            if (settings.RequireChecksums)
+            {
+                builder.Append("--require-checksums");
+            }
+
+            // Checksum
+            if (!string.IsNullOrEmpty(settings.Checksum))
+            {
+                builder.AppendSwitchQuoted("--download-checksum", separator, settings.Checksum);
+            }
+
+            // Checksum 64
+            if (!string.IsNullOrEmpty(settings.Checksum64))
+            {
+                builder.AppendSwitchQuoted("--download-checksum-x64", separator, settings.Checksum64);
+            }
+
+            // Checksum Type
+            if (!string.IsNullOrEmpty(settings.ChecksumType))
+            {
+                builder.AppendSwitchQuoted("--download-checksum-type", separator, settings.ChecksumType);
+            }
+
+            // Checksum Type 64
+            if (!string.IsNullOrEmpty(settings.ChecksumType64))
+            {
+                builder.AppendSwitchQuoted("--download-checksum-type-x64", separator, settings.ChecksumType64);
+            }
+
+            // Disable Repository Optimizations
+            if (settings.DisableRepositoryOptimizations)
+            {
+                builder.Append("--disable-repository-optimizations");
+            }
+
+            // Pin
+            if (settings.Pin)
+            {
+                builder.Append("--pin-package");
+            }
+
+            // Skip Download Cache
+            if (settings.SkipDownloadCache)
+            {
+                builder.Append("--skip-download-cache");
+            }
+
+            // Use Download Cache
+            if (settings.UseDownloadCache)
+            {
+                builder.Append("--use-download-cache");
+            }
+
+            // Skip Virus Check
+            if (settings.SkipVirusCheck)
+            {
+                builder.Append("--skip-virus-check");
+            }
+
+            // Virus Check
+            if (settings.VirusCheck)
+            {
+                builder.Append("--virus-check");
+            }
+
+            // Virus Positive Minimum
+            if (settings.VirusPositivesMinimum != 0)
+            {
+                builder.AppendSwitchQuoted("--virus-positives-minimum", separator, settings.VirusPositivesMinimum.ToString(CultureInfo.InvariantCulture));
+            }
+
+            // Install Arguments Sensitive
+            if (!string.IsNullOrWhiteSpace(settings.InstallArgumentsSensitive))
+            {
+                builder.AppendSwitchQuoted("--install-arguments-sensitive", separator, settings.InstallArgumentsSensitive);
+            }
+
+            // Package Parameters Sensitive
+            if (!string.IsNullOrEmpty(settings.PackageParametersSensitive))
+            {
+                builder.AppendSwitchQuoted("--package-parameters-sensitive", separator, settings.PackageParametersSensitive);
+            }
+
+            // Install Directory
+            if (settings.InstallDirectory != null)
+            {
+                builder.AppendSwitchQuoted("--install-directory", separator, settings.InstallDirectory.MakeAbsolute(_environment).FullPath);
+            }
+
+            // Maximum Download Bits Per Second
+            if (settings.MaximumDownloadBitsPerSecond != 0)
+            {
+                builder.AppendSwitchQuoted("--maximum-download-bits-per-second", separator, settings.MaximumDownloadBitsPerSecond.ToString(CultureInfo.InvariantCulture));
+            }
+
+            // Reduce Package Size
+            if (settings.ReducePackageSize)
+            {
+                builder.Append("--reduce-package-size");
+            }
+
+            // No Reduce Package Size
+            if (settings.NoReducePackageSize)
+            {
+                builder.Append("--no-reduce-package-size");
+            }
+
+            // Reduce Nupkg Only
+            if (settings.ReduceNupkgOnly)
+            {
+                builder.Append("--reduce-nupkg-only");
+            }
+
+            // Pin Reason
+            if (!string.IsNullOrEmpty(settings.PinReason))
+            {
+                builder.AppendSwitchQuoted("--pin-reason", separator, settings.PinReason);
             }
 
             return builder;

--- a/src/Cake.Common/Tools/Chocolatey/New/ChocolateyNewSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/New/ChocolateyNewSettings.cs
@@ -15,9 +15,24 @@ namespace Cake.Common.Tools.Chocolatey.New
         private readonly Dictionary<string, string> _additionalPropertyValues = new Dictionary<string, string>();
 
         /// <summary>
+        /// Gets or sets a value indicating whether to generate automatic package instead or normal.
+        /// </summary>
+        public bool AutomaticPackage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the template to generate new package with.
+        /// </summary>
+        public string TemplateName { get; set; }
+
+        /// <summary>
         /// Gets or sets the path where the package will be created.
         /// </summary>
         public DirectoryPath OutputDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use original built-in template, rather than an overridden one.
+        /// </summary>
+        public bool BuiltInTemplate { get; set; }
 
         /// <summary>
         /// Gets or sets the version of the package to be created.
@@ -64,5 +79,60 @@ namespace Cake.Common.Tools.Chocolatey.New
                 return _additionalPropertyValues;
             }
         }
+
+        /// <summary>
+        /// Gets or sets the file or URL to binary used for auto-detection and generation of package.
+        /// </summary>
+        public string File { get; set; }
+
+        /// <summary>
+        /// Gets or sets the file or URL to 64-bit binary used for auto-detection and generation of package.
+        /// </summary>
+        public string File64 { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use original location of binary in packaging.
+        /// </summary>
+        public bool UseOriginalFilesLocation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the checksum for 32 bit installation.
+        /// </summary>
+        public string Checksum { get; set; }
+
+        /// <summary>
+        /// Gets or sets the checksum for 64 bit installation.
+        /// </summary>
+        public string Checksum64 { get; set; }
+
+        /// <summary>
+        /// Gets or sets the checksum type to use for 32 bit installation.
+        /// </summary>
+        public string ChecksumType { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to pause when there is an error creating a package.
+        /// </summary>
+        public bool PauseOnError { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to attempt to compile the package after creating it.
+        /// </summary>
+        public bool BuildPackage { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to generate packages from the currenty installed software on a system.
+        /// </summary>
+        public bool GeneratePackagesFromInstalledSoftware { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to remove x86, x64, etc. from generated package id.
+        /// </summary>
+        public bool RemoveArchitectureFromName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to leave x86, x64, etc. as part of the generated package id.
+        /// </summary>
+        public bool IncludeArchitectureInPackageName { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/Chocolatey/New/ChocolateyScaffolder.cs
+++ b/src/Cake.Common/Tools/Chocolatey/New/ChocolateyScaffolder.cs
@@ -46,6 +46,7 @@ namespace Cake.Common.Tools.Chocolatey.New
             {
                 throw new ArgumentNullException(nameof(packageId));
             }
+
             if (settings == null)
             {
                 throw new ArgumentNullException(nameof(settings));
@@ -56,66 +57,151 @@ namespace Cake.Common.Tools.Chocolatey.New
 
         private ProcessArgumentBuilder GetArguments(string packageId, ChocolateyNewSettings settings)
         {
+            const string separator = "=";
             var builder = new ProcessArgumentBuilder();
 
             builder.Append("new");
             builder.AppendQuoted(packageId);
 
-            AddCommonArguments(settings, builder);
+            // Add common arguments using the inherited method
+            AddGlobalArguments(settings, builder);
+
+            // Automatic Packages
+            if (settings.AutomaticPackage)
+            {
+                builder.Append("--automaticpackage");
+            }
+
+            // Template Name
+            if (!string.IsNullOrEmpty(settings.TemplateName))
+            {
+                builder.AppendSwitchQuoted("--template-name", separator, settings.TemplateName);
+            }
 
             // Package version
             if (!string.IsNullOrWhiteSpace(settings.PackageVersion))
             {
-                builder.AppendSwitch("packageversion", "=", settings.PackageVersion.Quote());
+                builder.AppendSwitchQuoted("packageversion", separator, settings.PackageVersion);
             }
 
             // Owner
             if (!string.IsNullOrWhiteSpace(settings.MaintainerName))
             {
-                builder.AppendSwitch("maintainername", "=", settings.MaintainerName.Quote());
+                builder.AppendSwitchQuoted("maintainername", separator, settings.MaintainerName);
             }
 
             // Package source repository
             if (!string.IsNullOrWhiteSpace(settings.MaintainerRepo))
             {
-                builder.AppendSwitch("maintainerrepo", "=", settings.MaintainerRepo.Quote());
+                builder.AppendSwitchQuoted("maintainerrepo", separator, settings.MaintainerRepo);
             }
 
             // Installer type
             if (!string.IsNullOrWhiteSpace(settings.InstallerType))
             {
-                builder.AppendSwitch("installertype", "=", settings.InstallerType.Quote());
+                builder.AppendSwitchQuoted("installertype", separator, settings.InstallerType);
             }
 
             // URL
             if (!string.IsNullOrWhiteSpace(settings.Url))
             {
-                builder.AppendSwitch("url", "=", settings.Url.Quote());
+                builder.AppendSwitchQuoted("url", separator, settings.Url);
             }
 
             // URL64
             if (!string.IsNullOrWhiteSpace(settings.Url64))
             {
-                builder.AppendSwitch("url64", "=", settings.Url64.Quote());
+                builder.AppendSwitchQuoted("url64", separator, settings.Url64);
             }
 
             // Silent arguments
             if (!string.IsNullOrWhiteSpace(settings.SilentArgs))
             {
-                builder.AppendSwitch("silentargs", "=", settings.SilentArgs.Quote());
+                builder.AppendSwitchQuoted("silentargs", separator, settings.SilentArgs);
             }
 
             // Output directory
             if (settings.OutputDirectory != null)
             {
-                builder.Append("--outputdirectory");
-                builder.AppendQuoted(settings.OutputDirectory.MakeAbsolute(_environment).FullPath);
+                builder.AppendSwitchQuoted("--output-directory", separator, settings.OutputDirectory.MakeAbsolute(_environment).FullPath);
+            }
+
+            // Built In Template
+            if (settings.BuiltInTemplate)
+            {
+                builder.Append("--built-in-template");
             }
 
             // Additional properties
             foreach (var propertyValue in settings.AdditionalPropertyValues)
             {
-                builder.AppendSwitch(propertyValue.Key, "=", propertyValue.Value.Quote());
+                builder.AppendSwitchQuoted(propertyValue.Key, separator, propertyValue.Value);
+            }
+
+            // File
+            if (!string.IsNullOrEmpty(settings.File))
+            {
+                builder.AppendSwitchQuoted("--file", separator, settings.File);
+            }
+
+            // File 64
+            if (!string.IsNullOrEmpty(settings.File64))
+            {
+                builder.AppendSwitchQuoted("--file64", separator, settings.File64);
+            }
+
+            // Use Original Files Location
+            if (settings.UseOriginalFilesLocation)
+            {
+                builder.Append("--use-original-files-location");
+            }
+
+            // Checksum
+            if (!string.IsNullOrEmpty(settings.Checksum))
+            {
+                builder.AppendSwitchQuoted("--download-checksum", separator, settings.Checksum);
+            }
+
+            // Checksum 64
+            if (!string.IsNullOrEmpty(settings.Checksum64))
+            {
+                builder.AppendSwitchQuoted("--download-checksum-x64", separator, settings.Checksum64);
+            }
+
+            // Checksum Type
+            if (!string.IsNullOrEmpty(settings.ChecksumType))
+            {
+                builder.AppendSwitchQuoted("--download-checksum-type", separator, settings.ChecksumType);
+            }
+
+            // Pause On Error
+            if (settings.PauseOnError)
+            {
+                builder.Append("--pause-on-error");
+            }
+
+            // Build Package
+            if (settings.BuildPackage)
+            {
+                builder.Append("--build-package");
+            }
+
+            // Generate Packages From Installed Software
+            if (settings.GeneratePackagesFromInstalledSoftware)
+            {
+                builder.Append("--from-programs-and-features");
+            }
+
+            // Remove Architecture From Name
+            if (settings.RemoveArchitectureFromName)
+            {
+                builder.Append("--remove-architecture-from-name");
+            }
+
+            // Include Architecture In Package Name
+            if (settings.IncludeArchitectureInPackageName)
+            {
+                builder.Append("--include-architecture-in-name");
             }
 
             return builder;

--- a/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyPackSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyPackSettings.cs
@@ -5,14 +5,13 @@
 using System;
 using System.Collections.Generic;
 using Cake.Core.IO;
-using Cake.Core.Tooling;
 
 namespace Cake.Common.Tools.Chocolatey.Pack
 {
     /// <summary>
     /// Contains settings used by <see cref="ChocolateyPacker"/>.
     /// </summary>
-    public sealed class ChocolateyPackSettings : ToolSettings
+    public sealed class ChocolateyPackSettings : ChocolateySettings
     {
         /// <summary>
         /// Gets or sets the package ID.
@@ -25,12 +24,6 @@ namespace Cake.Common.Tools.Chocolatey.Pack
         /// </summary>
         /// <value>The package title.</value>
         public string Title { get; set; }
-
-        /// <summary>
-        /// Gets or sets the Nuspec version.
-        /// </summary>
-        /// <value>The Nuspec version.</value>
-        public string Version { get; set; }
 
         /// <summary>
         /// Gets or sets the package authors.
@@ -150,53 +143,10 @@ namespace Cake.Common.Tools.Chocolatey.Pack
         public ICollection<ChocolateyNuSpecDependency> Dependencies { get; set; } = new List<ChocolateyNuSpecDependency>();
 
         /// <summary>
-        /// Gets or sets a value indicating whether to run in debug mode.
+        /// Gets or sets the Nuspec version.
         /// </summary>
-        /// <value>The debug flag.</value>
-        public bool Debug { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in verbose mode.
-        /// </summary>
-        /// <value>The verbose flag.</value>
-        public bool Verbose { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in forced mode.
-        /// </summary>
-        /// <value>The force flag.</value>
-        public bool Force { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in noop mode.
-        /// </summary>
-        /// <value>The noop flag.</value>
-        public bool Noop { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in limited output mode.
-        /// </summary>
-        /// <value>The limit output flag.</value>
-        public bool LimitOutput { get; set; }
-
-        /// <summary>
-        /// Gets or sets the execution timeout value.
-        /// </summary>
-        /// <value>The execution timeout.</value>
-        /// <remarks>Default is 2700 seconds.</remarks>
-        public int ExecutionTimeout { get; set; }
-
-        /// <summary>
-        /// Gets or sets the location of the download cache.
-        /// </summary>
-        /// <value>The download cache location.</value>
-        public string CacheLocation { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in allow unofficial mode.
-        /// </summary>
-        /// <value>The allow unofficial flag.</value>
-        public bool AllowUnofficial { get; set; }
+        /// <value>The Nuspec version.</value>
+        public string Version { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating the Working Directory that should be used while running choco.exe.

--- a/src/Cake.Common/Tools/Chocolatey/Pin/ChocolateyPinSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Pin/ChocolateyPinSettings.cs
@@ -2,68 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Core.Tooling;
-
 namespace Cake.Common.Tools.Chocolatey.Pin
 {
     /// <summary>
     /// Contains settings used by <see cref="ChocolateyPinner"/>.
     /// </summary>
-    public sealed class ChocolateyPinSettings : ToolSettings
+    public sealed class ChocolateyPinSettings : ChocolateySettings
     {
         /// <summary>
-        /// Gets or sets a value indicating whether to run in debug mode.
-        /// </summary>
-        /// <value>The debug flag.</value>
-        public bool Debug { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in verbose mode.
-        /// </summary>
-        /// <value>The verbose flag.</value>
-        public bool Verbose { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in forced mode.
-        /// </summary>
-        /// <value>The force flag.</value>
-        public bool Force { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in noop mode.
-        /// </summary>
-        /// <value>The noop flag.</value>
-        public bool Noop { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in limited output mode.
-        /// </summary>
-        /// <value>The limit output flag.</value>
-        public bool LimitOutput { get; set; }
-
-        /// <summary>
-        /// Gets or sets the execution timeout value.
-        /// </summary>
-        /// <value>The execution timeout.</value>
-        /// <remarks>Default is 2700 seconds.</remarks>
-        public int ExecutionTimeout { get; set; }
-
-        /// <summary>
-        /// Gets or sets the location of the download cache.
-        /// </summary>
-        /// <value>The download cache location.</value>
-        public string CacheLocation { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in allow unofficial mode.
-        /// </summary>
-        /// <value>The allow unofficial flag.</value>
-        public bool AllowUnofficial { get; set; }
-
-        /// <summary>
-        /// Gets or sets the version of the package to install.
-        /// If none specified, the latest will be used.
+        /// Gets or sets the version of the package to pin.
         /// </summary>
         public string Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets a reason for pinning a package during installation.
+        /// </summary>
+        public string PinReason { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/Chocolatey/Pin/ChocolateyPinner.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Pin/ChocolateyPinner.cs
@@ -54,72 +54,27 @@ namespace Cake.Common.Tools.Chocolatey.Pin
 
         private ProcessArgumentBuilder GetArguments(string name, ChocolateyPinSettings settings)
         {
+            const string separator = "=";
             var builder = new ProcessArgumentBuilder();
 
             builder.Append("pin");
             builder.Append("add");
 
-            builder.Append("-n");
-            builder.AppendQuoted(name);
+            builder.AppendSwitchQuoted("--name", separator, name);
+
+            // Add common arguments using the inherited method
+            AddGlobalArguments(settings, builder);
 
             // Version
             if (settings.Version != null)
             {
-                builder.Append("--version");
-                builder.AppendQuoted(settings.Version);
+                builder.AppendSwitchQuoted("--version", separator, settings.Version);
             }
 
-            // Debug
-            if (settings.Debug)
+            // Pin Reason
+            if (!string.IsNullOrEmpty(settings.PinReason))
             {
-                builder.Append("-d");
-            }
-
-            // Verbose
-            if (settings.Verbose)
-            {
-                builder.Append("-v");
-            }
-
-            // Always say yes, so as to not show interactive prompt
-            builder.Append("-y");
-
-            // Force
-            if (settings.Force)
-            {
-                builder.Append("-f");
-            }
-
-            // Noop
-            if (settings.Noop)
-            {
-                builder.Append("--noop");
-            }
-
-            // Limit Output
-            if (settings.LimitOutput)
-            {
-                builder.Append("-r");
-            }
-
-            // Execution Timeout
-            if (settings.ExecutionTimeout != 0)
-            {
-                builder.Append("--execution-timeout");
-                builder.AppendQuoted(settings.ExecutionTimeout.ToString(CultureInfo.InvariantCulture));
-            }
-
-            // Cache Location
-            if (!string.IsNullOrWhiteSpace(settings.CacheLocation))
-            {
-                builder.Append("-c");
-                builder.AppendQuoted(settings.CacheLocation);
-            }
-
-            // Allow Unofficial
-            if (settings.AllowUnofficial)
-            {
-                builder.Append("--allowunofficial");
+                builder.AppendSwitchQuoted("--pin-reason", separator, settings.PinReason);
             }
 
             return builder;

--- a/src/Cake.Common/Tools/Chocolatey/Push/ChocolateyPushSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Push/ChocolateyPushSettings.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Core.Tooling;
-
 namespace Cake.Common.Tools.Chocolatey.Push
 {
     using System;
@@ -11,61 +9,12 @@ namespace Cake.Common.Tools.Chocolatey.Push
     /// <summary>
     /// Contains settings used by <see cref="ChocolateyPusher"/>.
     /// </summary>
-    public sealed class ChocolateyPushSettings : ToolSettings
+    public sealed class ChocolateyPushSettings : ChocolateySettings
     {
         /// <summary>
-        /// Gets or sets a value indicating whether to run in debug mode.
+        /// Gets or sets the source.
         /// </summary>
-        /// <value>The debug flag.</value>
-        public bool Debug { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in verbose mode.
-        /// </summary>
-        /// <value>The verbose flag.</value>
-        public bool Verbose { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in forced mode.
-        /// </summary>
-        /// <value>The force flag.</value>
-        public bool Force { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in noop mode.
-        /// </summary>
-        /// <value>The noop flag.</value>
-        public bool Noop { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in limited output mode.
-        /// </summary>
-        /// <value>The limit output flag.</value>
-        public bool LimitOutput { get; set; }
-
-        /// <summary>
-        /// Gets or sets the execution timeout value.
-        /// </summary>
-        /// <value>The execution timeout.</value>
-        /// <remarks>Default is 2700 seconds.</remarks>
-        public int ExecutionTimeout { get; set; }
-
-        /// <summary>
-        /// Gets or sets the location of the download cache.
-        /// </summary>
-        /// <value>The download cache location.</value>
-        public string CacheLocation { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in allow unofficial mode.
-        /// </summary>
-        /// <value>The allow unofficial flag.</value>
-        public bool AllowUnofficial { get; set; }
-
-        /// <summary>
-        /// Gets or sets the server URL. If not specified, chocolatey.org is used.
-        /// </summary>
-        /// <value>The server URL.</value>
+        /// <value>The source.</value>
         public string Source { get; set; }
 
         /// <summary>
@@ -75,10 +24,23 @@ namespace Cake.Common.Tools.Chocolatey.Push
         public string ApiKey { get; set; }
 
         /// <summary>
-        /// Gets or sets the timeout for pushing to a server.
-        /// Defaults to 300 seconds (5 minutes).
+        /// Gets or sets the client code generated for delegating access vy a user to the Intune endpoints.
         /// </summary>
-        /// <value>The timeout for pushing to a server.</value>
-        public TimeSpan? Timeout { get; set; }
+        public string ClientCode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL used when requesting the client code.
+        /// </summary>
+        public string RedirectUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Intune API endpoint to use.
+        /// </summary>
+        public string EndPoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to skip cleanup local files when pushing to Intune.
+        /// </summary>
+        public bool SkipCleanup { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/Chocolatey/Push/ChocolateyPusher.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Push/ChocolateyPusher.cs
@@ -46,6 +46,7 @@ namespace Cake.Common.Tools.Chocolatey.Push
             {
                 throw new ArgumentNullException(nameof(packageFilePath));
             }
+
             if (settings == null)
             {
                 throw new ArgumentNullException(nameof(settings));
@@ -56,80 +57,50 @@ namespace Cake.Common.Tools.Chocolatey.Push
 
         private ProcessArgumentBuilder GetArguments(FilePath packageFilePath, ChocolateyPushSettings settings)
         {
+            const string separator = "=";
             var builder = new ProcessArgumentBuilder();
+
             builder.Append("push");
 
             builder.AppendQuoted(packageFilePath.MakeAbsolute(_environment).FullPath);
 
+            // Add common arguments using the inherited method
+            AddGlobalArguments(settings, builder);
+
+            // Source
             if (settings.Source != null)
             {
-                builder.Append("-s");
-                builder.AppendQuoted(settings.Source);
+                builder.AppendSwitchQuoted("--source", separator, settings.Source);
             }
 
-            if (settings.Timeout != null)
-            {
-                builder.Append("-t");
-                builder.Append(Convert.ToInt32(settings.Timeout.Value.TotalSeconds).ToString(CultureInfo.InvariantCulture));
-            }
-
+            // Api Key
             if (settings.ApiKey != null)
             {
-                builder.Append("-k");
-                builder.AppendSecret(settings.ApiKey);
+                builder.AppendSwitchQuoted("--api-key", separator, settings.ApiKey);
             }
 
-            // Debug
-            if (settings.Debug)
+            // Client Code
+            if (!string.IsNullOrEmpty(settings.ClientCode))
             {
-                builder.Append("-d");
+                builder.AppendSwitchQuoted("--client-code", separator, settings.ClientCode);
             }
 
-            // Verbose
-            if (settings.Verbose)
+            // Redirect URL
+            if (!string.IsNullOrEmpty(settings.RedirectUrl))
             {
-                builder.Append("-v");
+                builder.AppendSwitchQuoted("--redirect-url", separator, settings.RedirectUrl);
             }
 
-            // Always say yes, so as to not show interactive prompt
-            builder.Append("-y");
-
-            // Force
-            if (settings.Force)
+            // Endpoint
+            if (!string.IsNullOrEmpty(settings.EndPoint))
             {
-                builder.Append("-f");
+                builder.AppendSwitchQuoted("--endpoint", separator, settings.EndPoint);
             }
 
-            // Noop
-            if (settings.Noop)
+            // Skip Cleanup
+            if (settings.SkipCleanup)
             {
-                builder.Append("--noop");
-            }
-
-            // Limit Output
-            if (settings.LimitOutput)
-            {
-                builder.Append("-r");
-            }
-
-            // Execution Timeout
-            if (settings.ExecutionTimeout != 0)
-            {
-                builder.Append("--execution-timeout");
-                builder.AppendQuoted(settings.ExecutionTimeout.ToString(CultureInfo.InvariantCulture));
-            }
-
-            // Cache Location
-            if (!string.IsNullOrWhiteSpace(settings.CacheLocation))
-            {
-                builder.Append("-c");
-                builder.AppendQuoted(settings.CacheLocation);
-            }
-
-            // Allow Unofficial
-            if (settings.AllowUnofficial)
-            {
-                builder.Append("--allowunofficial");
+                builder.Append("--skip-cleanup");
             }
 
             return builder;

--- a/src/Cake.Common/Tools/Chocolatey/Sources/ChocolateySourcesSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Sources/ChocolateySourcesSettings.cs
@@ -2,64 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Core.Tooling;
-
 namespace Cake.Common.Tools.Chocolatey.Sources
 {
+    using global::Cake.Core.IO;
+
     /// <summary>
     /// Contains settings used by <see cref="ChocolateySources"/>.
     /// </summary>
-    public sealed class ChocolateySourcesSettings : ToolSettings
+    public sealed class ChocolateySourcesSettings : ChocolateySettings
     {
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in debug mode.
-        /// </summary>
-        /// <value>The debug flag.</value>
-        public bool Debug { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in verbose mode.
-        /// </summary>
-        /// <value>The verbose flag.</value>
-        public bool Verbose { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in forced mode.
-        /// </summary>
-        /// <value>The force flag.</value>
-        public bool Force { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in noop mode.
-        /// </summary>
-        /// <value>The noop flag.</value>
-        public bool Noop { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in limited output mode.
-        /// </summary>
-        /// <value>The limit output flag.</value>
-        public bool LimitOutput { get; set; }
-
-        /// <summary>
-        /// Gets or sets the execution timeout value.
-        /// </summary>
-        /// <value>The execution timeout.</value>
-        /// <remarks>Default is 2700 seconds.</remarks>
-        public int ExecutionTimeout { get; set; }
-
-        /// <summary>
-        /// Gets or sets the location of the download cache.
-        /// </summary>
-        /// <value>The download cache location.</value>
-        public string CacheLocation { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to run in allow unofficial mode.
-        /// </summary>
-        /// <value>The allow unofficial flag.</value>
-        public bool AllowUnofficial { get; set; }
-
         /// <summary>
         /// Gets or sets the (optional) user name.
         /// </summary>
@@ -73,9 +24,34 @@ namespace Cake.Common.Tools.Chocolatey.Sources
         public string Password { get; set; }
 
         /// <summary>
+        /// Gets or sets the path to a PFX certificate for use with x509 authenticated feeds.
+        /// </summary>
+        public FilePath Certificate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the password for the <see cref="Certificate"/>.
+        /// </summary>
+        public string CertificatePassword { get; set; }
+
+        /// <summary>
         /// Gets or sets the (optional) priority.
         /// </summary>
         /// <value>Optional priority to be used when creating source.</value>
         public int Priority { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether  source should explicitly bypass any explicitly set proxy.
+        /// </summary>
+        public bool ByPassProxy { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether source should be allowed to be used in self service mode.
+        /// </summary>
+        public bool AllowSelfService { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether source should be visible to non-admin users.
+        /// </summary>
+        public bool AdminOnly { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/Chocolatey/Uninstall/ChocolateyUninstallSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Uninstall/ChocolateyUninstallSettings.cs
@@ -7,20 +7,8 @@ namespace Cake.Common.Tools.Chocolatey.Uninstall
     /// <summary>
     /// Contains settings used by <see cref="ChocolateyUninstaller"/>.
     /// </summary>
-    public sealed class ChocolateyUninstallSettings : ChocolateySettings
+    public sealed class ChocolateyUninstallSettings : ChocolateySharedSettings
     {
-        /// <summary>
-        /// Gets or sets a value indicating whether it fails on standard error output.
-        /// </summary>
-        /// <value>The fail on standard error flag.</value>
-        public bool FailOnStandardError { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether an external process is used instead of built in PowerShell host.
-        /// </summary>
-        /// <value>The use system powershell flag.</value>
-        public bool UseSystemPowershell { get; set; }
-
         /// <summary>
         /// Gets or sets a value indicating whether to uninstall all versions.
         /// </summary>
@@ -33,35 +21,10 @@ namespace Cake.Common.Tools.Chocolatey.Uninstall
         public string UninstallArguments { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether install arguments should be applied to dependent packages.
-        /// </summary>
-        /// <value>The global arguments flag.</value>
-        public bool GlobalArguments { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether global parameters are passed to the package.
-        /// </summary>
-        /// <value>The global package parameters flag.</value>
-        public bool GlobalPackageParameters { get; set; }
-
-        /// <summary>
         /// Gets or sets a value indicating whether to force dependencies.
         /// </summary>
         /// <value>The force dependencies flag.</value>
         public bool ForceDependencies { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to Exit with a 0 for success and 1 for non-success
-        /// no matter what package scripts provide for exit codes.
-        /// </summary>
-        /// <value>The ignore package exit codes flag.</value>
-        public bool IgnorePackageExitCodes { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to use package exit codes.
-        /// </summary>
-        /// <value>The use package exit codes flag.</value>
-        public bool UsePackageExitCodes { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to use auto uninstaller service when uninstalling.
@@ -87,6 +50,11 @@ namespace Cake.Common.Tools.Chocolatey.Uninstall
         /// uninstaller reports an error.
         /// </summary>
         /// <value>The ignore auto uninstaller flag.</value>
-        public bool IgnoreAutoUninstaller { get; set; }
+        public bool IgnoreAutoUninstallerFailure { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to uninstall a program from programs and features.
+        /// </summary>
+        public bool FromProgramsAndFeatures { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/Chocolatey/Uninstall/ChocolateyUninstaller.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Uninstall/ChocolateyUninstaller.cs
@@ -43,6 +43,7 @@ namespace Cake.Common.Tools.Chocolatey.Uninstall
             {
                 throw new ArgumentNullException(nameof(packageIds));
             }
+
             if (settings == null)
             {
                 throw new ArgumentNullException(nameof(settings));
@@ -53,6 +54,7 @@ namespace Cake.Common.Tools.Chocolatey.Uninstall
 
         private ProcessArgumentBuilder GetArguments(IEnumerable<string> packageIds, ChocolateyUninstallSettings settings)
         {
+            const string separator = "=";
             var builder = new ProcessArgumentBuilder();
 
             builder.Append("uninstall");
@@ -62,54 +64,27 @@ namespace Cake.Common.Tools.Chocolatey.Uninstall
             }
 
             // Add common arguments using the inherited method
-            AddCommonArguments(settings, builder);
+            AddGlobalArguments(settings, builder);
 
-            // Fail On Standard Error
-            if (settings.FailOnStandardError)
-            {
-                builder.Append("--failstderr");
-            }
-
-            // Use System Powershell
-            if (settings.UseSystemPowershell)
-            {
-                builder.Append("--use-system-powershell");
-            }
+            // Add shared arguments using the inherited method
+            AddSharedArguments(settings, builder);
 
             // All Versions
             if (settings.AllVersions)
             {
-                builder.Append("--allversions");
+                builder.Append("--all-versions");
             }
 
-            // Global Arguments
-            if (settings.GlobalArguments)
+            // Uninstall Arguments
+            if (!string.IsNullOrEmpty(settings.UninstallArguments))
             {
-                builder.Append("--argsglobal");
-            }
-
-            // Global Package Parameters
-            if (settings.GlobalPackageParameters)
-            {
-                builder.Append("--paramsglobal");
+                builder.AppendSwitchQuoted("--uninstall-arguments", separator, settings.UninstallArguments);
             }
 
             // Force Dependencies
             if (settings.ForceDependencies)
             {
-                builder.Append("-x");
-            }
-
-            // Ignore Package Codes
-            if (settings.IgnorePackageExitCodes)
-            {
-                builder.Append("--ignorepackageexitcodes");
-            }
-
-            // Use Package Exit Codes
-            if (settings.UsePackageExitCodes)
-            {
-                builder.Append("--usepackageexitcodes");
+                builder.Append("--force-dependencies");
             }
 
             // Use Auto Uninstaller
@@ -121,19 +96,24 @@ namespace Cake.Common.Tools.Chocolatey.Uninstall
             // Skip Auto Uninstaller
             if (settings.SkipAutoUninstaller)
             {
-                builder.Append("--skipautouninstaller");
+                builder.Append("--skip-autouninstaller");
             }
 
             // Fail on Auto Uninstaller
             if (settings.FailOnAutoUninstaller)
             {
-                builder.Append("--failonautouninstaller");
+                builder.Append("--fail-on-autouninstaller");
             }
 
             // Ignore Auto Uninstaller failure
-            if (settings.IgnoreAutoUninstaller)
+            if (settings.IgnoreAutoUninstallerFailure)
             {
-                builder.Append("--ignoreautouninstallerfailure");
+                builder.Append("--ignore-autouninstaller-failure");
+            }
+
+            if (settings.FromProgramsAndFeatures)
+            {
+                builder.Append("--from-programs-and-features");
             }
 
             return builder;

--- a/src/Cake.Common/Tools/Chocolatey/Upgrade/ChocolateyUpgradeSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Upgrade/ChocolateyUpgradeSettings.cs
@@ -4,10 +4,12 @@
 
 namespace Cake.Common.Tools.Chocolatey.Upgrade
 {
+    using global::Cake.Core.IO;
+
     /// <summary>
     /// Contains settings used by <see cref="ChocolateyUpgrader"/>.
     /// </summary>
-    public sealed class ChocolateyUpgradeSettings : ChocolateySettings
+    public sealed class ChocolateyUpgradeSettings : ChocolateySharedSettings
     {
         /// <summary>
         /// Gets or sets a value indicating whether to allow upgrading to prerelease versions.
@@ -48,6 +50,11 @@ namespace Cake.Common.Tools.Chocolatey.Upgrade
         public bool FailOnUnfound { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to ignore unfound packages if downloading more than one at a time.
+        /// </summary>
+        public bool IgnoreUnfound { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to fail on not installed packages.
         /// </summary>
         /// <value>The skip powershell flag.</value>
@@ -64,9 +71,169 @@ namespace Cake.Common.Tools.Chocolatey.Upgrade
         public string Password { get; set; }
 
         /// <summary>
+        /// Gets or sets the path to a PFX certificate for use with x509 authenticated feeds.
+        /// </summary>
+        public FilePath Certificate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the password for the <see cref="Certificate"/>.
+        /// </summary>
+        public string CertificatePassword { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to ignore checksums.
         /// </summary>
         /// <value>The ignore checksums flag.</value>
         public bool IgnoreChecksums { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow empty checksums for bare HTTP URLs during package installation.
+        /// </summary>
+        public bool AllowEmptyChecksums { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow empty checksums for HTTPS URLs during package installation.
+        /// </summary>
+        public bool AllowEmptyChecksumsSecure { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether checksums are required during package installation.
+        /// </summary>
+        public bool RequireChecksums { get; set; }
+
+        /// <summary>
+        /// Gets or sets the checksum for 32 bit installation.
+        /// </summary>
+        public string Checksum { get; set; }
+
+        /// <summary>
+        /// Gets or sets the checksum for 64 bit installation.
+        /// </summary>
+        public string Checksum64 { get; set; }
+
+        /// <summary>
+        /// Gets or sets the checksum type to use for 32 bit installation.
+        /// </summary>
+        public string ChecksumType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the checksum type to use for 64 bit installation.
+        /// </summary>
+        public string ChecksumType64 { get; set; }
+
+        /// <summary>
+        /// Gets or sets a comma separated list of package names that should not be upgraded when running upgrade all.
+        /// </summary>
+        public string Except { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether a package will be skipped if it is not installed during upgrade operation.
+        /// </summary>
+        public bool SkipIfNotInstalled { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to install a package that is not installed during the upgrade operation.
+        /// </summary>
+        public bool InstallIfNotInstalled { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether prerelease packages should be ignored for upgrades.
+        /// </summary>
+        public bool ExcludePrerelease { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use the remembered arguments for a package.
+        /// </summary>
+        public bool UseRememberedArguments { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to ignore the remembered arguments for package.
+        /// </summary>
+        public bool IgnoreRememeredArguments { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use optimizations for reducing bandwidth when communicating with repositories.
+        /// </summary>
+        public bool DisableRepositoryOptimizations { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to pin the package once installed.
+        /// </summary>
+        public bool Pin { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to skip the package download cache.
+        /// </summary>
+        public bool SkipDownloadCache { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use the package download cache.
+        /// </summary>
+        public bool UseDownloadCache { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether skip the virus checking for a package.
+        /// </summary>
+        public bool SkipVirusCheck { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to force virus checking for a package.
+        /// </summary>
+        public bool VirusCheck { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum allowed number of virus positives.
+        /// </summary>
+        public int VirusPositivesMinimum { get; set; }
+
+        /// <summary>
+        /// Gets or sets the install arguments sensitive to pass to native installer.
+        /// </summary>
+        public string InstallArgumentsSensitive { get; set; }
+
+        /// <summary>
+        /// Gets or sets sensitive parameters to pass to the package.
+        /// </summary>
+        public string PackageParametersSensitive { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default application installation directory.
+        /// </summary>
+        public DirectoryPath InstallDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum download bits per second when downloading a package.
+        /// </summary>
+        public int MaximumDownloadBitsPerSecond { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether package size should be reduced on installation.
+        /// </summary>
+        public bool ReducePackageSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether there should be no reduction in package size on installation.
+        /// </summary>
+        public bool NoReducePackageSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether only the nupkg file size should be reduced.
+        /// </summary>
+        public bool ReduceNupkgOnly { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to exclude all Chocolatey owned packages during upgrade all operation.
+        /// </summary>
+        public bool ExcludeChocolateyPackagesDuringUpgradeAll { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include all Chocolatey owned packages during upgrade all operation.
+        /// </summary>
+        public bool IncludeChocolateyPackagesDuringUpgradeAll { get; set; }
+
+        /// <summary>
+        /// Gets or sets a reason for pinning a package during installation.
+        /// </summary>
+        public string PinReason { get; set; }
     }
 }


### PR DESCRIPTION
- Make use of full option name
- Make sure to always use = in option value
- Add common options to all commands
- Add new options that have been added since aliases first created

- Fixes #4050 
- Fixes #1146
