### PR TITLE
Add Azure Pipelines group logging commands

### DIFF
--- a/src/Cake.Common.Tests/Unit/Build/AzurePipelines/AzurePipelinesCommandTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/AzurePipelines/AzurePipelinesCommandTests.cs
@@ -128,6 +128,48 @@ namespace Cake.Common.Tests.Unit.Build.AzurePipelines
             }
 
             [Fact]
+            public void Should_Begin_Group_With_Name()
+            {
+                // Given
+                var fixture = new AzurePipelinesFixture();
+                var service = fixture.CreateAzurePipelinesService();
+
+                // When
+                service.Commands.BeginGroup("Example Group");
+
+                // Then
+                Assert.Contains(fixture.Writer.Entries, m => m == $"##[group]Example Group");
+            }
+
+            [Fact]
+            public void Should_End_Group()
+            {
+                // Given
+                var fixture = new AzurePipelinesFixture();
+                var service = fixture.CreateAzurePipelinesService();
+
+                // When
+                service.Commands.EndGroup();
+
+                // Then
+                Assert.Contains(fixture.Writer.Entries, m => m == $"##[endgroup]");
+            }
+
+            [Fact]
+            public void Should_Section_With_Name()
+            {
+                // Given
+                var fixture = new AzurePipelinesFixture();
+                var service = fixture.CreateAzurePipelinesService();
+
+                // When
+                service.Commands.Section("Example Section");
+
+                // Then
+                Assert.Contains(fixture.Writer.Entries, m => m == $"##[section]Example Section");
+            }
+
+            [Fact]
             public void Should_Set_Current_Progress()
             {
                 // Given
@@ -152,7 +194,7 @@ namespace Cake.Common.Tests.Unit.Build.AzurePipelines
                 service.Commands.CompleteCurrentTask();
 
                 // Then
-                Assert.Contains(fixture.Writer.Entries, m => m == $"##vso[task.complete ]DONE");
+                Assert.Contains(fixture.Writer.Entries, m => m == $"##vso[task.complete]DONE");
             }
 
             [Fact]
@@ -281,7 +323,7 @@ namespace Cake.Common.Tests.Unit.Build.AzurePipelines
                 service.Commands.UploadTaskSummary("./summary.md");
 
                 // Then
-                Assert.Contains(fixture.Writer.Entries, m => m == $"##vso[task.uploadsummary ]{path}");
+                Assert.Contains(fixture.Writer.Entries, m => m == $"##vso[task.uploadsummary]{path}");
             }
 
             [Fact]
@@ -296,7 +338,7 @@ namespace Cake.Common.Tests.Unit.Build.AzurePipelines
                 service.Commands.UploadTaskLogFile("./logs/task.log");
 
                 // Then
-                Assert.Contains(fixture.Writer.Entries, m => m == $"##vso[task.uploadfile ]{path}");
+                Assert.Contains(fixture.Writer.Entries, m => m == $"##vso[task.uploadfile]{path}");
             }
 
             [Theory]
@@ -432,7 +474,7 @@ namespace Cake.Common.Tests.Unit.Build.AzurePipelines
                 service.Commands.UploadBuildLogFile("./dist/buildlog.txt");
 
                 // Then
-                Assert.Contains(fixture.Writer.Entries, m => m == $"##vso[build.uploadlog ]{path}");
+                Assert.Contains(fixture.Writer.Entries, m => m == $"##vso[build.uploadlog]{path}");
             }
 
             [Fact]
@@ -446,7 +488,7 @@ namespace Cake.Common.Tests.Unit.Build.AzurePipelines
                 service.Commands.UpdateBuildNumber("CIBuild_1");
 
                 // Then
-                Assert.Contains(fixture.Writer.Entries, m => m == "##vso[build.updatebuildnumber ]CIBuild_1");
+                Assert.Contains(fixture.Writer.Entries, m => m == "##vso[build.updatebuildnumber]CIBuild_1");
             }
 
             [Fact]
@@ -460,7 +502,7 @@ namespace Cake.Common.Tests.Unit.Build.AzurePipelines
                 service.Commands.AddBuildTag("Stable");
 
                 // Then
-                Assert.Contains(fixture.Writer.Entries, m => m == "##vso[build.addbuildtag ]Stable");
+                Assert.Contains(fixture.Writer.Entries, m => m == "##vso[build.addbuildtag]Stable");
             }
 
             [Fact]

--- a/src/Cake.Common/Build/AzurePipelines/AzurePipelinesCommands.cs
+++ b/src/Cake.Common/Build/AzurePipelines/AzurePipelinesCommands.cs
@@ -18,6 +18,7 @@ namespace Cake.Common.Build.AzurePipelines
     /// </summary>
     public sealed class AzurePipelinesCommands : IAzurePipelinesCommands
     {
+        private const string FormatPrefix = "##[";
         private const string MessagePrefix = "##vso[";
         private const string MessagePostfix = "]";
 
@@ -67,6 +68,24 @@ namespace Cake.Common.Build.AzurePipelines
             var properties = data.GetProperties();
             properties.Add("type", "error");
             WriteLoggingCommand("task.logissue", properties, message);
+        }
+
+        /// <inheritdoc/>
+        public void BeginGroup(string name)
+        {
+            WriteFormatCommand("group", name);
+        }
+
+        /// <inheritdoc/>
+        public void EndGroup()
+        {
+            WriteFormatCommand("endgroup", string.Empty);
+        }
+
+        /// <inheritdoc/>
+        public void Section(string name)
+        {
+            WriteFormatCommand("section", name);
         }
 
         /// <inheritdoc/>
@@ -287,9 +306,14 @@ namespace Cake.Common.Build.AzurePipelines
             PublishCodeCoverage(summaryFilePath, data);
         }
 
+        private void WriteFormatCommand(string actionName, string value)
+        {
+            _writer.Write("{0}{1}{2}{3}", FormatPrefix, actionName, MessagePostfix, value);
+        }
+
         private void WriteLoggingCommand(string actionName, string value)
         {
-            WriteLoggingCommand(actionName, new Dictionary<string, string>(), value);
+            _writer.Write("{0}{1}{2}{3}", MessagePrefix, actionName, MessagePostfix, value);
         }
 
         private void WriteLoggingCommand(string actionName, Dictionary<string, string> properties, string value)

--- a/src/Cake.Common/Build/AzurePipelines/AzurePipelinesDisposableExtensions.cs
+++ b/src/Cake.Common/Build/AzurePipelines/AzurePipelinesDisposableExtensions.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Cake.Common.Build.AzurePipelines
+{
+    /// <summary>
+    /// A set of extensions for allowing "using" with Azure Pipelines "blocks".
+    /// </summary>
+    public static class AzurePipelinesDisposableExtensions
+    {
+        /// <summary>
+        /// Groups Azure Pipelines output.
+        /// </summary>
+        /// <param name="azurePipelinesCommands">The Azure Pipelines Commands.</param>
+        /// <param name="name">The name.</param>
+        /// <returns>An <see cref="IDisposable"/>.</returns>
+        public static IDisposable Group(this IAzurePipelinesCommands azurePipelinesCommands, string name)
+        {
+            ArgumentNullException.ThrowIfNull(name);
+
+            azurePipelinesCommands.BeginGroup(name);
+            return new AzurePipelinesActionDisposable<IAzurePipelinesCommands>(azurePipelinesCommands, apc => apc.EndGroup());
+        }
+
+        /// <summary>
+        /// Disposable helper for writing Azure Pipelines message blocks.
+        /// </summary>
+        internal sealed class AzurePipelinesActionDisposable<T> : IDisposable
+        {
+            private readonly Action<T> _disposeAction;
+            private readonly T _instance;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="AzurePipelinesActionDisposable{T}"/> class.
+            /// </summary>
+            /// <param name="instance">The instance.</param>
+            /// <param name="disposeAction">The dispose action.</param>
+            public AzurePipelinesActionDisposable(T instance, Action<T> disposeAction)
+            {
+                _instance = instance;
+                _disposeAction = disposeAction;
+            }
+
+            /// <summary>
+            /// Calls dispose action.
+            /// </summary>
+            public void Dispose()
+            {
+                _disposeAction(_instance);
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Build/AzurePipelines/IAzurePipelinesCommands.cs
+++ b/src/Cake.Common/Build/AzurePipelines/IAzurePipelinesCommands.cs
@@ -40,6 +40,23 @@ namespace Cake.Common.Build.AzurePipelines
         void WriteError(string message, AzurePipelinesMessageData data);
 
         /// <summary>
+        /// Begin a collapsible group.
+        /// </summary>
+        /// <param name="name">The name of the group.</param>
+        public void BeginGroup(string name);
+
+        /// <summary>
+        /// End a collapsible group.
+        /// </summary>
+        public void EndGroup();
+
+        /// <summary>
+        /// Log section.
+        /// </summary>
+        /// <param name="name">The name of the section.</param>
+        public void Section(string name);
+
+        /// <summary>
         /// Set progress and current operation for current task.
         /// </summary>
         /// <param name="progress">Current progress as percentage.</param>

--- a/src/Cake.Frosting.Template/templates/cakefrosting/build/Build.csproj
+++ b/src/Cake.Frosting.Template/templates/cakefrosting/build/Build.csproj
@@ -5,6 +5,6 @@
     <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Frosting" Version="3.0.0" />
+    <PackageReference Include="Cake.Frosting" Version="3.1.0.0" />
   </ItemGroup>
 </Project>

--- a/tests/integration/Cake.Common/Build/AzurePipelines/AzurePipelinesProvider.cake
+++ b/tests/integration/Cake.Common/Build/AzurePipelines/AzurePipelinesProvider.cake
@@ -1,0 +1,22 @@
+Task("Cake.Common.Build.AzurePipelinesProvider.Commands.Group")
+    .Does(() => {
+        using (AzurePipelines.Commands.Group("Cake Group"))
+        {
+            Console.WriteLine("This is inside a group");
+        }
+});
+
+Task("Cake.Common.Build.AzurePipelinesProvider.Commands.Section")
+    .Does(() => {
+        AzurePipelines.Commands.Section("Cake Section");
+});
+
+
+var azurePipelinesProviderTask = Task("Cake.Common.Build.AzurePipelinesProvider");
+
+if(AzurePipelines.IsRunningOnAzurePipelines)
+{
+    azurePipelinesProviderTask
+        .IsDependentOn("Cake.Common.Build.AzurePipelinesProvider.Commands.Group")
+        .IsDependentOn("Cake.Common.Build.AzurePipelinesProvider.Commands.Section");
+}

--- a/tests/integration/Cake.Common/Build/BuildSystemAliases.cake
+++ b/tests/integration/Cake.Common/Build/BuildSystemAliases.cake
@@ -1,4 +1,5 @@
 #load "GitHubActions/GitHubActionsProvider.cake"
+#load "AzurePipelines/AzurePipelinesProvider.cake"
 
 Task("Cake.Common.Build.BuildSystemAliases.BuildProvider")
     .DoesForEach(
@@ -10,4 +11,5 @@ Task("Cake.Common.Build.BuildSystemAliases.BuildProvider")
 
 Task("Cake.Common.Build.BuildSystemAliases")
     .IsDependentOn("Cake.Common.Build.BuildSystemAliases.BuildProvider")
-    .IsDependentOn("Cake.Common.Build.GitHubActionsProvider");
+    .IsDependentOn("Cake.Common.Build.GitHubActionsProvider")
+    .IsDependentOn("Cake.Common.Build.AzurePipelinesProvider");


### PR DESCRIPTION
Add Azure Logging Command to create collapsible groups. See: 

[MSDocs: Logging commands -> Formatting commands](https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#formatting-commands)

There were some changes in other logging commands as well. This is because they contain redundant whitespaces, which ADO does tolerate sometimes, but not always, as is the case for the `##[group]` command. It is better to avoid them if possible.