### PR TITLE
GH2470: call multiple tasks from cli and pass them to run target

### DIFF
--- a/src/Cake.Cli/Hosts/BuildScriptHost.cs
+++ b/src/Cake.Cli/Hosts/BuildScriptHost.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Cake.Core;
 using Cake.Core.Diagnostics;
@@ -70,7 +71,21 @@ namespace Cake.Cli
         {
             Settings.SetTarget(target);
 
+            return await internalRunTargetAsync();
+        }
+
+        /// <inheritdoc/>
+        public override async Task<CakeReport> RunTargetsAsync(IEnumerable<string> targets)
+        {
+            Settings.SetTargets(targets);
+
+            return await internalRunTargetAsync();
+        }
+
+        private async Task<CakeReport> internalRunTargetAsync()
+        {
             var report = await Engine.RunTargetAsync(_context, _executionStrategy, Settings).ConfigureAwait(false);
+
             if (report != null && !report.IsEmpty)
             {
                 _reportPrinter.Write(report);

--- a/src/Cake.Cli/Hosts/DescriptionScriptHost.cs
+++ b/src/Cake.Cli/Hosts/DescriptionScriptHost.cs
@@ -34,6 +34,21 @@ namespace Cake.Cli
         /// <inheritdoc/>
         public override Task<CakeReport> RunTargetAsync(string target)
         {
+            PrintTaskDescriptions();
+
+            return System.Threading.Tasks.Task.FromResult<CakeReport>(null);
+        }
+
+        /// <inheritdoc/>
+        public override Task<CakeReport> RunTargetsAsync(IEnumerable<string> targets)
+        {
+            PrintTaskDescriptions();
+
+            return System.Threading.Tasks.Task.FromResult<CakeReport>(null);
+        }
+
+        private void PrintTaskDescriptions()
+        {
             var maxTaskNameLength = 29;
 
             foreach (var task in Tasks)
@@ -56,8 +71,6 @@ namespace Cake.Cli
             {
                 _console.WriteLine(lineFormat, key, _descriptions[key]);
             }
-
-            return System.Threading.Tasks.Task.FromResult<CakeReport>(null);
         }
-    }
+     }
 }

--- a/src/Cake.Cli/Hosts/DryRunScriptHost.cs
+++ b/src/Cake.Cli/Hosts/DryRunScriptHost.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Cake.Core;
 using Cake.Core.Diagnostics;
@@ -56,6 +57,25 @@ namespace Cake.Cli
             _log.Information(string.Empty);
 
             Settings.SetTarget(target);
+
+            var strategy = new DryRunExecutionStrategy(_log);
+            var result = await Engine.RunTargetAsync(Context, strategy, Settings).ConfigureAwait(false);
+
+            _log.Information(string.Empty);
+            _log.Information("This was a dry run.");
+            _log.Information("No tasks were actually executed.");
+
+            return result;
+        }
+
+        /// <inheritdoc/>
+        public override async Task<CakeReport> RunTargetsAsync(IEnumerable<string> targets)
+        {
+            _log.Information("Performing dry run...");
+            _log.Information("Targets are: {0}", string.Join(", ", targets));
+            _log.Information(string.Empty);
+
+            Settings.SetTargets(targets);
 
             var strategy = new DryRunExecutionStrategy(_log);
             var result = await Engine.RunTargetAsync(Context, strategy, Settings).ConfigureAwait(false);

--- a/src/Cake.Cli/Hosts/TreeScriptHost.cs
+++ b/src/Cake.Cli/Hosts/TreeScriptHost.cs
@@ -38,6 +38,21 @@ namespace Cake.Cli
         /// <inheritdoc/>
         public override Task<CakeReport> RunTargetAsync(string target)
         {
+            PrintTaskTree();
+
+            return System.Threading.Tasks.Task.FromResult<CakeReport>(null);
+        }
+
+        /// <inheritdoc/>
+        public override Task<CakeReport> RunTargetsAsync(IEnumerable<string> targets)
+        {
+            PrintTaskTree();
+
+            return System.Threading.Tasks.Task.FromResult<CakeReport>(null);
+        }
+
+        private void PrintTaskTree()
+        {
             var topLevelTasks = GetTopLevelTasks();
             _console.WriteLine();
 
@@ -46,8 +61,6 @@ namespace Cake.Cli
                 PrintTask(task, string.Empty, false, 0);
                 _console.WriteLine();
             }
-
-            return System.Threading.Tasks.Task.FromResult<CakeReport>(null);
         }
 
         private List<ICakeTaskInfo> GetTopLevelTasks()

--- a/src/Cake.Core.Tests/Fixtures/ScriptHostFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/ScriptHostFixture.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
@@ -20,6 +21,12 @@ namespace Cake.Core.Tests.Fixtures
             }
 
             public override Task<CakeReport> RunTargetAsync(string target)
+            {
+                return System.Threading.Tasks.Task.FromResult(new CakeReport());
+            }
+
+            /// <inheritdoc/>
+            public override Task<CakeReport> RunTargetsAsync(IEnumerable<string> targets)
             {
                 return System.Threading.Tasks.Task.FromResult(new CakeReport());
             }

--- a/src/Cake.Core.Tests/Unit/CakeEngineTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeEngineTests.cs
@@ -203,6 +203,24 @@ namespace Cake.Core.Tests.Unit
             }
 
             [Fact]
+            public async Task Should_Throw_If_Target_Task_Is_Skipped()
+            {
+                // Given
+                var fixture = new CakeEngineFixture();
+                var settings = new ExecutionSettings().SetTarget("A");
+                var engine = fixture.CreateEngine();
+                engine.RegisterTask("A").WithCriteria(() => false).Does(() => { });
+
+                // When
+                var result = await Record.ExceptionAsync(() =>
+                    engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings));
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("Could not reach target 'A' since it was skipped due to a criteria.", result?.Message);
+            }
+
+            [Fact]
             public async Task Should_Skip_Tasks_Where_Boolean_Criterias_Are_Not_Fulfilled()
             {
                 // Given
@@ -1155,7 +1173,14 @@ namespace Cake.Core.Tests.Unit
                 await engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings);
 
                 // Then
-                Assert.Equal(new List<string> { "TASK_SETUP:A", "Executing A", "TASK_SETUP:B", "Executing B" }, result);
+                Assert.Equal(
+                    new List<string>
+                    {
+                        "TASK_SETUP:A",
+                        "Executing A",
+                        "TASK_SETUP:B",
+                        "Executing B"
+                    }, result);
             }
 
             [Fact]
@@ -1430,7 +1455,6 @@ namespace Cake.Core.Tests.Unit
                 var settings = new ExecutionSettings().SetTarget("A");
                 var engine = fixture.CreateEngine();
                 engine.RegisterSetupAction(x => { });
-                engine.RegisterSetupAction(x => { });
                 engine.RegisterTask("A");
 
                 // When
@@ -1451,7 +1475,6 @@ namespace Cake.Core.Tests.Unit
                 var fixture = new CakeEngineFixture();
                 var settings = new ExecutionSettings().SetTarget("A");
                 var engine = fixture.CreateEngine();
-                engine.RegisterTeardownAction(x => { });
                 engine.RegisterTeardownAction(x => { });
                 engine.RegisterTask("A");
 
@@ -1557,6 +1580,350 @@ namespace Cake.Core.Tests.Unit
                 // Then
                 Assert.Equal(CakeTaskExecutionStatus.Delegated, report.First(e => e.TaskName == "A").ExecutionStatus);
                 Assert.Equal(CakeTaskExecutionStatus.Failed, report.First(e => e.TaskName == "B").ExecutionStatus);
+            }
+        }
+
+        public sealed class TheRunTargetAsyncMethod_MultipleTargets
+        {
+            [Fact]
+            public async Task Should_Throw_If_Targets_Is_Null()
+            {
+                // Given
+                var fixture = new CakeEngineFixture();
+                var engine = fixture.CreateEngine();
+                var settings = new ExecutionSettings().SetTargets(null);
+
+                // When
+                var result = await Record.ExceptionAsync(() =>
+                    engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings));
+
+                // Then
+                AssertEx.IsArgumentException(result, "settings", "No target specified.");
+            }
+
+            [Fact]
+            public async Task Should_Throw_If_Targets_Is_Empty()
+            {
+                // Given
+                var fixture = new CakeEngineFixture();
+                var engine = fixture.CreateEngine();
+                var settings = new ExecutionSettings().SetTargets(Array.Empty<string>());
+
+                // When
+                var result = await Record.ExceptionAsync(() =>
+                    engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings));
+
+                // Then
+                AssertEx.IsArgumentException(result, "settings", "No target specified.");
+            }
+
+            [Fact]
+            public async Task Should_Throw_If_Targets_Is_WhiteSpace()
+            {
+                // Given
+                var fixture = new CakeEngineFixture();
+                var engine = fixture.CreateEngine();
+                var settings = new ExecutionSettings().SetTargets(new string[] { " ", "   " });
+
+                // When
+                var result = await Record.ExceptionAsync(() =>
+                    engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings));
+
+                // Then
+                AssertEx.IsArgumentException(result, "settings", "No target specified.");
+            }
+
+            [Fact]
+            public async Task Should_Execute_Tasks_In_Order()
+            {
+                // Given
+                var result = new List<string>();
+                var fixture = new CakeEngineFixture();
+                var settings = new ExecutionSettings().SetTargets(new string[] { "A", "B" });
+                var engine = fixture.CreateEngine();
+                engine.RegisterTask("A").Does(() => result.Add("A"));
+                engine.RegisterTask("B").Does(() => result.Add("B"));
+
+                // When
+                await engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings);
+
+                // Then
+                Assert.Equal(2, result.Count);
+                Assert.Equal("A", result[0]);
+                Assert.Equal("B", result[1]);
+            }
+
+            [Fact]
+            public async Task Should_Only_Execute_Target_Tasks_In_Exclusive_Mode()
+            {
+                // Given
+                var result = new List<string>();
+                var fixture = new CakeEngineFixture();
+                var settings = new ExecutionSettings().SetTargets(new string[] { "B", "D" }).UseExclusiveTarget();
+                var engine = fixture.CreateEngine();
+                engine.RegisterTask("A").Does(() => result.Add("A"));
+                engine.RegisterTask("B").IsDependentOn("A").Does(() => result.Add("B"));
+                engine.RegisterTask("C").IsDependentOn("B").Does(() => result.Add("C"));
+                engine.RegisterTask("D").IsDependentOn("C").IsDependeeOf("E").Does(() => { result.Add("D"); });
+                engine.RegisterTask("E").Does(() => { result.Add("E"); });
+
+                // When
+                await engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings);
+
+                // Then
+                Assert.Equal(2, result.Count);
+                Assert.Equal("B", result[0]);
+                Assert.Equal("D", result[1]);
+            }
+
+            [Fact]
+            public async Task Should_Throw_If_Any_Target_Task_Is_Skipped()
+            {
+                // Given
+                var fixture = new CakeEngineFixture();
+                var settings = new ExecutionSettings().SetTargets(new string[] { "A", "B" });
+                var engine = fixture.CreateEngine();
+                engine.RegisterTask("A").Does(() => { });
+                engine.RegisterTask("B").WithCriteria(() => false).Does(() => { });
+
+                // When
+                var result = await Record.ExceptionAsync(() =>
+                    engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings));
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("Could not reach target 'B' since it was skipped due to a criteria.", result?.Message);
+            }
+
+            [Fact]
+            public async Task Should_Throw_If_Target_Was_Not_Found()
+            {
+                // Given
+                var fixture = new CakeEngineFixture();
+                var settings = new ExecutionSettings().SetTargets(new string[] { "Run-Some-Tests" });
+                var engine = fixture.CreateEngine();
+
+                // When
+                var result = await Record.ExceptionAsync(() =>
+                    engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings));
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("The target 'Run-Some-Tests' was not found.", result?.Message);
+            }
+
+            [Fact]
+            public async Task Should_Throw_If_All_Targets_Were_Not_Found()
+            {
+                // Given
+                var fixture = new CakeEngineFixture();
+                var settings = new ExecutionSettings().SetTargets(new string[] { "Run-Some-Tests", "Run-Some-More-Tests" });
+                var engine = fixture.CreateEngine();
+
+                // When
+                var result = await Record.ExceptionAsync(() =>
+                    engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings));
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("The targets 'Run-Some-Tests', 'Run-Some-More-Tests' were not found.", result?.Message);
+            }
+
+            [Fact]
+            public async Task Should_Throw_If_Any_Targets_Were_Not_Found()
+            {
+                // Given
+                var fixture = new CakeEngineFixture();
+                var settings = new ExecutionSettings().SetTargets(new string[] { "Run-Some-Tests", "A", "Run-Some-More-Tests" });
+                var engine = fixture.CreateEngine();
+                engine.RegisterTask("A").Does(() => { });
+
+                // When
+                var result = await Record.ExceptionAsync(() =>
+                    engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings));
+
+                // Then
+                Assert.IsType<CakeException>(result);
+                Assert.Equal("The targets 'Run-Some-Tests', 'Run-Some-More-Tests' were not found.", result?.Message);
+            }
+
+            [Fact]
+            public async Task Should_Not_Catch_Exceptions_From_Task_If_ContinueOnError_Is_Not_Set()
+            {
+                // Given
+                var fixture = new CakeEngineFixture();
+                var settings = new ExecutionSettings().SetTargets(new string[] { "A", "B" });
+                var engine = fixture.CreateEngine();
+                engine.RegisterTask("A").Does(() => { });
+                engine.RegisterTask("B").Does(() => { throw new InvalidOperationException("Whoopsie"); });
+
+                // When
+                var result = await Record.ExceptionAsync(() =>
+                    engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings));
+
+                // Then
+                Assert.IsType<InvalidOperationException>(result);
+                Assert.Equal("Whoopsie", result?.Message);
+            }
+
+            [Fact]
+            public async Task Should_Swallow_Exceptions_If_ContinueOnError_Is_Set()
+            {
+                // Given
+                var fixture = new CakeEngineFixture();
+                var settings = new ExecutionSettings().SetTargets(new string[] { "A", "B" });
+                var engine = fixture.CreateEngine();
+                engine.RegisterTask("A").Does(() => { });
+                engine.RegisterTask("B").ContinueOnError().Does(() => { throw new InvalidOperationException(); });
+
+                // When, Then
+                await engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings);
+            }
+
+            [Fact]
+            public async Task Should_Run_Setup_Before_First_Task()
+            {
+                // Given
+                var result = new List<string>();
+                var settings = new ExecutionSettings().SetTargets(new string[] { "A", "B" });
+                var fixture = new CakeEngineFixture();
+                var engine = fixture.CreateEngine();
+                engine.RegisterSetupAction(context => result.Add("Setup"));
+                engine.RegisterTask("A").Does(() => result.Add("A"));
+                engine.RegisterTask("B").Does(() => result.Add("B"));
+
+                // When
+                await engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings);
+
+                // Then
+                Assert.Equal(3, result.Count);
+                Assert.Equal("Setup", result[0]);
+            }
+
+            [Fact]
+            public async Task Should_Run_Teardown_After_Last_Running_Task()
+            {
+                // Given
+                var result = new List<string>();
+                var fixture = new CakeEngineFixture();
+                var settings = new ExecutionSettings().SetTargets(new string[] { "A", "B" });
+                var engine = fixture.CreateEngine();
+                engine.RegisterTask("A").Does(() => result.Add("A"));
+                engine.RegisterTask("B").Does(() => result.Add("B"));
+                engine.RegisterTeardownAction(context => result.Add("Teardown"));
+
+                // When
+                await engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings);
+
+                // Then
+                Assert.Equal(3, result.Count);
+                Assert.Equal("Teardown", result[2]);
+            }
+
+            [Fact]
+            public async Task Should_Run_Task_Setup_Before_Each_Task()
+            {
+                // Given
+                var result = new List<string>();
+                var fixture = new CakeEngineFixture();
+                var settings = new ExecutionSettings().SetTargets(new string[] { "B", "C" });
+                var engine = fixture.CreateEngine();
+                engine.RegisterTaskSetupAction(context => result.Add("TASK_SETUP:" + context.Task.Name));
+                engine.RegisterTask("A").Does(() => result.Add("Executing A"));
+                engine.RegisterTask("B").Does(() => result.Add("Executing B")).IsDependentOn("A");
+                engine.RegisterTask("C").Does(() => result.Add("Executing C"));
+
+                // When
+                await engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings);
+
+                // Then
+                Assert.Equal(
+                    new List<string>
+                    {
+                        "TASK_SETUP:A",
+                        "Executing A",
+                        "TASK_SETUP:B",
+                        "Executing B",
+                        "TASK_SETUP:C",
+                        "Executing C"
+                    }, result);
+            }
+
+            [Fact]
+            public async Task Should_Run_Task_Teardown_After_Each_Running_Task()
+            {
+                // Given
+                var result = new List<string>();
+                var fixture = new CakeEngineFixture();
+                var settings = new ExecutionSettings().SetTargets(new string[] { "B", "C" });
+                var engine = fixture.CreateEngine();
+                engine.RegisterTaskSetupAction(context => result.Add("TASK_SETUP:" + context.Task.Name));
+                engine.RegisterTaskTeardownAction(context => result.Add("TASK_TEARDOWN:" + context.Task.Name));
+                engine.RegisterTask("A").Does(() => result.Add("Executing A"));
+                engine.RegisterTask("B").Does(() => result.Add("Executing B")).IsDependentOn("A");
+                engine.RegisterTask("C").Does(() => result.Add("Executing C"));
+
+                // When
+                await engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings);
+
+                // Then
+                Assert.Equal(
+                    new List<string>
+                    {
+                        "TASK_SETUP:A",
+                        "Executing A",
+                        "TASK_TEARDOWN:A",
+                        "TASK_SETUP:B",
+                        "Executing B",
+                        "TASK_TEARDOWN:B",
+                        "TASK_SETUP:C",
+                        "Executing C",
+                        "TASK_TEARDOWN:C"
+                    }, result);
+            }
+
+            [Fact]
+            public async Task Should_Return_Report_That_Marks_Skipped_Tasks_As_Skipped()
+            {
+                // Given
+                var fixture = new CakeEngineFixture();
+                var settings = new ExecutionSettings().SetTargets(new string[] { "C", "D" });
+                var engine = fixture.CreateEngine();
+                engine.RegisterSetupAction(x => { });
+                engine.RegisterTask("A");
+                engine.RegisterTask("B").WithCriteria(() => false).IsDependentOn("A");
+                engine.RegisterTask("C").IsDependentOn("B");
+                engine.RegisterTask("D").ContinueOnError().Does(() => throw new Exception("error"));
+                engine.RegisterTeardownAction(x => { });
+
+                // When
+                var report = await engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings);
+
+                // Then
+                Assert.Equal(6, report.Count());
+
+                Assert.Equal("Setup", report.ElementAt(0).TaskName);
+                Assert.Equal(CakeReportEntryCategory.Setup, report.ElementAt(0).Category);
+                Assert.Equal(CakeTaskExecutionStatus.Executed, report.ElementAt(0).ExecutionStatus);
+
+                Assert.Equal("A", report.ElementAt(1).TaskName);
+                Assert.Equal(CakeReportEntryCategory.Task, report.ElementAt(1).Category);
+                Assert.Equal(CakeTaskExecutionStatus.Delegated, report.ElementAt(1).ExecutionStatus);
+
+                Assert.Equal("B", report.ElementAt(2).TaskName);
+                Assert.Equal(CakeReportEntryCategory.Task, report.ElementAt(2).Category);
+                Assert.Equal(CakeTaskExecutionStatus.Skipped, report.ElementAt(2).ExecutionStatus);
+
+                Assert.Equal("C", report.ElementAt(3).TaskName);
+                Assert.Equal(CakeReportEntryCategory.Task, report.ElementAt(3).Category);
+                Assert.Equal(CakeTaskExecutionStatus.Delegated, report.ElementAt(3).ExecutionStatus);
+
+                Assert.Equal("D", report.ElementAt(4).TaskName);
+                Assert.Equal(CakeReportEntryCategory.Task, report.ElementAt(4).Category);
+                Assert.Equal(CakeTaskExecutionStatus.Failed, report.ElementAt(4).ExecutionStatus);
+
+                Assert.Equal("Teardown", report.ElementAt(5).TaskName);
+                Assert.Equal(CakeReportEntryCategory.Teardown, report.ElementAt(5).Category);
             }
         }
 

--- a/src/Cake.Core.Tests/Unit/ExecutionSettingsTests.cs
+++ b/src/Cake.Core.Tests/Unit/ExecutionSettingsTests.cs
@@ -1,0 +1,144 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Cake.Core.Tests.Unit
+{
+    public sealed class ExecutionSettingsTests
+    {
+        [Fact]
+        public void Should_Have_Zero_Targets_Initially()
+        {
+            // Given
+            var settings = new ExecutionSettings();
+
+            // When
+
+            // Then
+            Assert.Equal(Array.Empty<string>(), settings.Targets);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("  ")]
+        public void Should_Not_Allow_Empty_Targets(string actual)
+        {
+            // Given
+            var settings = new ExecutionSettings().SetTarget(actual);
+
+            // When
+
+            // Then
+            Assert.Equal(Array.Empty<string>(), settings.Targets);
+        }
+
+        [Fact]
+        public void Should_Not_Allow_Empty_Targets_2()
+        {
+            // Given
+            var settings = new ExecutionSettings().SetTargets(new string[] { "" });
+
+            // When
+
+            // Then
+            Assert.Equal(Array.Empty<string>(), settings.Targets);
+        }
+
+        [Fact]
+        public void Should_Not_Allow_Empty_Targets_3()
+        {
+            // Given
+            var settings = new ExecutionSettings().SetTargets(new string[] { " " });
+
+            // When
+
+            // Then
+            Assert.Equal(Array.Empty<string>(), settings.Targets);
+        }
+
+        [Fact]
+        public void Should_Not_Allow_Empty_Targets_4()
+        {
+            // Given
+            var settings = new ExecutionSettings().SetTargets(new string[] { " ", " " });
+
+            // When
+
+            // Then
+            Assert.Equal(Array.Empty<string>(), settings.Targets);
+        }
+
+        [Fact]
+        public void Should_Not_Allow_Empty_Targets_5()
+        {
+            // Given
+            var settings = new ExecutionSettings().SetTargets(new string[] { " ", " ", "A" });
+
+            // When
+
+            // Then
+            Assert.Equal(new string[] { "A" }, settings.Targets);
+        }
+
+        [Fact]
+        public void Should_Clear_Existing_Targets_When_Setting_Targets_1()
+        {
+            // Given
+            var settings = new ExecutionSettings().SetTargets(new string[] { "B", "C" });
+
+            // When
+            settings.SetTarget("A");
+
+            // Then
+            Assert.Equal(new string[] { "A" }, settings.Targets);
+        }
+
+        [Fact]
+        public void Should_Clear_Existing_Targets_When_Setting_Targets_2()
+        {
+            // Given
+            var settings = new ExecutionSettings().SetTargets(new string[] { "B", "C" });
+
+            // When
+            settings.SetTarget("");
+
+            // Then
+            Assert.Equal(Array.Empty<string>(), settings.Targets);
+        }
+
+        [Fact]
+        public void Should_Clear_Existing_Targets_When_Setting_Targets_3()
+        {
+            // Given
+            var settings = new ExecutionSettings().SetTarget("A");
+
+            // When
+            settings.SetTargets(new string[] { "B", "C" });
+
+            // Then
+            Assert.Equal(new string[] { "B", "C" }, settings.Targets);
+        }
+
+        [Fact]
+        public void Should_Clear_Existing_Targets_When_Setting_Targets_4()
+        {
+            // Given
+            var settings = new ExecutionSettings().SetTarget("A");
+
+            // When
+            settings.SetTarget("");
+
+            // Then
+            Assert.Equal(Array.Empty<string>(), settings.Targets);
+        }
+    }
+}

--- a/src/Cake.Core/ExecutionSettings.cs
+++ b/src/Cake.Core/ExecutionSettings.cs
@@ -2,6 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using static Cake.Core.Constants;
+
 namespace Cake.Core
 {
     /// <summary>
@@ -10,9 +15,9 @@ namespace Cake.Core
     public sealed class ExecutionSettings
     {
         /// <summary>
-        /// Gets the target to be executed.
+        /// Gets the targets to be executed.
         /// </summary>
-        public string Target { get; private set; }
+        public IEnumerable<string> Targets { get; private set; }
 
         /// <summary>
         /// Gets a value indicating whether or not to use the target exclusively.
@@ -20,13 +25,35 @@ namespace Cake.Core
         public bool Exclusive { get; private set; }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ExecutionSettings"/> class.
+        /// </summary>
+        public ExecutionSettings()
+        {
+            Targets = Array.Empty<string>();
+            Exclusive = false;
+        }
+
+        /// <summary>
         /// Sets the target to be executed.
         /// </summary>
         /// <param name="target">The target.</param>
         /// <returns>The same <see cref="ExecutionSettings"/> instance so that multiple calls can be chained.</returns>
+        /// <remarks>Targets consisting of whitespace only will be ignored.</remarks>
         public ExecutionSettings SetTarget(string target)
         {
-            Target = target;
+            Targets = string.IsNullOrWhiteSpace(target) ? Array.Empty<string>() : new string[] { target };
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the targets to be executed.
+        /// </summary>
+        /// <param name="targets">The targets.</param>
+        /// <returns>The same <see cref="ExecutionSettings"/> instance so that multiple calls can be chained.</returns>
+        /// <remarks>Targets consisting of whitespace only will be ignored.</remarks>
+        public ExecutionSettings SetTargets(IEnumerable<string> targets)
+        {
+            Targets = targets?.ToArray().Where(s => !string.IsNullOrWhiteSpace(s)) ?? Array.Empty<string>();
             return this;
         }
 

--- a/src/Cake.Core/Scripting/IScriptHost.cs
+++ b/src/Cake.Core/Scripting/IScriptHost.cs
@@ -148,5 +148,19 @@ namespace Cake.Core.Scripting
         /// <param name="target">The target to run.</param>
         /// <returns>The resulting report.</returns>
         Task<CakeReport> RunTargetAsync(string target);
+
+        /// <summary>
+        /// Runs the specified targets.
+        /// </summary>
+        /// <param name="targets">The targets to run.</param>
+        /// <returns>The resulting report.</returns>
+        CakeReport RunTargets(IEnumerable<string> targets);
+
+        /// <summary>
+        /// Runs the specified targets.
+        /// </summary>
+        /// <param name="targets">The targets to run.</param>
+        /// <returns>The resulting report.</returns>
+        Task<CakeReport> RunTargetsAsync(IEnumerable<string> targets);
     }
 }

--- a/src/Cake.Core/Scripting/ScriptHost.cs
+++ b/src/Cake.Core/Scripting/ScriptHost.cs
@@ -112,5 +112,14 @@ namespace Cake.Core.Scripting
 
         /// <inheritdoc/>
         public abstract Task<CakeReport> RunTargetAsync(string target);
+
+        /// <inheritdoc/>
+        public CakeReport RunTargets(IEnumerable<string> targets)
+        {
+            return RunTargetsAsync(targets).GetAwaiter().GetResult();
+        }
+
+        /// <inheritdoc/>
+        public abstract Task<CakeReport> RunTargetsAsync(IEnumerable<string> targets);
     }
 }

--- a/tests/integration/Cake.Common/Tools/Cake/CakeAliases.cake
+++ b/tests/integration/Cake.Common/Tools/Cake/CakeAliases.cake
@@ -97,6 +97,43 @@ Task("Cake.Common.Tools.Cake.CakeAliases.CakeExecuteExpression.CakeException.Cus
     Assert.Equal(expect, (exception as CakeException)?.ExitCode);
 });
 
+Task("Cake.Common.Tools.Cake.CakeAliases.CakeExecuteScript.RunTargets")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Resources.Combine("./Cake.Common/Tools/Cake");
+    var file = path.CombineWithFilePath("./targets.cake");
+
+    // When
+    CakeExecuteScript(file, new CakeSettings {
+        ArgumentCustomization = args => args
+                                .AppendSwitchQuoted("--target", "=", "A")
+                                .AppendSwitchQuoted("--target", "=", "B")
+                                .AppendSwitchQuoted("--target", "=", "C")
+                                .AppendSwitchQuoted("--target", "=", "D")
+                                .AppendSwitchQuoted("--expected", "=", "A,B,C,E,D")
+     });
+});
+
+Task("Cake.Common.Tools.Cake.CakeAliases.CakeExecuteScript.RunTargets.Exclusive")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Resources.Combine("./Cake.Common/Tools/Cake");
+    var file = path.CombineWithFilePath("./targets.cake");
+
+    // When
+    CakeExecuteScript(file, new CakeSettings {
+        ArgumentCustomization = args => args
+                                .AppendSwitchQuoted("--target", "=", "A")
+                                .AppendSwitchQuoted("--target", "=", "B")
+                                .AppendSwitchQuoted("--target", "=", "C")
+                                .AppendSwitchQuoted("--target", "=", "D")
+                                .Append("--exclusive")
+                                .AppendSwitchQuoted("--expected", "=", "A,B,C,D")
+     });
+});
+
 Task("Cake.Common.Tools.Cake.CakeAliases")
     .IsDependentOn("Cake.Common.Tools.Cake.CakeAliases.CakeExecuteScript")
     .IsDependentOn("Cake.Common.Tools.Cake.CakeAliases.CakeExecuteScript.Settings.Ok")
@@ -104,4 +141,6 @@ Task("Cake.Common.Tools.Cake.CakeAliases")
     .IsDependentOn("Cake.Common.Tools.Cake.CakeAliases.CakeExecuteExpression")
     .IsDependentOn("Cake.Common.Tools.Cake.CakeAliases.CakeExecuteExpression.Settings.Ok")
     .IsDependentOn("Cake.Common.Tools.Cake.CakeAliases.CakeExecuteExpression.Settings.NotOk")
-    .IsDependentOn("Cake.Common.Tools.Cake.CakeAliases.CakeExecuteExpression.CakeException.CustomExitCode");
+    .IsDependentOn("Cake.Common.Tools.Cake.CakeAliases.CakeExecuteExpression.CakeException.CustomExitCode")
+    .IsDependentOn("Cake.Common.Tools.Cake.CakeAliases.CakeExecuteScript.RunTargets")
+    .IsDependentOn("Cake.Common.Tools.Cake.CakeAliases.CakeExecuteScript.RunTargets.Exclusive");

--- a/tests/integration/resources/Cake.Common/Tools/Cake/targets.cake
+++ b/tests/integration/resources/Cake.Common/Tools/Cake/targets.cake
@@ -1,0 +1,31 @@
+#load "../../../../utilities/xunit.cake"
+
+Setup(ctx => new List<string>());
+
+Teardown<List<string>>((ctx, data)=>{
+    var result = string.Join(',', data);
+    var expected = ctx.Argument("expected", string.Empty);
+    Assert.Equal(expected, result);
+});
+
+TaskTeardown<List<string>>((ctx, data) => data.Add(ctx.Task.Name));
+
+Task("A")
+    .Does(_=>{});
+
+Task("B")
+    .Does(_=>{});
+
+Task("C")
+    .Does(_=>{});
+
+Task("D")
+    .Does(_=>{})
+    .IsDependentOn("E");
+
+Task("E")
+    .Does(_=>{});
+
+Task("Default");
+
+RunTargets(Arguments<string>("target", new []{ "Default" }))


### PR DESCRIPTION
This PR fully implements #2470, 'Call multiple tasks from CLI and pass them to RunTarget'

Significant unit test coverage has been added for the changes, including minor refactoring and improvements to the existing codebase when encountered.

Significant effort was undertaken to ensure the changes introduced in this PR maintained backward compatibility.

Given the following cake build script, 

```
var targets = Arguments<string>("target", "A");

Task("A");

Task("B");

Task("C");

RunTargets(targets);
```

This PR extends Cake to operate as follows:

![image](https://user-images.githubusercontent.com/52075808/200390107-3ab0a894-b49d-4001-8780-d6bb633c47da.png)

![image](https://user-images.githubusercontent.com/52075808/200390494-55d46958-2a05-4111-9257-cb9d353598fb.png)

![image](https://user-images.githubusercontent.com/52075808/200390642-6b7d54c1-ea45-43cf-a113-1c87626ef6c6.png)

