### PR TITLE
GH4170/4171: Update NuGet.* to v6.6.1 & .NET SDK to 7.0.305

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
         "src"
     ],
     "sdk": {
-        "version": "7.0.100",
+        "version": "7.0.305",
         "rollForward": "latestFeature"
     }
 }

--- a/src/Cake.NuGet/Cake.NuGet.csproj
+++ b/src/Cake.NuGet/Cake.NuGet.csproj
@@ -18,17 +18,17 @@
   </ItemGroup>
   <!-- Global packages -->
   <ItemGroup>
-    <PackageReference Include="NuGet.Frameworks" Version="6.4.0" />
-    <PackageReference Include="NuGet.Versioning" Version="6.4.0" />
-    <PackageReference Include="NuGet.Protocol" Version="6.4.0" />
-    <PackageReference Include="NuGet.Packaging" Version="6.4.0" />
-    <PackageReference Include="NuGet.Resolver" Version="6.4.0" />
-    <PackageReference Include="NuGet.Common" Version="6.4.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="NuGet.Frameworks" Version="6.6.1" />
+    <PackageReference Include="NuGet.Versioning" Version="6.6.1" />
+    <PackageReference Include="NuGet.Protocol" Version="6.6.1" />
+    <PackageReference Include="NuGet.Packaging" Version="6.6.1" />
+    <PackageReference Include="NuGet.Resolver" Version="6.6.1" />
+    <PackageReference Include="NuGet.Common" Version="6.6.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.0" GeneratePathProperty="true">
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.3" GeneratePathProperty="true">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <EmbeddedResource Include="$(PkgMicrosoft_NETCore_Platforms)\runtime.json">


### PR DESCRIPTION
Fixes #4170 and #4171 dependencies that need to be updated together for a successful build.
Replaces #4166 & #4167