### PR TITLE
GH4278: Update Spectre.Console to 0.49.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [windows-latest, macos-13, ubuntu-latest]
     steps:
       - name: Get the sources
         uses: actions/checkout@v3

--- a/src/Cake.Cli/Cake.Cli.csproj
+++ b/src/Cake.Cli/Cake.Cli.csproj
@@ -19,7 +19,7 @@
 
     <ItemGroup>
       <PackageReference Include="Autofac" Version="8.0.0" />
-      <PackageReference Include="Spectre.Console" Version="0.47.0" />
-      <PackageReference Include="Spectre.Console.Cli" Version="0.47.0" />
+      <PackageReference Include="Spectre.Console" Version="0.49.1" />
+      <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
   </ItemGroup>
 </Project>

--- a/src/Cake/Commands/DefaultCommand.cs
+++ b/src/Cake/Commands/DefaultCommand.cs
@@ -129,10 +129,11 @@ namespace Cake.Commands
             // Keep the actual remaining arguments in the cake arguments
             foreach (var group in remainingArguments.Parsed)
             {
-                arguments[group.Key] = new List<string>();
+                string key = group.Key.TrimStart('-');
+                arguments[key] = new List<string>();
                 foreach (var argument in group)
                 {
-                    arguments[group.Key].Add(argument);
+                    arguments[key].Add(argument);
                 }
             }
 

--- a/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
+++ b/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
@@ -282,6 +282,7 @@ Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetWorkloadSearch")
 
 Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetWorkloadRepair")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
+    .OnError(exception => { Console.WriteLine(exception); })
     .Does(() =>
 {
     // When

--- a/tests/integration/Cake.Core/Scripting/AddinDirective.cake
+++ b/tests/integration/Cake.Core/Scripting/AddinDirective.cake
@@ -67,7 +67,7 @@ Task("Cake.Core.Scripting.AddinDirective.LoadNativeAssemblies")
 {
     FilePath cakeCore = typeof(ICakeContext).GetTypeInfo().Assembly.Location;
     FilePath cake = cakeCore.GetDirectory().CombineWithFilePath("Cake.dll");
-    var script = @"#addin nuget:?package=Cake.Git&version=2.0.0
+    var script = @"#addin nuget:?package=Cake.Git&version=4.0.0
 
 var repoRoot = GitFindRootFromPath(Context.EnvironmentVariable(""CAKE_TEST_DIR""));
 


### PR DESCRIPTION
* fixes #4278