### PR TITLE
Add Url property to GitLabCIServerInfo (#4418)

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Build/GitLabCIInfoFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/GitLabCIInfoFixture.cs
@@ -60,6 +60,7 @@ namespace Cake.Common.Tests.Fixtures.Build
             Environment.GetEnvironmentVariable("CI_RUNNER_DESCRIPTION").Returns("my runner");
             Environment.GetEnvironmentVariable("CI_RUNNER_TAGS").Returns("[\"docker\", \"linux\"]");
             Environment.GetEnvironmentVariable("CI_SERVER").Returns("yes");
+            Environment.GetEnvironmentVariable("CI_SERVER_URL").Returns("https://gitlab.example.com:8080");
             Environment.GetEnvironmentVariable("CI_SERVER_NAME").Returns("GitLab");
             Environment.GetEnvironmentVariable("CI_SERVER_REVISION").Returns("70606bf");
             Environment.GetEnvironmentVariable("CI_SERVER_VERSION").Returns("8.9.0");

--- a/src/Cake.Common.Tests/Unit/Build/GitLabCI/Data/GitLabCIServerInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/GitLabCI/Data/GitLabCIServerInfoTests.cs
@@ -58,4 +58,20 @@ namespace Cake.Common.Tests.Unit.Build.GitLabCI.Data
             Assert.Equal("8.9.0", result);
         }
     }
+
+    public sealed class TheUrlProperty
+    {
+        [Fact]
+        public void Should_Return_Correct_Value()
+        {
+            // Given
+            var info = new GitLabCIInfoFixture().CreateServerInfo();
+
+            // When
+            var result = info.Url;
+
+            // Then
+            Assert.Equal("https://gitlab.example.com:8080", result);
+        }
+    }
 }

--- a/src/Cake.Common/Build/GitLabCI/Data/GitLabCIServerInfo.cs
+++ b/src/Cake.Common/Build/GitLabCI/Data/GitLabCIServerInfo.cs
@@ -43,5 +43,13 @@ namespace Cake.Common.Build.GitLabCI.Data
         /// The GitLab revision that is used to schedule builds.
         /// </value>
         public string Revision => GetEnvironmentString("CI_SERVER_REVISION");
+
+        /// <summary>
+        /// Gets the base URL of the GitLab instance, including protocol and port.
+        /// </summary>
+        /// <value>
+        /// The base URL of the GitLab instance, including protocol and port.
+        /// </value>
+        public string Url => GetEnvironmentString("CI_SERVER_URL");
     }
 }


### PR DESCRIPTION
The Url property returns the base url of the current GitLab server (read from the CI_SERVER_URL environment variable).

This fixes issue #4418
