### PR TITLE
Add ReportGenerator missing markdown report types

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/ReportGenerator/ReportGeneratorRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/ReportGenerator/ReportGeneratorRunnerTests.cs
@@ -179,6 +179,9 @@ namespace Cake.Common.Tests.Unit.Tools.ReportGenerator
             [InlineData("JsonSummary", 19)]
             [InlineData("lcov", 20)]
             [InlineData("TeamCitySummary", 21)]
+            [InlineData("MarkdownSummary", 22)]
+            [InlineData("MarkdownAssembliesSummary", 23)]
+            [InlineData("MarkdownSummaryGithub", 24)]
             public void Should_Set_Report_Types(string expected, int enumValue)
             {
                 // Given

--- a/src/Cake.Common/Tools/ReportGenerator/ReportGeneratorReportType.cs
+++ b/src/Cake.Common/Tools/ReportGenerator/ReportGeneratorReportType.cs
@@ -130,6 +130,30 @@ namespace Cake.Common.Tools.ReportGenerator
         /// <remarks>
         /// Requires ReportGenerator 4.1.3+
         /// </remarks>
-        TeamCitySummary = 21
+        TeamCitySummary = 21,
+
+        /// <summary>
+        /// Outputs a single Markdown file containing coverage information per class.
+        /// </summary>
+        /// <remarks>
+        /// Requires ReportGenerator 5.1.10+
+        /// </remarks>
+        MarkdownSummary = 22,
+
+        /// <summary>
+        /// Outputs a single Markdown file containing coverage information per assembly.
+        /// </summary>
+        /// <remarks>
+        /// Requires ReportGenerator 5.3.0+
+        /// </remarks>
+        MarkdownAssembliesSummary = 23,
+
+        /// <summary>
+        /// Outputs a single Markdown file containing coverage information per class. The report is optimized for GitHub.
+        /// </summary>
+        /// <remarks>
+        /// Requires ReportGenerator 5.1.13+
+        /// </remarks>
+        MarkdownSummaryGithub = 24
     }
 }


### PR DESCRIPTION
Add ReportGenerator missing markdown report types.

- MarkdownSummary (5.1.10+)
- MarkdownSummaryGithub (5.1.13+)
- MarkdownAssembliesSummary (5.3.0+)

https://reportgenerator.io/usage