### PR TITLE
Add .NET 9, C# 13 and remove out of support .NET 6 & 7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,20 +16,19 @@ jobs:
         os: [windows-latest, macos-13, ubuntu-latest]
     steps:
       - name: Get the sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Install .NET SDK 6.0.x - 8.0.x
-        uses: actions/setup-dotnet@v3
+      - name: Install .NET SDK 8.0.x - 9.0.x
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
 
       - name: Install .NET Core SDK (global.json)
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
 
@@ -47,7 +46,6 @@ jobs:
           script-path: tests/integration/Cake.Common/Build/GitHubActions/ValidateGitHubActionsProvider.cake
           cake-version: tool-manifest
           arguments: |
-            CAKE_NETCOREAPP_6_0_VERSION_OS: ${{ steps.build-cake.outputs.CAKE_NETCOREAPP_6_0_VERSION_OS }}
-            CAKE_NETCOREAPP_7_0_VERSION_OS: ${{ steps.build-cake.outputs.CAKE_NETCOREAPP_7_0_VERSION_OS }}
             CAKE_NETCOREAPP_8_0_VERSION_OS: ${{ steps.build-cake.outputs.CAKE_NETCOREAPP_8_0_VERSION_OS }}
+            CAKE_NETCOREAPP_9_0_VERSION_OS: ${{ steps.build-cake.outputs.CAKE_NETCOREAPP_9_0_VERSION_OS }}
             ValidateGitHubActionsProvider: true

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-next-version: 4.0.0
+next-version: 5.0.0
 branches:
   master:
     regex: main

--- a/build.cake
+++ b/build.cake
@@ -108,7 +108,7 @@ Task("Run-Unit-Tests")
         () => GetFiles("./src/**/*.Tests.csproj"),
         (parameters, project, context) =>
 {
-    foreach(var framework in new[] { "net6.0", "net7.0", "net8.0" })
+    foreach(var framework in new[] { "net8.0" })
     {
         FilePath testResultsPath = MakeAbsolute(parameters.Paths.Directories.TestResults
             .CombineWithFilePath($"{project.GetFilenameWithoutExtension()}_{framework}_TestResults.xml"));
@@ -368,8 +368,6 @@ Task("Run-Integration-Tests")
     .DeferOnError()
     .DoesForEach<BuildParameters, FilePath>(
         parameters => new[] {
-            GetFiles($"{parameters.Paths.Directories.IntegrationTestsBinTool.FullPath}/**/net6.0/**/Cake.dll").Single(),
-            GetFiles($"{parameters.Paths.Directories.IntegrationTestsBinTool.FullPath}/**/net7.0/**/Cake.dll").Single(),
             GetFiles($"{parameters.Paths.Directories.IntegrationTestsBinTool.FullPath}/**/net8.0/**/Cake.dll").Single()
         },
         (parameters, cakeAssembly, context) =>

--- a/build.cake
+++ b/build.cake
@@ -108,7 +108,7 @@ Task("Run-Unit-Tests")
         () => GetFiles("./src/**/*.Tests.csproj"),
         (parameters, project, context) =>
 {
-    foreach(var framework in new[] { "net8.0" })
+    foreach(var framework in new[] { "net8.0", "net9.0" })
     {
         FilePath testResultsPath = MakeAbsolute(parameters.Paths.Directories.TestResults
             .CombineWithFilePath($"{project.GetFilenameWithoutExtension()}_{framework}_TestResults.xml"));
@@ -368,7 +368,8 @@ Task("Run-Integration-Tests")
     .DeferOnError()
     .DoesForEach<BuildParameters, FilePath>(
         parameters => new[] {
-            GetFiles($"{parameters.Paths.Directories.IntegrationTestsBinTool.FullPath}/**/net8.0/**/Cake.dll").Single()
+            GetFiles($"{parameters.Paths.Directories.IntegrationTestsBinTool.FullPath}/**/net8.0/**/Cake.dll").Single(),
+            GetFiles($"{parameters.Paths.Directories.IntegrationTestsBinTool.FullPath}/**/net9.0/**/Cake.dll").Single()
         },
         (parameters, cakeAssembly, context) =>
 {

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
         "src"
     ],
     "sdk": {
-        "version": "8.0.403",
+        "version": "9.0.100-rc.2.24474.11",
         "rollForward": "latestFeature"
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Package/Add/DotNetPackageAdderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Package/Add/DotNetPackageAdderTests.cs
@@ -95,7 +95,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Package.Add
                 // Given
                 var fixture = new DotNetPackageAdderFixture();
                 fixture.PackageName = "Microsoft.AspNetCore.StaticFiles";
-                fixture.Settings.Framework = "net7.0";
+                fixture.Settings.Framework = "net8.0";
                 fixture.Settings.Interactive = true;
                 fixture.Settings.NoRestore = true;
                 fixture.Settings.PackageDirectory = "./src/project";
@@ -108,7 +108,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Package.Add
                 var result = fixture.Run();
 
                 // Then
-                var expected = "add package Microsoft.AspNetCore.StaticFiles --framework net7.0 --interactive --no-restore --package-directory \"/Working/src/project\" --prerelease --source \"http://www.nuget.org/api/v2/package\" --version \"1.0.0\" --verbosity diagnostic";
+                var expected = "add package Microsoft.AspNetCore.StaticFiles --framework net8.0 --interactive --no-restore --package-directory \"/Working/src/project\" --prerelease --source \"http://www.nuget.org/api/v2/package\" --version \"1.0.0\" --verbosity diagnostic";
                 Assert.Equal(expected, result.Args);
             }
         }

--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Package/List/DotNetPackageListerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Package/List/DotNetPackageListerTests.cs
@@ -78,7 +78,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Package.List
                 var fixture = new DotNetPackageListerFixture();
                 fixture.Settings.ConfigFile = "./nuget.config";
                 fixture.Settings.Deprecated = true;
-                fixture.Settings.Framework = "net7.0";
+                fixture.Settings.Framework = "net8.0";
                 fixture.Settings.HighestMinor = true;
                 fixture.Settings.HighestPatch = true;
                 fixture.Settings.Prerelease = true;
@@ -94,7 +94,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Package.List
                 var result = fixture.Run();
 
                 // Then
-                var expected = "list package --config \"/Working/nuget.config\" --deprecated --framework net7.0 --highest-minor --highest-patch --include-prerelease --include-transitive --interactive --outdated ";
+                var expected = "list package --config \"/Working/nuget.config\" --deprecated --framework net8.0 --highest-minor --highest-patch --include-prerelease --include-transitive --interactive --outdated ";
                 expected += "--source \"http://www.nuget.org/api/v2/package\" --source \"http://www.symbolserver.org/\" --vulnerable --format json --output-version 1";
                 Assert.Equal(expected, result.Args);
             }

--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Reference/Add/DotNetReferenceAdderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Reference/Add/DotNetReferenceAdderTests.cs
@@ -143,7 +143,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Reference.Add
                 var fixture = new DotNetReferenceAdderFixture();
                 fixture.ProjectReferences = new[] { (FilePath)"./lib1.csproj" };
                 fixture.Project = "ToDo.csproj";
-                fixture.Settings.Framework = "net7.0";
+                fixture.Settings.Framework = "net8.0";
                 fixture.Settings.Interactive = true;
                 fixture.Settings.Verbosity = DotNetVerbosity.Diagnostic;
 
@@ -151,7 +151,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Reference.Add
                 var result = fixture.Run();
 
                 // Then
-                var expected = "add \"ToDo.csproj\" reference \"/Working/lib1.csproj\" --framework net7.0 --interactive --verbosity diagnostic";
+                var expected = "add \"ToDo.csproj\" reference \"/Working/lib1.csproj\" --framework net8.0 --interactive --verbosity diagnostic";
                 Assert.Equal(expected, result.Args);
             }
         }

--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Reference/Remove/DotNetReferenceRemoverTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Reference/Remove/DotNetReferenceRemoverTests.cs
@@ -143,14 +143,14 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Reference.Remove
                 var fixture = new DotNetReferenceRemoverFixture();
                 fixture.ProjectReferences = new[] { (FilePath)"./lib1.csproj" };
                 fixture.Project = "ToDo.csproj";
-                fixture.Settings.Framework = "net7.0";
+                fixture.Settings.Framework = "net8.0";
                 fixture.Settings.Verbosity = DotNetVerbosity.Diagnostic;
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                var expected = "remove \"ToDo.csproj\" reference \"/Working/lib1.csproj\" --framework net7.0 --verbosity diagnostic";
+                var expected = "remove \"ToDo.csproj\" reference \"/Working/lib1.csproj\" --framework net8.0 --verbosity diagnostic";
                 Assert.Equal(expected, result.Args);
             }
         }

--- a/src/Cake.Common.Tests/Unit/Tools/OpenCover/OpenCoverTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/OpenCover/OpenCoverTests.cs
@@ -307,24 +307,6 @@ namespace Cake.Common.Tests.Unit.Tools.OpenCover
             }
 
             [Fact]
-            public void Should_Not_break_when_old_string_registrations_are_used()
-            {
-                // Given
-                var fixture = new OpenCoverFixture();
-#pragma warning disable CS0618 // Type or member is obsolete
-                fixture.Settings.Register = "Path64";
-#pragma warning restore CS0618 // Type or member is obsolete
-
-                // When
-                var result = fixture.Run();
-
-                // Then
-                Assert.Equal("-target:\"/Working/tools/Test.exe\" " +
-                             "-targetargs:\"-argument\" " +
-                             "-register:Path64 -output:\"/Working/result.xml\"", result.Args);
-            }
-
-            [Fact]
             public void Should_Add_ReturnTargetCode_If_ReturnTargetCodeOffset_Is_Set()
             {
                 // Given

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverRegisterOption.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverRegisterOption.cs
@@ -65,30 +65,6 @@ namespace Cake.Common.Tools.OpenCover
         {
             return commandLineValue;
         }
-
-        /// <summary>
-        /// Performs an implicit conversion from <see cref="System.String"/> to <see cref="OpenCoverRegisterOption"/>.
-        /// (Since the switch from pure string to <see cref="OpenCoverRegisterOption"/> is a breaking change.)
-        /// </summary>
-        /// <param name="option">The option.</param>
-        /// <returns>
-        /// The result of the conversion.
-        /// </returns>
-        [Obsolete("use new OpenCoverRegisterOption() instead.")]
-        public static implicit operator OpenCoverRegisterOption(string option)
-        {
-            if (string.IsNullOrEmpty(option))
-            {
-                return new OpenCoverRegisterOptionAdmin();
-            }
-
-            if (option.Equals("user", StringComparison.InvariantCultureIgnoreCase))
-            {
-                return new OpenCoverRegisterOptionUser();
-            }
-
-            return new OpenCoverRegisterOptionDll(new FilePath(option));
-        }
     }
 
     /// <summary>

--- a/src/Cake.Core.Tests/Unit/CakeRuntimeTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeRuntimeTests.cs
@@ -39,7 +39,9 @@ namespace Cake.Core.Tests.Unit
                 Assert.Equal(".NETStandard,Version=v2.0", framework.FullName);
 #else
                 var expect = string.Concat(".NETCoreApp,Version=v",
-#if NET8_0
+#if NET9_0
+                                "9.0");
+#elif NET8_0
                                 "8.0");
 #elif NET7_0
                                 "7.0");
@@ -71,6 +73,7 @@ namespace Cake.Core.Tests.Unit
                             case ".NETCoreApp,Version=v5.0":
                             case ".NETCoreApp,Version=v6.0":
                             case ".NETCoreApp,Version=v7.0":
+                            case ".NETCoreApp,Version=v8.0":
                                 {
                                     TestOutputHelper.WriteLine("Expect changed from {0} to {1}.", expect, framework.FullName);
                                     expect = framework.FullName;
@@ -88,6 +91,7 @@ namespace Cake.Core.Tests.Unit
                             case ".NETCoreApp,Version=v5.0":
                             case ".NETCoreApp,Version=v6.0":
                             case ".NETCoreApp,Version=v7.0":
+                            case ".NETCoreApp,Version=v8.0":
                             {
                                 TestOutputHelper.WriteLine("Expect changed from {0} to {1}.", expect, framework.FullName);
                                 expect = framework.FullName;
@@ -104,6 +108,7 @@ namespace Cake.Core.Tests.Unit
                             case ".NETCoreApp,Version=v5.0":
                             case ".NETCoreApp,Version=v6.0":
                             case ".NETCoreApp,Version=v7.0":
+                            case ".NETCoreApp,Version=v8.0":
                             {
                                 TestOutputHelper.WriteLine("Expect changed from {0} to {1}.", expect, framework.FullName);
                                 expect = framework.FullName;
@@ -119,6 +124,7 @@ namespace Cake.Core.Tests.Unit
                             case ".NETCoreApp,Version=v5.0":
                             case ".NETCoreApp,Version=v6.0":
                             case ".NETCoreApp,Version=v7.0":
+                            case ".NETCoreApp,Version=v8.0":
                                 {
                                     TestOutputHelper.WriteLine("Expect changed from {0} to {1}.", expect, framework.FullName);
                                     expect = framework.FullName;
@@ -133,6 +139,7 @@ namespace Cake.Core.Tests.Unit
                         {
                             case ".NETCoreApp,Version=v6.0":
                             case ".NETCoreApp,Version=v7.0":
+                            case ".NETCoreApp,Version=v8.0":
                                 {
                                     TestOutputHelper.WriteLine("Expect changed from {0} to {1}.", expect, framework.FullName);
                                     expect = framework.FullName;
@@ -146,6 +153,7 @@ namespace Cake.Core.Tests.Unit
                         switch (framework.FullName)
                         {
                             case ".NETCoreApp,Version=v7.0":
+                            case ".NETCoreApp,Version=v8.0":
                                 {
                                     TestOutputHelper.WriteLine("Expect changed from {0} to {1}.", expect, framework.FullName);
                                     expect = framework.FullName;

--- a/src/Cake.Core/Constants.cs
+++ b/src/Cake.Core/Constants.cs
@@ -11,7 +11,7 @@ namespace Cake.Core
         public const ConsoleColor DefaultConsoleColor = (ConsoleColor)(-1);
 
         public static readonly Version LatestBreakingChange = new Version(0, 26, 0);
-        public static readonly Version LatestPotentialBreakingChange = new Version(4, 0, 0);
+        public static readonly Version LatestPotentialBreakingChange = new Version(5, 0, 0);
 
         public static class Settings
         {

--- a/src/Cake.Core/Scripting/ScriptConventions.cs
+++ b/src/Cake.Core/Scripting/ScriptConventions.cs
@@ -128,6 +128,9 @@ namespace Cake.Core.Scripting
                 case ".NETCoreApp,Version=v8.0":
                     return "NET8_0";
 
+                case ".NETCoreApp,Version=v9.0":
+                    return "NET9_0";
+
                 default:
                     Console.Error.WriteLine(_runtime.BuiltFramework.FullName);
                     Console.Error.Flush();

--- a/src/Cake.Frosting.Template/templates/cakefrosting/.template.config/template.json
+++ b/src/Cake.Frosting.Template/templates/cakefrosting/.template.config/template.json
@@ -21,14 +21,6 @@
         "replaces": "TargetFrameworkValue",
         "choices": [
             {
-            "choice": "net6.0",
-            "description": "Target .NET 6"
-            },
-            {
-            "choice": "net7.0",
-            "description": "Target .NET 7"
-            },
-            {
             "choice": "net8.0",
             "description": "Target .NET 8"
             }

--- a/src/Cake.Frosting.Template/templates/cakefrosting/.template.config/template.json
+++ b/src/Cake.Frosting.Template/templates/cakefrosting/.template.config/template.json
@@ -17,12 +17,16 @@
         "type": "parameter",
         "description": "The target framework for the project.",
         "datatype": "choice",
-        "defaultValue": "net8.0",
+        "defaultValue": "net9.0",
         "replaces": "TargetFrameworkValue",
         "choices": [
             {
             "choice": "net8.0",
             "description": "Target .NET 8"
+            },
+            {
+              "choice": "net9.0",
+              "description": "Target .NET 9"
             }
         ]
     }

--- a/src/Cake.NuGet/Cake.NuGet.csproj
+++ b/src/Cake.NuGet/Cake.NuGet.csproj
@@ -25,6 +25,9 @@
     <PackageReference Include="NuGet.Resolver" />
     <PackageReference Include="NuGet.Common" />
     <PackageReference Include="Newtonsoft.Json" />
+
+    <!-- Pin nuget transitive packages vulnerability issues NuGet.Packaging -->
+    <PackageReference Include="System.Security.Cryptography.Pkcs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cake/Cake.csproj
+++ b/src/Cake/Cake.csproj
@@ -31,7 +31,5 @@
     <PackageReference Include="System.Reflection.Metadata"  />
     <PackageReference Include="Autofac" />
     <PackageReference Include="Basic.Reference.Assemblies.Net80" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Basic.Reference.Assemblies.Net70" Condition="'$(TargetFramework)' == 'net7.0'" />
-    <PackageReference Include="Basic.Reference.Assemblies.Net60" Condition="'$(TargetFramework)' == 'net6.0'" />
   </ItemGroup>
 </Project>

--- a/src/Cake/Cake.csproj
+++ b/src/Cake/Cake.csproj
@@ -31,5 +31,6 @@
     <PackageReference Include="System.Reflection.Metadata"  />
     <PackageReference Include="Autofac" />
     <PackageReference Include="Basic.Reference.Assemblies.Net80" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net90" Condition="'$(TargetFramework)' == 'net9.0'" />
   </ItemGroup>
 </Project>

--- a/src/Cake/Infrastructure/Scripting/ReferenceAssemblyResolver.cs
+++ b/src/Cake/Infrastructure/Scripting/ReferenceAssemblyResolver.cs
@@ -22,11 +22,7 @@ namespace Cake.Infrastructure.Scripting
             IEnumerable<Assembly> TryGetReferenceAssemblies()
             {
                 foreach (var reference in
-#if NET6_0
-            Basic.Reference.Assemblies.Net60.References.All)
-#elif NET7_0
-            Basic.Reference.Assemblies.Net70.References.All)
-#else
+#if NET8_0
             Basic.Reference.Assemblies.Net80.References.All)
 #endif
                 {

--- a/src/Cake/Infrastructure/Scripting/ReferenceAssemblyResolver.cs
+++ b/src/Cake/Infrastructure/Scripting/ReferenceAssemblyResolver.cs
@@ -24,6 +24,8 @@ namespace Cake.Infrastructure.Scripting
                 foreach (var reference in
 #if NET8_0
             Basic.Reference.Assemblies.Net80.References.All)
+#else
+            Basic.Reference.Assemblies.Net90.References.All)
 #endif
                 {
                     Assembly assembly;

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -8,6 +8,7 @@
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
     <PackageVersion Include="Autofac" Version="8.1.1" />
     <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.7.9" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.7.9" />
     <PackageVersion Include="Cake.Frosting" Version="3.1.0.0" />
     <PackageVersion Include="Castle.Core" Version="5.1.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.11.0" />
@@ -34,5 +35,9 @@
     <PackageVersion Include="Verify.Xunit" Version="27.0.1" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+
+    <!-- Pin nuget transitive packages vulnerability issues NuGet.Packaging -->
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.0-rc.2.24473.5" />
   </ItemGroup>
+
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.11.1" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="NSubstitute" Version="5.1.0" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NuGet.Common" Version="6.11.1" />
     <PackageVersion Include="NuGet.Frameworks" Version="6.11.1" />
     <PackageVersion Include="NuGet.Packaging" Version="6.11.1" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="Spectre.Verify.Extensions" Version="22.3.1" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Include="System.Reflection.Metadata" Version="8.0.1" />
-    <PackageVersion Include="Verify.Xunit" Version="27.0.1" />
+    <PackageVersion Include="Verify.Xunit" Version="27.1.0" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,8 +7,6 @@
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
     <PackageVersion Include="Autofac" Version="8.1.1" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net60" Version="1.7.9" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net70" Version="1.7.9" />
     <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.7.9" />
     <PackageVersion Include="Cake.Frosting" Version="3.1.0.0" />
     <PackageVersion Include="Castle.Core" Version="5.1.1" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.7.9" />
     <PackageVersion Include="Cake.Frosting" Version="3.1.0.0" />
     <PackageVersion Include="Castle.Core" Version="5.1.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.12.0-2.final" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.12.0-3.final" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0-rc.2.24473.5" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.1.2" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -11,9 +11,9 @@
     <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.7.9" />
     <PackageVersion Include="Cake.Frosting" Version="3.1.0.0" />
     <PackageVersion Include="Castle.Core" Version="5.1.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.11.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.12.0-2.final" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0-rc.2.24473.5" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.1.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
@@ -30,8 +30,8 @@
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.49.1" />
     <PackageVersion Include="Spectre.Verify.Extensions" Version="22.3.1" />
-    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="8.0.1" />
+    <PackageVersion Include="System.Collections.Immutable" Version="9.0.0-rc.2.24473.5" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="9.0.0-rc.2.24473.5" />
     <PackageVersion Include="Verify.Xunit" Version="27.1.0" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/src/Shared.msbuild
+++ b/src/Shared.msbuild
@@ -12,11 +12,20 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>Cake;Script;Build</PackageTags>
     <PackageProjectUrl>https://cakebuild.net</PackageProjectUrl>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <PackageReadmeFile>NuGet.org.md</PackageReadmeFile>
     <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
     <DebugType>portable</DebugType>
+    
+    <!-- 
+      While .NET 9 not released don't warn, remove as soon as non RC binaries shipped.
+      NU5104
+      A stable release of a package should not have a prerelease dependency. Either modify the version spec of dependency 
+      https://github.com/cake-build/cake/issues/4382
+    -->
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
+
   </PropertyGroup>
 
   <!-- Global solution information -->

--- a/src/Shared.msbuild
+++ b/src/Shared.msbuild
@@ -1,7 +1,7 @@
 <Project>
   <!-- General package metadata -->
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <PackageId>$(AssemblyName)</PackageId>
     <Copyright>Copyright (c) .NET Foundation and contributors</Copyright>
     <Authors>Patrik Svensson, Mattias Karlsson, Gary Ewan Park, Alistair Chapman, Martin Björkström, Dave Glick, Pascal Berger, Jérémie Desautels, Enrico Campidoglio, C. Augusto Proiete, Nils Andresen, and contributors</Authors>
@@ -14,10 +14,6 @@
     <PackageProjectUrl>https://cakebuild.net</PackageProjectUrl>
     <LangVersion>9.0</LangVersion>
     <PackageReadmeFile>NuGet.org.md</PackageReadmeFile>
-  </PropertyGroup>
-
-  <!-- Define .NET Core constants -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'  OR '$(TargetFramework)' == 'net8.0'">
     <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
     <DebugType>portable</DebugType>

--- a/src/Shared.msbuild
+++ b/src/Shared.msbuild
@@ -1,7 +1,7 @@
 <Project>
   <!-- General package metadata -->
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <PackageId>$(AssemblyName)</PackageId>
     <Copyright>Copyright (c) .NET Foundation and contributors</Copyright>
     <Authors>Patrik Svensson, Mattias Karlsson, Gary Ewan Park, Alistair Chapman, Martin Björkström, Dave Glick, Pascal Berger, Jérémie Desautels, Enrico Campidoglio, C. Augusto Proiete, Nils Andresen, and contributors</Authors>

--- a/tests/integration/Cake.Common/Build/GitHubActions/ValidateGitHubActionsProvider.cake
+++ b/tests/integration/Cake.Common/Build/GitHubActions/ValidateGitHubActionsProvider.cake
@@ -20,8 +20,6 @@ Setup(
 Task("ValidateEnvironment")
     .DoesForEach<BuildData, string>(
         data => new [] {
-            $"CAKE_{data.OS}_NETCOREAPP_6_0_VERSION",
-            $"CAKE_{data.OS}_NETCOREAPP_7_0_VERSION",
             $"CAKE_{data.OS}_NETCOREAPP_8_0_VERSION"
         },
         (data, envKey) => Assert.Equal(data.GitVersion, EnvironmentVariable(envKey))
@@ -31,8 +29,6 @@ Task("ValidatePath")
     .DoesForEach<BuildData, string>(
         new [] {
             "Cake\\WTool\\Wtools\\Wnet8\\W0",
-            "Cake\\WTool\\Wtools\\Wnet7\\W0",
-            "Cake\\WTool\\Wtools\\Wnet6\\W0"
         },
         (data, path) => Assert.Matches(path, data.Path)
     );
@@ -40,8 +36,6 @@ Task("ValidatePath")
 Task("ValidateVariable")
     .DoesForEach<BuildData, string>(
         () => new [] {
-            "CAKE_NETCOREAPP_6_0_VERSION_OS",
-            "CAKE_NETCOREAPP_7_0_VERSION_OS",
             "CAKE_NETCOREAPP_8_0_VERSION_OS"
         },
         (data, varKey) => Assert.Equal(data.GitVersionAndOS, Argument<string>(varKey))

--- a/tests/integration/Cake.Common/Build/GitHubActions/ValidateGitHubActionsProvider.cake
+++ b/tests/integration/Cake.Common/Build/GitHubActions/ValidateGitHubActionsProvider.cake
@@ -20,7 +20,8 @@ Setup(
 Task("ValidateEnvironment")
     .DoesForEach<BuildData, string>(
         data => new [] {
-            $"CAKE_{data.OS}_NETCOREAPP_8_0_VERSION"
+            $"CAKE_{data.OS}_NETCOREAPP_8_0_VERSION",
+            $"CAKE_{data.OS}_NETCOREAPP_9_0_VERSION"
         },
         (data, envKey) => Assert.Equal(data.GitVersion, EnvironmentVariable(envKey))
     );
@@ -29,6 +30,7 @@ Task("ValidatePath")
     .DoesForEach<BuildData, string>(
         new [] {
             "Cake\\WTool\\Wtools\\Wnet8\\W0",
+            "Cake\\WTool\\Wtools\\Wnet9\\W0"
         },
         (data, path) => Assert.Matches(path, data.Path)
     );
@@ -36,7 +38,8 @@ Task("ValidatePath")
 Task("ValidateVariable")
     .DoesForEach<BuildData, string>(
         () => new [] {
-            "CAKE_NETCOREAPP_8_0_VERSION_OS"
+            "CAKE_NETCOREAPP_8_0_VERSION_OS",
+            "CAKE_NETCOREAPP_9_0_VERSION_OS"
         },
         (data, varKey) => Assert.Equal(data.GitVersionAndOS, Argument<string>(varKey))
     );

--- a/tests/integration/Cake.Common/Tools/Command/CommandAliases.cake
+++ b/tests/integration/Cake.Common/Tools/Command/CommandAliases.cake
@@ -36,11 +36,7 @@ Usage:
 Arguments:
   <PACKAGE_ID>  The NuGet Package Id of the tool to list
 
-Options:
-  -g, --global        List tools installed for the current user.
-  --local             List the tools installed in the local tool manifest.
-  --tool-path <PATH>  The directory containing the tools to list.
-  -?, -h, --help      Show command line help.";
+Options:";
 
     // When
     var exitCode = ctx.Command(settings.ToolExecutableNames, out var standardOutput, "tool list -h");
@@ -65,11 +61,7 @@ Usage:
 Arguments:
   <PACKAGE_ID>  The NuGet Package Id of the tool to list
 
-Options:
-  -g, --global        List tools installed for the current user.
-  --local             List the tools installed in the local tool manifest.
-  --tool-path <PATH>  The directory containing the tools to list.
-  -?, -h, --help      Show command line help.";
+Options:";
 
     // When
     var exitCode = ctx.Command(settings, out var standardOutput, "tool list -h");
@@ -94,11 +86,7 @@ Usage:
 Arguments:
   <PACKAGE_ID>  The NuGet Package Id of the tool to list
 
-Options:
-  -g, --global        List tools installed for the current user.
-  --local             List the tools installed in the local tool manifest.
-  --tool-path <PATH>  The directory containing the tools to list.
-  -?, -h, --help      Show command line help.";
+Options:";
 
     // When
     var exitCode = ctx.Command(

--- a/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
+++ b/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
@@ -34,7 +34,7 @@ Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetBuild")
     // Given
     var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
     var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
-    var assembly = path.CombineWithFilePath("hwapp/bin/Debug/net8.0/hwapp.dll");
+    var assembly = path.CombineWithFilePath("hwapp/bin/Debug/net9.0/hwapp.dll");
 
     // When
     DotNetBuild(project.FullPath);
@@ -61,7 +61,7 @@ Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetVSTest")
 {
     // Given
     var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-    var assembly = path.CombineWithFilePath("hwapp.tests/bin/Debug/net8.0/hwapp.tests.dll");
+    var assembly = path.CombineWithFilePath("hwapp.tests/bin/Debug/net9.0/hwapp.tests.dll");
 
     // When
     DotNetVSTest(assembly.FullPath);
@@ -184,7 +184,7 @@ Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetExecute")
 {
     // Given
     var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-    var assembly = path.CombineWithFilePath("hwapp/bin/Debug/net8.0/hwapp.dll");
+    var assembly = path.CombineWithFilePath("hwapp/bin/Debug/net9.0/hwapp.dll");
 
     // When
     DotNetExecute(assembly);
@@ -197,7 +197,7 @@ Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetClean")
     // Given
     var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
     var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
-    var assembly = path.CombineWithFilePath("hwapp/bin/Debug/net8.0/hwapp.dll");
+    var assembly = path.CombineWithFilePath("hwapp/bin/Debug/net9.0/hwapp.dll");
     Assert.True(System.IO.File.Exists(assembly.FullPath));
 
     // When
@@ -214,7 +214,7 @@ Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetMSBuild")
     // Given
     var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
     var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
-    var assembly = path.CombineWithFilePath("hwapp/bin/Debug/net8.0/hwapp.dll");
+    var assembly = path.CombineWithFilePath("hwapp/bin/Debug/net9.0/hwapp.dll");
 
     // When
     DotNetMSBuild(project.FullPath);

--- a/tests/integration/Cake.Core/Scripting/AddinDirective.cake
+++ b/tests/integration/Cake.Core/Scripting/AddinDirective.cake
@@ -23,7 +23,8 @@ Task("Cake.Core.Scripting.AddinDirective.LoadTargetedAddin")
                                  .SetTargetFramework(
                                      cake switch
                                      {
-                                        _ => "net8.0"
+                                        FilePath net8_0Path         when net8_0Path.FullPath.Contains("net8.0")                 => "net8.0",
+                                        _ => "net9.0"
                                      }
                                  );
 

--- a/tests/integration/Cake.Core/Scripting/AddinDirective.cake
+++ b/tests/integration/Cake.Core/Scripting/AddinDirective.cake
@@ -23,8 +23,6 @@ Task("Cake.Core.Scripting.AddinDirective.LoadTargetedAddin")
                                  .SetTargetFramework(
                                      cake switch
                                      {
-                                        FilePath net6_0Path         when net6_0Path.FullPath.Contains("net6.0")                 => "net6.0",
-                                        FilePath net7_0Path         when net7_0Path.FullPath.Contains("net7.0")                 => "net7.0",
                                         _ => "net8.0"
                                      }
                                  );

--- a/tests/integration/Cake.Core/Scripting/DefineDirective.cake
+++ b/tests/integration/Cake.Core/Scripting/DefineDirective.cake
@@ -70,8 +70,7 @@ Task("Cake.Core.Scripting.DefineDirective.Cake")
     Assert.True(cake);
 });
 
-#if NET6_0 || NET7_0 || NET8_0
-    Task("Cake.Core.Scripting.DefineDirective.C#9")
+Task("Cake.Core.Scripting.DefineDirective.C#9")
     .Does(() =>
 {
     // given
@@ -80,10 +79,8 @@ Task("Cake.Core.Scripting.DefineDirective.Cake")
 });
 
 public record CSharpNine(bool IsNine);
-#endif
 
-#if NET6_0 || NET7_0 || NET8_0
-    Task("Cake.Core.Scripting.DefineDirective.C#10")
+Task("Cake.Core.Scripting.DefineDirective.C#10")
     .Does(() =>
 {
     // Given
@@ -97,10 +94,8 @@ public record CSharpNine(bool IsNine);
     Assert.Equal("Hello world!", helloWorld);
 });
 
-#endif
 
-#if NET7_0 || NET8_0
-    Task("Cake.Core.Scripting.DefineDirective.C#11")
+Task("Cake.Core.Scripting.DefineDirective.C#11")
     .Does(() =>
 {
     // Given / When / Then
@@ -114,9 +109,6 @@ public record CSharpNine(bool IsNine);
     """;
 });
 
-#endif
-
-#if NET8_0
     Task("Cake.Core.Scripting.DefineDirective.C#12")
     .Does(() =>
 {
@@ -127,23 +119,13 @@ public record CSharpNine(bool IsNine);
     int[] single = [..row0, ..row1, ..row2];
 });
 
-#endif
-
 //////////////////////////////////////////////////////////////////////////////
 
 Task("Cake.Core.Scripting.DefineDirective")
-#if NET6_0 || NET7_0 || NET8_0
     .IsDependentOn("Cake.Core.Scripting.DefineDirective.C#9")
-#endif
-#if NET6_0 || NET7_0 || NET8_0
     .IsDependentOn("Cake.Core.Scripting.DefineDirective.C#10")
-#endif
-#if NET7_0 || NET8_0
     .IsDependentOn("Cake.Core.Scripting.DefineDirective.C#11")
-#endif
-#if NET8_0
     .IsDependentOn("Cake.Core.Scripting.DefineDirective.C#12")
-#endif
     .IsDependentOn("Cake.Core.Scripting.DefineDirective.Defined")
     .IsDependentOn("Cake.Core.Scripting.DefineDirective.NotDefined")
     .IsDependentOn("Cake.Core.Scripting.DefineDirective.Runtime")

--- a/tests/integration/Cake.Core/Scripting/DefineDirective.cake
+++ b/tests/integration/Cake.Core/Scripting/DefineDirective.cake
@@ -54,6 +54,8 @@ Task("Cake.Core.Scripting.DefineDirective.Runtime")
                     "7.0",
 #elif NET8_0
                     "8.0",
+#elif NET9_0
+                    "9.0",
 #endif
                     context.Environment.Runtime.BuiltFramework.FullName);
 });

--- a/tests/integration/Cake.Core/Scripting/DefineDirective.cake
+++ b/tests/integration/Cake.Core/Scripting/DefineDirective.cake
@@ -111,7 +111,7 @@ Task("Cake.Core.Scripting.DefineDirective.C#11")
     """;
 });
 
-    Task("Cake.Core.Scripting.DefineDirective.C#12")
+Task("Cake.Core.Scripting.DefineDirective.C#12")
     .Does(() =>
 {
     // Given / When / Then
@@ -121,6 +121,23 @@ Task("Cake.Core.Scripting.DefineDirective.C#11")
     int[] single = [..row0, ..row1, ..row2];
 });
 
+#if NET9_0
+Task("Cake.Core.Scripting.DefineDirective.C#13")
+    .Does(() =>
+{
+    // Given
+    string Concat(params ReadOnlySpan<string> items)
+        => $"\e[31m{items[^1]}\e[31m{items[^2]}";
+    var concat = Concat;
+
+    // When
+    var result = concat("World", "Hello");
+
+    // Then
+    Assert.Equal("\e[31mHello\e[31mWorld", result);
+});
+#endif
+
 //////////////////////////////////////////////////////////////////////////////
 
 Task("Cake.Core.Scripting.DefineDirective")
@@ -128,6 +145,9 @@ Task("Cake.Core.Scripting.DefineDirective")
     .IsDependentOn("Cake.Core.Scripting.DefineDirective.C#10")
     .IsDependentOn("Cake.Core.Scripting.DefineDirective.C#11")
     .IsDependentOn("Cake.Core.Scripting.DefineDirective.C#12")
+#if NET9_0
+    .IsDependentOn("Cake.Core.Scripting.DefineDirective.C#13")
+#endif
     .IsDependentOn("Cake.Core.Scripting.DefineDirective.Defined")
     .IsDependentOn("Cake.Core.Scripting.DefineDirective.NotDefined")
     .IsDependentOn("Cake.Core.Scripting.DefineDirective.Runtime")

--- a/tests/integration/Cake.Frosting/build/Build.csproj
+++ b/tests/integration/Cake.Frosting/build/Build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
 
     <!-- Make sure start same folder .NET Core CLI and Visual Studio -->

--- a/tests/integration/Cake.Frosting/build/Build.csproj
+++ b/tests/integration/Cake.Frosting/build/Build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
 
     <!-- Make sure start same folder .NET Core CLI and Visual Studio -->

--- a/tests/integration/resources/Cake.Common/Tools/DotNet/hwapp.tests/hwapp.tests.csproj
+++ b/tests/integration/resources/Cake.Common/Tools/DotNet/hwapp.tests/hwapp.tests.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="xunit" Version="2.6.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/integration/resources/Cake.Common/Tools/DotNet/hwapp/hwapp.csproj
+++ b/tests/integration/resources/Cake.Common/Tools/DotNet/hwapp/hwapp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\hwapp.common\hwapp.common.csproj" />


### PR DESCRIPTION
* [x] fixes #4379
* [x] fixes #4345
* [x] fixes #4346
* [x] fixes #4378
* [x] fixes #4380
* [x] fixes #4383 
* [x] fixes #4384
* [x] fixes #4387


Todo #4382 (depends on .NET 9 Release) will come in a separate PR on .NET launch, would be nice to be able to integration test against Azure Artifacts pre-release feed.