### PR TITLE
Add defaultValue param to the GetArgument helper

### DIFF
--- a/src/Cake.Core/Extensions/CakeArgumentsExtensions.cs
+++ b/src/Cake.Core/Extensions/CakeArgumentsExtensions.cs
@@ -17,6 +17,22 @@ namespace Cake.Core
         /// </remarks>
         /// <param name="arguments">The arguments.</param>
         /// <param name="name">The argument name.</param>
+        /// <param name="defaultValue">The default value to use if the argument is not found.</param>
+        /// <returns>The argument value.</returns>
+        public static string GetArgument(this ICakeArguments arguments, string name, string defaultValue)
+        {
+            return arguments.GetArgument(name) ?? defaultValue;
+        }
+
+        /// <summary>
+        /// Gets the value for an argument.
+        /// </summary>
+        /// <remarks>
+        /// If multiple arguments with the same name are
+        /// specified, the last argument value is returned.
+        /// </remarks>
+        /// <param name="arguments">The arguments.</param>
+        /// <param name="name">The argument name.</param>
         /// <returns>The argument value.</returns>
         public static string GetArgument(this ICakeArguments arguments, string name)
         {


### PR DESCRIPTION
This PR adds ability to specify the desired default value of an argument when retrieving it with the helper function with cake frosting, ie:
```cs
ArtifactsDir = context.Arguments.GetArgument("artifactsDir", "artifacts");
```

