### PR TITLE
Add source and target branch to GitLabCIPullRequestInfo (#4416)

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Build/GitLabCIInfoFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/GitLabCIInfoFixture.cs
@@ -65,6 +65,8 @@ namespace Cake.Common.Tests.Fixtures.Build
             Environment.GetEnvironmentVariable("CI_SERVER_VERSION").Returns("8.9.0");
             Environment.GetEnvironmentVariable("GITLAB_USER_ID").Returns("42");
             Environment.GetEnvironmentVariable("GITLAB_USER_EMAIL").Returns("anthony@warwickcontrol.com");
+            Environment.GetEnvironmentVariable("CI_MERGE_REQUEST_SOURCE_BRANCH_NAME").Returns("source-branch");
+            Environment.GetEnvironmentVariable("CI_MERGE_REQUEST_TARGET_BRANCH_NAME").Returns("main");
         }
 
         public GitLabCIBuildInfo CreateBuildInfo()

--- a/src/Cake.Common.Tests/Unit/Build/GitLabCI/Data/GitLabCIPullRequestInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/GitLabCI/Data/GitLabCIPullRequestInfoTests.cs
@@ -61,5 +61,37 @@ namespace Cake.Common.Tests.Unit.Build.GitLabCI.Data
                 Assert.Equal(1, result);
             }
         }
+
+        public sealed class TheSourceBranchProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreatePullRequestInfo();
+
+                // When
+                var result = info.SourceBranch;
+
+                // Then
+                Assert.Equal("source-branch", result);
+            }
+        }
+
+        public sealed class TheTargetBranchProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitLabCIInfoFixture().CreatePullRequestInfo();
+
+                // When
+                var result = info.TargetBranch;
+
+                // Then
+                Assert.Equal("main", result);
+            }
+        }
     }
 }

--- a/src/Cake.Common/Build/GitLabCI/Data/GitLabCIPullRequestInfo.cs
+++ b/src/Cake.Common/Build/GitLabCI/Data/GitLabCIPullRequestInfo.cs
@@ -43,5 +43,21 @@ namespace Cake.Common.Build.GitLabCI.Data
         ///   The pull request id.
         /// </value>
         public int IId => GetEnvironmentInteger("CI_MERGE_REQUEST_IID");
+
+        /// <summary>
+        /// Gets the source branch of the pull request.
+        /// </summary>
+        /// <value>
+        ///   The source branch of the pull request.
+        /// </value>
+        public string SourceBranch => GetEnvironmentString("CI_MERGE_REQUEST_SOURCE_BRANCH_NAME");
+
+        /// <summary>
+        /// Gets the target branch of the pull request.
+        /// </summary>
+        /// <value>
+        ///   The target branch name of the pull request.
+        /// </value>
+        public string TargetBranch => GetEnvironmentString("CI_MERGE_REQUEST_TARGET_BRANCH_NAME");
     }
 }


### PR DESCRIPTION
Add properties "SourceBranch" and "TargetBranch" to GitLabCIPullRequestInfo.


This fixes #4416 