### PR TITLE
GH4505: Update Basic.Reference.Assemblies.Net* to 1.8.1

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,8 +7,8 @@
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
     <PackageVersion Include="Autofac" Version="8.3.0" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.0" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.0" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.1" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.1" />
     <PackageVersion Include="Cake.Frosting" Version="3.1.0.0" />
     <PackageVersion Include="Castle.Core" Version="5.2.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.14.0" />


### PR DESCRIPTION
* fixes #4505
