### PR TITLE
Add support for capturing MSBuild properties, items and target results

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/DotNet/MSBuild/DotNetCoreMSBuildBuilderFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/DotNet/MSBuild/DotNetCoreMSBuildBuilderFixture.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
 using Cake.Common.Tools.DotNet.MSBuild;
 
 namespace Cake.Common.Tests.Fixtures.Tools.DotNet.MSBuild
@@ -9,11 +11,12 @@ namespace Cake.Common.Tests.Fixtures.Tools.DotNet.MSBuild
     internal sealed class DotNetMSBuildBuilderFixture : DotNetFixture<DotNetMSBuildSettings>
     {
         public string Project { get; set; }
+        public Action<IEnumerable<string>> StandardOutputAction { get; set; }
 
         protected override void RunTool()
         {
             var tool = new DotNetMSBuildBuilder(FileSystem, Environment, ProcessRunner, Tools);
-            tool.Build(Project, Settings);
+            tool.Build(Project, Settings, StandardOutputAction);
         }
     }
 }

--- a/src/Cake.Common.Tests/Fixtures/Tools/MSBuildRunnerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/MSBuildRunnerFixture.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using Cake.Common.Tools.MSBuild;
 using Cake.Core;
@@ -15,6 +16,7 @@ namespace Cake.Common.Tests.Fixtures.Tools
     {
         public HashSet<FilePath> KnownMSBuildPaths { get; }
         public FilePath Solution { get; set; }
+        public Action<IEnumerable<string>> StandardOutputAction { get; set; }
 
         public MSBuildRunnerFixture(bool is64BitOperativeSystem, PlatformFamily platformFamily)
             : base("MSBuild.exe")
@@ -83,7 +85,7 @@ namespace Cake.Common.Tests.Fixtures.Tools
         protected override void RunTool()
         {
             var runner = new MSBuildRunner(FileSystem, Environment, ProcessRunner, Tools);
-            runner.Run(Solution, Settings);
+            runner.Run(Solution, Settings, StandardOutputAction);
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/MSBuild/DotNetMSBuildBuilderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/MSBuild/DotNetMSBuildBuilderTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using Cake.Common.Tests.Fixtures.Tools;
 using Cake.Common.Tests.Fixtures.Tools.DotNet.MSBuild;
 using Cake.Common.Tools.DotNet;
@@ -203,6 +204,113 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.MSBuild
 
                 // Then
                 AssertEx.IsArgumentException(result, "Properties", "A property must have at least one non-empty value");
+            }
+
+            [Fact]
+            public void Should_Append_GetProperty_To_Process_Arguments_And_Collects_Output()
+            {
+                IEnumerable<string> msbuildOutput = null;
+
+                // Given
+                var fixture = new DotNetMSBuildBuilderFixture();
+                fixture.Settings.WithGetProperty("A");
+                fixture.Settings.WithGetProperty("B");
+                fixture.StandardOutputAction = lines => msbuildOutput = lines;
+                var standardOutput = new string[]
+                {
+                    "{",
+                    "  \"Properties\": {",
+                    "    \"A\": \"A value\",",
+                    "    \"B\": \"B value\"",
+                    "  }",
+                    "}",
+                };
+                fixture.ProcessRunner.Process.SetStandardOutput(standardOutput);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /getProperty:A /getProperty:B",
+                             result.Args);
+
+                Assert.Equal(standardOutput, msbuildOutput);
+            }
+
+            [Fact]
+            public void Should_Append_GetItem_To_Process_Arguments_And_Collects_Output()
+            {
+                IEnumerable<string> msbuildOutput = null;
+
+                // Given
+                var fixture = new DotNetMSBuildBuilderFixture();
+                fixture.Settings.WithGetItem("A");
+                fixture.Settings.WithGetItem("B");
+                fixture.StandardOutputAction = lines => msbuildOutput = lines;
+                var standardOutput = new string[]
+                {
+                    "{",
+                    "  \"Items\": {",
+                    "    \"A\": [",
+                    "      {",
+                    "         \"Identity\": \"Identity value\"",
+                    "      }",
+                    "    ],",
+                    "    \"B\": [",
+                    "      {",
+                    "         \"Identity\": \"Identity value\"",
+                    "      }",
+                    "    ],",
+                    "  }",
+                    "}",
+                };
+                fixture.ProcessRunner.Process.SetStandardOutput(standardOutput);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /getItem:A /getItem:B",
+                             result.Args);
+
+                Assert.Equal(standardOutput, msbuildOutput);
+            }
+
+            [Fact]
+            public void Should_Append_GetTargetResult_To_Process_Arguments_And_Collects_Output()
+            {
+                IEnumerable<string> msbuildOutput = null;
+
+                // Given
+                var fixture = new DotNetMSBuildBuilderFixture();
+                fixture.Settings.WithGetTargetResult("A");
+                fixture.Settings.WithGetTargetResult("B");
+                fixture.StandardOutputAction = lines => msbuildOutput = lines;
+                var standardOutput = new string[]
+                {
+                    "{",
+                    "  \"TargetResults\": {",
+                    "    \"A\": {",
+                    "      \"Result\": \"Success\"",
+                    "      \"Items\": []",
+                    "    },",
+                    "    \"B\": {",
+                    "      \"Result\": \"Success\"",
+                    "      \"Items\": []",
+                    "    }",
+                    "  }",
+                    "}",
+                };
+                fixture.ProcessRunner.Process.SetStandardOutput(standardOutput);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("msbuild /getTargetResult:A /getTargetResult:B",
+                             result.Args);
+
+                Assert.Equal(standardOutput, msbuildOutput);
             }
 
             [Theory]

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Cake.Common.Tests.Fixtures.Tools;
 using Cake.Common.Tools.MSBuild;
 using Cake.Core;
@@ -1012,6 +1013,113 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
                 // Then
                 Assert.Equal("/v:normal /p:DefineConstants=A;B /p:A=A%3BB /target:Build " +
                              "\"C:/Working/src/Solution.sln\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_GetProperty_To_Process_Arguments_And_Collects_Output()
+            {
+                IEnumerable<string> msbuildOutput = null;
+
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows);
+                fixture.Settings.WithGetProperty("A");
+                fixture.Settings.WithGetProperty("B");
+                fixture.StandardOutputAction = lines => msbuildOutput = lines;
+                var standardOutput = new string[]
+                {
+                    "{",
+                    "  \"Properties\": {",
+                    "    \"A\": \"A value\",",
+                    "    \"B\": \"B value\"",
+                    "  }",
+                    "}",
+                };
+                fixture.ProcessRunner.Process.SetStandardOutput(standardOutput);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/v:normal /target:Build /getProperty:A /getProperty:B " +
+                             "\"C:/Working/src/Solution.sln\"", result.Args);
+
+                Assert.Equal(standardOutput, msbuildOutput);
+            }
+
+            [Fact]
+            public void Should_Append_GetItem_To_Process_Arguments_And_Collects_Output()
+            {
+                IEnumerable<string> msbuildOutput = null;
+
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows);
+                fixture.Settings.WithGetItem("A");
+                fixture.Settings.WithGetItem("B");
+                fixture.StandardOutputAction = lines => msbuildOutput = lines;
+                var standardOutput = new string[]
+                {
+                    "{",
+                    "  \"Items\": {",
+                    "    \"A\": [",
+                    "      {",
+                    "         \"Identity\": \"Identity value\"",
+                    "      }",
+                    "    ],",
+                    "    \"B\": [",
+                    "      {",
+                    "         \"Identity\": \"Identity value\"",
+                    "      }",
+                    "    ],",
+                    "  }",
+                    "}",
+                };
+                fixture.ProcessRunner.Process.SetStandardOutput(standardOutput);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/v:normal /target:Build /getItem:A /getItem:B " +
+                             "\"C:/Working/src/Solution.sln\"", result.Args);
+
+                Assert.Equal(standardOutput, msbuildOutput);
+            }
+
+            [Fact]
+            public void Should_Append_GetTargetResult_To_Process_Arguments_And_Collects_Output()
+            {
+                IEnumerable<string> msbuildOutput = null;
+
+                // Given
+                var fixture = new MSBuildRunnerFixture(false, PlatformFamily.Windows);
+                fixture.Settings.WithGetTargetResult("A");
+                fixture.Settings.WithGetTargetResult("B");
+                fixture.StandardOutputAction = lines => msbuildOutput = lines;
+                var standardOutput = new string[]
+                {
+                    "{",
+                    "  \"TargetResults\": {",
+                    "    \"A\": {",
+                    "      \"Result\": \"Success\"",
+                    "      \"Items\": []",
+                    "    },",
+                    "    \"B\": {",
+                    "      \"Result\": \"Success\"",
+                    "      \"Items\": []",
+                    "    }",
+                    "  }",
+                    "}",
+                };
+                fixture.ProcessRunner.Process.SetStandardOutput(standardOutput);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/v:normal /target:Build /getTargetResult:A /getTargetResult:B " +
+                             "\"C:/Working/src/Solution.sln\"", result.Args);
+
+                Assert.Equal(standardOutput, msbuildOutput);
             }
 
             [Theory]

--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.MSBuild.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.MSBuild.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using Cake.Common.Tools.DotNet.MSBuild;
 using Cake.Core;
 using Cake.Core.Annotations;
@@ -33,7 +34,7 @@ namespace Cake.Common.Tools.DotNet
         [CakeNamespaceImport("Cake.Common.Tools.DotNet.MSBuild")]
         public static void DotNetMSBuild(this ICakeContext context)
         {
-            context.DotNetMSBuild(null, null);
+            context.DotNetMSBuild((string)null, (DotNetMSBuildSettings)null);
         }
 
         /// <summary>
@@ -87,6 +88,32 @@ namespace Cake.Common.Tools.DotNet
         }
 
         /// <summary>
+        /// Builds the specified targets in a project file found in the current working directory.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        /// <param name="standardOutputAction">The action to invoke with the standard output.</param>
+        /// <example>
+        /// <code>
+        /// var settings = new DotNetMSBuildSettings
+        /// {
+        ///     NoLogo = true,
+        ///     MaxCpuCount = -1
+        /// };
+        ///
+        /// DotNetMSBuild(settings,
+        ///     output => foreach(var line in output) outputBuilder.AppendLine(line));
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("MSBuild")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.MSBuild")]
+        public static void DotNetMSBuild(this ICakeContext context, DotNetMSBuildSettings settings, Action<IEnumerable<string>> standardOutputAction)
+        {
+            context.DotNetMSBuild(null, settings, standardOutputAction);
+        }
+
+        /// <summary>
         /// Builds the specified targets in the project file.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -123,7 +150,49 @@ namespace Cake.Common.Tools.DotNet
             }
 
             var builder = new DotNetMSBuildBuilder(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            builder.Build(projectOrDirectory, settings);
+            builder.Build(projectOrDirectory, settings, null);
+        }
+
+        /// <summary>
+        /// Builds the specified targets in the project file.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="projectOrDirectory">Project file or directory to search for project file.</param>
+        /// <param name="settings">The settings.</param>
+        /// <param name="standardOutputAction">The action to invoke with the standard output.</param>
+        /// <example>
+        /// <code>
+        /// var settings = new DotNetMSBuildSettings
+        /// {
+        ///     NoLogo = true,
+        ///     MaxCpuCount = -1
+        /// };
+        ///
+        /// DotNetMSBuild("foobar.proj", settings,
+        ///     output => foreach(var line in output) outputBuilder.AppendLine(line));
+        /// </code>
+        /// </example>
+        /// <remarks>
+        /// If a project file is not specified, MSBuild searches the current working directory for a file that has a file
+        /// extension that ends in "proj" and uses that file. If a directory is specified, MSBuild searches that directory for a project file.
+        /// </remarks>
+        [CakeMethodAlias]
+        [CakeAliasCategory("MSBuild")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.MSBuild")]
+        public static void DotNetMSBuild(this ICakeContext context, string projectOrDirectory, DotNetMSBuildSettings settings, Action<IEnumerable<string>> standardOutputAction)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (settings is null)
+            {
+                settings = new DotNetMSBuildSettings();
+            }
+
+            var builder = new DotNetMSBuildBuilder(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            builder.Build(projectOrDirectory, settings, standardOutputAction);
         }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/MSBuild/DotNetMSBuildBuilder.cs
+++ b/src/Cake.Common/Tools/DotNet/MSBuild/DotNetMSBuildBuilder.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
@@ -37,14 +38,19 @@ namespace Cake.Common.Tools.DotNet.MSBuild
         /// </summary>
         /// <param name="projectOrDirectory">The target project path.</param>
         /// <param name="settings">The settings.</param>
-        public void Build(string projectOrDirectory, DotNetMSBuildSettings settings)
+        /// <param name="standardOutputAction">The action to invoke with the standard output.</param>
+        public void Build(string projectOrDirectory, DotNetMSBuildSettings settings, Action<IEnumerable<string>> standardOutputAction)
         {
             if (settings == null)
             {
                 throw new ArgumentNullException(nameof(settings));
             }
 
-            RunCommand(settings, GetArguments(projectOrDirectory, settings));
+            RunCommand(
+                settings,
+                GetArguments(projectOrDirectory, settings),
+                standardOutputAction == null ? null : new ProcessSettings { RedirectStandardOutput = true },
+                standardOutputAction == null ? null : new Action<IProcess>(process => standardOutputAction(process.GetStandardOutput())));
         }
 
         private ProcessArgumentBuilder GetArguments(string projectOrDirectory, DotNetMSBuildSettings settings)

--- a/src/Cake.Common/Tools/DotNet/MSBuild/DotNetMSBuildSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/MSBuild/DotNetMSBuildSettings.cs
@@ -136,6 +136,27 @@ namespace Cake.Common.Tools.DotNet.MSBuild
         public ICollection<string> Targets { get; }
 
         /// <summary>
+        /// Gets the properties to retrieve.
+        /// </summary>
+        /// <value>The properties to retrieve.</value>
+        /// <remarks>For more information, refer to <see href="https://learn.microsoft.com/en-us/visualstudio/msbuild/evaluate-items-and-properties">Evaluate items and properties and display results of targets</see>.</remarks>
+        public HashSet<string> GetProperties { get; }
+
+        /// <summary>
+        /// Gets the items to retrieve.
+        /// </summary>
+        /// <value>The items to retrieve.</value>
+        /// <remarks>For more information, refer to <see href="https://learn.microsoft.com/en-us/visualstudio/msbuild/evaluate-items-and-items">Evaluate items and items and display results of targets</see>.</remarks>
+        public HashSet<string> GetItems { get; }
+
+        /// <summary>
+        /// Gets the target results to retrieve.
+        /// </summary>
+        /// <value>The target results to retrieve.</value>
+        /// <remarks>For more information, refer to <see href="https://learn.microsoft.com/en-us/visualstudio/msbuild/evaluate-items-and-items">Evaluate items and items and display results of targets</see>.</remarks>
+        public HashSet<string> GetTargetResults { get; }
+
+        /// <summary>
         /// Gets or sets the version of the Toolset to use to build the project.
         /// </summary>
         public MSBuildVersion? ToolVersion { get; set; }
@@ -228,6 +249,9 @@ namespace Cake.Common.Tools.DotNet.MSBuild
         {
             Properties = new Dictionary<string, ICollection<string>>(StringComparer.OrdinalIgnoreCase);
             Targets = new List<string>();
+            GetProperties = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            GetItems = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            GetTargetResults = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             ResponseFiles = new List<FilePath>();
             DistributedLoggers = new List<MSBuildDistributedLogger>();
             FileLoggers = new List<MSBuildFileLoggerSettings>();

--- a/src/Cake.Common/Tools/DotNet/MSBuild/DotNetMSBuildSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/DotNet/MSBuild/DotNetMSBuildSettingsExtensions.cs
@@ -58,6 +58,84 @@ namespace Cake.Common.Tools.DotNet.MSBuild
         }
 
         /// <summary>
+        /// Adds a property to retrieve the value.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="name">The name of the property to retrieve the value.</param>
+        /// <returns>The same <see cref="DotNetMSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetMSBuildSettings WithGetProperty(this DotNetMSBuildSettings settings, string name)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException(nameof(name));
+            }
+
+            settings.GetProperties.Add(name);
+
+            return settings;
+        }
+
+        /// <summary>
+        /// Adds a item to retrieve the value.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="name">The name of the item to retrieve the value.</param>
+        /// <returns>The same <see cref="DotNetMSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetMSBuildSettings WithGetItem(this DotNetMSBuildSettings settings, string name)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException(nameof(name));
+            }
+
+            settings.GetItems.Add(name);
+
+            return settings;
+        }
+
+        /// <summary>
+        /// Adds a target to retrieve the result.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="name">The name of the target to retrieve the result.</param>
+        /// <returns>The same <see cref="DotNetMSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotNetMSBuildSettings WithGetTargetResult(this DotNetMSBuildSettings settings, string name)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException(nameof(name));
+            }
+
+            settings.GetTargetResults.Add(name);
+
+            return settings;
+        }
+
+        /// <summary>
         /// Shows detailed information at the end of the build log about the configurations that were built and how they were scheduled to nodes.
         /// </summary>
         /// <param name="settings">The settings.</param>

--- a/src/Cake.Common/Tools/DotNet/MSBuild/MSBuildArgumentBuilderExtensions.cs
+++ b/src/Cake.Common/Tools/DotNet/MSBuild/MSBuildArgumentBuilderExtensions.cs
@@ -63,6 +63,39 @@ namespace Cake.Common.Tools.DotNet.MSBuild
                 msBuilder.AppendMSBuildSwitch("property", $"{property.Key}={property.BuildMSBuildPropertyParameterString()}");
             }
 
+            // Got any properties to retrieve?
+            foreach (var property in settings.GetProperties)
+            {
+                if (property == null || string.IsNullOrWhiteSpace(property))
+                {
+                    throw new ArgumentException("A property to retrieve must have have non-empty name", nameof(settings.Properties));
+                }
+
+                msBuilder.AppendMSBuildSwitch("getProperty", property);
+            }
+
+            // Got any items to retrieve?
+            foreach (var item in settings.GetItems)
+            {
+                if (item == null || string.IsNullOrWhiteSpace(item))
+                {
+                    throw new ArgumentException("An item to retrieve must have have non-empty name", nameof(settings.Properties));
+                }
+
+                msBuilder.AppendMSBuildSwitch("getItem", item);
+            }
+
+            // Got any target results to retrieve?
+            foreach (var target in settings.GetTargetResults)
+            {
+                if (target == null || string.IsNullOrWhiteSpace(target))
+                {
+                    throw new ArgumentException("An target to retrieve results must have have non-empty name", nameof(settings.Properties));
+                }
+
+                msBuilder.AppendMSBuildSwitch("getTargetResult", target);
+            }
+
             // Set the maximum number of processors?
             if (settings.MaxCpuCount.HasValue)
             {

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettings.cs
@@ -17,6 +17,9 @@ namespace Cake.Common.Tools.MSBuild
     {
         private readonly HashSet<string> _targets;
         private readonly Dictionary<string, IList<string>> _properties;
+        private readonly HashSet<string> _getProperties;
+        private readonly HashSet<string> _getItems;
+        private readonly HashSet<string> _getTargetResults;
         private readonly List<MSBuildLogger> _loggers;
         private readonly List<MSBuildFileLogger> _fileLoggers;
         private readonly HashSet<string> _warningsAsErrorCodes;
@@ -35,6 +38,27 @@ namespace Cake.Common.Tools.MSBuild
         /// </summary>
         /// <value>The properties.</value>
         public IDictionary<string, IList<string>> Properties => _properties;
+
+        /// <summary>
+        /// Gets the properties to retrieve.
+        /// </summary>
+        /// <value>The properties to retrieve.</value>
+        /// <remarks>For more information, refer to <see href="https://learn.microsoft.com/en-us/visualstudio/msbuild/evaluate-items-and-properties">Evaluate items and properties and display results of targets</see>.</remarks>
+        public HashSet<string> GetProperties => _getProperties;
+
+        /// <summary>
+        /// Gets the items to retrieve.
+        /// </summary>
+        /// <value>The items to retrieve.</value>
+        /// <remarks>For more information, refer to <see href="https://learn.microsoft.com/en-us/visualstudio/msbuild/evaluate-items-and-items">Evaluate items and items and display results of targets</see>.</remarks>
+        public HashSet<string> GetItems => _getItems;
+
+        /// <summary>
+        /// Gets the target results to retrieve.
+        /// </summary>
+        /// <value>The target results to retrieve.</value>
+        /// <remarks>For more information, refer to <see href="https://learn.microsoft.com/en-us/visualstudio/msbuild/evaluate-items-and-items">Evaluate items and items and display results of targets</see>.</remarks>
+        public HashSet<string> GetTargetResults => _getTargetResults;
 
         /// <summary>
         /// Gets or sets the platform target.
@@ -295,6 +319,9 @@ namespace Cake.Common.Tools.MSBuild
         {
             _targets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             _properties = new Dictionary<string, IList<string>>(StringComparer.OrdinalIgnoreCase);
+            _getProperties = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _getItems = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _getTargetResults = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             _loggers = new List<MSBuildLogger>();
             _fileLoggers = new List<MSBuildFileLogger>();
             _warningsAsErrorCodes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);

--- a/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildSettingsExtensions.cs
@@ -202,6 +202,84 @@ namespace Cake.Common.Tools.MSBuild
         }
 
         /// <summary>
+        /// Adds a property to retrieve the value.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="name">The name of the property to retrieve the value.</param>
+        /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static MSBuildSettings WithGetProperty(this MSBuildSettings settings, string name)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException(nameof(name));
+            }
+
+            settings.GetProperties.Add(name);
+
+            return settings;
+        }
+
+        /// <summary>
+        /// Adds a item to retrieve the value.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="name">The name of the item to retrieve the value.</param>
+        /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static MSBuildSettings WithGetItem(this MSBuildSettings settings, string name)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException(nameof(name));
+            }
+
+            settings.GetItems.Add(name);
+
+            return settings;
+        }
+
+        /// <summary>
+        /// Adds a target to retrieve the result.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="name">The name of the target to retrieve the result.</param>
+        /// <returns>The same <see cref="MSBuildSettings"/> instance so that multiple calls can be chained.</returns>
+        public static MSBuildSettings WithGetTargetResult(this MSBuildSettings settings, string name)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException(nameof(name));
+            }
+
+            settings.GetTargetResults.Add(name);
+
+            return settings;
+        }
+
+        /// <summary>
         /// Sets the configuration.
         /// </summary>
         /// <param name="settings">The settings.</param>

--- a/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
+++ b/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
@@ -237,15 +237,18 @@ Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetMSBuild.Results")
         GetTargetResults = { "Build", "Compile", },
     };
 
-    IEnumerable<string> result = null;
+    System.Text.Json.JsonDocument result = null;
 
     // When
-    DotNetMSBuild(project.FullPath, settings, output => result = output);
+    DotNetMSBuild(project.FullPath, settings, output => result = System.Text.Json.JsonDocument.Parse(output.SelectMany(x => x).ToArray()));
 
     // Then
     Assert.NotNull(result);
-    Assert.Equal(result.First(), "{");
-    Assert.Equal(result.Last(), "}");
+    Assert.Equal("1.0.0", result.RootElement.GetProperty("Properties").GetProperty("Version").GetString());
+    Assert.Equal("net9.0", result.RootElement.GetProperty("Properties").GetProperty("TargetFramework").GetString());
+    Assert.Equal(1, result.RootElement.GetProperty("Items").GetProperty("ProjectReference").GetArrayLength());
+    Assert.Equal("Success", result.RootElement.GetProperty("TargetResults").GetProperty("Build").GetProperty("Result").GetString());
+    Assert.Equal("Success", result.RootElement.GetProperty("TargetResults").GetProperty("Compile").GetProperty("Result").GetString());
 });
 
 Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTest.Fail")

--- a/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
+++ b/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
@@ -232,7 +232,7 @@ Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetMSBuild.Results")
     var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
     var settings = new DotNetMSBuildSettings
     {
-        GetProperties = { "Version", "TargetFramwork", },
+        GetProperties = { "Version", "TargetFramework", },
         GetItems = { "ProjectReference", },
         GetTargetResults = { "Build", "Compile", },
     };

--- a/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
+++ b/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
@@ -223,6 +223,31 @@ Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetMSBuild")
     Assert.True(System.IO.File.Exists(assembly.FullPath));
 });
 
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetMSBuild.Results")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRestore")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
+    var settings = new DotNetMSBuildSettings
+    {
+        GetProperties = { "Version", "TargetFramwork", },
+        GetItems = { "ProjectReference", },
+        GetTargetResults = { "Build", "Compile", },
+    };
+
+    IEnumerable<string> result = null;
+
+    // When
+    DotNetMSBuild(project.FullPath, settings, output => result = output);
+
+    // Then
+    Assert.NotNull(result);
+    Assert.Equal(result.First(), "{");
+    Assert.Equal(result.Last(), "}");
+});
+
 Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTest.Fail")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTest")
     .Does(() =>
@@ -489,6 +514,7 @@ Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetBuildServerShutdown")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetExecute")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetClean")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetMSBuild")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetMSBuild.Results")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTest.Fail")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetFormat")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSDKCheck")


### PR DESCRIPTION
Add support for capturing MSBuild properties, items and target results using [Evaluate items and properties and display results of targets](https://learn.microsoft.com/en-us/visualstudio/msbuild/evaluate-items-and-properties).

- Added `StandardOutputAction` properties to `DotNetCoreMSBuildBuilderFixture` and `MSBuildRunnerFixture`.
- Updated `RunTool` methods to pass `StandardOutputAction` to `Build` and `Run` methods.
- Added new test cases in `DotNetMSBuildBuilderTests` and `MSBuildRunnerTests` to verify functionality.
- Added overloads in `DotNetAliases` and `MSBuildAliases` to accept `standardOutputAction` parameter.
- Updated `DotNetMSBuildBuilder` and `MSBuildRunner` to handle `standardOutputAction` and configure process settings.
- Enhanced `MSBuildArgumentBuilderExtensions` to append MSBuild arguments for properties, items, and target results.
- Extended `DotNetMSBuildSettings` and `MSBuildSettings` with new properties and collections.
- Added extension methods in `DotNetMSBuildSettingsExtensions` for fluent configuration.


<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over CONTRIBUTING - https://github.com/cake-build/cake/blob/develop/CONTRIBUTING.md. We provide VERY defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - You are not submitting a pull request from your MASTER branch.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
