### PR TITLE
GH4286: Update DotNetToolRunner to append command using quotes

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Tool/DotNetToolTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Tool/DotNetToolTests.cs
@@ -96,6 +96,22 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Tool
                 // Then
                 AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
             }
+
+            [Fact]
+            public void Should_Wrap_Command_In_Quotes()
+            {
+                // Given
+                var fixture = new DotNetToolFixture();
+                fixture.ProjectPath = "./tests/Cake.Common.Tests/";
+                fixture.Command = "C:\\example\\path with\\spaces";
+                fixture.Settings = new DotNetToolSettings();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("\"C:\\example\\path with\\spaces\"", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Tool/DotNetToolRunner.cs
+++ b/src/Cake.Common/Tools/DotNet/Tool/DotNetToolRunner.cs
@@ -60,7 +60,9 @@ namespace Cake.Common.Tools.DotNet.Tool
         {
             var builder = CreateArgumentBuilder(settings);
 
-            builder.Append(command);
+            // Appending quoted to cater for scenarios where the command passed is not a .NET CLI command,
+            // but the path of an application to run that contains whitespace
+            builder.AppendQuoted(command);
 
             // Arguments
             if (!arguments.IsNullOrEmpty())


### PR DESCRIPTION
As per discussion in #4286, this PR resolves an issue where the command passed to [DotNetToolRunner](https://github.com/cake-build/cake/blob/main/src/Cake.Common/Tools/DotNet/Tool/DotNetToolRunner.cs) is the path of an application to run and it contains whitespace.

Sample verbose output before this change:

```
begin /k:"test-project" /n:"Test Project" /d:sonar.login="[REDACTED]"
We're launching for CoreCLR with executable C:/tmp/Cake Test/tools/dotnet-sonarscanner.10.3.0/tools/netcoreapp3.1/any/SonarScanner.MSBuild.dll
Resolved tool to path C:/Program Files/dotnet/dotnet.exe
Executing: "C:/Program Files/dotnet/dotnet.exe" C:/tmp/Cake Test/tools/dotnet-sonarscanner.10.3.0/tools/netcoreapp3.1/any/SonarScanner.MSBuild.dll begin /k:"test-project" /n:"Test Project" /d:sonar.login="[REDACTED]"
Could not execute because the specified command or file was not found.
Possible reasons for this include:
  * You misspelled a built-in dotnet command.
  * You intended to execute a .NET program, but dotnet-C:/tmp/Cake does not exist.
  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.
An error occurred when executing task 'Sonar-Qube-Start-Analysis'.
```
Output following the change - note the surrounding quotes around the application being run:

```
begin /k:"test-project" /n:"Test Project" /d:sonar.login="[REDACTED]"
We're launching for CoreCLR with executable C:/tmp/Cake Test/tools/dotnet-sonarscanner.10.3.0/tools/netcoreapp3.1/any/SonarScanner.MSBuild.dll
Resolved tool to path C:/Program Files/dotnet/dotnet.exe
Executing: "C:/Program Files/dotnet/dotnet.exe" "C:/tmp/Cake Test/tools/dotnet-sonarscanner.10.3.0/tools/netcoreapp3.1/any/SonarScanner.MSBuild.dll" begin /k:"test-project" /n:"Test Project" /d:sonar.login="[REDACTED]"
SonarScanner for MSBuild 10.3
Using the .NET Core version of the Scanner for MSBuild
Pre-processing started.
```

All unit tests (that I can run on my Windows machine) pass:

<img width="1020" height="378" alt="image" src="https://github.com/user-attachments/assets/323cb0c2-46a5-43c6-970d-405bd6daa741" />

This includes a new test I have added to verify that the command is now quoted.