### PR TITLE
Add DotNetListPackage alias for dotnet list package command

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/DotNet/Package/List/DotNetPackageListerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/DotNet/Package/List/DotNetPackageListerFixture.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNet.Package.List;
+
+namespace Cake.Common.Tests.Fixtures.Tools.DotNet.Package.List
+{
+    internal sealed class DotNetPackageListerFixture : DotNetFixture<DotNetPackageListSettings>
+    {
+        public string Project { get; set; }
+        public DotNetPackageList Result { get; set; }
+
+        public void GivenPackgeListResult()
+        {
+            ProcessRunner.Process.SetStandardOutput(new string[]
+            {
+                "{",
+                "  \"version\": 1,",
+                "  \"parameters\": \"\",",
+                "  \"projects\": [",
+                "    {",
+                "      \"path\": \"src/lib/MyProject.csproj\",",
+                "      \"frameworks\": [",
+                "        {",
+                "          \"framework\": \"netstandard2.0\",",
+                "          \"topLevelPackages\": [",
+                "            {",
+                "              \"id\": \"NETStandard.Library\",",
+                "              \"requestedVersion\": \"[2.0.3, )\",",
+                "              \"resolvedVersion\": \"2.0.3\",",
+                "              \"autoReferenced\": \"true\"",
+                "            }",
+                "          ]",
+                "        }",
+                "      ]",
+                "    }",
+                "  ]",
+                "}"
+            });
+        }
+
+        protected override void RunTool()
+        {
+            var tool = new DotNetPackageLister(FileSystem, Environment, ProcessRunner, Tools);
+            Result = tool.List(Project, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Package/List/DotNetPackageListerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Package/List/DotNetPackageListerTests.cs
@@ -1,0 +1,118 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tests.Fixtures.Tools.DotNet.Package.List;
+using Cake.Common.Tools.DotNet;
+using Cake.Testing;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.DotNet.Package.List
+{
+    public sealed class DotNetPackageListerTests
+    {
+        public sealed class TheListMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Process_Was_Not_Started()
+            {
+                // Given
+                var fixture = new DotNetPackageListerFixture();
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, ".NET CLI: Process was not started.");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
+            {
+                // Given
+                var fixture = new DotNetPackageListerFixture();
+                fixture.GivenProcessExitsWithCode(1);
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new DotNetPackageListerFixture();
+                fixture.Settings = null;
+                fixture.GivenDefaultToolDoNotExist();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Add_Project_Argument()
+            {
+                // Given
+                var fixture = new DotNetPackageListerFixture();
+                fixture.Project = "ToDo.csproj";
+                fixture.GivenPackgeListResult();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("list \"ToDo.csproj\" package --format json --output-version 1", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Additional_Arguments()
+            {
+                // Given
+                var fixture = new DotNetPackageListerFixture();
+                fixture.Settings.ConfigFile = "./nuget.config";
+                fixture.Settings.Deprecated = true;
+                fixture.Settings.Framework = "net7.0";
+                fixture.Settings.HighestMinor = true;
+                fixture.Settings.HighestPatch = true;
+                fixture.Settings.Prerelease = true;
+                fixture.Settings.Transitive = true;
+                fixture.Settings.Interactive = true;
+                fixture.Settings.Outdated = true;
+                fixture.Settings.Source.Add("http://www.nuget.org/api/v2/package");
+                fixture.Settings.Source.Add("http://www.symbolserver.org/");
+                fixture.Settings.Vulnerable = true;
+                fixture.GivenPackgeListResult();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                var expected = "list package --config \"/Working/nuget.config\" --deprecated --framework net7.0 --highest-minor --highest-patch --include-prerelease --include-transitive --interactive --outdated ";
+                expected += "--source \"http://www.nuget.org/api/v2/package\" --source \"http://www.symbolserver.org/\" --vulnerable --format json --output-version 1";
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Fact]
+            public void Should_Return_Correct_Result()
+            {
+                // Given
+                var fixture = new DotNetPackageListerFixture();
+                fixture.GivenPackgeListResult();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(1, fixture.Result.Version);
+                Assert.Contains(fixture.Result.Projects, item => item.Path == "src/lib/MyProject.csproj");
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
@@ -16,6 +16,7 @@ using Cake.Common.Tools.DotNet.NuGet.Push;
 using Cake.Common.Tools.DotNet.NuGet.Source;
 using Cake.Common.Tools.DotNet.Pack;
 using Cake.Common.Tools.DotNet.Package.Add;
+using Cake.Common.Tools.DotNet.Package.List;
 using Cake.Common.Tools.DotNet.Package.Remove;
 using Cake.Common.Tools.DotNet.Package.Search;
 using Cake.Common.Tools.DotNet.Publish;
@@ -2621,6 +2622,79 @@ namespace Cake.Common.Tools.DotNet
             }
             var runner = new DotNetPackageSearcher(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             return runner.Search(null, settings);
+        }
+
+        /// <summary>
+        /// Lists the package references for a project or solution.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <returns>The the package references.</returns>
+        /// <example>
+        /// <code>
+        /// DotNetPackageList output = DotNetListPackage();
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Package")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Package.List")]
+        public static DotNetPackageList DotNetListPackage(this ICakeContext context)
+        {
+            return context.DotNetListPackage(null);
+        }
+
+        /// <summary>
+        /// Lists the package references for a project or solution.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="project">The project or solution file to operate on. If not specified, the command searches the current directory for one. If more than one solution or project is found, an error is thrown.</param>
+        /// <returns>The the package references.</returns>
+        /// <example>
+        /// <code>
+        /// DotNetPackageList output = DotNetListPackage("./src/MyProject/MyProject.csproj");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Package")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Package.List")]
+        public static DotNetPackageList DotNetListPackage(this ICakeContext context, string project)
+        {
+            return context.DotNetListPackage(project, null);
+        }
+
+        /// <summary>
+        /// Lists the package references for a project or solution.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="project">The project or solution file to operate on. If not specified, the command searches the current directory for one. If more than one solution or project is found, an error is thrown.</param>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The the package references.</returns>
+        /// <example>
+        /// <code>
+        /// var settings = new DotNetPackageListSettings
+        /// {
+        ///     Outdated = true
+        /// };
+        ///
+        /// DotNetPackageList output = DotNetListPackage("./src/MyProject/MyProject.csproj", settings);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Package")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Package.List")]
+        public static DotNetPackageList DotNetListPackage(this ICakeContext context, string project, DotNetPackageListSettings settings)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (settings is null)
+            {
+                settings = new DotNetPackageListSettings();
+            }
+
+            var lister = new DotNetPackageLister(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            return lister.List(project, settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Package/List/DotNetPackageList.cs
+++ b/src/Cake.Common/Tools/DotNet/Package/List/DotNetPackageList.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Cake.Common.Tools.DotNet.Package.List
+{
+    /// <summary>
+    /// An result as returned by <see cref="DotNetPackageLister"/>.
+    /// </summary>
+    public sealed class DotNetPackageList
+    {
+        /// <summary>
+        /// Gets the output version.
+        /// </summary>
+        [JsonInclude]
+        public int Version { get; private set; }
+
+        /// <summary>
+        /// Gets the specified parameters.
+        /// </summary>
+        [JsonInclude]
+        public string Parameters { get; private set; }
+
+        /// <summary>
+        /// Gets the problems.
+        /// </summary>
+        [JsonInclude]
+        public IEnumerable<DotNetPackageListProblemItem> Problems { get; private set; }
+
+        /// <summary>
+        /// Gets the used sources.
+        /// </summary>
+        [JsonInclude]
+        public IEnumerable<string> Sources { get; private set; }
+
+        /// <summary>
+        /// Gets the projects.
+        /// </summary>
+        [JsonInclude]
+        public IEnumerable<DotNetPackageListProjectItem> Projects { get; private set; }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/Package/List/DotNetPackageListAlternativePackageItem.cs
+++ b/src/Cake.Common/Tools/DotNet/Package/List/DotNetPackageListAlternativePackageItem.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Serialization;
+
+namespace Cake.Common.Tools.DotNet.Package.List
+{
+    /// <summary>
+    /// The alternative package information.
+    /// </summary>
+    public sealed class DotNetPackageListAlternativePackageItem
+    {
+        /// <summary>
+        /// Gets the alternative package id.
+        /// </summary>
+        [JsonInclude]
+        public string Id { get; private set; }
+
+        /// <summary>
+        /// Gets the alternative package versions.
+        /// </summary>
+        [JsonInclude]
+        public string VersionRange { get; private set; }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/Package/List/DotNetPackageListFrameworkItem.cs
+++ b/src/Cake.Common/Tools/DotNet/Package/List/DotNetPackageListFrameworkItem.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Cake.Common.Tools.DotNet.Package.List
+{
+    /// <summary>
+    /// The framework information.
+    /// </summary>
+    public sealed class DotNetPackageListFrameworkItem
+    {
+        /// <summary>
+        /// Gets the framework name.
+        /// </summary>
+        [JsonInclude]
+        public string Framework { get; private set; }
+
+        /// <summary>
+        /// Gets the top-level packages.
+        /// </summary>
+        [JsonInclude]
+        public IEnumerable<DotNetPackageListPackageItem> TopLevelPackages { get; private set; }
+
+        /// <summary>
+        /// Gets transitive packages.
+        /// </summary>
+        [JsonInclude]
+        public IEnumerable<DotNetPackageListPackageItem> TransitivePackages { get; private set; }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/Package/List/DotNetPackageListPackageItem.cs
+++ b/src/Cake.Common/Tools/DotNet/Package/List/DotNetPackageListPackageItem.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Cake.Common.Tools.DotNet.Package.List
+{
+    /// <summary>
+    /// The package information.
+    /// </summary>
+    public sealed class DotNetPackageListPackageItem
+    {
+        /// <summary>
+        /// Gets the package id.
+        /// </summary>
+        [JsonInclude]
+        public string Id { get; private set; }
+
+        /// <summary>
+        /// Gets the requested version.
+        /// </summary>
+        [JsonInclude]
+        public string RequestedVersion { get; private set; }
+
+        /// <summary>
+        /// Gets the resolved version.
+        /// </summary>
+        [JsonInclude]
+        public string ResolvedVersion { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the package is auto-referenced.
+        /// </summary>
+        [JsonInclude]
+        public string AutoReferenced { get; private set; }
+
+        /// <summary>
+        /// Gets the latest version.
+        /// </summary>
+        [JsonInclude]
+        public string LatestVersion { get; private set; }
+
+        /// <summary>
+        /// Gets the deprecation reasons.
+        /// </summary>
+        [JsonInclude]
+        public IEnumerable<string> DeprecationReasons { get; private set; }
+
+        /// <summary>
+        /// Gets the alternative package.
+        /// </summary>
+        [JsonInclude]
+        public DotNetPackageListAlternativePackageItem AlternativePackage { get; private set; }
+
+        /// <summary>
+        /// Gets the vulnerabilities list.
+        /// </summary>
+        [JsonInclude]
+        public IEnumerable<DotNetPackageListVulnerabilityItem> Vulnerabilities { get; private set; }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/Package/List/DotNetPackageListProblemItem.cs
+++ b/src/Cake.Common/Tools/DotNet/Package/List/DotNetPackageListProblemItem.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Serialization;
+
+namespace Cake.Common.Tools.DotNet.Package.List
+{
+    /// <summary>
+    /// The problem information.
+    /// </summary>
+    public sealed class DotNetPackageListProblemItem
+    {
+        /// <summary>
+        /// Gets the problem level.
+        /// </summary>
+        [JsonInclude]
+        public DotNetPackageListProblemType? Level { get; private set; }
+
+        /// <summary>
+        /// Gets the problem text.
+        /// </summary>
+        [JsonInclude]
+        public string Text { get; private set; }
+
+        /// <summary>
+        /// Gets the project path.
+        /// </summary>
+        [JsonInclude]
+        public string Project { get; private set; }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/Package/List/DotNetPackageListProblemType.cs
+++ b/src/Cake.Common/Tools/DotNet/Package/List/DotNetPackageListProblemType.cs
@@ -2,25 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Cake.Common.Tools.DotNet.Format
+namespace Cake.Common.Tools.DotNet.Package.List
 {
     /// <summary>
-    /// Severity of dotnet format.
+    /// The problem types.
     /// </summary>
-    public enum DotNetFormatSeverity
+    public enum DotNetPackageListProblemType
     {
         /// <summary>
-        /// Information
-        /// </summary>
-        Info,
-
-        /// <summary>
-        /// Warning
+        /// Warning.
         /// </summary>
         Warning,
 
         /// <summary>
-        /// Error
+        /// Error.
         /// </summary>
         Error
     }

--- a/src/Cake.Common/Tools/DotNet/Package/List/DotNetPackageListProjectItem.cs
+++ b/src/Cake.Common/Tools/DotNet/Package/List/DotNetPackageListProjectItem.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Cake.Common.Tools.DotNet.Package.List
+{
+    /// <summary>
+    /// The project information.
+    /// </summary>
+    public sealed class DotNetPackageListProjectItem
+    {
+        /// <summary>
+        /// Gets the project path.
+        /// </summary>
+        [JsonInclude]
+        public string Path { get; private set; }
+
+        /// <summary>
+        /// Gets the list of frameworks.
+        /// </summary>
+        [JsonInclude]
+        public IEnumerable<DotNetPackageListFrameworkItem> Frameworks { get; private set; }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/Package/List/DotNetPackageListSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Package/List/DotNetPackageListSettings.cs
@@ -1,0 +1,79 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotNet.Package.List
+{
+    /// <summary>
+    /// Contains settings used by <see cref="DotNetPackageLister" />.
+    /// </summary>
+    public sealed class DotNetPackageListSettings : DotNetSettings
+    {
+        /// <summary>
+        /// Gets or sets the NuGet configuration file (nuget.config) to use.
+        /// Requires the <see cref="Outdated"/> option.
+        /// </summary>
+        public FilePath ConfigFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to display packages that have been deprecated.
+        /// </summary>
+        public bool Deprecated { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to list packages that have newer versions available.
+        /// </summary>
+        public bool Outdated { get; set; }
+
+        /// <summary>
+        /// Gets or sets a specific framework to compile.
+        /// </summary>
+        public string Framework { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to display only the packages with a matching major version number when searching for newer packages.
+        /// Requires the <see cref="Outdated"/> or <see cref="Deprecated"/> option.
+        /// </summary>
+        public bool HighestMinor { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to display only the packages with a matching major and minor version numbers when searching for newer packages.
+        /// Requires the <see cref="Outdated"/> or <see cref="Deprecated"/> option.
+        /// </summary>
+        public bool HighestPatch { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to list packages with prerelease versions when searching for newer packages.
+        /// Requires the <see cref="Outdated"/> or <see cref="Deprecated"/> option.
+        /// </summary>
+        public bool Prerelease { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to list transitive packages, in addition to the top-level packages.
+        /// When specifying this option, you get a list of packages that the top-level packages depend on.
+        /// </summary>
+        public bool Transitive { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow the command to stop and wait for user input or action.
+        /// For example, to complete authentication. Available since .NET Core 3.0 SDK.
+        /// </summary>
+        public bool Interactive { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URI of the NuGet package source to use.
+        /// Requires the <see cref="Outdated"/> or <see cref="Deprecated"/> option.
+        /// </summary>
+        public ICollection<string> Source { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to list packages that have known vulnerabilities.
+        /// Cannot be combined with <see cref="Outdated"/> or <see cref="Deprecated"/> options.
+        /// Nuget.org is the source of information about vulnerabilities.
+        /// </summary>
+        public bool Vulnerable { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/Package/List/DotNetPackageListVulnerabilityItem.cs
+++ b/src/Cake.Common/Tools/DotNet/Package/List/DotNetPackageListVulnerabilityItem.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text.Json.Serialization;
+
+namespace Cake.Common.Tools.DotNet.Package.List
+{
+    /// <summary>
+    /// The vulnerability information.
+    /// </summary>
+    public sealed class DotNetPackageListVulnerabilityItem
+    {
+        /// <summary>
+        /// Gets the severity level: Low, Moderate, High, Critical.
+        /// </summary>
+        [JsonInclude]
+        public string Severity { get; private set; }
+
+        /// <summary>
+        /// Gets the URL of advisory.
+        /// </summary>
+        [JsonInclude]
+        public Uri AdvisoryUrl { get; private set; }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/Package/List/DotNetPackageLister.cs
+++ b/src/Cake.Common/Tools/DotNet/Package/List/DotNetPackageLister.cs
@@ -1,0 +1,154 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Text.Json;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.DotNet.Package.List
+{
+    /// <summary>
+    /// .NET package lister.
+    /// </summary>
+    public sealed class DotNetPackageLister : DotNetTool<DotNetPackageListSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotNetPackageLister" /> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="tools">The tool locator.</param>
+        public DotNetPackageLister(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IToolLocator tools) : base(fileSystem, environment, processRunner, tools)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Lists the package references for a project or solution.
+        /// </summary>
+        /// <param name="project">The project or solution file to operate on. If not specified, the command searches the current directory for one. If more than one solution or project is found, an error is thrown.</param>
+        /// <param name="settings">The settings.</param>
+        /// <returns>A task with the GitVersion results.</returns>
+        public DotNetPackageList List(string project, DotNetPackageListSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            var output = string.Empty;
+            Run(settings, GetArguments(project, settings), new ProcessSettings { RedirectStandardOutput = true }, process =>
+            {
+                output = string.Join("\n", process.GetStandardOutput());
+            });
+
+            return JsonSerializer.Deserialize<DotNetPackageList>(output, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+        }
+
+        private ProcessArgumentBuilder GetArguments(string project, DotNetPackageListSettings settings)
+        {
+            var builder = CreateArgumentBuilder(settings);
+
+            builder.Append("list");
+
+            // Project path
+            if (project != null)
+            {
+                builder.AppendQuoted(project);
+            }
+
+            builder.Append("package");
+
+            // Config File
+            if (settings.ConfigFile != null)
+            {
+                builder.AppendSwitchQuoted("--config", settings.ConfigFile.MakeAbsolute(_environment).FullPath);
+            }
+
+            // Deprecated
+            if (settings.Deprecated)
+            {
+                builder.Append("--deprecated");
+            }
+
+            // Framework
+            if (!string.IsNullOrEmpty(settings.Framework))
+            {
+                builder.AppendSwitch("--framework", settings.Framework);
+            }
+
+            // Highest Minor
+            if (settings.HighestMinor)
+            {
+                builder.Append("--highest-minor");
+            }
+
+            // Highest Patch
+            if (settings.HighestPatch)
+            {
+                builder.Append("--highest-patch");
+            }
+
+            // Prerelease
+            if (settings.Prerelease)
+            {
+                builder.Append("--include-prerelease");
+            }
+
+            // Transitive
+            if (settings.Transitive)
+            {
+                builder.Append("--include-transitive");
+            }
+
+            // Interactive
+            if (settings.Interactive)
+            {
+                builder.Append("--interactive");
+            }
+
+            // Outdated
+            if (settings.Outdated)
+            {
+                builder.Append("--outdated");
+            }
+
+            // Source
+            if (settings.Source != null && settings.Source.Any())
+            {
+                foreach (var source in settings.Source)
+                {
+                    builder.AppendSwitchQuoted("--source", source);
+                }
+            }
+
+            // Vulnerable
+            if (settings.Vulnerable)
+            {
+                builder.Append("--vulnerable");
+            }
+
+            // Format
+            builder.Append("--format json");
+
+            // Version
+            builder.Append("--output-version 1");
+
+            return builder;
+        }
+    }
+}

--- a/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
+++ b/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
@@ -397,6 +397,7 @@ Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetListPackage")
     var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
     var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
     // When
+    DotNetRestore(project.FullPath);
     var result = DotNetListPackage(project.FullPath);
     // Then
     Assert.Equal(1, result.Version);

--- a/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
+++ b/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
@@ -389,6 +389,20 @@ Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSearchPackage")
     Assert.Contains(package, result.Select(x => x.Name));
 });
 
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetListPackage")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRestore")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
+    // When
+    var result = DotNetListPackage(project.FullPath);
+    // Then
+    Assert.Equal(1, result.Version);
+    Assert.Contains(result.Projects, item => item.Path == project);
+});
+
 Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetBuildServerShutdown")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRestore")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetBuild")
@@ -414,6 +428,7 @@ Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetBuildServerShutdown")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRemovePackage")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetAddReference")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSearchPackage")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetListPackage")
     .Does(() =>
 {
     // When


### PR DESCRIPTION
Add an alias for `dotnet list package` command

Fixes #4224

Here is the basic implementation. I need your suggestion on what we should do with the output.
If the format is `console` we will receive smth like this
![image](https://github.com/cake-build/cake/assets/9221694/fa47b13a-cee8-4362-8862-be9edd1ef6f7)
- hard to parse into model.
If the format is json, there could be a several different output which is dependent on the input params
![image](https://github.com/cake-build/cake/assets/9221694/ae9cc7dc-445a-469d-bcf9-2c78a421a9e1)
![image](https://github.com/cake-build/cake/assets/9221694/ff4af09d-7666-4d1b-a1f1-79854cdd3dae)
when error
![image](https://github.com/cake-build/cake/assets/9221694/11f11076-098a-4d6f-8de9-23c89d859546)

If we allow only JSON, then I'll be able to create models and deserialize (for `console` format it is almost impossible) and return the result for `public ListResult DotNetListPackage(...)` but what if someone just wants to get the output and that's all. 
What do you think?

Thank you in advance