### PR TITLE
Add .NET package search to Cake scripts

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/DotNet/Package/Search/DotNetPackageSearcherFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/DotNet/Package/Search/DotNetPackageSearcherFixture.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Cake.Common.Tools.DotNet.Package.Search;
+
+namespace Cake.Common.Tests.Fixtures.Tools.DotNet.Package.Search
+{
+    internal class DotNetPackageSearcherFixture : DotNetFixture<DotNetPackageSearchSettings>
+    {
+        public string SearchTerm { get; set; }
+
+        public IEnumerable<DotNetPackageSearchItem> Result { get; private set; }
+
+        protected override void RunTool()
+        {
+            var tool = new DotNetPackageSearcher(FileSystem, Environment, ProcessRunner, Tools);
+            Result = tool.Search(SearchTerm, Settings);
+        }
+
+        internal void GivenNormalPackageResult()
+        {
+            ProcessRunner.Process.SetStandardOutput(new string[]
+            {
+                "{",
+                "  \"version\": 2,",
+                "  \"problems\": [],",
+                "  \"searchResult\": [",
+                "    {",
+                "      \"sourceName\": \"nuget.org\",",
+                "      \"packages\": [",
+                "        {",
+                "          \"id\": \"Cake\",",
+                "          \"latestVersion\": \"0.22.2\"",
+                "        },",
+                "        {",
+                "          \"id\": \"Cake.Core\",",
+                "          \"latestVersion\": \"0.22.2\"",
+                "        },",
+                "        {",
+                "          \"id\": \"Cake.CoreCLR\",",
+                "          \"latestVersion\": \"0.22.2\"",
+                "        }",
+                "      ]",
+                "    }",
+                "  ]",
+                "}",
+            });
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Package/Search/DotNetPackageSearchSettingsTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Package/Search/DotNetPackageSearchSettingsTests.cs
@@ -1,0 +1,51 @@
+﻿using Cake.Common.Tools.DotNet.Package.Search;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.DotNet.Package.Search
+{
+    public sealed class DotNetPackageSearchSettingsTests
+    {
+        public sealed class TheConstructor
+        {
+            [Fact]
+            public void Should_Set_ExactMatch_To_False_By_Default()
+            {
+                // Given, When
+                var settings = new DotNetPackageSearchSettings();
+
+                // Then
+                Assert.False(settings.ExactMatch);
+            }
+
+            [Fact]
+            public void Should_Set_Take_To_Null_By_Default()
+            {
+                // Given, When
+                var settings = new DotNetPackageSearchSettings();
+
+                // Then
+                Assert.Null(settings.Take);
+            }
+
+            [Fact]
+            public void Should_Set_Skip_To_Null_By_Default()
+            {
+                // Given, When
+                var settings = new DotNetPackageSearchSettings();
+
+                // Then
+                Assert.Null(settings.Skip);
+            }
+
+            [Fact]
+            public void Should_Set_Prerelease_To_False_By_Default()
+            {
+                // Given, When
+                var settings = new DotNetPackageSearchSettings();
+
+                // Then
+                Assert.False(settings.Prerelease);
+            }
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Package/Search/DotNetPackageSearcherTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Package/Search/DotNetPackageSearcherTests.cs
@@ -1,0 +1,173 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tests.Fixtures.Tools.DotNet.Package.Search;
+using Cake.Common.Tools.DotNet;
+using Cake.Testing;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.DotNet.Package.Search
+{
+    public sealed class DotNetPackageSearcherTests
+    {
+        public sealed class TheSearchMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var fixture = new DotNetPackageSearcherFixture();
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "settings");
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_Arguments()
+            {
+                // Given
+                var fixture = new DotNetPackageSearcherFixture();
+                fixture.SearchTerm = "Cake";
+                fixture.GivenNormalPackageResult();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("package search \"Cake\" --verbosity normal --format json", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_ExactMatch_To_Arguments_If_True()
+            {
+                // Given
+                var fixture = new DotNetPackageSearcherFixture();
+                fixture.SearchTerm = "Cake";
+                fixture.Settings.ExactMatch = true;
+                fixture.GivenNormalPackageResult();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("package search \"Cake\" --exact-match --verbosity normal --format json", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Prerelease_To_Arguments_If_True()
+            {
+                // Given
+                var fixture = new DotNetPackageSearcherFixture();
+                fixture.SearchTerm = "Cake";
+                fixture.Settings.Prerelease = true;
+                fixture.GivenNormalPackageResult();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("package search \"Cake\" --prerelease --verbosity normal --format json", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Take_To_Arguments_If_True()
+            {
+                // Given
+                var fixture = new DotNetPackageSearcherFixture();
+                fixture.SearchTerm = "Cake";
+                fixture.Settings.Take = 10;
+                fixture.GivenNormalPackageResult();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("package search \"Cake\" --take 10 --verbosity normal --format json", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Skip_To_Arguments_If_True()
+            {
+                // Given
+                var fixture = new DotNetPackageSearcherFixture();
+                fixture.SearchTerm = "Cake";
+                fixture.Settings.Skip = 10;
+                fixture.GivenNormalPackageResult();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("package search \"Cake\" --skip 10 --verbosity normal --format json", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Sources_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new DotNetPackageSearcherFixture();
+                fixture.SearchTerm = "Cake";
+                fixture.Settings.Sources = new[] { "A", "B", "C", };
+                fixture.GivenNormalPackageResult();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("package search \"Cake\" --source \"A\" --source \"B\" --source \"C\" --verbosity normal --format json", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_ConfigFile_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new DotNetPackageSearcherFixture();
+                fixture.SearchTerm = "Cake";
+                fixture.Settings.ConfigFile = "./nuget.config";
+                fixture.GivenNormalPackageResult();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("package search \"Cake\" --configfile \"/Working/nuget.config\" " +
+                             "--verbosity normal --format json", result.Args);
+            }
+
+            [Fact]
+            public void Should_Return_Correct_List_Of_DotNetPackageSearchItems()
+            {
+                // Given
+                var fixture = new DotNetPackageSearcherFixture();
+                fixture.SearchTerm = "Cake";
+                fixture.GivenNormalPackageResult();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Collection(fixture.Result,
+                    item =>
+                    {
+                        Assert.Equal(item.Name, "Cake");
+                        Assert.Equal(item.Version, "0.22.2");
+                    },
+                    item =>
+                    {
+                        Assert.Equal(item.Name, "Cake.Core");
+                        Assert.Equal(item.Version, "0.22.2");
+                    },
+                    item =>
+                    {
+                        Assert.Equal(item.Name, "Cake.CoreCLR");
+                        Assert.Equal(item.Version, "0.22.2");
+                    });
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.cs
@@ -17,6 +17,7 @@ using Cake.Common.Tools.DotNet.NuGet.Source;
 using Cake.Common.Tools.DotNet.Pack;
 using Cake.Common.Tools.DotNet.Package.Add;
 using Cake.Common.Tools.DotNet.Package.Remove;
+using Cake.Common.Tools.DotNet.Package.Search;
 using Cake.Common.Tools.DotNet.Publish;
 using Cake.Common.Tools.DotNet.Reference.Add;
 using Cake.Common.Tools.DotNet.Restore;
@@ -2526,6 +2527,100 @@ namespace Cake.Common.Tools.DotNet
 
             var adder = new DotNetReferenceAdder(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             adder.Add(project, projectReferences, settings);
+        }
+
+        /// <summary>
+        /// List packages on available from source using specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="searchTerm">The search term.</param>
+        /// <param name="settings">The settings.</param>
+        /// <returns>List of packages with their version.</returns>
+        /// <example>
+        /// <code>
+        /// var packageList = DotNetPackageSearch("Cake", new DotNetPackageSearchSettings {
+        ///     AllVersions = false,
+        ///     Prerelease = false
+        ///     });
+        /// foreach(var package in packageList)
+        /// {
+        ///     Information("Found package {0}, version {1}", package.Name, package.Version);
+        /// }
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Package")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Package.Search")]
+        public static IEnumerable<DotNetPackageSearchItem> DotNetSearchPackage(this ICakeContext context, string searchTerm, DotNetPackageSearchSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            var runner = new DotNetPackageSearcher(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            return runner.Search(searchTerm, settings);
+        }
+
+        /// <summary>
+        /// List packages on available from source using specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="searchTerm">The package Id.</param>
+        /// <returns>List of packages with their version.</returns>
+        /// <example>
+        /// <code>
+        /// var packageList = DotNetPackageSearch("Cake", new DotNetPackageSearchSettings {
+        ///     AllVersions = false,
+        ///     Prerelease = false
+        ///     });
+        /// foreach(var package in packageList)
+        /// {
+        ///     Information("Found package {0}, version {1}", package.Name, package.Version);
+        /// }
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Package")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Package.Search")]
+        public static IEnumerable<DotNetPackageSearchItem> DotNetSearchPackage(this ICakeContext context, string searchTerm)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            var runner = new DotNetPackageSearcher(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            return runner.Search(searchTerm, new DotNetPackageSearchSettings());
+        }
+
+        /// <summary>
+        /// List packages on available from source using specified settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        /// <returns>List of packages with their version.</returns>
+        /// <example>
+        /// <code>
+        /// var packageList = DotNetPackageSearch("Cake", new DotNetPackageSearchSettings {
+        ///     AllVersions = false,
+        ///     Prerelease = false
+        ///     });
+        /// foreach(var package in packageList)
+        /// {
+        ///     Information("Found package {0}, version {1}", package.Name, package.Version);
+        /// }
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Package")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Package.Search")]
+        public static IEnumerable<DotNetPackageSearchItem> DotNetSearchPackage(this ICakeContext context, DotNetPackageSearchSettings settings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            var runner = new DotNetPackageSearcher(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            return runner.Search(null, settings);
         }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Package/Search/DotNetPackageSearchItem.cs
+++ b/src/Cake.Common/Tools/DotNet/Package/Search/DotNetPackageSearchItem.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Tools.DotNet.Package.Search
+{
+    /// <summary>
+    /// An item as returned by <see cref="DotNetAliases.DotNetSearchPackage(Core.ICakeContext, string, DotNetPackageSearchSettings)"/>.
+    /// </summary>
+    public class DotNetPackageSearchItem
+    {
+        /// <summary>
+        /// Gets or sets the name of the NuGetListItem.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version of the NuGetListItem as string.
+        /// </summary>
+        public string Version { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/Package/Search/DotNetPackageSearchSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Package/Search/DotNetPackageSearchSettings.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotNet.Package.Search
+{
+    /// <summary>
+    /// Represents the settings for searching .NET packages.
+    /// </summary>
+    public class DotNetPackageSearchSettings : DotNetSettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow prerelease packages to be shown.
+        /// </summary>
+        public bool Prerelease { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether an exact match is required. Causes <see cref="Take"/> and <see cref="Skip"/> options to be ignored.
+        /// </summary>
+        public bool ExactMatch { get; set; }
+
+        /// <summary>
+        /// Gets or sets the NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used.
+        /// </summary>
+        /// <seealso href="https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior"/>
+        public FilePath ConfigFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets a list of package sources to search.
+        /// </summary>
+        public ICollection<string> Sources { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets the number of results to return.
+        /// </summary>
+        public int? Take { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of results to skip, to allow pagination.
+        /// </summary>
+        public int? Skip { get; set; }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/Package/Search/DotNetPackageSearcher.cs
+++ b/src/Cake.Common/Tools/DotNet/Package/Search/DotNetPackageSearcher.cs
@@ -1,0 +1,165 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Common.Tools.DotNet.Package.Search
+{
+    /// <summary>
+    /// .NET package searcher.
+    /// </summary>
+    public sealed class DotNetPackageSearcher : DotNetTool<DotNetPackageSearchSettings>
+    {
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotNetPackageSearcher" /> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="tools">The tool locator.</param>
+        public DotNetPackageSearcher(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IToolLocator tools) : base(fileSystem, environment, processRunner, tools)
+        {
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Searches for packages.
+        /// </summary>
+        /// <param name="searchTerm">The search term.</param>
+        /// <param name="settings">The search settings.</param>
+        /// <returns>A collection of <see cref="DotNetPackageSearchItem"/>.</returns>
+        public IEnumerable<DotNetPackageSearchItem> Search(string searchTerm, DotNetPackageSearchSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            var processSettings = new ProcessSettings
+            {
+                RedirectStandardOutput = true
+            };
+
+            using var ms = new MemoryStream();
+            RunCommand(
+                settings,
+                GetArguments(searchTerm, settings),
+                processSettings,
+                process =>
+                {
+                    using var sr = new StreamWriter(ms, leaveOpen: true);
+                    foreach (var line in process.GetStandardOutput())
+                    {
+                        sr.WriteLine(line);
+                    }
+                });
+
+            return Parse(ms.GetBuffer().AsMemory(0, (int)ms.Length)).ToList();
+        }
+
+        private ProcessArgumentBuilder GetArguments(string searchTerm, DotNetPackageSearchSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            builder.Append("package search");
+
+            if (!string.IsNullOrEmpty(searchTerm))
+            {
+                builder.AppendQuoted(searchTerm);
+            }
+
+            if (settings.Prerelease)
+            {
+                builder.Append("--prerelease");
+            }
+
+            if (settings.ExactMatch)
+            {
+                builder.Append("--exact-match");
+            }
+
+            if (settings.Sources != null && settings.Sources.Count > 0)
+            {
+                foreach (var source in settings.Sources)
+                {
+                    builder.Append("--source");
+                    builder.AppendQuoted(source);
+                }
+            }
+
+            if (settings.ConfigFile != null)
+            {
+                builder.Append("--configfile");
+                builder.AppendQuoted(settings.ConfigFile.MakeAbsolute(_environment).FullPath);
+            }
+
+            if (settings.Take is { } take)
+            {
+                builder.Append("--take");
+                builder.Append(take.ToString());
+            }
+
+            if (settings.Skip is { } skip)
+            {
+                builder.Append("--skip");
+                builder.Append(skip.ToString());
+            }
+
+            builder.Append("--verbosity normal");
+
+            builder.Append("--format json");
+
+            return builder;
+        }
+
+        private static IEnumerable<DotNetPackageSearchItem> Parse(ReadOnlyMemory<byte> json)
+        {
+            var result = JsonSerializer.Deserialize<Result>(json.Span, _jsonSerializerOptions);
+
+            if (result is not null)
+            {
+                foreach (var searchResult in result.SearchResult)
+                {
+                    foreach (var package in searchResult.Packages)
+                    {
+                        yield return new DotNetPackageSearchItem { Name = package.Id, Version = package.LatestVersion };
+                    }
+                }
+            }
+        }
+
+        private sealed class Result
+        {
+            public List<SearchResult> SearchResult { get; set; }
+        }
+
+        private sealed class SearchResult
+        {
+            public List<Package> Packages { get; set; }
+        }
+
+        private sealed class Package
+        {
+            public string Id { get; set; }
+
+            public string LatestVersion { get; set; }
+        }
+    }
+}

--- a/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
+++ b/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
@@ -375,6 +375,20 @@ Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetAddReference")
     Assert.Equal(projectReference, value);
 });
 
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSearchPackage")
+    .Does(() =>
+{
+    // Given
+    var package = "Cake.Tool";
+
+    // When
+    var result = DotNetSearchPackage(package);
+
+    // Then
+    Assert.NotNull(result);
+    Assert.Contains(package, result.Select(x => x.Name));
+});
+
 Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetBuildServerShutdown")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRestore")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetBuild")
@@ -399,6 +413,7 @@ Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetBuildServerShutdown")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetAddPackage")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRemovePackage")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetAddReference")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSearchPackage")
     .Does(() =>
 {
     // When


### PR DESCRIPTION
The [(NuGet CLI) commands](https://learn.microsoft.com/en-us/nuget/reference/nuget-exe-cli-reference) [list](https://learn.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-list) and [search](https://learn.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-search) do not exist in `dotnet nuget`.

This PR introduces `DotNetSearchPackage` that uses [`dotnet package search`](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-package-search) as an alternative to [`NuGetList`](https://cakebuild.net/dsl/nuget/#List) for environments that do not have `nuget.exe` but have `dotnet.exe`.