### PR TITLE
Update .NET SDK and package dependencies

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
         "src"
     ],
     "sdk": {
-        "version": "9.0.300",
+        "version": "9.0.302",
         "rollForward": "latestFeature"
     }
 }

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -39,7 +39,7 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" />
 
     <!-- Pin nuget transitive packages vulnerability issues NuGet.Packaging -->
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.5" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.7" />
   </ItemGroup>
 
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -33,9 +33,9 @@
     <PackageVersion Include="System.Reflection.Metadata" Version="9.0.5" />
     <PackageVersion Include="Verify.XunitV3" Version="30.3.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.v3" Version="2.0.2" />
-    <PackageVersion Include="xunit.v3.assert" Version="2.0.2" />
-    <PackageVersion Include="xunit.v3.extensibility.core" Version="2.0.2" />
+    <PackageVersion Include="xunit.v3" Version="2.0.3" />
+    <PackageVersion Include="xunit.v3.assert" Version="2.0.3" />
+    <PackageVersion Include="xunit.v3.extensibility.core" Version="2.0.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />
 
     <!-- Pin nuget transitive packages vulnerability issues NuGet.Packaging -->

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.12.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.12.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.14.1" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -30,7 +30,7 @@
     <PackageVersion Include="Spectre.Console.Cli" Version="0.50.0" />
     <PackageVersion Include="Spectre.Verify.Extensions" Version="28.16.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="9.0.7" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="9.0.5" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="9.0.7" />
     <PackageVersion Include="Verify.XunitV3" Version="30.4.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.v3" Version="2.0.3" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -29,7 +29,7 @@
     <PackageVersion Include="Spectre.Console" Version="0.50.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.50.0" />
     <PackageVersion Include="Spectre.Verify.Extensions" Version="28.16.0" />
-    <PackageVersion Include="System.Collections.Immutable" Version="9.0.5" />
+    <PackageVersion Include="System.Collections.Immutable" Version="9.0.7" />
     <PackageVersion Include="System.Reflection.Metadata" Version="9.0.5" />
     <PackageVersion Include="Verify.XunitV3" Version="30.4.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Castle.Core" Version="5.2.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.7" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.12.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Microsoft.NETCore.Platforms" Version="7.0.4" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -31,12 +31,12 @@
     <PackageVersion Include="Spectre.Verify.Extensions" Version="28.16.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="9.0.5" />
     <PackageVersion Include="System.Reflection.Metadata" Version="9.0.5" />
-    <PackageVersion Include="Verify.XunitV3" Version="30.3.1" />
+    <PackageVersion Include="Verify.XunitV3" Version="30.4.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.v3" Version="2.0.3" />
     <PackageVersion Include="xunit.v3.assert" Version="2.0.3" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="2.0.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" />
 
     <!-- Pin nuget transitive packages vulnerability issues NuGet.Packaging -->
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.5" />


### PR DESCRIPTION
Updates the .NET SDK from version `9.0.300` to `9.0.302` and upgrades several NuGet packages to their latest versions:

- **Microsoft.Extensions.DependencyInjection**: `9.0.5` → `9.0.7`
- **Microsoft.IdentityModel.JsonWebTokens**: `8.12.0` → `8.12.1`
- **System.Collections.Immutable**: `9.0.5` → `9.0.7`
- **System.Reflection.Metadata**: `9.0.5` → `9.0.7`
- **Verify.XunitV3**: `30.3.1` → `30.4.0`
- **xunit.v3 packages**: `2.0.2` → `2.0.3`
- **xunit.runner.visualstudio**: `3.1.0` → `3.1.1`
- **System.Security.Cryptography.Pkcs**: `9.0.5` → `9.0.7`