### PR TITLE
Ability to force clean readonly files

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/IO/FileSystemFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/IO/FileSystemFixture.cs
@@ -47,6 +47,7 @@ namespace Cake.Common.Tests.Fixtures.IO
             fileSystem.CreateFile("/Temp/HasFiles/A.txt");
             fileSystem.CreateFile("/HasReadonly/Readonly.txt", FileAttributes.ReadOnly);
             fileSystem.CreateFile("/HasReadonly/Not-Readonly.txt");
+            fileSystem.CreateFile("/HasReadonly/Hidden.txt").Hide();
             return fileSystem;
         }
     }

--- a/src/Cake.Common/IO/CleanDirectorySettings.cs
+++ b/src/Cake.Common/IO/CleanDirectorySettings.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.IO
+{
+    /// <summary>
+    /// Contains settings used by <c>CleanDirectory</c>.
+    /// </summary>
+    public class CleanDirectorySettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to clean read-only files if set to <c>true</c>.
+        /// <remarks>
+        /// It is set to <c>false</c> by default.
+        /// </remarks>
+        /// </summary>
+        public bool Force { get; set; }
+    }
+}

--- a/src/Cake.Common/IO/DirectoryAliases.cs
+++ b/src/Cake.Common/IO/DirectoryAliases.cs
@@ -169,6 +169,31 @@ namespace Cake.Common.IO
         /// </summary>
         /// <example>
         /// <code>
+        /// CleanDirectories("./src/**/bin/debug", new CleanDirectorySettings() { Force = true });
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="pattern">The pattern to match.</param>
+        /// <param name="settings">The clean settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Clean")]
+        public static void CleanDirectories(this ICakeContext context, GlobPattern pattern, CleanDirectorySettings settings)
+        {
+            var directories = context.GetDirectories(pattern);
+            if (directories.Count == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any directories.");
+                return;
+            }
+            CleanDirectories(context, directories, settings);
+        }
+
+        /// <summary>
+        /// Cleans the directories matching the specified pattern.
+        /// Cleaning the directory will remove all its content but not the directory itself.
+        /// </summary>
+        /// <example>
+        /// <code>
         /// Func&lt;IFileSystemInfo, bool&gt; exclude_node_modules =
         /// fileSystemInfo=>!fileSystemInfo.Path.FullPath.EndsWith(
         ///                 "node_modules",
@@ -190,6 +215,36 @@ namespace Cake.Common.IO
                 return;
             }
             CleanDirectories(context, directories);
+        }
+
+        /// <summary>
+        /// Cleans the directories matching the specified pattern.
+        /// Cleaning the directory will remove all its content but not the directory itself.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// Func&lt;IFileSystemInfo, bool&gt; exclude_node_modules =
+        /// fileSystemInfo=>!fileSystemInfo.Path.FullPath.EndsWith(
+        ///                 "node_modules",
+        ///                 StringComparison.OrdinalIgnoreCase);
+        /// CleanDirectories("./src/**/bin/debug", exclude_node_modules, new CleanDirectorySettings() { Force = true });
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="pattern">The pattern to match.</param>
+        /// <param name="predicate">The predicate used to filter directories based on file system information.</param>
+        /// <param name="settings">The clean settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Clean")]
+        public static void CleanDirectories(this ICakeContext context, GlobPattern pattern, Func<IFileSystemInfo, bool> predicate, CleanDirectorySettings settings)
+        {
+            var directories = context.GetDirectories(pattern, new GlobberSettings { Predicate = predicate });
+            if (directories.Count == 0)
+            {
+                context.Log.Verbose("The provided pattern did not match any directories.");
+                return;
+            }
+            CleanDirectories(context, directories, settings);
         }
 
         /// <summary>
@@ -224,6 +279,33 @@ namespace Cake.Common.IO
         /// </summary>
         /// <example>
         /// <code>
+        /// var directoriesToClean = GetDirectories("./src/**/bin/");
+        /// CleanDirectories(directoriesToClean, new CleanDirectorySettings() { Force = true });
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="directories">The directory paths.</param>
+        /// <param name="settings">The clean settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Clean")]
+        public static void CleanDirectories(this ICakeContext context, IEnumerable<DirectoryPath> directories, CleanDirectorySettings settings)
+        {
+            if (directories == null)
+            {
+                throw new ArgumentNullException(nameof(directories));
+            }
+            foreach (var directory in directories)
+            {
+                CleanDirectory(context, directory, settings);
+            }
+        }
+
+        /// <summary>
+        /// Cleans the specified directories.
+        /// Cleaning a directory will remove all its content but not the directory itself.
+        /// </summary>
+        /// <example>
+        /// <code>
         /// var directoriesToClean = new []{
         ///     "./src/Cake/obj",
         ///     "./src/Cake.Common/obj"
@@ -249,6 +331,37 @@ namespace Cake.Common.IO
         }
 
         /// <summary>
+        /// Cleans the specified directories.
+        /// Cleaning a directory will remove all its content but not the directory itself.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var directoriesToClean = new []{
+        ///     "./src/Cake/obj",
+        ///     "./src/Cake.Common/obj"
+        /// };
+        /// CleanDirectories(directoriesToClean, new CleanDirectorySettings() { Force = true });
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="directories">The directory paths.</param>
+        /// <param name="settings">The clean settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Clean")]
+        public static void CleanDirectories(this ICakeContext context, IEnumerable<string> directories, CleanDirectorySettings settings)
+        {
+            if (directories == null)
+            {
+                throw new ArgumentNullException(nameof(directories));
+            }
+            var paths = directories.Select(p => new DirectoryPath(p));
+            foreach (var directory in paths)
+            {
+                CleanDirectory(context, directory, settings);
+            }
+        }
+
+        /// <summary>
         /// Cleans the specified directory.
         /// </summary>
         /// <example>
@@ -270,6 +383,26 @@ namespace Cake.Common.IO
         /// </summary>
         /// <example>
         /// <code>
+        /// CleanDirectory("./src/Cake.Common/obj", new CleanDirectorySettings {
+        ///     Force = true
+        /// });
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="path">The directory path.</param>
+        /// <param name="settings">The clean settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Clean")]
+        public static void CleanDirectory(this ICakeContext context, DirectoryPath path, CleanDirectorySettings settings)
+        {
+            DirectoryCleaner.Clean(context, path, settings);
+        }
+
+        /// <summary>
+        /// Cleans the specified directory.
+        /// </summary>
+        /// <example>
+        /// <code>
         /// CleanDirectory("./src/Cake.Common/obj", fileSystemInfo=>!fileSystemInfo.Hidden);
         /// </code>
         /// </example>
@@ -281,6 +414,27 @@ namespace Cake.Common.IO
         public static void CleanDirectory(this ICakeContext context, DirectoryPath path, Func<IFileSystemInfo, bool> predicate)
         {
             DirectoryCleaner.Clean(context, path, predicate);
+        }
+
+        /// <summary>
+        /// Cleans the specified directory.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// CleanDirectory("./src/Cake.Common/obj", fileSystemInfo=>!fileSystemInfo.Hidden, new CleanDirectorySettings {
+        ///     Force = true
+        /// });
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="path">The directory path.</param>
+        /// <param name="predicate">Predicate used to determine which files/directories should get deleted.</param>
+        /// <param name="settings">The clean settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Clean")]
+        public static void CleanDirectory(this ICakeContext context, DirectoryPath path, Func<IFileSystemInfo, bool> predicate, CleanDirectorySettings settings)
+        {
+            DirectoryCleaner.Clean(context, path, predicate, settings);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR successfully addresses #1317, 'CleanDirectory does not clean readonly files.'

I have familarised myself with #1574 when making this change (as @bjorkstromm mentioned) and in a similar manner, introduced a `CleanDirectorySettings` class which has a `Force` flag that defaults to false, but when enabled, will ensure the `DirectoryCleaner` will force clean readonly files.

I avoided making this a breaking change by creating overloads of the `DirectoryCleaner` methods that take an additional `CleanDirectorySettings` parameter, and did the same for the various `DirectoryAliases` methods. 

If it was, however, decided that every clean method should take a settings parameter, we can keep the overloaded methods and simply remove the initial methods that didn't accept `CleanDirectorySettings`.