### PR TITLE
(build) Add Cake.Testing.Xunit.v3 to build params

### DIFF
--- a/build/parameters.cake
+++ b/build/parameters.cake
@@ -99,6 +99,7 @@ public class BuildParameters
                 "Cake.Common",
                 "Cake.Testing",
                 "Cake.Testing.Xunit",
+                "Cake.Testing.Xunit.v3",
                 "Cake.NuGet",
                 "Cake.Tool",
                 "Cake.Frosting",


### PR DESCRIPTION
* Cake.Testing.Xunit.v3 missing from publishable packages
* relates to #4427