### PR TITLE
Add FreeBSD Platform Detection

### DIFF
--- a/src/Cake.Common.Tests/Unit/EnvironmentAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/EnvironmentAliasesTests.cs
@@ -182,6 +182,7 @@ namespace Cake.Common.Tests.Unit
             [Theory]
             [InlineData(PlatformFamily.Linux, false)]
             [InlineData(PlatformFamily.OSX, false)]
+            [InlineData(PlatformFamily.FreeBSD, false)]
             [InlineData(PlatformFamily.Windows, true)]
             public void Should_Return_Correct_Value(PlatformFamily family, bool expected)
             {
@@ -212,6 +213,7 @@ namespace Cake.Common.Tests.Unit
             [Theory]
             [InlineData(PlatformFamily.Linux, true)]
             [InlineData(PlatformFamily.OSX, true)]
+            [InlineData(PlatformFamily.FreeBSD, true)]
             [InlineData(PlatformFamily.Windows, false)]
             public void Should_Return_Correct_Value(PlatformFamily family, bool expected)
             {
@@ -242,6 +244,7 @@ namespace Cake.Common.Tests.Unit
             [Theory]
             [InlineData(PlatformFamily.Linux, true)]
             [InlineData(PlatformFamily.OSX, false)]
+            [InlineData(PlatformFamily.FreeBSD, false)]
             [InlineData(PlatformFamily.Windows, false)]
             public void Should_Return_Correct_Value(PlatformFamily family, bool expected)
             {
@@ -272,6 +275,7 @@ namespace Cake.Common.Tests.Unit
             [Theory]
             [InlineData(PlatformFamily.Linux, false)]
             [InlineData(PlatformFamily.OSX, true)]
+            [InlineData(PlatformFamily.FreeBSD, false)]
             [InlineData(PlatformFamily.Windows, false)]
             public void Should_Return_Correct_Value(PlatformFamily family, bool expected)
             {
@@ -281,6 +285,36 @@ namespace Cake.Common.Tests.Unit
 
                 // When
                 var result = EnvironmentAliases.IsRunningOnMacOs(context);
+
+                // Then
+                Assert.Equal(expected, result);
+            }
+        }
+        public sealed class TheIsRunningOnFreeBSDMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Context_Is_Null()
+            {
+                // Given, When
+                var result = Record.Exception(() => EnvironmentAliases.IsRunningOnFreeBSD(null));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "context");
+            }
+
+            [Theory]
+            [InlineData(PlatformFamily.Linux, false)]
+            [InlineData(PlatformFamily.OSX, false)]
+            [InlineData(PlatformFamily.FreeBSD, true)]
+            [InlineData(PlatformFamily.Windows, false)]
+            public void Should_Return_Correct_Value(PlatformFamily family, bool expected)
+            {
+                // Given
+                var context = Substitute.For<ICakeContext>();
+                context.Environment.Returns(new FakeEnvironment(family));
+
+                // When
+                var result = EnvironmentAliases.IsRunningOnFreeBSD(context);
 
                 // Then
                 Assert.Equal(expected, result);

--- a/src/Cake.Common.Tests/Unit/EnvironmentAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/EnvironmentAliasesTests.cs
@@ -290,6 +290,7 @@ namespace Cake.Common.Tests.Unit
                 Assert.Equal(expected, result);
             }
         }
+
         public sealed class TheIsRunningOnFreeBSDMethod
         {
             [Fact]

--- a/src/Cake.Common/EnviromentAliases.cs
+++ b/src/Cake.Common/EnviromentAliases.cs
@@ -235,7 +235,7 @@ namespace Cake.Common
         [CakeAliasCategory("Platform")]
         public static bool IsRunningOnFreeBSD(this ICakeContext context)
         {
-            if (context == null)
+            if (context is null)
             {
                 throw new ArgumentNullException(nameof(context));
             }

--- a/src/Cake.Common/EnviromentAliases.cs
+++ b/src/Cake.Common/EnviromentAliases.cs
@@ -217,6 +217,32 @@ namespace Cake.Common
         }
 
         /// <summary>
+        /// Determines whether the build script running on a FreeBSD based system.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// if (IsRunningOnFreeBSD())
+        /// {
+        ///     Information("FreeBSD!");
+        /// }
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <returns>
+        ///   <c>true</c> if the build script running on a FreeBSD based system; otherwise <c>false</c>.
+        /// </returns>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Platform")]
+        public static bool IsRunningOnFreeBSD(this ICakeContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            return context.Environment.Platform.FreeBSD();
+        }
+
+        /// <summary>
         /// Determines whether the build script running on a Linux based system.
         /// </summary>
         /// <example>

--- a/src/Cake.Common/EnviromentAliases.cs
+++ b/src/Cake.Common/EnviromentAliases.cs
@@ -239,7 +239,7 @@ namespace Cake.Common
             {
                 throw new ArgumentNullException(nameof(context));
             }
-            return context.Environment.Platform.FreeBSD();
+            return context.Environment.Platform.IsFreeBSD();
         }
 
         /// <summary>

--- a/src/Cake.Common/Tools/MSBuild/MSBuildResolver.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildResolver.cs
@@ -41,6 +41,17 @@ namespace Cake.Common.Tools.MSBuild
 
                 throw new CakeException("Could not resolve MSBuild.");
             }
+            else if (environment.Platform.Family == PlatformFamily.FreeBSD)
+            {
+                var freebsdMSBuildPath = new FilePath("/usr/local/bin/msbuild");
+
+                if (fileSystem.Exist(freebsdMSBuildPath))
+                {
+                    return freebsdMSBuildPath;
+                }
+
+                throw new CakeException("Could not resolve MSBuild.");
+            }
 
             var binPath = settings.ToolVersion == MSBuildToolVersion.Default
                 ? GetHighestAvailableMSBuildVersion(fileSystem, environment, buildPlatform, settings.AllowPreviewVersion)

--- a/src/Cake.Core/Extensions/CakePlatformExtensions.cs
+++ b/src/Cake.Core/Extensions/CakePlatformExtensions.cs
@@ -76,7 +76,7 @@ namespace Cake.Core
         /// <returns><c>true</c> if the platform is a FreeBSD platform; otherwise <c>false</c>.</returns>
         public static bool IsFreeBSD(this ICakePlatform platform)
         {
-            if (platform == null)
+            if (platform is null)
             {
                 throw new ArgumentNullException(nameof(platform));
             }

--- a/src/Cake.Core/Extensions/CakePlatformExtensions.cs
+++ b/src/Cake.Core/Extensions/CakePlatformExtensions.cs
@@ -68,5 +68,19 @@ namespace Cake.Core
             }
             return EnvironmentHelper.IsLinux(platform.Family);
         }
+
+        /// <summary>
+        /// Determines whether the specified platform is a FreeBSD platform.
+        /// </summary>
+        /// <param name="platform">The platform.</param>
+        /// <returns><c>true</c> if the platform is a FreeBSD platform; otherwise <c>false</c>.</returns>
+        public static bool IsFreeBSD(this ICakePlatform platform)
+        {
+            if (platform == null)
+            {
+                throw new ArgumentNullException(nameof(platform));
+            }
+            return EnvironmentHelper.IsFreeBSD(platform.Family);
+        }
     }
 }

--- a/src/Cake.Core/PlatformFamily.cs
+++ b/src/Cake.Core/PlatformFamily.cs
@@ -33,6 +33,6 @@ namespace Cake.Core
         /// <summary>
         /// Represents the FreeBSD platform family.
         /// </summary>
-        FreeBSD = 4
+        FreeBSD = 4,
     }
 }

--- a/src/Cake.Core/PlatformFamily.cs
+++ b/src/Cake.Core/PlatformFamily.cs
@@ -28,6 +28,11 @@ namespace Cake.Core
         /// Represents the OSX platform family.
         /// </summary>
         // ReSharper disable once InconsistentNaming
-        OSX = 3
+        OSX = 3,
+
+        /// <summary>
+        /// Represents the FreeBSD platform family.
+        /// </summary>
+        FreeBSD = 4
     }
 }

--- a/src/Cake.Core/Polyfill/EnvironmentHelper.cs
+++ b/src/Cake.Core/Polyfill/EnvironmentHelper.cs
@@ -54,6 +54,16 @@ namespace Cake.Core.Polyfill
             catch (PlatformNotSupportedException)
             {
             }
+            try
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
+                {
+                    return PlatformFamily.FreeBSD;
+                }
+            }
+            catch (PlatformNotSupportedException)
+            {
+            }
 
             return PlatformFamily.Unknown;
         }
@@ -81,7 +91,8 @@ namespace Cake.Core.Polyfill
         public static bool IsUnix(PlatformFamily family)
         {
             return family == PlatformFamily.Linux
-                   || family == PlatformFamily.OSX;
+                   || family == PlatformFamily.OSX
+                   || family == PlatformFamily.FreeBSD;
         }
 
         public static bool IsOSX(PlatformFamily family)
@@ -92,6 +103,10 @@ namespace Cake.Core.Polyfill
         public static bool IsLinux(PlatformFamily family)
         {
             return family == PlatformFamily.Linux;
+        }
+        public static bool IsFreeBSD(PlatformFamily family)
+        {
+            return family == PlatformFamily.FreeBSD;
         }
 
         public static Runtime GetRuntime()

--- a/src/Cake.Core/Polyfill/EnvironmentHelper.cs
+++ b/src/Cake.Core/Polyfill/EnvironmentHelper.cs
@@ -56,7 +56,7 @@ namespace Cake.Core.Polyfill
             }
             try
             {
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD")))
                 {
                     return PlatformFamily.FreeBSD;
                 }
@@ -104,6 +104,7 @@ namespace Cake.Core.Polyfill
         {
             return family == PlatformFamily.Linux;
         }
+
         public static bool IsFreeBSD(PlatformFamily family)
         {
             return family == PlatformFamily.FreeBSD;


### PR DESCRIPTION
Closes https://github.com/cake-build/cake/issues/4310

This PR adds FreeBSD as a detected platform to Cake. It also includes a platform test. 

As .NET Standard does not support FreeBSD directly, and not to break .NET Standard compatibility, the function `RuntimeInformation.IsOSPlatform(OSPlatform.Create())` is used.

After building I did find test failures that seem to originate from `VerifyTests` as it does not support FreeBSD either. I will open a PR at that repo to address it. Tests are attached below

Even after this, Cake will not dogfood under FreeBSD as the tool `GitVersion` uses `Lib2GitSharp` which consumes a NuGet made by https://github.com/libgit2/libgit2sharp.nativebinaries that does not include a FreeBSD library. `GitVersion` uses Cake to build. 

Zip'd results using `/logger:html` for tests
[results.zip](https://github.com/cake-build/cake/files/15300092/results.zip)

