### PR TITLE
Mark Cake 2.x as out of suppport

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 | Version   | Supported          |
 | --------- | ------------------ |
 | 3.x.x     | :white_check_mark: |
-| 2.x.x     | :white_check_mark: |
+| 2.x.x     | :x:                |
 | 1.0.x     | :x:                |
 | 0.38.5    | :x:                |
 | <= 0.38.4 | :x:                |


### PR DESCRIPTION
Following [Cake Support Lifecycle](https://cakebuild.net/docs/getting-started/lifecycle) Cake 2.x is now out of support