### PR TITLE
Fix detection of current GitHub pull request in Azure Pipelines (#4410)

### DIFF
--- a/src/Cake.Common.Tests/Unit/Build/AzurePipelines/Data/AzurePipelinesPullRequestInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/AzurePipelines/Data/AzurePipelinesPullRequestInfoTests.cs
@@ -32,6 +32,7 @@ namespace Cake.Common.Tests.Unit.Build.AzurePipelines.Data
             }
         }
 
+        [Obsolete("The Id property is marked obsolete since the type will change to long in the next major version")]
         public sealed class TheIdProperty
         {
             [Fact]

--- a/src/Cake.Common.Tests/Unit/Build/AzurePipelines/Data/AzurePipelinesPullRequestInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/AzurePipelines/Data/AzurePipelinesPullRequestInfoTests.cs
@@ -34,6 +34,22 @@ namespace Cake.Common.Tests.Unit.Build.AzurePipelines.Data
 
         public sealed class TheIdProperty
         {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new AzurePipelinesInfoFixture().CreatePullRequestInfo();
+
+                // When
+                var result = info.Id;
+
+                // Then
+                Assert.Equal(1, result);
+            }
+        }
+
+        public sealed class TheLongIdProperty
+        {
             [Theory]
             [InlineData("1", 1)]
             [InlineData("2147483648", 2147483648)]
@@ -45,7 +61,7 @@ namespace Cake.Common.Tests.Unit.Build.AzurePipelines.Data
                 var info = fixture.CreatePullRequestInfo();
 
                 // When
-                var result = info.Id;
+                var result = info.LongId;
 
                 // Then
                 Assert.Equal(expected, result);

--- a/src/Cake.Common.Tests/Unit/Build/AzurePipelines/Data/AzurePipelinesPullRequestInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/AzurePipelines/Data/AzurePipelinesPullRequestInfoTests.cs
@@ -15,6 +15,7 @@ namespace Cake.Common.Tests.Unit.Build.AzurePipelines.Data
         {
             [Theory]
             [InlineData("1", true)]
+            [InlineData("2147483648", true)]
             [InlineData("0", false)]
             public void Should_Return_Correct_Value(string value, bool expected)
             {
@@ -33,17 +34,21 @@ namespace Cake.Common.Tests.Unit.Build.AzurePipelines.Data
 
         public sealed class TheIdProperty
         {
-            [Fact]
-            public void Should_Return_Correct_Value()
+            [Theory]
+            [InlineData("1", 1)]
+            [InlineData("2147483648", 2147483648)]
+            public void Should_Return_Correct_Value(string value, long expected)
             {
                 // Given
-                var info = new AzurePipelinesInfoFixture().CreatePullRequestInfo();
+                var fixture = new AzurePipelinesInfoFixture();
+                fixture.Environment.GetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID").Returns(value);
+                var info = fixture.CreatePullRequestInfo();
 
                 // When
                 var result = info.Id;
 
                 // Then
-                Assert.Equal(1, result);
+                Assert.Equal(expected, result);
             }
         }
 

--- a/src/Cake.Common/Build/AzurePipelines/AzurePipelinesInfo.cs
+++ b/src/Cake.Common/Build/AzurePipelines/AzurePipelinesInfo.cs
@@ -54,6 +54,25 @@ namespace Cake.Common.Build.AzurePipelines
         }
 
         /// <summary>
+        /// Gets an environment variable as a <see cref="System.Int64"/>.
+        /// </summary>
+        /// <param name="variable">The environment variable name.</param>
+        /// <returns>The environment variable.</returns>
+        protected long GetEnvironmentLongInteger(string variable)
+        {
+            var value = GetEnvironmentString(variable);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                long result;
+                if (long.TryParse(value, out result))
+                {
+                    return result;
+                }
+            }
+            return 0;
+        }
+
+        /// <summary>
         /// Gets an environment variable as a <see cref="System.Boolean"/>.
         /// </summary>
         /// <param name="variable">The environment variable name.</param>

--- a/src/Cake.Common/Build/AzurePipelines/Data/AzurePipelinesPullRequestInfo.cs
+++ b/src/Cake.Common/Build/AzurePipelines/Data/AzurePipelinesPullRequestInfo.cs
@@ -41,7 +41,7 @@ namespace Cake.Common.Build.AzurePipelines.Data
         /// <value>
         ///   The ID of the pull request that caused this build.
         /// </value>
-        public int Id => GetEnvironmentInteger("SYSTEM_PULLREQUEST_PULLREQUESTID");
+        public long Id => GetEnvironmentLongInteger("SYSTEM_PULLREQUEST_PULLREQUESTID");
 
         /// <summary>
         /// Gets the number of the pull request that caused this build.

--- a/src/Cake.Common/Build/AzurePipelines/Data/AzurePipelinesPullRequestInfo.cs
+++ b/src/Cake.Common/Build/AzurePipelines/Data/AzurePipelinesPullRequestInfo.cs
@@ -32,7 +32,7 @@ namespace Cake.Common.Build.AzurePipelines.Data
         /// <value>
         ///   <c>true</c> if the current build was started by a pull request; otherwise, <c>false</c>.
         /// </value>
-        public bool IsPullRequest => Id > 0;
+        public bool IsPullRequest => LongId > 0;
 
         /// <summary>
         /// Gets the ID of the pull request that caused this build.
@@ -41,7 +41,17 @@ namespace Cake.Common.Build.AzurePipelines.Data
         /// <value>
         ///   The ID of the pull request that caused this build.
         /// </value>
-        public long Id => GetEnvironmentLongInteger("SYSTEM_PULLREQUEST_PULLREQUESTID");
+        [Obsolete("Type will change in next major version to long, meanwhile use LongId to ensure proper value returned.")]
+        public int Id => GetEnvironmentInteger("SYSTEM_PULLREQUEST_PULLREQUESTID");
+
+        /// <summary>
+        /// Gets the ID of the pull request that caused this build.
+        /// This value is set only if the build ran because of a Git PR affected by a branch policy.
+        /// </summary>
+        /// <value>
+        ///   The ID of the pull request that caused this build.
+        /// </value>
+        public long LongId => GetEnvironmentLongInteger("SYSTEM_PULLREQUEST_PULLREQUESTID");
 
         /// <summary>
         /// Gets the number of the pull request that caused this build.


### PR DESCRIPTION
Fix detection of GitHub Pull Request builds in Azure Pipelines.  
This fixes the issue described in #4410.

To fix the issue, use a `long` instead of an `int` to store the current Pull Request id (read from the Azure Pipelines variable `SYSTEM_PULLREQUEST_PULLREQUESTID`).

I am aware that is a breaking change that might break all code that accesses `AzurePipelinesPullRequestInfo.Id` - however I am not aware of any other way to potentially fix this,