### PR TITLE
Update .NET SDK to 8.0.108

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
         "src"
     ],
     "sdk": {
-        "version": "8.0.403",
+        "version": "8.0.108",
         "rollForward": "latestFeature"
     }
 }


### PR DESCRIPTION
currently, the dotnet sdk coming with the dotnet formula (8.x) is 8.0.108, so updating the sdk version value to it. since there is already `"rollForward": "latestFeature"`, the build behavior wont change that much.

relates to https://github.com/Homebrew/homebrew-core/pull/195372

also, this is the same thing adopted with kiota project, https://github.com/microsoft/kiota/pull/5606