### PR TITLE
GH4055: Add task skip reason to task summary output

### DIFF
--- a/src/Cake.Cli/Infrastructure/CakeSpectreReportPrinter.cs
+++ b/src/Cake.Cli/Infrastructure/CakeSpectreReportPrinter.cs
@@ -1,0 +1,162 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using Spectre.Console;
+
+namespace Cake.Cli
+{
+    /// <summary>
+    /// The default report printer.
+    /// </summary>
+    public sealed class CakeSpectreReportPrinter : ICakeReportPrinter
+    {
+        private readonly IAnsiConsole _console;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CakeSpectreReportPrinter"/> class.
+        /// </summary>
+        /// <param name="console">The console.</param>
+        public CakeSpectreReportPrinter(IAnsiConsole console)
+        {
+            _console = console;
+        }
+
+        /// <inheritdoc/>
+        public void Write(CakeReport report)
+        {
+            // Create a table
+            var table = new Table().Border(TableBorder.SimpleHeavy);
+            table.Width(100);
+            table.BorderStyle(new Style().Foreground(ConsoleColor.Green));
+
+            var includeSkippedReasonColumn = report.Any(r => !string.IsNullOrEmpty(r.SkippedMessage));
+            var rowStyle = new Style(ConsoleColor.Green);
+
+            // Add some columns
+            table.AddColumn(new TableColumn(new Text("Task", rowStyle)).Footer(new Text("Total:", rowStyle)).PadRight(10));
+            table.AddColumn(
+                new TableColumn(
+                    new Text("Duration", rowStyle)).Footer(
+                        new Text(FormatTime(GetTotalTime(report)), rowStyle)));
+
+            if (includeSkippedReasonColumn)
+            {
+                table.AddColumn(new TableColumn(new Text("Skip Reason", rowStyle)));
+            }
+
+            foreach (var item in report)
+            {
+                var itemStyle = GetItemStyle(item);
+
+                if (includeSkippedReasonColumn)
+                {
+                    table.AddRow(new Markup(item.TaskName, itemStyle),
+                                new Markup(FormatDuration(item), itemStyle),
+                                new Markup(item.SkippedMessage, itemStyle));
+                }
+                else
+                {
+                    table.AddRow(new Markup(item.TaskName, itemStyle),
+                                new Markup(FormatDuration(item), itemStyle));
+                }
+            }
+
+            // Render the table to the console
+            _console.Write(table);
+        }
+
+        /// <inheritdoc/>
+        public void WriteStep(string name, Verbosity verbosity)
+        {
+            if (verbosity < Verbosity.Normal)
+            {
+                return;
+            }
+
+            var table = new Table().Border(DoubleBorder.Shared);
+            table.Width(100);
+            table.AddColumn(name);
+            _console.Write(new Padder(table).Padding(0, 1, 0, 0));
+        }
+
+        /// <inheritdoc/>
+        public void WriteLifeCycleStep(string name, Verbosity verbosity)
+        {
+            if (verbosity < Verbosity.Normal)
+            {
+                return;
+            }
+
+            _console.WriteLine();
+
+            var table = new Table().Border(SingleBorder.Shared);
+            table.Width(100);
+            table.AddColumn(name);
+            _console.Write(table);
+        }
+
+        /// <inheritdoc/>
+        public void WriteSkippedStep(string name, Verbosity verbosity)
+        {
+            if (verbosity < Verbosity.Verbose)
+            {
+                return;
+            }
+
+            _console.WriteLine();
+
+            var table = new Table().Border(DoubleBorder.Shared);
+            table.Width(100);
+            table.AddColumn(name);
+            _console.Write(table);
+        }
+
+        private static string FormatDuration(CakeReportEntry item)
+        {
+            if (item.ExecutionStatus == CakeTaskExecutionStatus.Skipped)
+            {
+                return "Skipped";
+            }
+
+            return FormatTime(item.Duration);
+        }
+
+        private static Style GetItemStyle(CakeReportEntry item)
+        {
+            if (item.Category == CakeReportEntryCategory.Setup || item.Category == CakeReportEntryCategory.Teardown)
+            {
+                return new Style(ConsoleColor.Cyan);
+            }
+
+            if (item.ExecutionStatus == CakeTaskExecutionStatus.Failed)
+            {
+                return new Style(ConsoleColor.Red);
+            }
+
+            if (item.ExecutionStatus == CakeTaskExecutionStatus.Executed)
+            {
+                return new Style(ConsoleColor.Green);
+            }
+
+            return new Style(ConsoleColor.Gray);
+        }
+
+        private static string FormatTime(TimeSpan time)
+        {
+            return time.ToString("c", CultureInfo.InvariantCulture);
+        }
+
+        private static TimeSpan GetTotalTime(IEnumerable<CakeReportEntry> entries)
+        {
+            return entries.Select(i => i.Duration)
+                .Aggregate(TimeSpan.Zero, (t1, t2) => t1 + t2);
+        }
+    }
+}

--- a/src/Cake.Cli/Infrastructure/DoubleBorder.cs
+++ b/src/Cake.Cli/Infrastructure/DoubleBorder.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace Cake.Cli
+{
+    /// <summary>
+    /// A custom Spectre.Console border class, used for outputting information about steps.
+    /// </summary>
+    public class DoubleBorder : TableBorder
+    {
+        /// <summary>
+        /// Gets a single instance of the DoubleBorder class.
+        /// </summary>
+        public static DoubleBorder Shared { get; } = new DoubleBorder();
+
+        /// <summary>
+        /// Get information about the custom border.
+        /// </summary>
+        /// <param name="part">The part that needs a border applied to it.</param>
+        /// <returns>A simple double border character.</returns>
+        public override string GetPart(TableBorderPart part)
+        {
+            return part switch
+            {
+                TableBorderPart.HeaderTop => "=",
+                TableBorderPart.FooterBottom => "=",
+                _ => string.Empty,
+            };
+        }
+    }
+}

--- a/src/Cake.Cli/Infrastructure/SingleBorder.cs
+++ b/src/Cake.Cli/Infrastructure/SingleBorder.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace Cake.Cli
+{
+    /// <summary>
+    /// A custom Spectre.Console border class, used for outputting information about steps.
+    /// </summary>
+    public class SingleBorder : TableBorder
+    {
+        /// <summary>
+        /// Gets a single instance of the SingleBorder class.
+        /// </summary>
+        public static SingleBorder Shared { get; } = new SingleBorder();
+
+        /// <summary>
+        /// Get information about the custom border.
+        /// </summary>
+        /// <param name="part">The part that needs a border applied to it.</param>
+        /// <returns>A simple single border character.</returns>
+        public override string GetPart(TableBorderPart part)
+        {
+            return part switch
+            {
+                TableBorderPart.HeaderTop => "-",
+                TableBorderPart.FooterBottom => "-",
+                _ => string.Empty,
+            };
+        }
+    }
+}

--- a/src/Cake.Core.Tests/Fixtures/CakeEngineFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/CakeEngineFixture.cs
@@ -17,6 +17,7 @@ namespace Cake.Core.Tests.Fixtures
         public ICakeArguments Arguments { get; set; }
         public IProcessRunner ProcessRunner { get; set; }
         public ICakeContext Context { get; set; }
+        public ICakeReportPrinter ReportPrinter { get; set; }
         public IExecutionStrategy ExecutionStrategy { get; set; }
         public ICakeDataService DataService { get; set; }
 
@@ -28,7 +29,8 @@ namespace Cake.Core.Tests.Fixtures
             Globber = Substitute.For<IGlobber>();
             Arguments = Substitute.For<ICakeArguments>();
             ProcessRunner = Substitute.For<IProcessRunner>();
-            ExecutionStrategy = new DefaultExecutionStrategy(Log);
+            ReportPrinter = Substitute.For<ICakeReportPrinter>();
+            ExecutionStrategy = new DefaultExecutionStrategy(Log, ReportPrinter);
             DataService = Substitute.For<ICakeDataService>();
 
             Context = Substitute.For<ICakeContext>();

--- a/src/Cake.Core.Tests/Unit/CakeReportTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeReportTests.cs
@@ -61,7 +61,7 @@ namespace Cake.Core.Tests.Unit
                 var taskName = "task";
 
                 // When
-                report.AddSkipped(taskName);
+                report.AddSkipped(taskName, "This task was skipped for a great reason!");
 
                 // Then
                 var firstTask = report.First();
@@ -75,12 +75,12 @@ namespace Cake.Core.Tests.Unit
             {
                 // Given
                 var report = new CakeReport();
-                report.AddSkipped("task 1");
+                report.AddSkipped("task 1", "This task was skipped for a great reason!");
 
                 var taskName = "task 2";
 
                 // When
-                report.AddSkipped(taskName);
+                report.AddSkipped(taskName, "This task was skipped for a great reason!");
 
                 // Then
                 var lastTask = report.Last();
@@ -115,7 +115,7 @@ namespace Cake.Core.Tests.Unit
             {
                 // Given
                 var report = new CakeReport();
-                report.AddSkipped("task 1");
+                report.AddSkipped("task 1", "This task was skipped for a great reason!");
 
                 var taskName = "task 2";
                 var duration = TimeSpan.FromMilliseconds(100);
@@ -156,7 +156,7 @@ namespace Cake.Core.Tests.Unit
             {
                 // Given
                 var report = new CakeReport();
-                report.AddSkipped("task 1");
+                report.AddSkipped("task 1", "This task was skipped for a great reason!");
 
                 var taskName = "task 2";
                 var duration = TimeSpan.FromMilliseconds(100);

--- a/src/Cake.Core/CakeEngine.cs
+++ b/src/Cake.Core/CakeEngine.cs
@@ -242,6 +242,7 @@ namespace Cake.Core
             {
                 if (!ShouldTaskExecute(context, task, criteria, isTarget))
                 {
+                    criteria.CausedSkippingOfTask = true;
                     SkipTask(context, strategy, task, report, criteria);
                     skipped = true;
                     break;
@@ -437,7 +438,17 @@ namespace Cake.Core
             PerformTaskTeardown(context, strategy, task, TimeSpan.Zero, true, null);
 
             // Add the skipped task to the report.
-            report.AddSkipped(task.Name);
+            var skippedTaskCriteria = task.Criterias.FirstOrDefault(c => c.CausedSkippingOfTask == true);
+            var skippedMessage = string.Empty;
+            if (skippedTaskCriteria != null)
+            {
+                if (!string.IsNullOrEmpty(skippedTaskCriteria.Message))
+                {
+                    skippedMessage = skippedTaskCriteria.Message;
+                }
+            }
+
+            report.AddSkipped(task.Name, skippedMessage);
         }
 
         private static bool IsDelegatedTask(CakeTask task)

--- a/src/Cake.Core/CakeReport.cs
+++ b/src/Cake.Core/CakeReport.cs
@@ -38,7 +38,7 @@ namespace Cake.Core
         /// <param name="span">The span.</param>
         public void Add(string task, TimeSpan span)
         {
-            Add(task, CakeReportEntryCategory.Task, span, CakeTaskExecutionStatus.Executed);
+            Add(task, string.Empty, CakeReportEntryCategory.Task, span, CakeTaskExecutionStatus.Executed);
         }
 
         /// <summary>
@@ -49,16 +49,17 @@ namespace Cake.Core
         /// <param name="span">The span.</param>
         public void Add(string task, CakeReportEntryCategory category, TimeSpan span)
         {
-            Add(task, category, span, CakeTaskExecutionStatus.Executed);
+            Add(task, string.Empty, category, span, CakeTaskExecutionStatus.Executed);
         }
 
         /// <summary>
         /// Adds a skipped task result to the report.
         /// </summary>
         /// <param name="task">The task.</param>
-        public void AddSkipped(string task)
+        /// <param name="skippedMessage">The message explaining why the task was skipped.</param>
+        public void AddSkipped(string task, string skippedMessage)
         {
-            Add(task, CakeReportEntryCategory.Task, TimeSpan.Zero, CakeTaskExecutionStatus.Skipped);
+            Add(task, skippedMessage, CakeReportEntryCategory.Task, TimeSpan.Zero, CakeTaskExecutionStatus.Skipped);
         }
 
         /// <summary>
@@ -68,7 +69,7 @@ namespace Cake.Core
         /// <param name="span">The span.</param>
         public void AddFailed(string task, TimeSpan span)
         {
-            Add(task, CakeReportEntryCategory.Task, span, CakeTaskExecutionStatus.Failed);
+            Add(task, string.Empty, CakeReportEntryCategory.Task, span, CakeTaskExecutionStatus.Failed);
         }
 
         /// <summary>
@@ -78,19 +79,20 @@ namespace Cake.Core
         /// <param name="span">The span.</param>
         public void AddDelegated(string task, TimeSpan span)
         {
-            Add(task, CakeReportEntryCategory.Task, span, CakeTaskExecutionStatus.Delegated);
+            Add(task, string.Empty, CakeReportEntryCategory.Task, span, CakeTaskExecutionStatus.Delegated);
         }
 
         /// <summary>
         /// Adds a task result to the report.
         /// </summary>
         /// <param name="task">The task.</param>
+        /// <param name="skippedMessage">The message explaining why the task was skipped.</param>
         /// <param name="category">The category.</param>
         /// <param name="span">The span.</param>
         /// <param name="executionStatus">The execution status.</param>
-        public void Add(string task, CakeReportEntryCategory category, TimeSpan span, CakeTaskExecutionStatus executionStatus)
+        public void Add(string task, string skippedMessage, CakeReportEntryCategory category, TimeSpan span, CakeTaskExecutionStatus executionStatus)
         {
-            _report.Add(new CakeReportEntry(task, category, span, executionStatus));
+            _report.Add(new CakeReportEntry(task, skippedMessage, category, span, executionStatus));
         }
 
         /// <summary>

--- a/src/Cake.Core/CakeReportEntry.cs
+++ b/src/Cake.Core/CakeReportEntry.cs
@@ -18,6 +18,11 @@ namespace Cake.Core
         public string TaskName { get; }
 
         /// <summary>
+        /// Gets the message explaining why task was skipped.
+        /// </summary>
+        public string SkippedMessage { get; }
+
+        /// <summary>
         /// Gets the task category.
         /// </summary>
         /// <value>The category.</value>
@@ -39,10 +44,11 @@ namespace Cake.Core
         /// Initializes a new instance of the <see cref="CakeReportEntry"/> class.
         /// </summary>
         /// <param name="taskName">The name of the task.</param>
+        /// <param name="skippedMessage">The message explaining why the task was skipped.</param>
         /// <param name="category">The task category.</param>
         /// <param name="duration">The duration.</param>
-        public CakeReportEntry(string taskName, CakeReportEntryCategory category, TimeSpan duration)
-            : this(taskName, category, duration, CakeTaskExecutionStatus.Executed)
+        public CakeReportEntry(string taskName, string skippedMessage, CakeReportEntryCategory category, TimeSpan duration)
+            : this(taskName, skippedMessage, category, duration, CakeTaskExecutionStatus.Executed)
         {
         }
 
@@ -50,12 +56,14 @@ namespace Cake.Core
         /// Initializes a new instance of the <see cref="CakeReportEntry"/> class.
         /// </summary>
         /// <param name="taskName">The name of the task.</param>
+        /// <param name="skippedMessage">The message explaining why the task was skipped.</param>
         /// <param name="category">The task category.</param>
         /// <param name="duration">The duration.</param>
         /// <param name="executionStatus">The execution status.</param>
-        public CakeReportEntry(string taskName, CakeReportEntryCategory category, TimeSpan duration, CakeTaskExecutionStatus executionStatus)
+        public CakeReportEntry(string taskName, string skippedMessage, CakeReportEntryCategory category, TimeSpan duration, CakeTaskExecutionStatus executionStatus)
         {
             TaskName = taskName;
+            SkippedMessage = skippedMessage;
             Category = category;
             Duration = duration;
             ExecutionStatus = executionStatus;

--- a/src/Cake.Core/CakeReportPrinter.cs
+++ b/src/Cake.Core/CakeReportPrinter.cs
@@ -78,6 +78,48 @@ namespace Cake.Core
             }
         }
 
+        /// <inheritdoc/>
+        public void WriteStep(string name, Verbosity verbosity)
+        {
+            if (verbosity < Verbosity.Normal)
+            {
+                return;
+            }
+
+            _console.WriteLine();
+            _console.WriteLine("========================================");
+            _console.WriteLine(name);
+            _console.WriteLine("========================================");
+        }
+
+        /// <inheritdoc/>
+        public void WriteLifeCycleStep(string name, Verbosity verbosity)
+        {
+            if (verbosity < Verbosity.Normal)
+            {
+                return;
+            }
+
+            _console.WriteLine();
+            _console.WriteLine("----------------------------------------");
+            _console.WriteLine(name);
+            _console.WriteLine("----------------------------------------");
+        }
+
+        /// <inheritdoc/>
+        public void WriteSkippedStep(string name, Verbosity verbosity)
+        {
+            if (verbosity < Verbosity.Verbose)
+            {
+                return;
+            }
+
+            _console.WriteLine();
+            _console.WriteLine("----------------------------------------");
+            _console.WriteLine(name);
+            _console.WriteLine("----------------------------------------");
+        }
+
         private bool ShouldWriteTask(CakeReportEntry item)
         {
             if (item.ExecutionStatus == CakeTaskExecutionStatus.Delegated)
@@ -88,7 +130,7 @@ namespace Cake.Core
             return true;
         }
 
-        private static string FormatDuration(CakeReportEntry item)
+        private string FormatDuration(CakeReportEntry item)
         {
             if (item.ExecutionStatus == CakeTaskExecutionStatus.Skipped)
             {

--- a/src/Cake.Core/CakeTaskCriteria.cs
+++ b/src/Cake.Core/CakeTaskCriteria.cs
@@ -12,6 +12,11 @@ namespace Cake.Core
     public sealed class CakeTaskCriteria
     {
         /// <summary>
+        /// Gets or sets a value indicating whether this criteria caused the task to be skipped.
+        /// </summary>
+        public bool CausedSkippingOfTask { get; set; }
+
+        /// <summary>
         /// Gets the criteria predicate.
         /// </summary>
         /// <value>The criteria predicate.</value>

--- a/src/Cake.Core/DefaultExecutionStrategy.cs
+++ b/src/Cake.Core/DefaultExecutionStrategy.cs
@@ -14,14 +14,17 @@ namespace Cake.Core
     public sealed class DefaultExecutionStrategy : IExecutionStrategy
     {
         private readonly ICakeLog _log;
+        private readonly ICakeReportPrinter _reportPrinter;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultExecutionStrategy"/> class.
         /// </summary>
         /// <param name="log">The log.</param>
-        public DefaultExecutionStrategy(ICakeLog log)
+        /// <param name="reportPrinter">The report printer.</param>
+        public DefaultExecutionStrategy(ICakeLog log, ICakeReportPrinter reportPrinter)
         {
             _log = log;
+            _reportPrinter = reportPrinter;
         }
 
         /// <inheritdoc/>
@@ -29,10 +32,8 @@ namespace Cake.Core
         {
             if (action != null)
             {
-                _log.Information(string.Empty);
-                _log.Information("----------------------------------------");
-                _log.Information("Setup");
-                _log.Information("----------------------------------------");
+                _reportPrinter.WriteLifeCycleStep("Setup", _log.Verbosity);
+
                 _log.Verbose("Executing custom setup action...");
 
                 action(context);
@@ -48,10 +49,8 @@ namespace Cake.Core
             }
             if (action != null)
             {
-                _log.Information(string.Empty);
-                _log.Information("----------------------------------------");
-                _log.Information("Teardown");
-                _log.Information("----------------------------------------");
+                _reportPrinter.WriteLifeCycleStep("TearDown", _log.Verbosity);
+
                 _log.Verbose("Executing custom teardown action...");
 
                 action(teardownContext);
@@ -63,10 +62,8 @@ namespace Cake.Core
         {
             if (task != null)
             {
-                _log.Information(string.Empty);
-                _log.Information("========================================");
-                _log.Information(task.Name);
-                _log.Information("========================================");
+                _reportPrinter.WriteStep(task.Name, _log.Verbosity);
+
                 _log.Verbose("Executing task: {0}", task.Name);
 
                 await task.Execute(context).ConfigureAwait(false);
@@ -80,10 +77,7 @@ namespace Cake.Core
         {
             if (task != null)
             {
-                _log.Verbose(string.Empty);
-                _log.Verbose("========================================");
-                _log.Verbose(task.Name);
-                _log.Verbose("========================================");
+                _reportPrinter.WriteSkippedStep(task.Name, _log.Verbosity);
 
                 var message = string.IsNullOrWhiteSpace(criteria.Message)
                     ? task.Name : criteria.Message;

--- a/src/Cake.Core/ICakeReportPrinter.cs
+++ b/src/Cake.Core/ICakeReportPrinter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Core.Diagnostics;
+
 namespace Cake.Core
 {
     /// <summary>
@@ -14,5 +16,26 @@ namespace Cake.Core
         /// </summary>
         /// <param name="report">The report to write.</param>
         void Write(CakeReport report);
+
+        /// <summary>
+        /// Writes the specified lifecyle steps (i.e. Setup/TearDown) to a target.
+        /// </summary>
+        /// <param name="name">The name of the lifecycyle step.</param>
+        /// <param name="verbosity">The <see cref="Verbosity"/> at which the step should be written.</param>
+        void WriteLifeCycleStep(string name, Verbosity verbosity);
+
+        /// <summary>
+        /// Writes the specified step to a target.
+        /// </summary>
+        /// <param name="name">The name of the step.</param>
+        /// <param name="verbosity">The <see cref="Verbosity"/> at which the step should be written.</param>
+        void WriteStep(string name, Verbosity verbosity);
+
+        /// <summary>
+        /// Writes the skipped step to a target.
+        /// </summary>
+        /// <param name="name">The name of the step.</param>
+        /// <param name="verbosity">The <see cref="Verbosity"/> at which the step should be written.</param>
+        void WriteSkippedStep(string name, Verbosity verbosity);
     }
 }

--- a/src/Cake.DotNetTool.Module.Tests/DotNetToolPackageInstallerFixture.cs
+++ b/src/Cake.DotNetTool.Module.Tests/DotNetToolPackageInstallerFixture.cs
@@ -10,7 +10,7 @@ using NSubstitute;
 namespace Cake.DotNetTool.Module.Tests
 {
     /// <summary>
-    /// Fixture used for testing DotNetToolPackageInstaller
+    /// Fixture used for testing DotNetToolPackageInstaller.
     /// </summary>
     internal sealed class DotNetToolPackageInstallerFixture
     {

--- a/src/Cake.DotNetTool.Module.Tests/DotNetToolPackageInstallerTests.cs
+++ b/src/Cake.DotNetTool.Module.Tests/DotNetToolPackageInstallerTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 namespace Cake.DotNetTool.Module.Tests
 {
     /// <summary>
-    /// DotNetToolPackageInstaller unit tests
+    /// DotNetToolPackageInstaller unit tests.
     /// </summary>
     public sealed class DotNetToolPackageInstallerTests
     {

--- a/src/Cake/Infrastructure/Constants.cs
+++ b/src/Cake/Infrastructure/Constants.cs
@@ -9,6 +9,7 @@ namespace Cake.Infrastructure
         public static class Settings
         {
             public const string EnableScriptCache = "Settings_EnableScriptCache";
+            public const string UseSpectreConsoleForConsoleOutput = "Settings_UseSpectreConsoleForConsoleOutput";
         }
 
         public static class Paths

--- a/src/Cake/Infrastructure/ContainerConfigurator.cs
+++ b/src/Cake/Infrastructure/ContainerConfigurator.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Cake.Cli;
 using Cake.Common.Modules;
 using Cake.Core;
@@ -13,6 +14,7 @@ using Cake.Core.Scripting;
 using Cake.DotNetTool.Module;
 using Cake.Infrastructure.Scripting;
 using Cake.NuGet;
+using Spectre.Console;
 using Spectre.Console.Cli;
 
 namespace Cake.Infrastructure
@@ -47,6 +49,17 @@ namespace Cake.Infrastructure
 
             // Misc registrations.
             registrar.RegisterType<CakeReportPrinter>().As<ICakeReportPrinter>().Singleton();
+
+            registrar.RegisterInstance(AnsiConsole.Console).As<IAnsiConsole>().Singleton();
+
+            var useSpectreConsoleForConsoleOutputString = configuration.GetValue(Constants.Settings.UseSpectreConsoleForConsoleOutput);
+            var useSpectreConsoleForConsoleOutput = useSpectreConsoleForConsoleOutputString != null && useSpectreConsoleForConsoleOutputString.Equals("true", StringComparison.OrdinalIgnoreCase);
+
+            if (useSpectreConsoleForConsoleOutput)
+            {
+                registrar.RegisterType<CakeSpectreReportPrinter>().As<ICakeReportPrinter>().Singleton();
+            }
+
             registrar.RegisterType<CakeConsole>().As<IConsole>().Singleton();
             registrar.RegisterInstance(configuration).As<ICakeConfiguration>().Singleton();
         }


### PR DESCRIPTION
Via a new setting, --Settings_UseSpectreConsoleForConsoleOutput, it is
now possible to output the task headers, and task summary using
Spectre.Console.  This allows for the easy addition of a new column in
the task summary, which includes information about _why_ any given task
has been skipped.

The old CakeReportPrinter is still in play, but some implementation has
been moved from within the DefaultExecutionStrategy to the reporter
class.  Depending on the setting mentioned above, either the
Spectre.Console version of the reporter will be added to the IoC
container, or the old version will be in place.

Fixes #4055 
