### PR TITLE
GH2028: Adding credential support for inprocess nuget client

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ jobs:
         id: build-cake
         uses: cake-build/cake-action@v3.0.1
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AZURE_DEVOPS_NUGET_API_KEY: ${{ secrets.AZURE_DEVOPS_NUGET_API_KEY }}
           AZURE_DEVOPS_NUGET_API_URL: ${{ secrets.AZURE_DEVOPS_NUGET_API_URL }}
         with:

--- a/src/Cake.NuGet/Cake.NuGet.csproj
+++ b/src/Cake.NuGet/Cake.NuGet.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
   <!-- Global packages -->
   <ItemGroup>
+    <PackageReference Include="NuGet.Credentials"/>
     <PackageReference Include="NuGet.Frameworks"/>
     <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="NuGet.Protocol" />

--- a/src/Cake.NuGet/Client/NuGetLogger.cs
+++ b/src/Cake.NuGet/Client/NuGetLogger.cs
@@ -50,23 +50,23 @@ namespace Cake.NuGet
             _log = log ?? throw new ArgumentNullException(nameof(log));
         }
 
-        public void LogDebug(string data) => _log.Debug(data);
+        public void LogDebug(string data) => _log.Debug("{0}", data);
 
-        public void LogVerbose(string data) => _log.Debug(data);
+        public void LogVerbose(string data) => _log.Debug("{0}", data);
 
-        public void LogInformation(string data) => _log.Debug(data);
+        public void LogInformation(string data) => _log.Debug("{0}", data);
 
-        public void LogMinimal(string data) => _log.Information(data);
+        public void LogMinimal(string data) => _log.Information("{0}", data);
 
-        public void LogWarning(string data) => _log.Warning(data);
+        public void LogWarning(string data) => _log.Warning("{0}", data);
 
-        public void LogError(string data) => _log.Error(data);
+        public void LogError(string data) => _log.Error("{0}", data);
 
-        public void LogInformationSummary(string data) => _log.Information(data);
+        public void LogInformationSummary(string data) => _log.Information("{0}", data);
 
-        public void LogErrorSummary(string data) => _log.Error(data);
+        public void LogErrorSummary(string data) => _log.Error("{0}", data);
 
-        public void Log(LogLevel level, string data) => _log.Write(GetVerbosity(level), GetLogLevel(level), data);
+        public void Log(LogLevel level, string data) => _log.Write(GetVerbosity(level), GetLogLevel(level), "{0}", data);
 
         public Task LogAsync(LogLevel level, string data)
         {

--- a/src/Cake.NuGet/Constants.cs
+++ b/src/Cake.NuGet/Constants.cs
@@ -27,6 +27,11 @@ namespace Cake.NuGet
             /// The config key name for overriding the default NuGet config file.
             /// </summary>
             public const string ConfigFile = "NuGet_ConfigFile";
+
+            /// <summary>
+            /// The config key name for non-interactive mode.
+            /// </summary>
+            public const string NonInteractive = "NuGet_NonInteractive";
         }
 
         public static class Paths

--- a/src/Cake.NuGet/Installers/InProcessInstaller.cs
+++ b/src/Cake.NuGet/Installers/InProcessInstaller.cs
@@ -12,6 +12,7 @@ using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using NuGet.Common;
 using NuGet.Configuration;
+using NuGet.Credentials;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
@@ -113,6 +114,14 @@ namespace Cake.NuGet
             var allRepositories = new HashSet<SourceRepository>(new NuGetSourceRepositoryComparer());
             allRepositories.AddRange(localAndPrimaryRepositories);
             allRepositories.AddRange(sourceRepositoryProvider.Repositories);
+
+            var nonInteractiveString = _config.GetValue(Constants.NuGet.NonInteractive) ?? bool.TrueString;
+            if (!bool.TryParse(nonInteractiveString, out bool nonInteractive))
+            {
+                // If there is no explicit preference, use non interactive.
+                nonInteractive = true;
+            }
+            DefaultCredentialServiceUtility.SetupDefaultCredentialService(_nugetLogger, nonInteractive);
 
             var packageIdentity = GetPackageId(package, localAndPrimaryRepositories, targetFramework, _sourceCacheContext, _nugetLogger);
             if (packageIdentity == null)

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -28,6 +28,7 @@
     <PackageVersion Include="NuGet.Protocol" Version="$(NuGetVersion)" />
     <PackageVersion Include="NuGet.Resolver" Version="$(NuGetVersion)" />
     <PackageVersion Include="NuGet.Versioning" Version="$(NuGetVersion)" />
+    <PackageVersion Include="NuGet.Credentials" Version="$(NuGetVersion)" />
     <PackageVersion Include="Spectre.Console" Version="0.54.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.53.1" />
     <PackageVersion Include="Spectre.Console.Testing" Version="0.54.0" />

--- a/tests/integration/Cake.NuGet/InProcessInstaller.cake
+++ b/tests/integration/Cake.NuGet/InProcessInstaller.cake
@@ -133,9 +133,65 @@ Task("Cake.NuGet.InProcessInstaller.VersionPinRange.Wildcard")
         });
 });
 
+Task("Cake.NuGet.InProcessInstaller.DotNetTool.AuthenticatedFeed")
+    .IsDependentOn("Cake.NuGet.InProcessInstaller.Setup")
+    .WithCriteria(() => BuildSystem.GitHubActions.IsRunningOnGitHubActions || Argument<string>("target", "Default") == "Cake.NuGet.InProcessInstaller.DotNetTool.AuthenticatedFeed")
+    .Does(()=>
+{
+    var scriptPath = Paths.Temp.Combine("./Cake.NuGet.InProcessInstaller/").CombineWithFilePath("build.cake");
+    var scriptToolsPath = Paths.Temp.Combine("./Cake.NuGet.InProcessInstaller/tools");
+    var nugetConfigPath = Paths.Temp.Combine("./Cake.NuGet.InProcessInstaller/").CombineWithFilePath("nuget.config");
+    
+    // Create NuGet.config without credentials
+    var githubToken = EnvironmentVariable("GITHUB_TOKEN");
+    
+    var nugetConfig = 
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <configuration>
+            <packageSources>
+                <clear />
+                <add key="github" value="https://nuget.pkg.github.com/devlead/index.json" />
+            </packageSources>
+        </configuration>
+        """;
+    System.IO.File.WriteAllText(nugetConfigPath.FullPath, nugetConfig);
+
+    // If githubToken is provided, update the source with credentials using DotNetNuGetUpdateSource
+    if (!string.IsNullOrEmpty(githubToken))
+    {
+        var sourceSettings = new DotNetNuGetSourceSettings
+        {
+            Source = "https://nuget.pkg.github.com/devlead/index.json",
+            UserName = GitHubActions.Environment.Workflow.RepositoryOwner,
+            Password = githubToken,
+            StorePasswordInClearText = true,
+            ConfigFile = nugetConfigPath
+        };
+        DotNetNuGetUpdateSource("github", sourceSettings);
+    }
+
+    var script = @"#addin nuget:https://nuget.pkg.github.com/devlead/index.json?package=litjson&version=0.19.0-alpha0044&prerelease
+                var result = LitJson.JsonMapper.ToJson(new { Name = ""John"", Age = 30 });
+                ";
+
+    System.IO.File.WriteAllText(scriptPath.FullPath, script);
+
+    CakeExecuteScript(scriptPath,
+        new CakeSettings
+        {
+            EnvironmentVariables = {
+                                        { "CAKE_PATHS_TOOLS", scriptToolsPath.FullPath },
+                                        { "CAKE_PATHS_ADDINS", scriptToolsPath.Combine("Addins").FullPath },
+                                        { "CAKE_PATHS_MODULES", scriptToolsPath.Combine("Modules").FullPath }
+                                    }
+        });
+});
+
 Task("Cake.NuGet.InProcessInstaller")
     .IsDependentOn("Cake.NuGet.InProcessInstaller.Setup")
     .IsDependentOn("Cake.NuGet.InProcessInstaller.VersionPinExact")
     .IsDependentOn("Cake.NuGet.InProcessInstaller.VersionPinRange.InclusiveExclusive")
     .IsDependentOn("Cake.NuGet.InProcessInstaller.VersionPinRange.InclusiveInclusive")
-    .IsDependentOn("Cake.NuGet.InProcessInstaller.VersionPinRange.Wildcard");
+    .IsDependentOn("Cake.NuGet.InProcessInstaller.VersionPinRange.Wildcard")
+    .IsDependentOn("Cake.NuGet.InProcessInstaller.DotNetTool.AuthenticatedFeed");


### PR DESCRIPTION
Solution:
* Added NuGet.Credentials package
* Added call to DefaultCredentialServiceUtility.SetupDefaultCredentialService to configure the CredentialService

I don't know how to implement any test on this, but I've tested loading a recipe from an Azure DevOps Artifacts NuGet feed.

Fixes #2028 