### PR TITLE
GH4499: Update to Cake.Twitter 5.0.0

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,5 @@
 // Install addins.
-#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Twitter&version=3.0.0"
+#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Twitter&version=5.0.0"
 
 // Install .NET Core Global tools.
 #tool "dotnet:https://api.nuget.org/v3/index.json?package=GitVersion.Tool&version=5.12.0"


### PR DESCRIPTION
This addin has been updated to compile against Cake.Core 5.0.0 which removes a warning that is being output as part of the build.

Fixes #4499 