### PR TITLE
Upgrade Spectre.Console to v0.46.0

### DIFF
--- a/src/Cake.Cli/Cake.Cli.csproj
+++ b/src/Cake.Cli/Cake.Cli.csproj
@@ -19,7 +19,7 @@
 
     <ItemGroup>
       <PackageReference Include="Autofac" Version="6.5.0" />
-      <PackageReference Include="Spectre.Console" Version="0.45.0" />
-      <PackageReference Include="Spectre.Console.Cli" Version="0.45.0" />
+      <PackageReference Include="Spectre.Console" Version="0.46.0" />
+      <PackageReference Include="Spectre.Console.Cli" Version="0.46.0" />
   </ItemGroup>
 </Project>

--- a/src/Cake.Frosting/CakeHost.cs
+++ b/src/Cake.Frosting/CakeHost.cs
@@ -90,7 +90,7 @@ namespace Cake.Frosting
                 config.ValidateExamples();
 
                 // Top level examples.
-                config.AddExample(new[] { string.Empty });
+                config.AddExample(Array.Empty<string>());
                 config.AddExample(new[] { "--verbosity", "quiet" });
                 config.AddExample(new[] { "--tree" });
             });

--- a/src/Cake/Program.cs
+++ b/src/Cake/Program.cs
@@ -58,7 +58,7 @@ namespace Cake
                 }
 
                 // Top level examples.
-                config.AddExample(new[] { string.Empty });
+                config.AddExample(Array.Empty<string>());
                 config.AddExample(new[] { "build.cake", "--verbosity", "quiet" });
                 config.AddExample(new[] { "build.cake", "--tree" });
             });

--- a/tests/integration/Cake.Core/Scripting/SpectreConsole.cake
+++ b/tests/integration/Cake.Core/Scripting/SpectreConsole.cake
@@ -5,7 +5,7 @@ Task("Cake.Core.Scripting.Spectre.Console.FigletText")
 {
     AnsiConsole.Render(
         new FigletText("Cake")
-            .LeftAligned()
+            .LeftJustified()
             .Color(Color.Red));
 });
 


### PR DESCRIPTION

This PR upgrades spectre.console from 0.45.0 to 0.46.0 (latest) by upgrading the NuGet package reference, and the subsequent minor build issue introduced (see: https://github.com/cake-build/cake/issues/4138) has been fixed by a trivial code change.

**Background:** my interest in upgrading to the latest spectre.console is in anticipation of being able to fix this cake issue, https://github.com/cake-build/cake/issues/3279. The necessary change to spectre.console has been made and committed ([714cf179cb349597a8b775287ac8299584b18617](https://github.com/spectreconsole/spectre.console/commit/714cf179cb349597a8b775287ac8299584b18617)), although it does not reside in the 0.46.0 release and is scheduled for 0.47.0. Either way, I wanted to upgrade the version of spectre.console used by cake to the latest and address any issues that may arise, to ease the future upgrade to 0.47.0 

nb. spectre.console release notes for 0.46.0 are here: https://github.com/spectreconsole/spectre.console/releases/tag/0.46.0

The biggest visible improvement arising from using spectre.console 0.46.0 for cake users is showing the default value of any arguments, see:

![image](https://user-images.githubusercontent.com/52075808/230081206-3e10a891-cc3b-4f9f-a05e-ae5139f530a4.png)
