### PR TITLE
GH4150/4197: Codegen styling & nullable param

### DIFF
--- a/src/Cake.Core.Tests/Data/MethodAliasGeneratorData.cs
+++ b/src/Cake.Core.Tests/Data/MethodAliasGeneratorData.cs
@@ -246,5 +246,21 @@ namespace Cake.Core.Tests.Data
         {
             throw new NotImplementedException();
         }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static void NonGeneric_ExtensionMethodWithNullableParameter(this ICakeContext context, string? parameter)
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static string? NonGeneric_ExtensionMethodWithNullableReturnValue(this ICakeContext context)
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Cake.Core.Tests/Data/PropertyAliasGeneratorData.cs
+++ b/src/Cake.Core.Tests/Data/PropertyAliasGeneratorData.cs
@@ -123,5 +123,13 @@ namespace Cake.Core.Tests.Data
         {
             throw new NotImplementedException();
         }
+
+        [CakePropertyAlias(Cache = true)]
+#nullable enable
+        public static string? Cached_Nullable_Type(this ICakeContext context)
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Generic_Methods_name=Generic_ExtensionMethod.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Generic_Methods_name=Generic_ExtensionMethod.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void Generic_ExtensionMethod<TTest>()
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.Generic_ExtensionMethod<TTest>(Context);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.Generic_ExtensionMethod<TTest>(Context);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Generic_Methods_name=Generic_ExtensionMethodWithGenericReturnValue.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Generic_Methods_name=Generic_ExtensionMethodWithGenericReturnValue.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public TTest Generic_ExtensionMethodWithGenericReturnValue<TTest>(TTest value)
-{
-    return Cake.Core.Tests.Data.MethodAliasGeneratorData.Generic_ExtensionMethodWithGenericReturnValue<TTest>(Context, value);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.Generic_ExtensionMethodWithGenericReturnValue<TTest>(Context, value);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Generic_Methods_name=Generic_ExtensionMethodWithGenericReturnValueAndTypeParamConstraints.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Generic_Methods_name=Generic_ExtensionMethodWithGenericReturnValueAndTypeParamConstraints.verified.cake
@@ -2,6 +2,4 @@
 public TOut Generic_ExtensionMethodWithGenericReturnValueAndTypeParamConstraints<TIn, TOut>(TIn arg)
 where TIn : class, new()
 where TOut : System.Collections.ArrayList, System.IDisposable
-{
-    return Cake.Core.Tests.Data.MethodAliasGeneratorData.Generic_ExtensionMethodWithGenericReturnValueAndTypeParamConstraints<TIn, TOut>(Context, arg);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.Generic_ExtensionMethodWithGenericReturnValueAndTypeParamConstraints<TIn, TOut>(Context, arg);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Generic_Methods_name=Generic_ExtensionMethodWithParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Generic_Methods_name=Generic_ExtensionMethodWithParameter.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void Generic_ExtensionMethodWithParameter<TTest>(TTest value)
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.Generic_ExtensionMethodWithParameter<TTest>(Context, value);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.Generic_ExtensionMethodWithParameter<TTest>(Context, value);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithDynamicReturnValue.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithDynamicReturnValue.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public dynamic NonGeneric_ExtensionMethodWithDynamicReturnValue()
-{
-    return Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithDynamicReturnValue(Context);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithDynamicReturnValue(Context);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithGenericCollectionOfNestedType.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithGenericCollectionOfNestedType.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithGenericCollectionOfNestedType(System.Collections.Generic.ICollection<Cake.Core.Tests.Data.MethodAliasGeneratorData.TestNestedEnum> items)
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithGenericCollectionOfNestedType(Context, items);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithGenericCollectionOfNestedType(Context, items);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithGenericExpressionArrayParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithGenericExpressionArrayParameter.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithGenericExpressionArrayParameter(System.Linq.Expressions.Expression<System.Func<System.String, System.String>>[] expression)
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithGenericExpressionArrayParameter(Context, expression);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithGenericExpressionArrayParameter(Context, expression);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithGenericExpressionParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithGenericExpressionParameter.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithGenericExpressionParameter(System.Linq.Expressions.Expression<System.Func<System.String, System.String>> expression)
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithGenericExpressionParameter(Context, expression);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithGenericExpressionParameter(Context, expression);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithGenericExpressionParamsArrayParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithGenericExpressionParamsArrayParameter.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithGenericExpressionParamsArrayParameter(params System.Linq.Expressions.Expression<System.Func<System.String, System.String>>[] expression)
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithGenericExpressionParamsArrayParameter(Context, expression);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithGenericExpressionParamsArrayParameter(Context, expression);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithGenericParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithGenericParameter.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithGenericParameter(System.Action<System.Int32> value)
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithGenericParameter(Context, value);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithGenericParameter(Context, value);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNoParameters.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNoParameters.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithNoParameters()
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNoParameters(Context);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNoParameters(Context);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableParameter.verified.cake
@@ -1,0 +1,3 @@
+﻿[System.Diagnostics.DebuggerStepThrough]
+public void NonGeneric_ExtensionMethodWithNullableParameter(System.String? parameter)
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableParameter(Context, parameter);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableReturnValue.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableReturnValue.verified.cake
@@ -1,0 +1,3 @@
+﻿[System.Diagnostics.DebuggerStepThrough]
+public System.String? NonGeneric_ExtensionMethodWithNullableReturnValue()
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableReturnValue(Context);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalBooleanParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalBooleanParameter.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithOptionalBooleanParameter(System.Int32 value, System.Boolean flag = false)
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalBooleanParameter(Context, value, flag);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalBooleanParameter(Context, value, flag);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalCharParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalCharParameter.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithOptionalCharParameter(System.String s, System.Char c = 's')
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalCharParameter(Context, s, c);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalCharParameter(Context, s, c);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalDecimalParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalDecimalParameter.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithOptionalDecimalParameter(System.String s, System.Decimal value = (System.Decimal)12.12)
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalDecimalParameter(Context, s, value);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalDecimalParameter(Context, s, value);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalEnumParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalEnumParameter.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithOptionalEnumParameter(System.Int32 value, System.AttributeTargets targets = (System.AttributeTargets)4)
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalEnumParameter(Context, value, targets);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalEnumParameter(Context, value, targets);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalNullableBooleanParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalNullableBooleanParameter.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithOptionalNullableBooleanParameter(System.String s, System.Nullable<System.Boolean> value = (System.Boolean)false)
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalNullableBooleanParameter(Context, s, value);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalNullableBooleanParameter(Context, s, value);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalNullableCharParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalNullableCharParameter.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithOptionalNullableCharParameter(System.String s, System.Nullable<System.Char> value = (System.Char)'s')
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalNullableCharParameter(Context, s, value);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalNullableCharParameter(Context, s, value);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalNullableDecimalParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalNullableDecimalParameter.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithOptionalNullableDecimalParameter(System.String s, System.Nullable<System.Decimal> value = (System.Decimal)123.12)
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalNullableDecimalParameter(Context, s, value);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalNullableDecimalParameter(Context, s, value);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalNullableDoubleParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalNullableDoubleParameter.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithOptionalNullableDoubleParameter(System.String s, System.Nullable<System.Double> value = (System.Double)1234567890.12)
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalNullableDoubleParameter(Context, s, value);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalNullableDoubleParameter(Context, s, value);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalNullableEnumParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalNullableEnumParameter.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithOptionalNullableEnumParameter(System.String s, System.Nullable<System.AttributeTargets> targets = (System.AttributeTargets)4)
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalNullableEnumParameter(Context, s, targets);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalNullableEnumParameter(Context, s, targets);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalNullableLongParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalNullableLongParameter.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithOptionalNullableLongParameter(System.String s, System.Nullable<System.Int64> value = (System.Int64)1234567890)
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalNullableLongParameter(Context, s, value);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalNullableLongParameter(Context, s, value);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalNullableTParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalNullableTParameter.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithOptionalNullableTParameter(System.String s, System.Nullable<System.Int32> value = (System.Int32)0)
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalNullableTParameter(Context, s, value);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalNullableTParameter(Context, s, value);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalObjectParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalObjectParameter.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithOptionalObjectParameter(System.Int32 value, System.Object option = null)
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalObjectParameter(Context, value, option);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalObjectParameter(Context, value, option);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalStringParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOptionalStringParameter.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithOptionalStringParameter(System.Int32 value, System.String s = "there is a \"string\" here and a \t tab")
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalStringParameter(Context, value, s);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOptionalStringParameter(Context, value, s);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOutputParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithOutputParameter.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithOutputParameter(out System.IDisposable arg)
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOutputParameter(Context, out arg);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithOutputParameter(Context, out arg);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithParameter.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithParameter(System.Int32 value)
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithParameter(Context, value);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithParameter(Context, value);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithParameterArray.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithParameterArray.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithParameterArray(params System.Int32[] values)
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithParameterArray(Context, values);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithParameterArray(Context, values);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithParameterAttributes.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithParameterAttributes.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithParameterAttributes([System.Runtime.CompilerServices.CallerMemberName] System.String memberName = "", [System.Runtime.CompilerServices.CallerFilePath] System.String sourceFilePath = "", [System.Runtime.CompilerServices.CallerLineNumber] System.Int32 sourceLineNumber = (System.Int32)0)
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithParameterAttributes(Context, memberName, sourceFilePath, sourceLineNumber);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithParameterAttributes(Context, memberName, sourceFilePath, sourceLineNumber);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithReservedKeywordParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithReservedKeywordParameter.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithReservedKeywordParameter(System.Int32 @new)
-{
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithReservedKeywordParameter(Context, @new);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithReservedKeywordParameter(Context, @new);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithReturnValue.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithReturnValue.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public System.String NonGeneric_ExtensionMethodWithReturnValue()
-{
-    return Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithReturnValue(Context);
-}
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithReturnValue(Context);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Obsolete_Methods_name=Obsolete_ExplicitError_WithMessage.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Obsolete_Methods_name=Obsolete_ExplicitError_WithMessage.verified.cake
@@ -1,5 +1,3 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void Obsolete_ExplicitError_WithMessage()
-{
-    throw new Cake.Core.CakeException("The alias Obsolete_ExplicitError_WithMessage has been made obsolete. Please use Foo.Bar instead.");
-}
+    => throw new Cake.Core.CakeException("The alias Obsolete_ExplicitError_WithMessage has been made obsolete. Please use Foo.Bar instead.");

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Obsolete_Methods_name=Obsolete_ExplicitWarning_WithMessage.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Obsolete_Methods_name=Obsolete_ExplicitWarning_WithMessage.verified.cake
@@ -1,8 +1,5 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void Obsolete_ExplicitWarning_WithMessage()
-{
-    Context.Log.Warning("Warning: The alias Obsolete_ExplicitWarning_WithMessage has been made obsolete. Please use Foo.Bar instead.");
 #pragma warning disable 0618
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.Obsolete_ExplicitWarning_WithMessage(Context);
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.Obsolete_ExplicitWarning_WithMessage(Context);
 #pragma warning restore 0618
-}

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Obsolete_Methods_name=Obsolete_ImplicitWarning_NoMessage.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Obsolete_Methods_name=Obsolete_ImplicitWarning_NoMessage.verified.cake
@@ -1,8 +1,5 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void Obsolete_ImplicitWarning_NoMessage()
-{
-    Context.Log.Warning("Warning: The alias Obsolete_ImplicitWarning_NoMessage has been made obsolete.");
 #pragma warning disable 0618
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.Obsolete_ImplicitWarning_NoMessage(Context);
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.Obsolete_ImplicitWarning_NoMessage(Context);
 #pragma warning restore 0618
-}

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Obsolete_Methods_name=Obsolete_ImplicitWarning_WithMessage.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Obsolete_Methods_name=Obsolete_ImplicitWarning_WithMessage.verified.cake
@@ -1,8 +1,5 @@
 ﻿[System.Diagnostics.DebuggerStepThrough]
 public void Obsolete_ImplicitWarning_WithMessage()
-{
-    Context.Log.Warning("Warning: The alias Obsolete_ImplicitWarning_WithMessage has been made obsolete. Please use Foo.Bar instead.");
 #pragma warning disable 0618
-    Cake.Core.Tests.Data.MethodAliasGeneratorData.Obsolete_ImplicitWarning_WithMessage(Context);
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.Obsolete_ImplicitWarning_WithMessage(Context);
 #pragma warning restore 0618
-}

--- a/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Cached_Obsolete_Properties_name=Cached_Obsolete_ExplicitError_WithMessage.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Cached_Obsolete_Properties_name=Cached_Obsolete_ExplicitError_WithMessage.verified.cake
@@ -1,8 +1,5 @@
-﻿public System.Int32 Cached_Obsolete_ExplicitError_WithMessage
-{
-    [System.Diagnostics.DebuggerStepThrough]
-    get
-    {
-        throw new Cake.Core.CakeException("The alias Cached_Obsolete_ExplicitError_WithMessage has been made obsolete. Please use Foo.Bar instead.");
-    }
-}
+﻿[Obsolete("Please use Foo.Bar instead.", true)]
+public System.Int32 Cached_Obsolete_ExplicitError_WithMessage
+#pragma warning disable CS0618
+    => Cake.Core.Tests.Data.PropertyAliasGeneratorData.Cached_Obsolete_ExplicitError_WithMessage(Context);
+#pragma warning restore CS0618

--- a/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Cached_Obsolete_Properties_name=Cached_Obsolete_ExplicitWarning_WithMessage.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Cached_Obsolete_Properties_name=Cached_Obsolete_ExplicitWarning_WithMessage.verified.cake
@@ -1,17 +1,6 @@
 ﻿private System.Int32? _Cached_Obsolete_ExplicitWarning_WithMessage;
-[Obsolete("Please use Foo.Bar instead.")]
+[Obsolete("Please use Foo.Bar instead.", false)]
 public System.Int32 Cached_Obsolete_ExplicitWarning_WithMessage
-{
-    [System.Diagnostics.DebuggerStepThrough]
-    get
-    {
-        Context.Log.Warning("Warning: The alias Cached_Obsolete_ExplicitWarning_WithMessage has been made obsolete. Please use Foo.Bar instead.");
-        if (_Cached_Obsolete_ExplicitWarning_WithMessage==null)
-        {
 #pragma warning disable CS0618
-            _Cached_Obsolete_ExplicitWarning_WithMessage = Cake.Core.Tests.Data.PropertyAliasGeneratorData.Cached_Obsolete_ExplicitWarning_WithMessage(Context);
+    => _Cached_Obsolete_ExplicitWarning_WithMessage ??= Cake.Core.Tests.Data.PropertyAliasGeneratorData.Cached_Obsolete_ExplicitWarning_WithMessage(Context);
 #pragma warning restore CS0618
-        }
-        return _Cached_Obsolete_ExplicitWarning_WithMessage.Value;
-    }
-}

--- a/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Cached_Obsolete_Properties_name=Cached_Obsolete_ImplicitWarning_NoMessage.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Cached_Obsolete_Properties_name=Cached_Obsolete_ImplicitWarning_NoMessage.verified.cake
@@ -1,17 +1,6 @@
 ﻿private System.Int32? _Cached_Obsolete_ImplicitWarning_NoMessage;
 [Obsolete]
 public System.Int32 Cached_Obsolete_ImplicitWarning_NoMessage
-{
-    [System.Diagnostics.DebuggerStepThrough]
-    get
-    {
-        Context.Log.Warning("Warning: The alias Cached_Obsolete_ImplicitWarning_NoMessage has been made obsolete.");
-        if (_Cached_Obsolete_ImplicitWarning_NoMessage==null)
-        {
 #pragma warning disable CS0618
-            _Cached_Obsolete_ImplicitWarning_NoMessage = Cake.Core.Tests.Data.PropertyAliasGeneratorData.Cached_Obsolete_ImplicitWarning_NoMessage(Context);
+    => _Cached_Obsolete_ImplicitWarning_NoMessage ??= Cake.Core.Tests.Data.PropertyAliasGeneratorData.Cached_Obsolete_ImplicitWarning_NoMessage(Context);
 #pragma warning restore CS0618
-        }
-        return _Cached_Obsolete_ImplicitWarning_NoMessage.Value;
-    }
-}

--- a/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Cached_Obsolete_Properties_name=Cached_Obsolete_ImplicitWarning_WithMessage.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Cached_Obsolete_Properties_name=Cached_Obsolete_ImplicitWarning_WithMessage.verified.cake
@@ -1,17 +1,6 @@
 ﻿private System.Int32? _Cached_Obsolete_ImplicitWarning_WithMessage;
-[Obsolete("Please use Foo.Bar instead.")]
+[Obsolete("Please use Foo.Bar instead.", false)]
 public System.Int32 Cached_Obsolete_ImplicitWarning_WithMessage
-{
-    [System.Diagnostics.DebuggerStepThrough]
-    get
-    {
-        Context.Log.Warning("Warning: The alias Cached_Obsolete_ImplicitWarning_WithMessage has been made obsolete. Please use Foo.Bar instead.");
-        if (_Cached_Obsolete_ImplicitWarning_WithMessage==null)
-        {
 #pragma warning disable CS0618
-            _Cached_Obsolete_ImplicitWarning_WithMessage = Cake.Core.Tests.Data.PropertyAliasGeneratorData.Cached_Obsolete_ImplicitWarning_WithMessage(Context);
+    => _Cached_Obsolete_ImplicitWarning_WithMessage ??= Cake.Core.Tests.Data.PropertyAliasGeneratorData.Cached_Obsolete_ImplicitWarning_WithMessage(Context);
 #pragma warning restore CS0618
-        }
-        return _Cached_Obsolete_ImplicitWarning_WithMessage.Value;
-    }
-}

--- a/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Cached_Properties_name=Cached_Dynamic_Type.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Cached_Properties_name=Cached_Dynamic_Type.verified.cake
@@ -1,13 +1,3 @@
 ﻿private dynamic _Cached_Dynamic_Type;
 public dynamic Cached_Dynamic_Type
-{
-    [System.Diagnostics.DebuggerStepThrough]
-    get
-    {
-        if (_Cached_Dynamic_Type==null)
-        {
-            _Cached_Dynamic_Type = Cake.Core.Tests.Data.PropertyAliasGeneratorData.Cached_Dynamic_Type(Context);
-        }
-        return _Cached_Dynamic_Type;
-    }
-}
+    => _Cached_Dynamic_Type ??= Cake.Core.Tests.Data.PropertyAliasGeneratorData.Cached_Dynamic_Type(Context);

--- a/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Cached_Properties_name=Cached_Nullable_Type.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Cached_Properties_name=Cached_Nullable_Type.verified.cake
@@ -1,0 +1,3 @@
+﻿private System.String? _Cached_Nullable_Type;
+public System.String? Cached_Nullable_Type
+    => _Cached_Nullable_Type ??= Cake.Core.Tests.Data.PropertyAliasGeneratorData.Cached_Nullable_Type(Context);

--- a/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Cached_Properties_name=Cached_Reference_Type.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Cached_Properties_name=Cached_Reference_Type.verified.cake
@@ -1,13 +1,3 @@
 ﻿private System.String _Cached_Reference_Type;
 public System.String Cached_Reference_Type
-{
-    [System.Diagnostics.DebuggerStepThrough]
-    get
-    {
-        if (_Cached_Reference_Type==null)
-        {
-            _Cached_Reference_Type = Cake.Core.Tests.Data.PropertyAliasGeneratorData.Cached_Reference_Type(Context);
-        }
-        return _Cached_Reference_Type;
-    }
-}
+    => _Cached_Reference_Type ??= Cake.Core.Tests.Data.PropertyAliasGeneratorData.Cached_Reference_Type(Context);

--- a/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Cached_Properties_name=Cached_Value_Type.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Cached_Properties_name=Cached_Value_Type.verified.cake
@@ -1,13 +1,3 @@
 ﻿private System.Boolean? _Cached_Value_Type;
 public System.Boolean Cached_Value_Type
-{
-    [System.Diagnostics.DebuggerStepThrough]
-    get
-    {
-        if (_Cached_Value_Type==null)
-        {
-            _Cached_Value_Type = Cake.Core.Tests.Data.PropertyAliasGeneratorData.Cached_Value_Type(Context);
-        }
-        return _Cached_Value_Type.Value;
-    }
-}
+    => _Cached_Value_Type ??= Cake.Core.Tests.Data.PropertyAliasGeneratorData.Cached_Value_Type(Context);

--- a/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Non_Cached_Obsolete_Properties_name=NonCached_Obsolete_ExplicitError_WithMessage.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Non_Cached_Obsolete_Properties_name=NonCached_Obsolete_ExplicitError_WithMessage.verified.cake
@@ -1,8 +1,5 @@
-﻿public System.Int32 NonCached_Obsolete_ExplicitError_WithMessage
-{
-    [System.Diagnostics.DebuggerStepThrough]
-    get
-    {
-        throw new Cake.Core.CakeException("The alias NonCached_Obsolete_ExplicitError_WithMessage has been made obsolete. Please use Foo.Bar instead.");
-    }
-}
+﻿[Obsolete("Please use Foo.Bar instead.", true)]
+public System.Int32 NonCached_Obsolete_ExplicitError_WithMessage
+#pragma warning disable CS0618
+    => Cake.Core.Tests.Data.PropertyAliasGeneratorData.NonCached_Obsolete_ExplicitError_WithMessage(Context);
+#pragma warning restore CS0618

--- a/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Non_Cached_Obsolete_Properties_name=NonCached_Obsolete_ExplicitWarning_WithMessage.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Non_Cached_Obsolete_Properties_name=NonCached_Obsolete_ExplicitWarning_WithMessage.verified.cake
@@ -1,9 +1,5 @@
-﻿public System.Int32 NonCached_Obsolete_ExplicitWarning_WithMessage
-{
-    [System.Diagnostics.DebuggerStepThrough]
-    get
-    {
-        Context.Log.Warning("Warning: The alias NonCached_Obsolete_ExplicitWarning_WithMessage has been made obsolete. Please use Foo.Bar instead.");
-        return Cake.Core.Tests.Data.PropertyAliasGeneratorData.NonCached_Obsolete_ExplicitWarning_WithMessage(Context);
-    }
-}
+﻿[Obsolete("Please use Foo.Bar instead.", false)]
+public System.Int32 NonCached_Obsolete_ExplicitWarning_WithMessage
+#pragma warning disable CS0618
+    => Cake.Core.Tests.Data.PropertyAliasGeneratorData.NonCached_Obsolete_ExplicitWarning_WithMessage(Context);
+#pragma warning restore CS0618

--- a/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Non_Cached_Obsolete_Properties_name=NonCached_Obsolete_ImplicitWarning_NoMessage.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Non_Cached_Obsolete_Properties_name=NonCached_Obsolete_ImplicitWarning_NoMessage.verified.cake
@@ -1,9 +1,5 @@
-﻿public System.Int32 NonCached_Obsolete_ImplicitWarning_NoMessage
-{
-    [System.Diagnostics.DebuggerStepThrough]
-    get
-    {
-        Context.Log.Warning("Warning: The alias NonCached_Obsolete_ImplicitWarning_NoMessage has been made obsolete.");
-        return Cake.Core.Tests.Data.PropertyAliasGeneratorData.NonCached_Obsolete_ImplicitWarning_NoMessage(Context);
-    }
-}
+﻿[Obsolete]
+public System.Int32 NonCached_Obsolete_ImplicitWarning_NoMessage
+#pragma warning disable CS0618
+    => Cake.Core.Tests.Data.PropertyAliasGeneratorData.NonCached_Obsolete_ImplicitWarning_NoMessage(Context);
+#pragma warning restore CS0618

--- a/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Non_Cached_Obsolete_Properties_name=NonCached_Obsolete_ImplicitWarning_WithMessage.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Non_Cached_Obsolete_Properties_name=NonCached_Obsolete_ImplicitWarning_WithMessage.verified.cake
@@ -1,9 +1,5 @@
-﻿public System.Int32 NonCached_Obsolete_ImplicitWarning_WithMessage
-{
-    [System.Diagnostics.DebuggerStepThrough]
-    get
-    {
-        Context.Log.Warning("Warning: The alias NonCached_Obsolete_ImplicitWarning_WithMessage has been made obsolete. Please use Foo.Bar instead.");
-        return Cake.Core.Tests.Data.PropertyAliasGeneratorData.NonCached_Obsolete_ImplicitWarning_WithMessage(Context);
-    }
-}
+﻿[Obsolete("Please use Foo.Bar instead.", false)]
+public System.Int32 NonCached_Obsolete_ImplicitWarning_WithMessage
+#pragma warning disable CS0618
+    => Cake.Core.Tests.Data.PropertyAliasGeneratorData.NonCached_Obsolete_ImplicitWarning_WithMessage(Context);
+#pragma warning restore CS0618

--- a/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Non_Cached_Properties_name=NonCached_Dynamic_Type.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Non_Cached_Properties_name=NonCached_Dynamic_Type.verified.cake
@@ -1,8 +1,2 @@
 ﻿public dynamic NonCached_Dynamic_Type
-{
-    [System.Diagnostics.DebuggerStepThrough]
-    get
-    {
-        return Cake.Core.Tests.Data.PropertyAliasGeneratorData.NonCached_Dynamic_Type(Context);
-    }
-}
+    => Cake.Core.Tests.Data.PropertyAliasGeneratorData.NonCached_Dynamic_Type(Context);

--- a/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Non_Cached_Properties_name=NonCached_Value_Type.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Non_Cached_Properties_name=NonCached_Value_Type.verified.cake
@@ -1,8 +1,2 @@
 ﻿public System.Int32 NonCached_Value_Type
-{
-    [System.Diagnostics.DebuggerStepThrough]
-    get
-    {
-        return Cake.Core.Tests.Data.PropertyAliasGeneratorData.NonCached_Value_Type(Context);
-    }
-}
+    => Cake.Core.Tests.Data.PropertyAliasGeneratorData.NonCached_Value_Type(Context);

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/MethodAliasGeneratorTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/MethodAliasGeneratorTests.cs
@@ -61,6 +61,8 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
             [InlineData("ExtensionMethodWithGenericCollectionOfNestedType")]
             [InlineData("ExtensionMethodWithParameterAttributes")]
             [InlineData("ExtensionMethodWithDynamicReturnValue")]
+            [InlineData("ExtensionMethodWithNullableParameter")]
+            [InlineData("ExtensionMethodWithNullableReturnValue")]
             public Task Should_Return_Correct_Generated_Code_For_Non_Generic_Methods(string name)
             {
                 // Given / When

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/PropertyAliasGeneratorTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/PropertyAliasGeneratorTests.cs
@@ -132,6 +132,7 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
             [InlineData("Cached_Reference_Type")]
             [InlineData("Cached_Value_Type")]
             [InlineData("Cached_Dynamic_Type")]
+            [InlineData("Cached_Nullable_Type")]
             public Task Should_Return_Correct_Generated_Code_For_Cached_Properties(string name)
             {
                 // Given / When


### PR DESCRIPTION
* fixes #4150 - Fix styling warnings
* fixes #4197 - Fix parameter nullability error

Results in about 5k fewer lines of code generated.
Fixes issues with nullable return types and parameters.