### PR TITLE
GH-4107: Add OS to DotNetPublishSettings

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Publish/DotNetPublisherTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Publish/DotNetPublisherTests.cs
@@ -289,6 +289,20 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Publish
                 // Then
                 Assert.Equal("publish -p:EnableCompressionInSingleFile=true", result.Args);
             }
+
+            [Fact]
+            public void Should_Add_Os()
+            {
+                // Given
+                var fixture = new DotNetPublisherFixture();
+                fixture.Settings.OS = "linux";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("publish --os linux", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Publish/DotNetPublishSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Publish/DotNetPublishSettings.cs
@@ -171,6 +171,16 @@ namespace Cake.Common.Tools.DotNet.Publish
         public ICollection<string> Sources { get; set; } = new List<string>();
 
         /// <summary>
+        /// Gets or sets the target operating system (OS).
+        /// This is a shorthand syntax for setting the Runtime Identifier (RID), where the provided value is combined with the default RID.
+        /// If you use this option, don't use the -r|--runtime option.
+        /// </summary>
+        /// <remarks>
+        /// Requires .NET 6 or newer.
+        /// </remarks>
+        public string OS { get; set; }
+
+        /// <summary>
         /// Gets or sets additional arguments to be passed to MSBuild.
         /// </summary>
         public DotNetMSBuildSettings MSBuildSettings { get; set; }

--- a/src/Cake.Common/Tools/DotNet/Publish/DotNetPublisher.cs
+++ b/src/Cake.Common/Tools/DotNet/Publish/DotNetPublisher.cs
@@ -266,6 +266,13 @@ namespace Cake.Common.Tools.DotNet.Publish
                 }
             }
 
+            // Os
+            if (!string.IsNullOrEmpty(settings.OS))
+            {
+                builder.Append("--os");
+                builder.Append(settings.OS);
+            }
+
             if (settings.MSBuildSettings != null)
             {
                 builder.AppendMSBuildSettings(settings.MSBuildSettings, _environment);


### PR DESCRIPTION
Add `--os <OS>` to [dotnet-publish](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-publish)

Fixes #4107

Please review.
Thank you in advance