### PR TITLE
GH-4534 Fix AzurePipelinesAgentInfo returning FilePaths instead of DirectoryPaths

### DIFF
--- a/src/Cake.Common/Build/AzurePipelines/Data/AzurePipelinesAgentInfo.cs
+++ b/src/Cake.Common/Build/AzurePipelines/Data/AzurePipelinesAgentInfo.cs
@@ -28,7 +28,7 @@ namespace Cake.Common.Build.AzurePipelines.Data
         /// The local path on the agent where all folders for a given build definition are created.
         /// </value>
         /// <example><c>c:\agent\_work\1</c>.</example>
-        public FilePath BuildDirectory => GetEnvironmentString("AGENT_BUILDDIRECTORY");
+        public DirectoryPath BuildDirectory => GetEnvironmentString("AGENT_BUILDDIRECTORY");
 
         /// <summary>
         /// Gets the directory the agent is installed into. This contains the agent software.
@@ -38,7 +38,7 @@ namespace Cake.Common.Build.AzurePipelines.Data
         /// The directory the agent is installed into.
         /// </value>
         /// <example><c>c:\agent\</c>.</example>
-        public FilePath HomeDirectory => GetEnvironmentString("AGENT_HOMEDIRECTORY");
+        public DirectoryPath HomeDirectory => GetEnvironmentString("AGENT_HOMEDIRECTORY");
 
         /// <summary>
         /// Gets the working directory for this agent.
@@ -46,7 +46,7 @@ namespace Cake.Common.Build.AzurePipelines.Data
         /// <value>
         /// The working directory for this agent.
         /// </value>
-        public FilePath WorkingDirectory => GetEnvironmentString("AGENT_WORKFOLDER");
+        public DirectoryPath WorkingDirectory => GetEnvironmentString("AGENT_WORKFOLDER");
 
         /// <summary>
         /// Gets the ID of the agent.
@@ -98,7 +98,7 @@ namespace Cake.Common.Build.AzurePipelines.Data
         /// <value>
         /// The task directory.
         /// </value>
-        public FilePath ToolsDirectory => GetEnvironmentString("AGENT_TOOLSDIRECTORY");
+        public DirectoryPath ToolsDirectory => GetEnvironmentString("AGENT_TOOLSDIRECTORY");
 
         /// <summary>
         /// Gets a value indicating whether the current agent is a Microsoft hosted agent.


### PR DESCRIPTION
As described in the linked issue. Currently `AzurePipelinesAgentInfo` returns `FilePaths` for properties that are directory paths. This means than a build author needs to convert the file paths to `DirectoryPath` before being able to combine the path with other paths.

So in this PR I am changing the properties to return `DirectoryPath` instead.

This is likely a breaking change.

Fixes #4534 