### PR TITLE
GH4517: - Cake Frosting WithCriteria Description

### DIFF
--- a/src/Cake.Frosting/AsyncFrostingTask.cs
+++ b/src/Cake.Frosting/AsyncFrostingTask.cs
@@ -26,7 +26,7 @@ namespace Cake.Frosting
         where T : ICakeContext
     {
         /// <inheritdoc/>
-        public virtual List<CakeTaskCriteria> ShouldRunCriteria => new();
+        public virtual List<CakeTaskCriteria> ShouldRunCriteria => new List<CakeTaskCriteria>();
 
         /// <summary>
         /// Runs the task using the specified context.

--- a/src/Cake.Frosting/AsyncFrostingTask.cs
+++ b/src/Cake.Frosting/AsyncFrostingTask.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Cake.Core;
 
@@ -24,6 +25,9 @@ namespace Cake.Frosting
     public abstract class AsyncFrostingTask<T> : IFrostingTask
         where T : ICakeContext
     {
+        /// <inheritdoc/>
+        public virtual List<CakeTaskCriteria> ShouldRunCriteria => new();
+
         /// <summary>
         /// Runs the task using the specified context.
         /// </summary>
@@ -41,6 +45,7 @@ namespace Cake.Frosting
         /// <returns>
         ///   <c>true</c> if the task should run; otherwise <c>false</c>.
         /// </returns>
+        [Obsolete("ShouldRun method will be removed in a future version")]
         public virtual bool ShouldRun(T context)
         {
             return true;
@@ -79,6 +84,7 @@ namespace Cake.Frosting
         }
 
         /// <inheritdoc/>
+        [Obsolete("ShouldRun method will be removed in a future version")]
         bool IFrostingTask.ShouldRun(ICakeContext context)
         {
             if (context is null)

--- a/src/Cake.Frosting/FrostingTask.cs
+++ b/src/Cake.Frosting/FrostingTask.cs
@@ -26,7 +26,7 @@ namespace Cake.Frosting
         where T : ICakeContext
     {
         /// <inheritdoc/>
-        public virtual List<CakeTaskCriteria> ShouldRunCriteria => new();
+        public virtual List<CakeTaskCriteria> ShouldRunCriteria => new List<CakeTaskCriteria>();
 
         /// <summary>
         /// Runs the task using the specified context.

--- a/src/Cake.Frosting/FrostingTask.cs
+++ b/src/Cake.Frosting/FrostingTask.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Cake.Core;
 
@@ -24,6 +25,9 @@ namespace Cake.Frosting
     public abstract class FrostingTask<T> : IFrostingTask
         where T : ICakeContext
     {
+        /// <inheritdoc/>
+        public virtual List<CakeTaskCriteria> ShouldRunCriteria => new();
+
         /// <summary>
         /// Runs the task using the specified context.
         /// </summary>

--- a/src/Cake.Frosting/IFrostingTask.cs
+++ b/src/Cake.Frosting/IFrostingTask.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Cake.Core;
 
@@ -13,6 +14,11 @@ namespace Cake.Frosting
     /// </summary>
     public interface IFrostingTask
     {
+        /// <summary>
+        /// Gets ShouldRunCriteria for this task.
+        /// </summary>
+        List<CakeTaskCriteria> ShouldRunCriteria { get; }
+
         /// <summary>
         /// Runs the task using the specified context.
         /// </summary>
@@ -27,6 +33,7 @@ namespace Cake.Frosting
         /// <returns>
         ///   <c>true</c> if the task should run; otherwise <c>false</c>.
         /// </returns>
+        [Obsolete("ShouldRun method will be removed in a future version")]
         bool ShouldRun(ICakeContext context);
 
         /// <summary>

--- a/src/Cake.Frosting/Internal/Extensions/FrostingTaskExtensions.cs
+++ b/src/Cake.Frosting/Internal/Extensions/FrostingTaskExtensions.cs
@@ -61,6 +61,7 @@ namespace Cake.Frosting.Internal
             throw new InvalidOperationException($"This method expects all {nameof(IFrostingTask)} to be instances of {nameof(FrostingTask)} or {nameof(AsyncFrostingTask)}.");
         }
 
+        [Obsolete("ShouldRun method will be removed in a future version")]
         public static bool IsShouldRunOverridden(this IFrostingTask task, IFrostingContext context)
         {
             return task.GetType().GetMethod(nameof(IFrostingTask.ShouldRun), new[] { context.GetType() }).IsOverriden();

--- a/src/Cake.Frosting/Internal/FrostingEngine.cs
+++ b/src/Cake.Frosting/Internal/FrostingEngine.cs
@@ -126,7 +126,7 @@ namespace Cake.Frosting.Internal
                         cakeTask.Does(task.RunAsync);
                     }
 
-                    // Is the criteria method overridden?
+                    // Check if and criteria added to ShouldRunCriteria?
                     if (task.ShouldRunCriteria.Any())
                     {
                         foreach (var criteria in task.ShouldRunCriteria)
@@ -134,6 +134,13 @@ namespace Cake.Frosting.Internal
                             cakeTask.WithCriteria(criteria.Predicate, criteria.Message);
                         }
                     }
+                    // Check to see if obsoleted ShouldRun is overridden?  Done to not break old projects.
+#pragma warning disable CS0618 // Type or member is obsolete
+                    else if (task.IsShouldRunOverridden(_context))
+                    {
+                        cakeTask.WithCriteria(task.ShouldRun, task.SkippedMessage);
+                    }
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     // Continue on error?
                     if (task.IsContinueOnError())

--- a/src/Cake.Frosting/Internal/FrostingEngine.cs
+++ b/src/Cake.Frosting/Internal/FrostingEngine.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Core.Scripting;
@@ -126,9 +127,12 @@ namespace Cake.Frosting.Internal
                     }
 
                     // Is the criteria method overridden?
-                    if (task.IsShouldRunOverridden(_context))
+                    if (task.ShouldRunCriteria.Any())
                     {
-                        cakeTask.WithCriteria(task.ShouldRun, task.SkippedMessage);
+                        foreach (var criteria in task.ShouldRunCriteria)
+                        {
+                            cakeTask.WithCriteria(criteria.Predicate, criteria.Message);
+                        }
                     }
 
                     // Continue on error?


### PR DESCRIPTION
Marked the current ShouldRun method obsolete.
Added a new property to IFrostingTask, ShouldRunCriteria which is a List of CakeTaskCriteria.  This allows you to have multiple criteria just like what could be done in Cake.Tool.

The current method of the ShouldRun method that you could override and the SkippedMessage has shortcoming when compared to Cake.Tool.  First the SkippedMessage could not be set the way it is currently implemented and it only allowed for one message for the task being skipped.  It could not be changed if you had multiple criteria to check for skipping a task. 

The new ShouldRunCriteria property allows you to setup multiple criteria and have a different message for each one just like Cake.Tool.

This would be nice to have in 5.1 to allow me to continue converting a current cake recipe here at work over to Cake.Frosting.  The one downfall is since Cake.Frosting does not support the Spectre Console output the skipped messages are not shown in the summary at this time.

