### PR TITLE
GH4374: Fix Frosting argument parsing

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -342,7 +342,8 @@ Task("Frosting-Integration-Tests")
 
         DotNetRun(test.Project.FullPath,
             new ProcessArgumentBuilder()
-                .AppendSwitchQuoted("--verbosity", "=", "quiet"),
+                .AppendSwitchQuoted("--verbosity", "=", "quiet")
+                .AppendSwitchQuoted("--name", "=", "world"),
             new DotNetRunSettings
             {
                 Configuration = parameters.Configuration,

--- a/src/Cake.Cli/Infrastructure/RemainingArgsParser.cs
+++ b/src/Cake.Cli/Infrastructure/RemainingArgsParser.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cake.Core;
+using Spectre.Console.Cli;
+
+namespace Cake.Cli.Infrastructure
+{
+    /// <summary>
+    /// Spectre.Console <see cref="IRemainingArguments"/> extensions.
+    /// </summary>
+    public static class IRemainingArgumentsExtensions
+    {
+        /// <summary>
+        /// Parses Spectre.Console <see cref="IRemainingArguments"/> to <see cref="CakeArguments"/>.
+        /// </summary>
+        /// <param name="remainingArguments">The remainingArguments.</param>
+        /// <param name="targets">The optional targets, i.e. if specified by command.</param>
+        /// <param name="preProcessArgs">The optional pre-process arguments.</param>
+        /// <returns><see cref="CakeArguments"/>.</returns>
+        public static CakeArguments ToCakeArguments(
+            this IRemainingArguments remainingArguments,
+            string[] targets = null,
+            Action<IDictionary<string, List<string>>> preProcessArgs = null)
+        {
+            var arguments = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+            // Keep the actual remaining arguments in the cake arguments
+            foreach (var group in remainingArguments.Parsed)
+            {
+                string key = group.Key.TrimStart('-');
+                arguments[key] = new List<string>();
+                foreach (var argument in group)
+                {
+                    arguments[key].Add(argument);
+                }
+            }
+
+            // Fixes #3291, We have to add arguments manually which are defined within the DefaultCommandSettings type. Those are not considered "as remaining" because they could be parsed
+            const string targetArgumentName = "target";
+            if (!arguments.ContainsKey(targetArgumentName))
+            {
+                arguments[targetArgumentName] = new List<string>();
+            }
+
+            if (targets != null)
+            {
+                foreach (var target in targets)
+                {
+                    arguments[targetArgumentName].Add(target);
+                }
+            }
+
+            preProcessArgs?.Invoke(arguments);
+
+            var argumentLookUp = arguments.SelectMany(a => a.Value, Tuple.Create).ToLookup(a => a.Item1.Key, a => a.Item2);
+            return new CakeArguments(argumentLookUp);
+        }
+    }
+}

--- a/src/Cake.Frosting/Internal/Commands/DefaultCommand.cs
+++ b/src/Cake.Frosting/Internal/Commands/DefaultCommand.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Cake.Cli;
+using Cake.Cli.Infrastructure;
 using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
@@ -81,31 +82,7 @@ namespace Cake.Frosting.Internal
 
         private static CakeArguments CreateCakeArguments(IRemainingArguments remainingArguments, DefaultCommandSettings settings)
         {
-            var arguments = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
-
-            // Keep the actual remaining arguments in the cake arguments
-            foreach (var group in remainingArguments.Parsed)
-            {
-                arguments[group.Key] = new List<string>();
-                foreach (var argument in group)
-                {
-                    arguments[group.Key].Add(argument);
-                }
-            }
-
-            // Fixes #3291, We have to add arguments manually which are defined within the DefaultCommandSettings type. Those are not considered "as remaining" because they could be parsed
-            const string targetArgumentName = "target";
-            if (!arguments.ContainsKey(targetArgumentName))
-            {
-                arguments[targetArgumentName] = new List<string>();
-            }
-            foreach (var target in settings.Targets)
-            {
-                arguments[targetArgumentName].Add(target);
-            }
-
-            var argumentLookUp = arguments.SelectMany(a => a.Value, Tuple.Create).ToLookup(a => a.Item1.Key, a => a.Item2);
-            return new CakeArguments(argumentLookUp);
+            return remainingArguments.ToCakeArguments(settings.Targets);
         }
 
         private void InstallTools(ServiceProvider provider)

--- a/tests/integration/Cake.Frosting/build/Tasks/Hello.cs
+++ b/tests/integration/Cake.Frosting/build/Tasks/Hello.cs
@@ -1,3 +1,4 @@
+using Cake.Common;
 using Cake.Common.Diagnostics;
 using Cake.Frosting;
 
@@ -6,6 +7,6 @@ public sealed class Hello : FrostingTask<Context>
 {
     public override void Run(Context context)
     {
-        context.Information("Hello World");
+        context.Information("Hello {0}", context.Argument<string>("name"));
     }
 }


### PR DESCRIPTION
* Add argument to Forsting integration tests
* Unify Scripting / Frosting Spectre.Console IRemainingArguments to CakeArguments parsing
* fixes #4374
