### PR TITLE
Mark Cake 3.x as out of support

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version   | Supported          |
 | --------- | ------------------ |
-| 3.x.x     | :white_check_mark: |
+| 4.x.x     | :white_check_mark: |
+| 3.x.x     | :x:                |
 | 2.x.x     | :x:                |
 | 1.0.x     | :x:                |
 | 0.38.5    | :x:                |


### PR DESCRIPTION
Following [Cake Support Lifecycle](https://cakebuild.net/docs/getting-started/lifecycle) Cake 3.x is now out of support