### PR TITLE
GH4561: Migrate to GitHub Actions for release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
             8.0.x
             9.0.x
 
-      - name: Install .NET Core SDK (global.json)
+      - name: Install .NET SDK (global.json)
         uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
@@ -46,8 +46,11 @@ jobs:
       - name: Run Cake script
         id: build-cake
         uses: cake-build/cake-action@master
+        env:
+          AZURE_DEVOPS_NUGET_API_KEY: ${{ secrets.AZURE_DEVOPS_NUGET_API_KEY }}
+          AZURE_DEVOPS_NUGET_API_URL: ${{ secrets.AZURE_DEVOPS_NUGET_API_URL }}
         with:
-          target: Run-Integration-Tests
+          target: GitHubActions
           cake-version: tool-manifest
 
       - name: Validate Integration Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  id-token: write
+  contents: write
+  packages: write
+  issues: write
+
+
+jobs:
+  deployment:
+    runs-on: windows-latest
+    environment: Production
+    steps:
+      - name: Get the sources
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Install .NET SDK 8.0.x - 9.0.x
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+
+      - name: Install .NET SDK (global.json)
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Build & Release Cake 
+        uses: cake-build/cake-action@master
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CAKE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AZURE_DEVOPS_NUGET_API_KEY: ${{ secrets.AZURE_DEVOPS_NUGET_API_KEY }}
+          AZURE_DEVOPS_NUGET_API_URL: ${{ secrets.AZURE_DEVOPS_NUGET_API_URL }}
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_API_URL: ${{ secrets.NUGET_API_URL }}
+          SIGN_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          SIGN_CLIENT_SUBSCRIPTION: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          SIGN_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          SIGN_KEYVAULT_URL: ${{ secrets.SIGN_KEYVAULT_URL }}
+          SIGN_KEYVAULT_CERTIFICATE: ${{ secrets.SIGN_KEYVAULT_CERTIFICATE }}
+        with:
+          cake-version: tool-manifest
+          target: GitHubActions-Release

--- a/build/credentials.cake
+++ b/build/credentials.cake
@@ -1,7 +1,7 @@
 public record CodeSigningCredentials(
     string SignTenantId,
     string SignClientId,
-    string SignClientSecret,
+    string SignClientSubsription,
     string SignKeyVaultCertificate,
     string SignKeyVaultUrl
 )
@@ -13,7 +13,7 @@ public record CodeSigningCredentials(
             return
                 !string.IsNullOrEmpty(SignTenantId) &&
                 !string.IsNullOrEmpty(SignClientId) &&
-                !string.IsNullOrEmpty(SignClientSecret) &&
+                !string.IsNullOrEmpty(SignClientSubsription) &&
                 !string.IsNullOrEmpty(SignKeyVaultCertificate) &&
                 !string.IsNullOrEmpty(SignKeyVaultUrl);
         }
@@ -24,7 +24,7 @@ public record CodeSigningCredentials(
         return new CodeSigningCredentials(
             SignTenantId: context.EnvironmentVariable("SIGN_TENANT_ID"),
             SignClientId: context.EnvironmentVariable("SIGN_CLIENT_ID"),
-            SignClientSecret: context.EnvironmentVariable("SIGN_CLIENT_SECRET"),
+            SignClientSubsription: context.EnvironmentVariable("SIGN_CLIENT_SUBSCRIPTION"),
             SignKeyVaultCertificate: context.EnvironmentVariable("SIGN_KEYVAULT_CERTIFICATE"),
             SignKeyVaultUrl: context.EnvironmentVariable("SIGN_KEYVAULT_URL"));
     }

--- a/build/parameters.cake
+++ b/build/parameters.cake
@@ -11,6 +11,7 @@ public class BuildParameters
     public bool IsRunningOnUnix { get; }
     public bool IsRunningOnWindows { get; }
     public bool IsRunningOnAppVeyor { get; }
+    public bool IsRunningOnGitHubActions { get; }
     public bool IsPullRequest { get; }
     public bool IsMainCakeRepo { get; }
     public bool IsMainCakeBranch { get; }
@@ -34,17 +35,26 @@ public class BuildParameters
     {
         get
         {
-            return !IsLocalBuild && !IsPullRequest && IsMainCakeRepo
-                && IsMainCakeBranch && IsTagged;
+            return IsRunningOnGitHubActions
+                && IsRunningOnWindows
+                && !IsLocalBuild
+                && !IsPullRequest
+                && IsMainCakeRepo
+                && IsMainCakeBranch
+                && IsTagged;
         }
     }
 
-    public bool ShouldPublishToMyGet
+    public bool ShouldPublishToAzureDevOps
     {
         get
         {
-            return false; /* !IsLocalBuild && !IsPullRequest && IsMainCakeRepo
-                && (IsTagged || IsDevelopCakeBranch);*/
+            return IsRunningOnGitHubActions
+                && IsRunningOnWindows
+                && !IsLocalBuild
+                && !IsPullRequest
+                && IsMainCakeRepo
+                && (IsTagged || IsDevelopCakeBranch);
         }
     }
 
@@ -76,10 +86,8 @@ public class BuildParameters
         IsRunningOnUnix = context.IsRunningOnUnix();
         IsRunningOnWindows = context.IsRunningOnWindows();
         IsRunningOnAppVeyor = buildSystem.AppVeyor.IsRunningOnAppVeyor;
-        IsPullRequest = buildSystem.AppVeyor.Environment.PullRequest.IsPullRequest;
-        IsMainCakeRepo = StringComparer.OrdinalIgnoreCase.Equals("cake-build/cake", buildSystem.AppVeyor.Environment.Repository.Name);
-        IsMainCakeBranch = StringComparer.OrdinalIgnoreCase.Equals("main", buildSystem.AppVeyor.Environment.Repository.Branch);
-        IsDevelopCakeBranch = StringComparer.OrdinalIgnoreCase.Equals("develop", buildSystem.AppVeyor.Environment.Repository.Branch);
+        IsRunningOnGitHubActions = buildSystem.GitHubActions.IsRunningOnGitHubActions;
+        IsPullRequest = buildSystem.AppVeyor.Environment.PullRequest.IsPullRequest || buildSystem.GitHubActions.Environment.PullRequest.IsPullRequest;
         IsTagged = IsBuildTagged(buildSystem);
         GitHub = BuildCredentials.GetGitHubCredentials(context);
         Twitter = TwitterCredentials.GetTwitterCredentials(context);
@@ -90,6 +98,9 @@ public class BuildParameters
         SkipSigning = StringComparer.OrdinalIgnoreCase.Equals("True", context.Argument("skipsigning", "False"));
         SkipGitVersion = StringComparer.OrdinalIgnoreCase.Equals("True", context.EnvironmentVariable("CAKE_SKIP_GITVERSION"));
         Version = BuildVersion.Calculate(context, this);
+        IsMainCakeBranch = StringComparer.OrdinalIgnoreCase.Equals("main", buildSystem.AppVeyor.Environment.Repository.Branch) || StringComparer.OrdinalIgnoreCase.Equals("main", Version.BranchName);
+        IsDevelopCakeBranch = StringComparer.OrdinalIgnoreCase.Equals("develop", buildSystem.AppVeyor.Environment.Repository.Branch) || StringComparer.OrdinalIgnoreCase.Equals("develop", Version.BranchName);
+        IsMainCakeRepo = StringComparer.OrdinalIgnoreCase.Equals("cake-build/cake", buildSystem.AppVeyor.Environment.Repository.Name) || StringComparer.OrdinalIgnoreCase.Equals("cake-build", buildSystem.GitHubActions.Environment.Workflow.RepositoryOwner);
         Paths = BuildPaths.GetPaths(context, Configuration, Version.SemVersion);
         Packages = BuildPackages.GetPackages(
             Paths.Directories.NuGetRoot,
@@ -136,8 +147,7 @@ public class BuildParameters
 
     private static bool IsBuildTagged(BuildSystem buildSystem)
     {
-        return buildSystem.AppVeyor.Environment.Repository.Tag.IsTag
-            && !string.IsNullOrWhiteSpace(buildSystem.AppVeyor.Environment.Repository.Tag.Name);
+        return buildSystem.GitHubActions.IsRunningOnGitHubActions && buildSystem.GitHubActions.Environment.Workflow.RefType == GitHubActionsRefType.Tag;
     }
 
     private static bool IsReleasing(string target)

--- a/build/version.cake
+++ b/build/version.cake
@@ -3,7 +3,8 @@ public record BuildVersion(
     string SemVersion,
     string DotNetAsterix,
     string Milestone,
-    string CakeVersion
+    string CakeVersion,
+    string BranchName
 )
 {
     public static BuildVersion Calculate(ICakeContext context, BuildParameters parameters)
@@ -16,6 +17,7 @@ public record BuildVersion(
         string version = null;
         string semVersion = null;
         string milestone = null;
+        string branchName = null;
 
         if (!parameters.SkipGitVersion)
         {
@@ -58,6 +60,7 @@ public record BuildVersion(
             version = assertedVersions.MajorMinorPatch;
             semVersion = assertedVersions.LegacySemVerPadded;
             milestone = string.Concat("v", version);
+            branchName = assertedVersions.BranchName;
 
             context.Information("Calculated Semantic Version: {0} (Version: {1}, Milestone: {2})", semVersion, version, milestone);
         }
@@ -79,7 +82,8 @@ public record BuildVersion(
             SemVersion: semVersion,
             DotNetAsterix: semVersion.Substring(version.Length).TrimStart('-'),
             Milestone: milestone,
-            CakeVersion: cakeVersion
+            CakeVersion: cakeVersion,
+            BranchName: branchName
         );
     }
 


### PR DESCRIPTION
* Replace AppVeyor build configuration with GitHub Actions workflows
* Add new release workflow for automated releases on version tags
* Update code signing to use Azure CLI credentials instead of client secret
* Replace MyGet publishing with Azure DevOps NuGet feed
* Add GitHub Actions specific build targets (GitHubActions, GitHubActions-Release)
* Update build parameters to detect GitHub Actions environment
* Remove AppVeyor-specific dependencies and configurations
* Update tag detection logic to work with GitHub Actions
* fixes #4561
