### PR TITLE
GH4475: Always show task execution summary

### DIFF
--- a/src/Cake.Cli/Hosts/BuildScriptHost.cs
+++ b/src/Cake.Cli/Hosts/BuildScriptHost.cs
@@ -84,14 +84,26 @@ namespace Cake.Cli
 
         private async Task<CakeReport> internalRunTargetAsync()
         {
-            var report = await Engine.RunTargetAsync(_context, _executionStrategy, Settings).ConfigureAwait(false);
-
-            if (report != null && !report.IsEmpty)
+            try
             {
-                _reportPrinter.Write(report);
-            }
+                var report = await Engine.RunTargetAsync(_context, _executionStrategy, Settings).ConfigureAwait(false);
 
-            return report;
+                if (report != null && !report.IsEmpty)
+                {
+                    _reportPrinter.Write(report);
+                }
+
+                return report;
+            }
+            catch (CakeReportException cre)
+            {
+                if (cre.Report != null && !cre.Report.IsEmpty)
+                {
+                    _reportPrinter.Write(cre.Report);
+                }
+
+                throw;
+            }
         }
     }
 }

--- a/src/Cake.Cli/Infrastructure/CakeSpectreReportPrinter.cs
+++ b/src/Cake.Cli/Infrastructure/CakeSpectreReportPrinter.cs
@@ -46,6 +46,10 @@ namespace Cake.Cli
                     new Text("Duration", rowStyle)).Footer(
                         new Text(FormatTime(GetTotalTime(report)), rowStyle)));
 
+            table.AddColumn(
+                new TableColumn(
+                    new Text("Status", rowStyle)));
+
             if (includeSkippedReasonColumn)
             {
                 table.AddColumn(new TableColumn(new Text("Skip Reason", rowStyle)));
@@ -59,12 +63,14 @@ namespace Cake.Cli
                 {
                     table.AddRow(new Markup(item.TaskName, itemStyle),
                                 new Markup(FormatDuration(item), itemStyle),
+                                new Markup(item.ExecutionStatus.ToString(), itemStyle),
                                 new Markup(item.SkippedMessage, itemStyle));
                 }
                 else
                 {
                     table.AddRow(new Markup(item.TaskName, itemStyle),
-                                new Markup(FormatDuration(item), itemStyle));
+                                new Markup(FormatDuration(item), itemStyle),
+                                new Markup(item.ExecutionStatus.ToString(), itemStyle));
                 }
             }
 
@@ -122,7 +128,7 @@ namespace Cake.Cli
         {
             if (item.ExecutionStatus == CakeTaskExecutionStatus.Skipped)
             {
-                return "Skipped";
+                return "-";
             }
 
             return FormatTime(item.Duration);

--- a/src/Cake.Core.Tests/Unit/CakeEngineTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeEngineTests.cs
@@ -216,7 +216,7 @@ namespace Cake.Core.Tests.Unit
                     engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings));
 
                 // Then
-                Assert.IsType<CakeException>(result);
+                Assert.IsType<CakeReportException>(result);
                 Assert.Equal("Could not reach target 'A' since it was skipped due to a criteria.", result?.Message);
             }
 
@@ -442,7 +442,7 @@ namespace Cake.Core.Tests.Unit
                     engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings));
 
                 // Then
-                Assert.IsType<InvalidOperationException>(result);
+                Assert.IsType<CakeReportException>(result);
                 Assert.Equal("Whoopsie", result?.Message);
             }
 
@@ -705,7 +705,7 @@ namespace Cake.Core.Tests.Unit
                     engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings));
 
                 // Then
-                Assert.IsType<InvalidOperationException>(result);
+                Assert.IsType<CakeReportException>(result);
                 Assert.Equal("Totally my fault", result?.Message);
             }
 
@@ -743,7 +743,7 @@ namespace Cake.Core.Tests.Unit
                     engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings));
 
                 // Then
-                Assert.IsType<CakeException>(result);
+                Assert.IsType<CakeReportException>(result);
                 Assert.Equal("Could not reach target 'B' since it was skipped due to a criteria.", result?.Message);
             }
 
@@ -826,7 +826,7 @@ namespace Cake.Core.Tests.Unit
 
                 // Then
                 Assert.NotNull(result);
-                Assert.IsType<InvalidOperationException>(result);
+                Assert.IsType<CakeReportException>(result);
                 Assert.Equal("Fail", result?.Message);
                 Assert.Contains(fixture.Log.Entries, x => x.Message == "Executing custom teardown action...");
             }
@@ -849,7 +849,7 @@ namespace Cake.Core.Tests.Unit
 
                 // Then
                 Assert.NotNull(result);
-                Assert.IsType<InvalidOperationException>(result);
+                Assert.IsType<CakeReportException>(result);
                 Assert.Equal("Fail", result?.Message);
                 Assert.Contains(fixture.Log.Entries, x => x.Message == "Executing custom teardown action...");
             }
@@ -872,7 +872,7 @@ namespace Cake.Core.Tests.Unit
 
                 // Then
                 Assert.NotNull(result);
-                Assert.IsType<InvalidOperationException>(result);
+                Assert.IsType<CakeReportException>(result);
                 Assert.Equal("Setup", result?.Message);
             }
 
@@ -988,7 +988,7 @@ namespace Cake.Core.Tests.Unit
                     engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings));
 
                 // Then
-                Assert.IsType<InvalidOperationException>(result);
+                Assert.IsType<CakeReportException>(result);
                 Assert.Contains(fixture.Log.Entries, x => x.Message.StartsWith("Teardown error: Teardown #1"));
                 Assert.Contains(fixture.Log.Entries, x => x.Message.StartsWith("Teardown error: Teardown #2"));
             }
@@ -1010,7 +1010,7 @@ namespace Cake.Core.Tests.Unit
 
                 // Then
                 Assert.NotNull(result);
-                Assert.IsType<InvalidOperationException>(result);
+                Assert.IsType<CakeReportException>(result);
                 Assert.Equal("Task", result?.Message);
             }
 
@@ -1032,7 +1032,7 @@ namespace Cake.Core.Tests.Unit
                     engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings));
 
                 // Then
-                Assert.IsType<InvalidOperationException>(result);
+                Assert.IsType<CakeReportException>(result);
                 Assert.Contains(fixture.Log.Entries, x => x.Message.StartsWith("Teardown error: Teardown #1"));
                 Assert.Contains(fixture.Log.Entries, x => x.Message.StartsWith("Teardown error: Teardown #2"));
             }
@@ -1291,7 +1291,7 @@ namespace Cake.Core.Tests.Unit
 
                 // Then
                 Assert.NotNull(exception);
-                Assert.IsType<InvalidOperationException>(exception);
+                Assert.IsType<CakeReportException>(exception);
                 Assert.Equal("Fail", exception?.Message);
                 Assert.Equal(
                     new List<string>
@@ -1326,7 +1326,7 @@ namespace Cake.Core.Tests.Unit
 
                 // Then
                 Assert.NotNull(exception);
-                Assert.IsType<InvalidOperationException>(exception);
+                Assert.IsType<CakeReportException>(exception);
                 Assert.Equal("Fail", exception?.Message);
                 Assert.Equal(
                     new List<string>
@@ -1355,7 +1355,7 @@ namespace Cake.Core.Tests.Unit
 
                 // Then
                 Assert.NotNull(result);
-                Assert.IsType<InvalidOperationException>(result);
+                Assert.IsType<CakeReportException>(result);
                 Assert.Equal("Task Setup: A", result?.Message);
             }
 
@@ -1377,7 +1377,7 @@ namespace Cake.Core.Tests.Unit
 
                 // Then
                 Assert.NotNull(result);
-                Assert.IsType<InvalidOperationException>(result);
+                Assert.IsType<CakeReportException>(result);
                 Assert.Equal("Task Teardown: A", result?.Message);
             }
 
@@ -1401,7 +1401,7 @@ namespace Cake.Core.Tests.Unit
 
                 // Then
                 Assert.NotNull(result);
-                Assert.IsType<InvalidOperationException>(result);
+                Assert.IsType<CakeReportException>(result);
                 Assert.Equal("Task Setup: A", result?.Message);
                 Assert.Contains(fixture.Log.Entries, x => x.Message.StartsWith("Task Teardown error (A):"));
             }
@@ -1424,7 +1424,7 @@ namespace Cake.Core.Tests.Unit
 
                 // Then
                 Assert.NotNull(result);
-                Assert.IsType<InvalidOperationException>(result);
+                Assert.IsType<CakeReportException>(result);
                 Assert.Equal("Task: A", result?.Message);
             }
 
@@ -1691,7 +1691,7 @@ namespace Cake.Core.Tests.Unit
                     engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings));
 
                 // Then
-                Assert.IsType<CakeException>(result);
+                Assert.IsType<CakeReportException>(result);
                 Assert.Equal("Could not reach target 'B' since it was skipped due to a criteria.", result?.Message);
             }
 
@@ -1762,7 +1762,7 @@ namespace Cake.Core.Tests.Unit
                     engine.RunTargetAsync(fixture.Context, fixture.ExecutionStrategy, settings));
 
                 // Then
-                Assert.IsType<InvalidOperationException>(result);
+                Assert.IsType<CakeReportException>(result);
                 Assert.Equal("Whoopsie", result?.Message);
             }
 

--- a/src/Cake.Core/CakeEngine.cs
+++ b/src/Cake.Core/CakeEngine.cs
@@ -205,7 +205,8 @@ namespace Cake.Core
             {
                 exceptionWasThrown = true;
                 thrownException = ex;
-                throw;
+
+                throw new CakeReportException(report, ex.Message, ex);
             }
             finally
             {
@@ -351,20 +352,20 @@ namespace Cake.Core
                 PerformTaskTeardown(context, strategy, task, stopWatch.Elapsed, false, taskException);
 
                 _log.Verbose($"Completed in {stopWatch.Elapsed}");
-            }
 
-            // Add the task results to the report
-            if (IsDelegatedTask(task))
-            {
-                report.AddDelegated(task.Name, stopWatch.Elapsed);
-            }
-            else if (taskException is null)
-            {
-                report.Add(task.Name, CakeReportEntryCategory.Task, stopWatch.Elapsed);
-            }
-            else
-            {
-                report.AddFailed(task.Name, stopWatch.Elapsed);
+                // Add the task results to the report
+                if (IsDelegatedTask(task))
+                {
+                    report.AddDelegated(task.Name, stopWatch.Elapsed);
+                }
+                else if (taskException is null)
+                {
+                    report.Add(task.Name, CakeReportEntryCategory.Task, stopWatch.Elapsed);
+                }
+                else
+                {
+                    report.AddFailed(task.Name, stopWatch.Elapsed);
+                }
             }
         }
 

--- a/src/Cake.Core/CakeReportException.cs
+++ b/src/Cake.Core/CakeReportException.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Cake.Core
+{
+    /// <summary>
+    /// Represent errors that occur during script execution.
+    /// </summary>
+    public sealed class CakeReportException : Exception
+    {
+        /// <summary>
+        /// Gets or sets the Cake Report.
+        /// </summary>
+        public CakeReport Report { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CakeReportException"/> class.
+        /// </summary>
+        public CakeReportException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CakeReportException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public CakeReportException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CakeReportException"/> class.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
+        public CakeReportException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CakeReportException"/> class.
+        /// </summary>
+        /// <param name="report">The Cake Report.</param>
+        public CakeReportException(CakeReport report)
+        {
+            Report = report;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CakeReportException"/> class.
+        /// </summary>
+        /// <param name="report">The Cake Report.</param>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        public CakeReportException(CakeReport report, string message)
+            : base(message)
+        {
+            Report = report;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CakeReportException"/> class.
+        /// </summary>
+        /// <param name="report">The Cake Report.</param>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
+        public CakeReportException(CakeReport report, string message, Exception innerException)
+            : base(message, innerException)
+        {
+            Report = report;
+        }
+    }
+}

--- a/src/Cake.Core/CakeReportPrinter.cs
+++ b/src/Cake.Core/CakeReportPrinter.cs
@@ -49,13 +49,13 @@ namespace Cake.Core
                 }
 
                 maxTaskNameLength++;
-                string lineFormat = "{0,-" + maxTaskNameLength + "}{1,-20}";
+                string lineFormat = "{0,-" + maxTaskNameLength + "}{1,-20}{2,-20}";
                 _console.ForegroundColor = ConsoleColor.Green;
 
                 // Write header.
                 _console.WriteLine();
-                _console.WriteLine(lineFormat, "Task", "Duration");
-                _console.WriteLine(new string('-', 20 + maxTaskNameLength));
+                _console.WriteLine(lineFormat, "Task", "Duration", "Status");
+                _console.WriteLine(new string('-', 40 + maxTaskNameLength));
 
                 // Write task status.
                 foreach (var item in report)
@@ -63,14 +63,14 @@ namespace Cake.Core
                     if (ShouldWriteTask(item))
                     {
                         _console.ForegroundColor = GetItemForegroundColor(item);
-                        _console.WriteLine(lineFormat, item.TaskName, FormatDuration(item));
+                        _console.WriteLine(lineFormat, item.TaskName, FormatDuration(item), item.ExecutionStatus);
                     }
                 }
 
                 // Write footer.
                 _console.ForegroundColor = ConsoleColor.Green;
-                _console.WriteLine(new string('-', 20 + maxTaskNameLength));
-                _console.WriteLine(lineFormat, "Total:", FormatTime(GetTotalTime(report)));
+                _console.WriteLine(new string('-', 40 + maxTaskNameLength));
+                _console.WriteLine(lineFormat, "Total:", FormatTime(GetTotalTime(report)), string.Empty);
             }
             finally
             {
@@ -134,7 +134,7 @@ namespace Cake.Core
         {
             if (item.ExecutionStatus == CakeTaskExecutionStatus.Skipped)
             {
-                return "Skipped";
+                return "-";
             }
 
             return FormatTime(item.Duration);


### PR DESCRIPTION
Currently, Cake prints out a task execution summary on each successful execution.  This summary includes which tasks were executed or skipped, and the duration of the task.  However, then an execution of Cake fails, the task summary is not printed, and it is necessary to scroll through the Cake output, to find out what task failed.  You also lose the information about which tasks, if any, were skipped.

Any changes to this workflow will have to be done carefully though, as we don't want to alter how tasks are executed, in what order, or what is done in the cases of ContinueOnError, etc.  There are a number of unit tests that check for this execution, and these will need to continue to pass.

This commit aims to address this problem by introducing a new CakeReportException, which has a property called Report of type CakeReport.  That way, when an exception needs to be thrown, the current execution status report can be passed along with it, and from there, the task execution summary can be printed.

The introduction of the CakeReportException has meant that a number of unit tests have had to be updated, since there is an expectation that an InvalidOperationException will be returned, however, I think that this is "ok", since it hasn't meant a change to how the workflow of task executions completes.
