### PR TITLE
GH4442: directory and combinedfilepath

### DIFF
--- a/src/Cake.Common.Tests/Unit/IO/Paths/ConvertableFilePathTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/Paths/ConvertableFilePathTests.cs
@@ -2,10 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using Cake.Common.IO.Paths;
 using Cake.Core.IO;
+using NSubstitute;
 using Xunit;
+using Xunit.v3;
 
 namespace Cake.Common.Tests.Unit.IO.Paths
 {
@@ -69,6 +73,65 @@ namespace Cake.Common.Tests.Unit.IO.Paths
 
                     // Then
                     Assert.Null(result);
+                }
+
+                [Fact]
+                [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull")]
+                public void Should_Return_Null_Exception_If_Convertable_Directory_Path_Is_Null()
+                {
+                    // Given
+                    DirectoryPath dirPath = null;
+
+                    // When
+                    var filePath = new ConvertableFilePath("file.txt");
+                    // Then
+                    var ex = Assert.Throws<ArgumentNullException>(() => (dirPath + filePath).ToString());
+                }
+
+                [Fact]
+                [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull")]
+                public void Should_Return_Null_Exception_If_Convertable_FilePath_Is_Null()
+                {
+                    // Given
+                    DirectoryPath dirPath = new DirectoryPath("X");
+
+                    // When
+                    ConvertableFilePath filePath = null;
+                    // Then
+                    var ex = Assert.Throws<ArgumentNullException>(() => (dirPath + filePath).ToString());
+                }
+
+                [Fact]
+                [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull")]
+                public void Should_Return_Combined_Directorypath_FilePath_Including_Separator()
+                {
+                    // Given
+                    DirectoryPath dirPath = new DirectoryPath("X");
+                    var filePath = new ConvertableFilePath("file.txt");
+
+                    // When
+                    var result = (dirPath + filePath).ToString();
+
+                    // Then
+                    Assert.Equal("X/file.txt", result);
+                }
+
+                [Fact]
+                [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull")]
+                public void Should_Return_Combined_RootPath_Directorypath_FilePath_Including_Separator()
+                {
+                    // Given
+                    var contextcake = Substitute.For<Core.ICakeContext>();
+
+                    DirectoryPath dirPath = new ConvertableDirectoryPath(new DirectoryPath("X"));
+                    var filePath = new ConvertableFilePath(new FilePath("file.txt"));
+                    var rootdir = new ConvertableDirectoryPath(new DirectoryPath(".."));
+
+                    // When
+                    var result = (rootdir + dirPath + filePath).ToString();
+
+                    // Then
+                    Assert.Equal("../X/file.txt", result);
                 }
             }
 

--- a/src/Cake.Common.Tests/Unit/IO/Paths/ConvertableFilePathTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/Paths/ConvertableFilePathTests.cs
@@ -2,14 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
 using Cake.Common.IO.Paths;
 using Cake.Core.IO;
 using NSubstitute;
-using Xunit;
-using Xunit.v3;
 
 namespace Cake.Common.Tests.Unit.IO.Paths
 {
@@ -110,7 +106,7 @@ namespace Cake.Common.Tests.Unit.IO.Paths
                     var filePath = new ConvertableFilePath("file.txt");
 
                     // When
-                    var result = (dirPath + filePath).ToString();
+                    string result = dirPath + filePath;
 
                     // Then
                     Assert.Equal("X/file.txt", result);

--- a/src/Cake.Common/IO/Paths/ConvertableFilePath.cs
+++ b/src/Cake.Common/IO/Paths/ConvertableFilePath.cs
@@ -58,5 +58,26 @@ namespace Cake.Common.IO.Paths
         {
             return Path.FullPath;
         }
+
+        /// <summary>
+        /// Combines the directory path and file path with the separator.
+        /// </summary>
+        /// <param name="dir">DirectoryPath.</param>
+        /// <param name="file">ConvertableFilePath.</param>
+        /// <returns>
+        /// A <see cref="System.String" /> that represents this instance.
+        /// </returns>
+        public static string operator +(DirectoryPath dir, ConvertableFilePath file)
+        {
+            if (dir == null)
+            {
+                throw new ArgumentNullException(nameof(dir));
+            }
+            if (file == null)
+            {
+                throw new ArgumentNullException(nameof(file));
+            }
+            return string.Concat(dir.FullPath, dir.Separator.ToString(), file);
+        }
     }
 }

--- a/src/Cake.Common/IO/Paths/ConvertableFilePath.cs
+++ b/src/Cake.Common/IO/Paths/ConvertableFilePath.cs
@@ -65,19 +65,14 @@ namespace Cake.Common.IO.Paths
         /// <param name="dir">DirectoryPath.</param>
         /// <param name="file">ConvertableFilePath.</param>
         /// <returns>
-        /// A <see cref="System.String" /> that represents this instance.
+        /// A <see cref="ConvertableFilePath" /> that represents this instance.
         /// </returns>
-        public static string operator +(DirectoryPath dir, ConvertableFilePath file)
+        public static ConvertableFilePath operator +(DirectoryPath dir, ConvertableFilePath file)
         {
-            if (dir == null)
-            {
-                throw new ArgumentNullException(nameof(dir));
-            }
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-            return string.Concat(dir.FullPath, dir.Separator.ToString(), file);
+            ArgumentNullException.ThrowIfNull(dir);
+            ArgumentNullException.ThrowIfNull(file);
+
+            return new ConvertableFilePath(dir.CombineWithFilePath(file));
         }
     }
 }

--- a/tests/integration/Cake.Core/IO/Path.cake
+++ b/tests/integration/Cake.Core/IO/Path.cake
@@ -42,13 +42,68 @@ Task("Cake.Core.IO.Path.FilePath.Absolute")
     var absoluteFilePath2 = MakeAbsolute(FilePath.FromString(".\\MyProject\\MyApp.csproj"));
 
     // When / Then
-    Assert.Equal(absoluteFilePath1, absoluteFilePath1);
+    Assert.Equal(absoluteFilePath1, absoluteFilePath2);
 });
 
+Task("Cake.Core.IO.Path.ConvertableFilePath.DirectoryPathPlusFilePath")
+    .Does(() =>
+{
+    // Given - DirectoryPath + ConvertableFilePath operator (Cake.Common) returns combined path with separator
+    var dirPath = DirectoryPath.FromString("X");
+    var filePath = File("file.txt");
 
+    // When
+    var result = dirPath + filePath;
+
+    // Then
+    Assert.Equal("X/file.txt", result);
+});
+
+Task("Cake.Core.IO.Path.ConvertableFilePath.DirectoryPathPlusFilePath.NullDirectoryThrows")
+    .Does(() =>
+{
+    // Given
+    DirectoryPath dirPath = null;
+    var filePath = File("file.txt");
+
+    // When / Then
+    var ex = Assert.Throws<ArgumentNullException>(() => dirPath + filePath);
+    Assert.Equal("dir", ex.ParamName);
+});
+
+Task("Cake.Core.IO.Path.ConvertableFilePath.DirectoryPathPlusFilePath.NullFileThrows")
+    .Does(() =>
+{
+    // Given
+    var dirPath = DirectoryPath.FromString("X");
+    Cake.Common.IO.Paths.ConvertableFilePath filePath = null;
+
+    // When / Then
+    var ex = Assert.Throws<ArgumentNullException>(() => dirPath + filePath);
+    Assert.Equal("file", ex.ParamName);
+});
+
+Task("Cake.Core.IO.Path.ConvertableFilePath.ConvertableDirectoryPathChain")
+    .Does(() =>
+{
+    // Given - root + dir + file using ConvertableDirectoryPath chain (Directory + Directory + File)
+    var rootDir = Directory("..");
+    var dirPath = Directory("X");
+    var filePath = File("file.txt");
+
+    // When
+    var result = rootDir + dirPath + filePath;
+
+    // Then
+    Assert.Equal("../X/file.txt", result);
+});
 
 Task("Cake.Core.IO.Path")
     .IsDependentOn("Cake.Core.IO.Path.DirectoryPath.Relative")
     .IsDependentOn("Cake.Core.IO.Path.DirectoryPath.Absolute")
     .IsDependentOn("Cake.Core.IO.Path.FilePath.Relative")
-    .IsDependentOn("Cake.Core.IO.Path.FilePath.Absolute");
+    .IsDependentOn("Cake.Core.IO.Path.FilePath.Absolute")
+    .IsDependentOn("Cake.Core.IO.Path.ConvertableFilePath.DirectoryPathPlusFilePath")
+    .IsDependentOn("Cake.Core.IO.Path.ConvertableFilePath.DirectoryPathPlusFilePath.NullDirectoryThrows")
+    .IsDependentOn("Cake.Core.IO.Path.ConvertableFilePath.DirectoryPathPlusFilePath.NullFileThrows")
+    .IsDependentOn("Cake.Core.IO.Path.ConvertableFilePath.ConvertableDirectoryPathChain");


### PR DESCRIPTION
This PR contains the fix for below bug
https://github.com/cake-build/cake/issues/4442
Created the overload of operator + that accepts the DirectoryPath and ConvertableFilePath objects. This method has a logic to null check directory path and file parameters. It concatenates the full path of the directory + separator + file.
Also added the 4 unit test cases.
