### PR TITLE
(#4322) Removed check for OS on PathHelper.IsRooted

### DIFF
--- a/src/Cake.Core/IO/PathHelper.cs
+++ b/src/Cake.Core/IO/PathHelper.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using Cake.Core.Polyfill;
 
 namespace Cake.Core.IO
 {
@@ -9,8 +8,6 @@ namespace Cake.Core.IO
         private const char Backslash = '\\';
         private const char Slash = '/';
         private const string UncPrefix = @"\\";
-
-        private static readonly bool _isWindows = EnvironmentHelper.GetPlatformFamily() == PlatformFamily.Windows;
 
         public static string Combine(params string[] paths)
         {
@@ -271,13 +268,10 @@ namespace Cake.Core.IO
                     }
                 }
 
-                if (_isWindows)
+                // Windows drive?
+                if (length >= 2 && path[1] == ':')
                 {
-                    // Windows drive?
-                    if (length >= 2 && path[1] == ':')
-                    {
-                        return true;
-                    }
+                    return true;
                 }
             }
 


### PR DESCRIPTION
This PR removes the check for the currently running platform/OS before checking whether the path is a windows path, beginning with a drive letter.

fixes #4322 

Rationale:

I feel `Path` should be a very agnostic "thing" and `C:\temp\` should be a valid (and "absolute") path on any system, even if, if I were to use it on my linux system, it would simply not work. (Probably it would, somehow, but that's besides my point.)

My guess is, that while this is not a breaking change in API/ABI, it is a breaking change in "meaning" - even if I think most likely no-one is relying on the fact that currently `C:\temp` is an absolute path, if cake is running on a windows system and a relative path if cake is not running on a windows system.