### PR TITLE
GH-3279: Cake runner arguments as build script arguments

### DIFF
--- a/src/Cake.Cli/Cake.Cli.csproj
+++ b/src/Cake.Cli/Cake.Cli.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Cake.Cli</AssemblyName>
     <OutputType>Library</OutputType>

--- a/src/Cake.Frosting.Tests/CakeHostTests.cs
+++ b/src/Cake.Frosting.Tests/CakeHostTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Cake.Frosting.Tests/CakeHostTests.cs
+++ b/src/Cake.Frosting.Tests/CakeHostTests.cs
@@ -381,7 +381,7 @@ namespace Cake.Frosting.Tests
             fixture.Run("--version");
 
             // Then
-            Assert.Collection(fixture.Console.Messages, s => string.Compare(s, "FakeVersion"));
+            Assert.Collection(fixture.Console.Messages, s => s.Equals("FakeVersion"));
         }
 
         [Fact]
@@ -393,12 +393,12 @@ namespace Cake.Frosting.Tests
             fixture.Strategy = Substitute.For<IExecutionStrategy>();
 
             // When
-            fixture.Run("--version", "1.2.3");
+            fixture.Run("--target", "dummytask", "--version=1.2.3");
 
             // Then
             fixture.Strategy.Received(1).ExecuteAsync(
                 Arg.Any<CakeTask>(),
-                Arg.Is<ICakeContext>(cc => cc.Arguments.HasArgument("version") && cc.Arguments.GetArgument("version").Equals("1.2.3")));
+                Arg.Is<ICakeContext>(cc => cc.Arguments.HasArgument("version") && cc.Arguments.GetArgument("version") == "1.2.3"));
         }
     }
 }

--- a/src/Cake.Frosting.Tests/CakeHostTests.cs
+++ b/src/Cake.Frosting.Tests/CakeHostTests.cs
@@ -384,7 +384,7 @@ namespace Cake.Frosting.Tests
             Assert.Collection(fixture.Console.Messages, s => s.Equals("FakeVersion"));
         }
 
-        [Fact(Skip = "Excluded to see if the performance implication of this test is causing the integration tests to break on push to PR")]
+        [Fact]
         public void Should_Pass_Cake_Runner_Argument_And_Value_To_Build_Script()
         {
             // Given

--- a/src/Cake.Frosting.Tests/CakeHostTests.cs
+++ b/src/Cake.Frosting.Tests/CakeHostTests.cs
@@ -384,7 +384,7 @@ namespace Cake.Frosting.Tests
             Assert.Collection(fixture.Console.Messages, s => s.Equals("FakeVersion"));
         }
 
-        [Fact]
+        [Fact(Skip = "Excluded to see if the performance implication of this test is causing the integration tests to break on push to PR")]
         public void Should_Pass_Cake_Runner_Argument_And_Value_To_Build_Script()
         {
             // Given

--- a/src/Cake.Frosting.Tests/CakeHostTests.cs
+++ b/src/Cake.Frosting.Tests/CakeHostTests.cs
@@ -316,7 +316,7 @@ namespace Cake.Frosting.Tests
         }
 
         [Fact]
-        public void Should_pass_target_within_cakeContext_arguments()
+        public void Should_Pass_Target_Within_CakeContext_Arguments()
         {
             // Given
             var fixture = new CakeHostFixture();
@@ -358,6 +358,23 @@ namespace Cake.Frosting.Tests
                 fixture.Strategy.ExecuteAsync(Arg.Is<CakeTask>(t => t.Name == task1), Arg.Any<ICakeContext>());
                 fixture.Strategy.ExecuteAsync(Arg.Is<CakeTask>(t => t.Name == task2), Arg.Any<ICakeContext>());
             });
+        }
+
+        [Fact]
+        public void Should_Pass_Cake_Runner_Argument_And_Value_To_Build_Script()
+        {
+            // Given
+            var fixture = new CakeHostFixture();
+            fixture.RegisterTask<DummyTask>();
+            fixture.Strategy = Substitute.For<IExecutionStrategy>();
+
+            // When
+            fixture.Run("--version", "1.2.3");
+
+            // Then
+            fixture.Strategy.Received(1).ExecuteAsync(
+                Arg.Any<CakeTask>(), 
+                Arg.Is<ICakeContext>(cc => cc.Arguments.HasArgument("version") && cc.Arguments.GetArgument("version").Equals("1.2.3")));
         }
     }
 }

--- a/src/Cake.Frosting.Tests/Fakes/FakeVersionResolver.cs
+++ b/src/Cake.Frosting.Tests/Fakes/FakeVersionResolver.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Cli;
+
+namespace Cake.Frosting.Tests.Fakes
+{
+    internal sealed class FakeVersionResolver : IVersionResolver
+    {
+        public FakeVersionResolver()
+        {
+        }
+
+        public string GetVersion()
+        {
+            return "FakeVersion";
+        }
+
+        public string GetProductVersion()
+        {
+            return "ProductVersion";
+        }
+    }
+}

--- a/src/Cake.Frosting/CakeHost.cs
+++ b/src/Cake.Frosting/CakeHost.cs
@@ -93,6 +93,11 @@ namespace Cake.Frosting
                 config.AddExample(Array.Empty<string>());
                 config.AddExample(new[] { "--verbosity", "quiet" });
                 config.AddExample(new[] { "--tree" });
+
+                // Allow the Cake runner arguments, when found on the command line with a value,
+                // to be passed directly to the Cake build script as an argument
+                // eg. "--version=1.2.3" is accessable in the build script by calling Argument("version")
+                config.Settings.ConvertFlagsToRemainingArguments = true;
             });
 
             return app.Run(args);

--- a/src/Cake.Frosting/CakeHost.cs
+++ b/src/Cake.Frosting/CakeHost.cs
@@ -94,7 +94,7 @@ namespace Cake.Frosting
                 config.AddExample(new[] { "--verbosity", "quiet" });
                 config.AddExample(new[] { "--tree" });
 
-                // Allow the Cake runner arguments, when found on the command line with a value
+                // Allow the Cake runner arguments, when found on the command line with a value,
                 // to be passed directly to the Cake build script as an argument
                 // eg. "--version=1.2.3" is accessable in the build script by calling Argument("version")
                 config.Settings.ConvertFlagsToRemainingArguments = true;

--- a/src/Cake.Frosting/CakeHost.cs
+++ b/src/Cake.Frosting/CakeHost.cs
@@ -94,7 +94,7 @@ namespace Cake.Frosting
                 config.AddExample(new[] { "--verbosity", "quiet" });
                 config.AddExample(new[] { "--tree" });
 
-                // Allow the Cake runner arguments, when found on the command line with a value,
+                // Allow the Cake runner arguments, when found on the command line with a value
                 // to be passed directly to the Cake build script as an argument
                 // eg. "--version=1.2.3" is accessable in the build script by calling Argument("version")
                 config.Settings.ConvertFlagsToRemainingArguments = true;

--- a/src/Cake.Tests/Unit/ProgramTests.cs
+++ b/src/Cake.Tests/Unit/ProgramTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Autofac;
 using Cake.Cli;
 using Cake.Core;
@@ -129,6 +130,23 @@ namespace Cake.Tests.Unit
 
             // Then
             feature.Received(1).Run(fixture.Console);
+        }
+
+        [Fact]
+        public async void Should_Pass_Cake_Runner_Argument_And_Value_To_Build_Script()
+        {
+            // Given
+            var fixture = new ProgramFixture();
+            var feature = Substitute.For<IBuildFeature>();
+            fixture.Overrides.Add(builder => builder.RegisterInstance(feature));
+
+            // When
+            var result = await fixture.Run("--version", "1.2.3");
+
+            // Then
+            feature.Received(1).Run(
+                Arg.Is<IRemainingArguments>(arguments => arguments.Parsed.Contains("version") && arguments.Parsed["version"].Contains("1.2.3")),
+                Arg.Is<BuildFeatureSettings>(settings => settings.BuildHostKind == BuildHostKind.Build));
         }
     }
 }

--- a/src/Cake.Tests/Unit/ProgramTests.cs
+++ b/src/Cake.Tests/Unit/ProgramTests.cs
@@ -145,7 +145,7 @@ namespace Cake.Tests.Unit
 
             // Then
             feature.Received(1).Run(
-                Arg.Is<IRemainingArguments>(arguments => arguments.Parsed.Contains("version") && arguments.Parsed["version"].Contains("1.2.3")),
+                Arg.Is<ICakeArguments>(arguments => arguments.HasArgument("version") && arguments.GetArguments("version").Contains("1.2.3")),
                 Arg.Is<BuildFeatureSettings>(settings => settings.BuildHostKind == BuildHostKind.Build));
         }
     }

--- a/src/Cake.Tests/Unit/ProgramTests.cs
+++ b/src/Cake.Tests/Unit/ProgramTests.cs
@@ -132,7 +132,7 @@ namespace Cake.Tests.Unit
             feature.Received(1).Run(fixture.Console);
         }
 
-        [Fact(Skip = "Excluded to see if the performance implication of this test is causing the integration tests to break on push to PR")]
+        [Fact]
         public async void Should_Pass_Cake_Runner_Argument_And_Value_To_Build_Script()
         {
             // Given

--- a/src/Cake.Tests/Unit/ProgramTests.cs
+++ b/src/Cake.Tests/Unit/ProgramTests.cs
@@ -132,7 +132,7 @@ namespace Cake.Tests.Unit
             feature.Received(1).Run(fixture.Console);
         }
 
-        [Fact]
+        [Fact(Skip = "Excluded to see if the performance implication of this test is causing the integration tests to break on push to PR")]
         public async void Should_Pass_Cake_Runner_Argument_And_Value_To_Build_Script()
         {
             // Given

--- a/src/Cake.Tests/Unit/ProgramTests.cs
+++ b/src/Cake.Tests/Unit/ProgramTests.cs
@@ -141,7 +141,7 @@ namespace Cake.Tests.Unit
             fixture.Overrides.Add(builder => builder.RegisterInstance(feature));
 
             // When
-            var result = await fixture.Run("--version", "1.2.3");
+            var result = await fixture.Run("--version=1.2.3");
 
             // Then
             feature.Received(1).Run(

--- a/src/Cake/Program.cs
+++ b/src/Cake/Program.cs
@@ -61,6 +61,11 @@ namespace Cake
                 config.AddExample(Array.Empty<string>());
                 config.AddExample(new[] { "build.cake", "--verbosity", "quiet" });
                 config.AddExample(new[] { "build.cake", "--tree" });
+
+                // Allow the Cake runner arguments, when found on the command line with a value,
+                // to be passed directly to the Cake build script as an argument
+                // eg. "--version=1.2.3" is accessable in the build script by calling Argument("version")
+                config.Settings.ConvertFlagsToRemainingArguments = true;
             });
 
             return await app.RunAsync(args);


### PR DESCRIPTION
This PR fully addresses, https://github.com/cake-build/cake/issues/3279 "Allow users to use any of the Cake runner arguments as build script arguments" (and indirectly https://github.com/cake-build/cake/issues/2794, which should be closed)

The feature has been implemented for both Cake and also Frosting, unit tests written for each to exercise this new functionality and protect against any regressions.

eg. `cake --version` will (continue to) run the built-in cake version feature, `cake--version=1.2.3` will run the build feature and make the argument and value accessible to the cake build script. 

This PR enables the passing of _any_ of the built-in cake runner arguments, when found on the command line with an accompanying value, to the cake build script being executed.

** ***This PR will remain broken*** ** until spectre.console version 0.47.0 or above has been integrated, as it relies on a new configuration option that has been added to the spectre.console library particularly for this PR.

I will update the cake spectre.console package reference and push the change to this PR (fixing the build), once 0.47.0 is available on NuGet. FYI @patriksvensson 

