### PR TITLE
Update dependencies

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
         "src"
     ],
     "sdk": {
-        "version": "9.0.102",
+        "version": "9.0.300",
         "rollForward": "latestFeature"
     }
 }

--- a/src/Cake.Testing.Xunit.v3/Cake.Testing.Xunit.v3.csproj
+++ b/src/Cake.Testing.Xunit.v3/Cake.Testing.Xunit.v3.csproj
@@ -12,7 +12,8 @@
   </PropertyGroup>
    <!-- Global packages -->
   <ItemGroup>
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.assert" />
+    <PackageReference Include="xunit.v3.extensibility.core" />
   </ItemGroup>
   <!-- Import shared functionality -->
   <Import Project="..\Shared.msbuild" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -31,7 +31,7 @@
     <PackageVersion Include="Spectre.Console.Cli" Version="0.49.1" />
     <PackageVersion Include="Spectre.Verify.Extensions" Version="22.3.1" />
     <PackageVersion Include="System.Collections.Immutable" Version="9.0.5" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="9.0.1" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="9.0.5" />
     <PackageVersion Include="Verify.XunitV3" Version="28.9.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.v3" Version="1.0.1" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -27,8 +27,8 @@
     <PackageVersion Include="NuGet.Protocol" Version="6.14.0" />
     <PackageVersion Include="NuGet.Resolver" Version="6.14.0" />
     <PackageVersion Include="NuGet.Versioning" Version="6.14.0" />
-    <PackageVersion Include="Spectre.Console" Version="0.49.1" />
-    <PackageVersion Include="Spectre.Console.Cli" Version="0.49.1" />
+    <PackageVersion Include="Spectre.Console" Version="0.50.0" />
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.50.0" />
     <PackageVersion Include="Spectre.Verify.Extensions" Version="22.3.1" />
     <PackageVersion Include="System.Collections.Immutable" Version="9.0.5" />
     <PackageVersion Include="System.Reflection.Metadata" Version="9.0.5" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.0" />
     <PackageVersion Include="Cake.Frosting" Version="3.1.0.0" />
     <PackageVersion Include="Castle.Core" Version="5.2.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.12.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.11.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -35,7 +35,7 @@
     <PackageVersion Include="Verify.XunitV3" Version="28.9.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.v3" Version="1.0.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />
 
     <!-- Pin nuget transitive packages vulnerability issues NuGet.Packaging -->
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.5" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -30,7 +30,7 @@
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.49.1" />
     <PackageVersion Include="Spectre.Verify.Extensions" Version="22.3.1" />
-    <PackageVersion Include="System.Collections.Immutable" Version="9.0.1" />
+    <PackageVersion Include="System.Collections.Immutable" Version="9.0.5" />
     <PackageVersion Include="System.Reflection.Metadata" Version="9.0.1" />
     <PackageVersion Include="Verify.XunitV3" Version="28.9.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -21,12 +21,12 @@
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="NuGet.Common" Version="6.12.1" />
-    <PackageVersion Include="NuGet.Frameworks" Version="6.12.1" />
-    <PackageVersion Include="NuGet.Packaging" Version="6.12.1" />
-    <PackageVersion Include="NuGet.Protocol" Version="6.12.1" />
-    <PackageVersion Include="NuGet.Resolver" Version="6.12.1" />
-    <PackageVersion Include="NuGet.Versioning" Version="6.12.1" />
+    <PackageVersion Include="NuGet.Common" Version="6.14.0" />
+    <PackageVersion Include="NuGet.Frameworks" Version="6.14.0" />
+    <PackageVersion Include="NuGet.Packaging" Version="6.14.0" />
+    <PackageVersion Include="NuGet.Protocol" Version="6.14.0" />
+    <PackageVersion Include="NuGet.Resolver" Version="6.14.0" />
+    <PackageVersion Include="NuGet.Versioning" Version="6.14.0" />
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.49.1" />
     <PackageVersion Include="Spectre.Verify.Extensions" Version="22.3.1" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.12.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.3.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.11.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.12.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -35,6 +35,8 @@
     <PackageVersion Include="Verify.XunitV3" Version="30.1.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.v3" Version="2.0.2" />
+    <PackageVersion Include="xunit.v3.assert" Version="2.0.2" />
+    <PackageVersion Include="xunit.v3.extensibility.core" Version="2.0.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />
 
     <!-- Pin nuget transitive packages vulnerability issues NuGet.Packaging -->

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="Castle.Core" Version="5.2.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.12.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.11.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageVersion Include="Microsoft.NETCore.Platforms" Version="7.0.4" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,7 +6,7 @@
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
-    <PackageVersion Include="Autofac" Version="8.2.0" />
+    <PackageVersion Include="Autofac" Version="8.3.0" />
     <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.0" />
     <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.0" />
     <PackageVersion Include="Cake.Frosting" Version="3.1.0.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.11.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageVersion Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
-    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.14.0" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -38,7 +38,7 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
 
     <!-- Pin nuget transitive packages vulnerability issues NuGet.Packaging -->
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.1" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.5" />
   </ItemGroup>
 
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -34,7 +34,7 @@
     <PackageVersion Include="System.Reflection.Metadata" Version="9.0.5" />
     <PackageVersion Include="Verify.XunitV3" Version="28.9.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.v3" Version="1.0.1" />
+    <PackageVersion Include="xunit.v3" Version="2.0.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />
 
     <!-- Pin nuget transitive packages vulnerability issues NuGet.Packaging -->

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -29,7 +29,7 @@
     <PackageVersion Include="NuGet.Versioning" Version="6.14.0" />
     <PackageVersion Include="Spectre.Console" Version="0.50.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.50.0" />
-    <PackageVersion Include="Spectre.Verify.Extensions" Version="22.3.1" />
+    <PackageVersion Include="Spectre.Verify.Extensions" Version="28.16.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="9.0.5" />
     <PackageVersion Include="System.Reflection.Metadata" Version="9.0.5" />
     <PackageVersion Include="Verify.XunitV3" Version="30.1.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.0" />
     <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.0" />
     <PackageVersion Include="Cake.Frosting" Version="3.1.0.0" />
-    <PackageVersion Include="Castle.Core" Version="5.1.1" />
+    <PackageVersion Include="Castle.Core" Version="5.2.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.12.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.11.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageVersion Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.12.0" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="Spectre.Verify.Extensions" Version="22.3.1" />
     <PackageVersion Include="System.Collections.Immutable" Version="9.0.5" />
     <PackageVersion Include="System.Reflection.Metadata" Version="9.0.5" />
-    <PackageVersion Include="Verify.XunitV3" Version="28.9.0" />
+    <PackageVersion Include="Verify.XunitV3" Version="30.1.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.v3" Version="2.0.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />


### PR DESCRIPTION
- (GH-4479) Update .NET SDL to 9.0.300
- (GH-4480) Update Castle.Core to 5.2.1
- (GH-4481) Update NuGet.* to 6.14.0
- (GH-4482) Update Microsoft.IdentityModel.JsonWebTokens to 8.11.0
- (GH-4483) Update System.Security.Cryptography.Pkcs to 9.0.5
- (GH-4484) Update Microsoft.NET.Test.Sdk to 17.14.0
- (GH-4485) Update Microsoft.TestPlatform.ObjectModel to 17.14.0
- (GH-4487) Update xunit.runner.visualstudio to 3.1.0
- (GH-4488) Update Microsoft.Extensions.DependencyInjection to 9.0.5
- (GH-4489) Update Autofac to 8.3.0
- (GH-4490) Update System.Collections.Immutable to 9.0.5
- (GH-4491) Update System.Reflection.Metadata to 9.0.5
- (GH-4492) Update Microsoft.CodeAnalysis.CSharp.Scripting to 4.14.0
- (GH-4493) Update Spectre.Console to 0.50.0
- (GH-4494) Update xunit.v3 to 2.0.2
- (GH-4495) Update Verify.XunitV3 to 30.1.0
- (GH-4496) Spectre.Verify.Extensions update to 28.16.0
- (GH-4497) Cake.Testing.Xunit.v3 should not reference xunit.v3