### PR TITLE
File type check on macosx (if file is "dylib")

### DIFF
--- a/src/Cake.Core.Tests/Unit/IO/FileExtensionsTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/FileExtensionsTests.cs
@@ -261,7 +261,6 @@ namespace Cake.Core.Tests.Unit.IO
 
                 // When
                 file.Exists.Returns(true);
-                file.Path.Returns(new string(""));  // not ideal, but better then leave it null
                 file.Length.Returns(_validPeAndClrAssemblyBytes.Length);
                 file.OpenRead().Returns(new MemoryStream(_validPeAndClrAssemblyBytes));
 
@@ -277,7 +276,6 @@ namespace Cake.Core.Tests.Unit.IO
 
                 // When
                 file.Exists.Returns(true);
-                file.Path.Returns(new string(""));  // not ideal, but better then leave it null
                 file.Length.Returns(_validPeButNotClrAssemblyBytes.Length);
                 file.OpenRead().Returns(new MemoryStream(_validPeButNotClrAssemblyBytes));
 
@@ -293,7 +291,6 @@ namespace Cake.Core.Tests.Unit.IO
 
                 // When
                 file.Exists.Returns(true);
-                file.Path.Returns(new string(""));  // not ideal, but better then leave it null
                 file.Length.Returns(_invalidPeBytes.Length);
                 file.OpenRead().Returns(new MemoryStream(_invalidPeBytes));
 
@@ -309,9 +306,8 @@ namespace Cake.Core.Tests.Unit.IO
 
                 // When
                 file.Exists.Returns(true);
-                file.Path.Returns(new string("fulnname.dylib"));
+                file.Path.Returns(new string("fullname.dylib"));
                 file.Length.Returns(_invalidPeBytes.Length);
-                file.OpenRead().Returns(new MemoryStream(_invalidPeBytes));
 
                 // Then
                 Assert.False(FileExtensions.IsClrAssembly(file));

--- a/src/Cake.Core.Tests/Unit/IO/FileExtensionsTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/FileExtensionsTests.cs
@@ -261,6 +261,7 @@ namespace Cake.Core.Tests.Unit.IO
 
                 // When
                 file.Exists.Returns(true);
+                file.Path.Returns(new string(""));  // not ideal, but better then leave it null
                 file.Length.Returns(_validPeAndClrAssemblyBytes.Length);
                 file.OpenRead().Returns(new MemoryStream(_validPeAndClrAssemblyBytes));
 
@@ -276,6 +277,7 @@ namespace Cake.Core.Tests.Unit.IO
 
                 // When
                 file.Exists.Returns(true);
+                file.Path.Returns(new string(""));  // not ideal, but better then leave it null
                 file.Length.Returns(_validPeButNotClrAssemblyBytes.Length);
                 file.OpenRead().Returns(new MemoryStream(_validPeButNotClrAssemblyBytes));
 
@@ -291,6 +293,23 @@ namespace Cake.Core.Tests.Unit.IO
 
                 // When
                 file.Exists.Returns(true);
+                file.Path.Returns(new string(""));  // not ideal, but better then leave it null
+                file.Length.Returns(_invalidPeBytes.Length);
+                file.OpenRead().Returns(new MemoryStream(_invalidPeBytes));
+
+                // Then
+                Assert.False(FileExtensions.IsClrAssembly(file));
+            }
+
+            [Fact]
+            public void Should_Return_False_When_File_Is_MacOS_MachO_dylib()
+            {
+                // Given
+                var file = Substitute.For<IFile>();
+
+                // When
+                file.Exists.Returns(true);
+                file.Path.Returns(new string("fulnname.dylib"));
                 file.Length.Returns(_invalidPeBytes.Length);
                 file.OpenRead().Returns(new MemoryStream(_invalidPeBytes));
 

--- a/src/Cake.Core/IO/FileExtensions.cs
+++ b/src/Cake.Core/IO/FileExtensions.cs
@@ -116,7 +116,22 @@ namespace Cake.Core.IO
                 return false;
             }
 
-            if (file.Path != null && file.Path.FullPath.EndsWith(".dylib"))
+            if (file.Path != null 
+                && 
+                  ! (
+                    file.Path.FullPath.EndsWith(".dll") || file.Path.FullPath.EndsWith(".exe")
+                    ||
+                    file.Path.FullPath.EndsWith(".sys") || file.Path.FullPath.EndsWith(".tsp")
+                    ||
+                    file.Path.FullPath.EndsWith(".acm") || file.Path.FullPath.EndsWith(".ax")
+                    ||
+                    file.Path.FullPath.EndsWith(".cpl") || file.Path.FullPath.EndsWith(".drv")
+                    ||
+                    file.Path.FullPath.EndsWith(".efi") || file.Path.FullPath.EndsWith(".mui")
+                    ||
+                    file.Path.FullPath.EndsWith(".ocx") || file.Path.FullPath.EndsWith(".scr")
+                    )
+                )
             {
                 return false;
             }

--- a/src/Cake.Core/IO/FileExtensions.cs
+++ b/src/Cake.Core/IO/FileExtensions.cs
@@ -116,22 +116,26 @@ namespace Cake.Core.IO
                 return false;
             }
 
-            if (file.Path != null
-                &&
-                  !(
-                    file.Path.FullPath.EndsWith(".dll") || file.Path.FullPath.EndsWith(".exe")
-                    ||
-                    file.Path.FullPath.EndsWith(".sys") || file.Path.FullPath.EndsWith(".tsp")
-                    ||
-                    file.Path.FullPath.EndsWith(".acm") || file.Path.FullPath.EndsWith(".ax")
-                    ||
-                    file.Path.FullPath.EndsWith(".cpl") || file.Path.FullPath.EndsWith(".drv")
-                    ||
-                    file.Path.FullPath.EndsWith(".efi") || file.Path.FullPath.EndsWith(".mui")
-                    ||
-                    file.Path.FullPath.EndsWith(".ocx") || file.Path.FullPath.EndsWith(".scr")))
+            // Is known extension?
+            switch (file.Path?.GetExtension().ToLowerInvariant())
             {
-                return false;
+                case "dll":
+                case "exe":
+                case "sys":
+                case "tsp":
+                case "acm":
+                case "ax":
+                case "cpl":
+                case "drv":
+                case "efi":
+                case "mui":
+                case "ocx":
+                case "scr":
+                case null:
+                    break;
+
+                default:
+                    return false;
             }
 
             using (var fs = file.OpenRead())

--- a/src/Cake.Core/IO/FileExtensions.cs
+++ b/src/Cake.Core/IO/FileExtensions.cs
@@ -111,7 +111,12 @@ namespace Cake.Core.IO
         /// </remarks>
         public static bool IsClrAssembly(this IFile file)
         {
-            if (!file.Exists || file.Length < 365 || file.Path.GetExtension().ToLower().Equals("dylib"))
+            if (!file.Exists || file.Length < 365)
+            {
+                return false;
+            }
+
+            if (file.Path != null && file.Path.FullPath.EndsWith(".dylib"))
             {
                 return false;
             }

--- a/src/Cake.Core/IO/FileExtensions.cs
+++ b/src/Cake.Core/IO/FileExtensions.cs
@@ -111,7 +111,7 @@ namespace Cake.Core.IO
         /// </remarks>
         public static bool IsClrAssembly(this IFile file)
         {
-            if (!file.Exists || file.Length < 365)
+            if (!file.Exists || file.Length < 365 || file.Path.GetExtension().ToLower().Equals("dylib"))
             {
                 return false;
             }

--- a/src/Cake.Core/IO/FileExtensions.cs
+++ b/src/Cake.Core/IO/FileExtensions.cs
@@ -116,9 +116,9 @@ namespace Cake.Core.IO
                 return false;
             }
 
-            if (file.Path != null 
-                && 
-                  ! (
+            if (file.Path != null
+                &&
+                  !(
                     file.Path.FullPath.EndsWith(".dll") || file.Path.FullPath.EndsWith(".exe")
                     ||
                     file.Path.FullPath.EndsWith(".sys") || file.Path.FullPath.EndsWith(".tsp")
@@ -129,9 +129,7 @@ namespace Cake.Core.IO
                     ||
                     file.Path.FullPath.EndsWith(".efi") || file.Path.FullPath.EndsWith(".mui")
                     ||
-                    file.Path.FullPath.EndsWith(".ocx") || file.Path.FullPath.EndsWith(".scr")
-                    )
-                )
+                    file.Path.FullPath.EndsWith(".ocx") || file.Path.FullPath.EndsWith(".scr")))
             {
                 return false;
             }

--- a/src/Cake.Core/IO/FileExtensions.cs
+++ b/src/Cake.Core/IO/FileExtensions.cs
@@ -119,18 +119,18 @@ namespace Cake.Core.IO
             // Is known extension?
             switch (file.Path?.GetExtension().ToLowerInvariant())
             {
-                case "dll":
-                case "exe":
-                case "sys":
-                case "tsp":
-                case "acm":
-                case "ax":
-                case "cpl":
-                case "drv":
-                case "efi":
-                case "mui":
-                case "ocx":
-                case "scr":
+                case ".dll":
+                case ".exe":
+                case ".sys":
+                case ".tsp":
+                case ".acm":
+                case ".ax":
+                case ".cpl":
+                case ".drv":
+                case ".efi":
+                case ".mui":
+                case ".ocx":
+                case ".scr":
                 case null:
                     break;
 


### PR DESCRIPTION
Context: https://github.com/cake-build/cake/issues/3996

Added filetype/extension check.

Error experienced:

```
Error: Bad IL format. 
The format of the file 
    '/Users/runner/work/1/s/tools/Addins/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple.4.3.0/runtimes/osx.10.10-x64/native/System.Security.Cryptography.Native.Apple.dylib' 
is invalid. 
An error occurred when executing task Error: .NET CLI: Process returned an error (exit code 1)
```

The error was experienced at intermittent intervals in CI (and local, but not so often) builds for 2 repos:

https://github.com/xamarin/AndroidX
https://github.com/xamarin/GooglePlayServicesComponents

In last few weeks, alsmost all builds fail regularly.

https://github.com/xamarin/GooglePlayServicesComponents/pull/801