### PR TITLE
GH4601: AppVeyor don't install 6.0 & use CAKE_INSTALL_SUPPORTED_SDKS with build.ps1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,7 @@ init:
 
 # Build script
 build_script:
-  - ps: Invoke-RestMethod -Uri 'https://dot.net/v1/dotnet-install.ps1' -OutFile '.\dotnet-install.ps1'
-  - ps: New-Item -Path .\.dotnet -ItemType Directory -Force | Out-Null
-  - ps: .\dotnet-install.ps1 -Channel 6.0 -InstallDir .\.dotnet
+  - ps: $env:CAKE_INSTALL_SUPPORTED_SDKS='true'
   - ps: .\build.ps1 --target="AppVeyor"
 
 # Tests


### PR DESCRIPTION
* fixes #4601
