### PR TITLE
Adds two missing parameters for SignTool

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/SignTool/SignToolSignRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/SignTool/SignToolSignRunnerTests.cs
@@ -480,6 +480,34 @@ namespace Cake.Common.Tests.Unit.Tools.SignTool
                 // Then
                 Assert.Equal("SIGN /f \"/Working/cert.pfx\" /p secret /sm /s \"Special Test Store\" \"/Working/a.dll\"", result.Args);
             }
+
+            [Fact]
+            public void Should_Call_Sign_Tool_With_Correct_Parameters_With_Cryptographic_Service_Provider()
+            {
+                // Given
+                var fixture = new SignToolSignRunnerFixture();
+                fixture.Settings.CspName = "Test Service Provider";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("SIGN /f \"/Working/cert.pfx\" /p secret /csp \"Test Service Provider\" \"/Working/a.dll\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Call_Sign_Tool_With_Correct_Parameters_With_Private_Key_Container_Name()
+            {
+                // Given
+                var fixture = new SignToolSignRunnerFixture();
+                fixture.Settings.PrivateKeyContainerName = "[{{password}}]=TestContainerName";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("SIGN /f \"/Working/cert.pfx\" /p secret /kc \"[{{password}}]=TestContainerName\" \"/Working/a.dll\"", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common/Tools/SignTool/SignToolSignRunner.cs
+++ b/src/Cake.Common/Tools/SignTool/SignToolSignRunner.cs
@@ -241,6 +241,20 @@ namespace Cake.Common.Tools.SignTool
                 builder.Append("/sm");
             }
 
+            // Cryptographic Service Provider
+            if (!string.IsNullOrEmpty(settings.CspName))
+            {
+                builder.Append("/csp");
+                builder.AppendQuoted(settings.CspName);
+            }
+
+            // Private Key Container Name
+            if (!string.IsNullOrEmpty(settings.PrivateKeyContainerName))
+            {
+                builder.Append("/kc");
+                builder.AppendQuoted(settings.PrivateKeyContainerName);
+            }
+
             // open a specific certificate store
             if (!string.IsNullOrWhiteSpace(settings.StoreName))
             {

--- a/src/Cake.Common/Tools/SignTool/SignToolSignRunner.cs
+++ b/src/Cake.Common/Tools/SignTool/SignToolSignRunner.cs
@@ -241,6 +241,13 @@ namespace Cake.Common.Tools.SignTool
                 builder.Append("/sm");
             }
 
+            // open a specific certificate store
+            if (!string.IsNullOrWhiteSpace(settings.StoreName))
+            {
+                builder.Append("/s");
+                builder.AppendQuoted(settings.StoreName);
+            }
+
             // Cryptographic Service Provider
             if (!string.IsNullOrEmpty(settings.CspName))
             {
@@ -253,13 +260,6 @@ namespace Cake.Common.Tools.SignTool
             {
                 builder.Append("/kc");
                 builder.AppendQuoted(settings.PrivateKeyContainerName);
-            }
-
-            // open a specific certificate store
-            if (!string.IsNullOrWhiteSpace(settings.StoreName))
-            {
-                builder.Append("/s");
-                builder.AppendQuoted(settings.StoreName);
             }
 
             // Target Assemblies to sign.

--- a/src/Cake.Common/Tools/SignTool/SignToolSignSettings.cs
+++ b/src/Cake.Common/Tools/SignTool/SignToolSignSettings.cs
@@ -77,5 +77,15 @@ namespace Cake.Common.Tools.SignTool
         /// Gets or sets the store to open when searching for the certificate.
         /// </summary>
         public string StoreName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the cryptographic service provider (CSP) that contains the private key container.
+        /// </summary>
+        public string CspName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the private key container name.
+        /// </summary>
+        public string PrivateKeyContainerName { get; set; }
     }
 }


### PR DESCRIPTION
\csp - Cryptographic Service Provider
\kc - Private Key Container Name

Fix for #4404
