### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
         "src"
     ],
     "sdk": {
-        "version": "9.0.304",
+        "version": "9.0.305",
         "rollForward": "latestFeature"
     }
 }

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -35,9 +35,9 @@
     <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
     <PackageVersion Include="Verify.XunitV3" Version="30.7.3" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.v3" Version="3.0.1" />
-    <PackageVersion Include="xunit.v3.assert" Version="3.0.1" />
-    <PackageVersion Include="xunit.v3.extensibility.core" Version="3.0.1" />
+    <PackageVersion Include="xunit.v3" Version="3.1.0" />
+    <PackageVersion Include="xunit.v3.assert" Version="3.1.0" />
+    <PackageVersion Include="xunit.v3.extensibility.core" Version="3.1.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
 
     <!-- Pin nuget transitive packages vulnerability issues NuGet.Packaging -->

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -15,9 +15,9 @@
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.14.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageVersion Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
-    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.14.1" />
+    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="18.0.0" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="18.0.0" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NuGet.Common" Version="6.14.0" />
     <PackageVersion Include="NuGet.Frameworks" Version="6.14.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="Castle.Core" Version="5.2.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.14.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageVersion Include="Microsoft.NETCore.Platforms" Version="7.0.4" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -27,8 +27,8 @@
     <PackageVersion Include="NuGet.Protocol" Version="6.14.0" />
     <PackageVersion Include="NuGet.Resolver" Version="6.14.0" />
     <PackageVersion Include="NuGet.Versioning" Version="6.14.0" />
-    <PackageVersion Include="Spectre.Console" Version="0.50.0" />
-    <PackageVersion Include="Spectre.Console.Cli" Version="0.50.0" />
+    <PackageVersion Include="Spectre.Console" Version="0.51.1" />
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.51.1" />
     <PackageVersion Include="Spectre.Verify.Extensions" Version="28.16.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="9.0.9" />
     <PackageVersion Include="System.Reflection.Metadata" Version="9.0.9" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -38,7 +38,7 @@
     <PackageVersion Include="xunit.v3" Version="3.0.1" />
     <PackageVersion Include="xunit.v3.assert" Version="3.0.1" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="3.0.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
 
     <!-- Pin nuget transitive packages vulnerability issues NuGet.Packaging -->
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.8" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -33,7 +33,7 @@
     <PackageVersion Include="System.Collections.Immutable" Version="9.0.8" />
     <PackageVersion Include="System.Reflection.Metadata" Version="9.0.8" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
-    <PackageVersion Include="Verify.XunitV3" Version="30.7.3" />
+    <PackageVersion Include="Verify.XunitV3" Version="30.19.2" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.v3" Version="3.1.0" />
     <PackageVersion Include="xunit.v3.assert" Version="3.1.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -30,8 +30,8 @@
     <PackageVersion Include="Spectre.Console" Version="0.50.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.50.0" />
     <PackageVersion Include="Spectre.Verify.Extensions" Version="28.16.0" />
-    <PackageVersion Include="System.Collections.Immutable" Version="9.0.8" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="9.0.8" />
+    <PackageVersion Include="System.Collections.Immutable" Version="9.0.9" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="9.0.9" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
     <PackageVersion Include="Verify.XunitV3" Version="30.19.2" />
     <PackageVersion Include="xunit" Version="2.9.3" />
@@ -41,7 +41,7 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
 
     <!-- Pin nuget transitive packages vulnerability issues NuGet.Packaging -->
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.8" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.9" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR updates multiple dependencies to their latest versions, including the .NET SDK and various NuGet packages.

### Changes
- **.NET SDK**: Updated from 9.0.304 to 9.0.305
- **Microsoft.Extensions.DependencyInjection**: 9.0.8 → 9.0.9
- **Microsoft.NET.Test.Sdk**: 17.14.1 → 18.0.0
- **Microsoft.TestPlatform.ObjectModel**: 17.14.1 → 18.0.0
- **Newtonsoft.Json**: 13.0.3 → 13.0.4
- **Spectre.Console**: 0.50.0 → 0.51.1
- **Spectre.Console.Cli**: 0.50.0 → 0.51.1
- **System.Collections.Immutable**: 9.0.8 → 9.0.9
- **System.Reflection.Metadata**: 9.0.8 → 9.0.9
- **System.Security.Cryptography.Pkcs**: 9.0.8 → 9.0.9
- **Verify.XunitV3**: 30.7.3 → 30.19.2
- **xunit.v3**: 3.0.1 → 3.1.0
- **xunit.v3.assert**: 3.0.1 → 3.1.0
- **xunit.v3.extensibility.core**: 3.0.1 → 3.1.0
- **xunit.runner.visualstudio**: 3.1.4 → 3.1.5

### Issues Fixed
- Fixes #4585
- Fixes #4584
- Fixes #4583
- Fixes #4582
- Fixes #4581
- Fixes #4580
- Fixes #4579
- Fixes #4578
- Fixes #4577