### PR TITLE
Upgrade spectre.console to 0.47.0, modifying the Cake codebase to fix a breaking change this new version includes

### DIFF
--- a/src/Cake.Cli/Cake.Cli.csproj
+++ b/src/Cake.Cli/Cake.Cli.csproj
@@ -19,7 +19,7 @@
 
     <ItemGroup>
       <PackageReference Include="Autofac" Version="7.1.0" />
-      <PackageReference Include="Spectre.Console" Version="0.46.0" />
-      <PackageReference Include="Spectre.Console.Cli" Version="0.46.0" />
+      <PackageReference Include="Spectre.Console" Version="0.47.0" />
+      <PackageReference Include="Spectre.Console.Cli" Version="0.47.0" />
   </ItemGroup>
 </Project>

--- a/src/Cake.Frosting/Internal/Commands/DefaultCommand.cs
+++ b/src/Cake.Frosting/Internal/Commands/DefaultCommand.cs
@@ -82,6 +82,7 @@ namespace Cake.Frosting.Internal
         private static CakeArguments CreateCakeArguments(IRemainingArguments remainingArguments, DefaultCommandSettings settings)
         {
             var arguments = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
             // Keep the actual remaining arguments in the cake arguments
             foreach (var group in remainingArguments.Parsed)
             {
@@ -98,7 +99,6 @@ namespace Cake.Frosting.Internal
             {
                 arguments[targetArgumentName] = new List<string>();
             }
-
             foreach (var target in settings.Targets)
             {
                 arguments[targetArgumentName].Add(target);

--- a/src/Cake.Tests/Fixtures/BuildFeatureFixture.cs
+++ b/src/Cake.Tests/Fixtures/BuildFeatureFixture.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Cake.Core;
 using Cake.Core.Composition;
@@ -63,7 +65,10 @@ namespace Cake.Tests.Fixtures
 
         public BuildFeatureFixtureResult Run(BuildFeatureSettings settings, IDictionary<string, string> arguments = null)
         {
-            var remaining = new FakeRemainingArguments(arguments);
+            var parsed = (arguments ?? new Dictionary<string, string>())
+                .ToLookup(x => x.Key, x => x.Value, StringComparer.OrdinalIgnoreCase);
+
+            var remaining = new CakeArguments(parsed);
             var exitCode = ((IBuildFeature)this).Run(remaining, settings);
 
             return new BuildFeatureFixtureResult
@@ -88,7 +93,7 @@ namespace Cake.Tests.Fixtures
             return builder.ToString();
         }
 
-        int IBuildFeature.Run(IRemainingArguments arguments, BuildFeatureSettings settings)
+        int IBuildFeature.Run(ICakeArguments arguments, BuildFeatureSettings settings)
         {
             var feature = new BuildFeature(FileSystem, Environment, Bootstrapper, ModuleSearcher, Log);
             return feature.Run(arguments, settings);

--- a/src/Cake.Tests/Unit/ProgramTests.cs
+++ b/src/Cake.Tests/Unit/ProgramTests.cs
@@ -27,7 +27,7 @@ namespace Cake.Tests.Unit
 
             // Then
             feature.Received(1).Run(
-                Arg.Any<IRemainingArguments>(),
+                Arg.Any<ICakeArguments>(),
                 Arg.Is<BuildFeatureSettings>(settings =>
                     settings.BuildHostKind == BuildHostKind.Build &&
                     settings.Debug == false &&
@@ -53,7 +53,7 @@ namespace Cake.Tests.Unit
 
             // Then
             feature.Received(1).Run(
-                Arg.Any<IRemainingArguments>(),
+                Arg.Any<ICakeArguments>(),
                 Arg.Is<BuildFeatureSettings>(settings =>
                     settings.BuildHostKind == BuildHostKind.DryRun));
         }
@@ -73,7 +73,7 @@ namespace Cake.Tests.Unit
 
             // Then
             feature.Received(1).Run(
-                Arg.Any<IRemainingArguments>(),
+                Arg.Any<ICakeArguments>(),
                 Arg.Is<BuildFeatureSettings>(settings =>
                     settings.BuildHostKind == BuildHostKind.Tree));
         }
@@ -93,7 +93,7 @@ namespace Cake.Tests.Unit
 
             // Then
             feature.Received(1).Run(
-                Arg.Any<IRemainingArguments>(),
+                Arg.Any<ICakeArguments>(),
                 Arg.Is<BuildFeatureSettings>(settings =>
                     settings.BuildHostKind == BuildHostKind.Description));
         }

--- a/src/Cake.Tests/Utilities/TestContainerConfigurator.cs
+++ b/src/Cake.Tests/Utilities/TestContainerConfigurator.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using Cake.Core;
 using Cake.Core.Composition;
 using Cake.Core.Configuration;
 using Cake.Infrastructure;
-using Spectre.Console.Cli;
 
 namespace Cake.Tests.Fakes
 {
@@ -21,7 +21,7 @@ namespace Cake.Tests.Fakes
         public void Configure(
             ICakeContainerRegistrar registrar,
             ICakeConfiguration configuration,
-            IRemainingArguments arguments)
+            ICakeArguments arguments)
         {
             _decorated.Configure(registrar, configuration, arguments);
 

--- a/src/Cake/Commands/DefaultCommand.cs
+++ b/src/Cake/Commands/DefaultCommand.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Cake.Cli;
 using Cake.Core;
@@ -69,8 +70,10 @@ namespace Cake.Commands
                     }
                 }
 
+                var arguments = CreateCakeArguments(context.Remaining, settings);
+
                 // Run the build feature.
-                return _builder.Run(context.Remaining, new BuildFeatureSettings(host)
+                return _builder.Run(arguments, new BuildFeatureSettings(host)
                 {
                     Script = settings.Script,
                     Verbosity = settings.Verbosity,
@@ -110,11 +113,39 @@ namespace Cake.Commands
                 return 0;
             }
 
-            return _bootstrapper.Run(context.Remaining, new BootstrapFeatureSettings
+            var arguments = CreateCakeArguments(context.Remaining, settings);
+
+            return _bootstrapper.Run(arguments, new BootstrapFeatureSettings
             {
                 Script = settings.Script,
                 Verbosity = settings.Verbosity
             });
+        }
+
+        private static CakeArguments CreateCakeArguments(IRemainingArguments remainingArguments, DefaultCommandSettings settings)
+        {
+            var arguments = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+            // Keep the actual remaining arguments in the cake arguments
+            foreach (var group in remainingArguments.Parsed)
+            {
+                arguments[group.Key] = new List<string>();
+                foreach (var argument in group)
+                {
+                    arguments[group.Key].Add(argument);
+                }
+            }
+
+            // Fixes #4157, We have to add arguments manually which are defined within the DefaultCommandSettings type. Those are not considered "as remaining" because they could be parsed
+            const string recompileArgumentName = Infrastructure.Constants.Cache.InvalidateScriptCache;
+            if (settings.Recompile && !arguments.ContainsKey(recompileArgumentName))
+            {
+                arguments[recompileArgumentName] = new List<string>();
+                arguments[recompileArgumentName].Add(true.ToString());
+            }
+
+            var argumentLookUp = arguments.SelectMany(a => a.Value, Tuple.Create).ToLookup(a => a.Item1.Key, a => a.Item2);
+            return new CakeArguments(argumentLookUp);
         }
     }
 }

--- a/src/Cake/Features/Bootstrapping/BootstrapFeature.cs
+++ b/src/Cake/Features/Bootstrapping/BootstrapFeature.cs
@@ -17,7 +17,7 @@ namespace Cake.Features.Bootstrapping
 {
     public interface IBootstrapFeature
     {
-        int Run(IRemainingArguments arguments, BootstrapFeatureSettings settings);
+        int Run(ICakeArguments arguments, BootstrapFeatureSettings settings);
     }
 
     public sealed class BootstrapFeature : Feature, IBootstrapFeature
@@ -32,7 +32,7 @@ namespace Cake.Features.Bootstrapping
             _environment = environment;
         }
 
-        public int Run(IRemainingArguments arguments, BootstrapFeatureSettings settings)
+        public int Run(ICakeArguments arguments, BootstrapFeatureSettings settings)
         {
             // Fix the script path.
             settings.Script = settings.Script ?? new FilePath("build.cake");

--- a/src/Cake/Features/Building/BuildFeature.cs
+++ b/src/Cake/Features/Building/BuildFeature.cs
@@ -21,7 +21,7 @@ namespace Cake.Features.Building
 {
     public interface IBuildFeature
     {
-        int Run(IRemainingArguments arguments, BuildFeatureSettings settings);
+        int Run(ICakeArguments arguments, BuildFeatureSettings settings);
     }
 
     public sealed class BuildFeature : Feature, IBuildFeature
@@ -42,7 +42,7 @@ namespace Cake.Features.Building
             _log = log;
         }
 
-        public int Run(IRemainingArguments arguments, BuildFeatureSettings settings)
+        public int Run(ICakeArguments arguments, BuildFeatureSettings settings)
         {
             using (new ScriptAssemblyResolver(_environment, _log))
             {
@@ -50,7 +50,7 @@ namespace Cake.Features.Building
             }
         }
 
-        private int RunCore(IRemainingArguments arguments, BuildFeatureSettings settings)
+        private int RunCore(ICakeArguments arguments, BuildFeatureSettings settings)
         {
             // Fix the script path.
             settings.Script = settings.Script ?? new FilePath("build.cake");

--- a/src/Cake/Features/CakeFeature.cs
+++ b/src/Cake/Features/CakeFeature.cs
@@ -33,7 +33,7 @@ namespace Cake.Features
 
         protected IContainer CreateScope(
             ICakeConfiguration configuration,
-            IRemainingArguments arguments,
+            ICakeArguments arguments,
             Action<ICakeContainerRegistrar> action = null)
         {
             var registrar = new AutofacTypeRegistrar(new ContainerBuilder());
@@ -45,10 +45,10 @@ namespace Cake.Features
         }
 
         protected ICakeConfiguration ReadConfiguration(
-            IRemainingArguments remaining, DirectoryPath root)
+            ICakeArguments arguments, DirectoryPath root)
         {
             var provider = new CakeConfigurationProvider(_fileSystem, _environment);
-            var args = remaining.Parsed.ToDictionary(x => x.Key, x => x.FirstOrDefault() ?? string.Empty);
+            var args = arguments.GetArguments().ToDictionary(x => x.Key, x => x.Value?.FirstOrDefault() ?? string.Empty);
 
             return provider.CreateConfiguration(root, args);
         }

--- a/src/Cake/Infrastructure/ContainerConfigurator.cs
+++ b/src/Cake/Infrastructure/ContainerConfigurator.cs
@@ -24,10 +24,10 @@ namespace Cake.Infrastructure
         public void Configure(
             ICakeContainerRegistrar registrar,
             ICakeConfiguration configuration,
-            IRemainingArguments arguments)
+            ICakeArguments arguments)
         {
             // Arguments
-            registrar.RegisterInstance(new CakeArguments(arguments.Parsed)).AsSelf().As<ICakeArguments>();
+            registrar.RegisterInstance(arguments).AsSelf().As<ICakeArguments>();
 
             // Scripting
             registrar.RegisterType<RoslynScriptEngine>().As<IScriptEngine>().Singleton();

--- a/src/Cake/Infrastructure/IContainerConfigurator.cs
+++ b/src/Cake/Infrastructure/IContainerConfigurator.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Core;
 using Cake.Core.Composition;
 using Cake.Core.Configuration;
-using Spectre.Console.Cli;
 
 namespace Cake.Infrastructure
 {
@@ -17,6 +17,6 @@ namespace Cake.Infrastructure
         void Configure(
             ICakeContainerRegistrar registrar,
             ICakeConfiguration configuration,
-            IRemainingArguments arguments);
+            ICakeArguments arguments);
     }
 }


### PR DESCRIPTION
This PR fully addresses https://github.com/cake-build/cake/issues/4157, which was preventing spectre.console from being upgraded to 0.47.0. The PR also includes the actual upgrade to spectre.console 0.47.0

The approach taken is very similar to a previous Cake.Frosting issue, which has already been fixed: https://github.com/cake-build/cake/issues/3291 

This PR follows the same pattern introduced for the fix, which was located in Cake.Frosting.Internal.DefaultCommand, here: https://github.com/cake-build/cake/blob/c3cd2af8d73b4f270d6abe585c41f049ea92a0d7/src/Cake.Frosting/Internal/Commands/DefaultCommand.cs#L82

Within Cake proper (rather than Cake.Frosting)... Cake.Commands.DefaultCommand.Execute(...) has been modified to explicitly create the CakeArguments from CommandContext.Remaining, adding in the DefaultCommandSettings.Recompile flag, if necessary. 

This PR has indirectly resulted in a move towards to using `CakeArguments` rather than the spectre.console `IRemainingArgument`, which seems a lot cleaner and self-contained.

----

**Full disclosure:** I'm a little uncomfortable submitting a PR with no unit tests, however my reasons for doing it are as follows:

1. `DefaultCommand`, both Cake or Cake.Frosting ones, have entirely zero unit tests (rather, they seem to represent the top level container, and as such aren't tested)
2. https://github.com/cake-build/cake/issues/3291, which this PR was modelled on, didn't see the need to introduce unit tests to cover the IRemainingArguments behaviour
3. It's not entirely clear whether this is even the right level for unit testing

However, and relevant to both Cake and Cake.Frosting DefaultCommand's, I would consider introducing tests for this argument handling behaviour, if deemed necessary. 

[It might be some kind of factory to create the `CakeArguments`, added into the IServiceCollection, and injected into the DefaultCommand, two versions of factory I guess, one for Cake and one for Cake.Frosting (given both commands have different DefaultCommandSettings classes). But that's just some thinking off the top of my head]