### PR TITLE
GH4617: Remove unnecessary using directives&enforce IDE0005

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,7 @@ indent_size = 2
 [*.cs]
 indent_style = space
 indent_size = 4
+dotnet_diagnostic.IDE0005.severity = error
 
 [*.cake]
 indent_style = space

--- a/src/Cake.Common/Build/AzurePipelines/AzurePipelinesCommands.cs
+++ b/src/Cake.Common/Build/AzurePipelines/AzurePipelinesCommands.cs
@@ -8,7 +8,6 @@ using System.Globalization;
 using System.Linq;
 using Cake.Common.Build.AzurePipelines.Data;
 using Cake.Core;
-using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 
 namespace Cake.Common.Build.AzurePipelines

--- a/src/Cake.Common/Build/AzurePipelines/AzurePipelinesProvider.cs
+++ b/src/Cake.Common/Build/AzurePipelines/AzurePipelinesProvider.cs
@@ -5,7 +5,6 @@
 using System;
 using Cake.Common.Build.AzurePipelines.Data;
 using Cake.Core;
-using Cake.Core.Diagnostics;
 
 namespace Cake.Common.Build.AzurePipelines
 {

--- a/src/Cake.Common/DryRunAliases.cs
+++ b/src/Cake.Common/DryRunAliases.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.ComponentModel;
-using System.Globalization;
 using Cake.Core;
 using Cake.Core.Annotations;
 

--- a/src/Cake.Common/IO/DirectoryMover.cs
+++ b/src/Cake.Common/IO/DirectoryMover.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using Cake.Core;

--- a/src/Cake.Common/Security/FileHashCalculator.cs
+++ b/src/Cake.Common/Security/FileHashCalculator.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Globalization;
-using System.Security.Cryptography;
 using Cake.Core;
 using Cake.Core.IO;
 

--- a/src/Cake.Common/Tools/Chocolatey/ApiKey/ChocolateyApiKeySetter.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ApiKey/ChocolateyApiKeySetter.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Globalization;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;

--- a/src/Cake.Common/Tools/Chocolatey/ChocolateyTool.cs
+++ b/src/Cake.Common/Tools/Chocolatey/ChocolateyTool.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/src/Cake.Common/Tools/Chocolatey/Config/ChocolateyConfigSetter.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Config/ChocolateyConfigSetter.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Globalization;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;

--- a/src/Cake.Common/Tools/Chocolatey/Export/ChocolateyExporter.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Export/ChocolateyExporter.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Globalization;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;

--- a/src/Cake.Common/Tools/Chocolatey/Features/ChocolateyFeatureToggler.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Features/ChocolateyFeatureToggler.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Globalization;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;

--- a/src/Cake.Common/Tools/Chocolatey/New/ChocolateyScaffolder.cs
+++ b/src/Cake.Common/Tools/Chocolatey/New/ChocolateyScaffolder.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Globalization;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;

--- a/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyPacker.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Pack/ChocolateyPacker.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Globalization;
 using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;

--- a/src/Cake.Common/Tools/Chocolatey/Pin/ChocolateyPinner.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Pin/ChocolateyPinner.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Globalization;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;

--- a/src/Cake.Common/Tools/Chocolatey/Push/ChocolateyPushSettings.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Push/ChocolateyPushSettings.cs
@@ -4,8 +4,6 @@
 
 namespace Cake.Common.Tools.Chocolatey.Push
 {
-    using System;
-
     /// <summary>
     /// Contains settings used by <see cref="ChocolateyPusher"/>.
     /// </summary>

--- a/src/Cake.Common/Tools/Chocolatey/Push/ChocolateyPusher.cs
+++ b/src/Cake.Common/Tools/Chocolatey/Push/ChocolateyPusher.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Globalization;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;

--- a/src/Cake.Common/Tools/DotCover/DotCoverContext.cs
+++ b/src/Cake.Common/Tools/DotCover/DotCoverContext.cs
@@ -3,10 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using Cake.Core;
-using Cake.Core.Configuration;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
-using Cake.Core.Tooling;
 
 namespace Cake.Common.Tools.DotCover
 {

--- a/src/Cake.Common/Tools/DotCover/DotCoverCoverageSettings.cs
+++ b/src/Cake.Common/Tools/DotCover/DotCoverCoverageSettings.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using Cake.Core.IO;
-using Cake.Core.Tooling;
 
 namespace Cake.Common.Tools.DotCover
 {

--- a/src/Cake.Common/Tools/DotCover/DotCoverCoverageSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/DotCover/DotCoverCoverageSettingsExtensions.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Cake.Core;
-using Cake.Core.IO;
 
 namespace Cake.Common.Tools.DotCover
 {

--- a/src/Cake.Common/Tools/DotNet/MSBuild/MSBuildFileLoggerSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/MSBuild/MSBuildFileLoggerSettings.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Core.IO;
-
 namespace Cake.Common.Tools.DotNet.MSBuild
 {
     /// <summary>

--- a/src/Cake.Common/Tools/DotNet/MSBuild/MSBuildLoggerSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/MSBuild/MSBuildLoggerSettings.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Cake.Common.Tools.DotNet;
-
 namespace Cake.Common.Tools.DotNet.MSBuild
 {
     /// <summary>

--- a/src/Cake.Common/Tools/DotNet/Package/Search/DotNetPackageSearcher.cs
+++ b/src/Cake.Common/Tools/DotNet/Package/Search/DotNetPackageSearcher.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.Json;
 using Cake.Core;
 using Cake.Core.IO;

--- a/src/Cake.Common/Tools/DotNet/Test/DotNetTestSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Test/DotNetTestSettings.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using Cake.Common.Tools.DotNet.MSBuild;
 using Cake.Core.IO;

--- a/src/Cake.Common/Tools/InnoSetup/InnoSetupRunner.cs
+++ b/src/Cake.Common/Tools/InnoSetup/InnoSetupRunner.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using Cake.Common.Build.AppVeyor.Data;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.IO.Arguments;

--- a/src/Cake.Common/Tools/MSBuild/MSBuildBinaryLogImports.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildBinaryLogImports.cs
@@ -2,12 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Cake.Common.Tools.MSBuild
 {
     /// <summary>

--- a/src/Cake.Common/Tools/MSBuild/MSBuildBinaryLogSettings.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildBinaryLogSettings.cs
@@ -2,12 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Cake.Common.Tools.MSBuild
 {
     /// <summary>

--- a/src/Cake.Common/Tools/MSpec/MspecSettings.cs
+++ b/src/Cake.Common/Tools/MSpec/MspecSettings.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
 

--- a/src/Cake.Common/Tools/NUnit/NUnitInternalTraceLevelExtensions.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnitInternalTraceLevelExtensions.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Cake.Common.Tools.NUnit;
 
 namespace Cake.Common.Tools.NUnit
 {

--- a/src/Cake.Common/Tools/NuGet/Delete/NuGetDeleteSettings.cs
+++ b/src/Cake.Common/Tools/NuGet/Delete/NuGetDeleteSettings.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
 

--- a/src/Cake.Common/Tools/NuGet/Delete/NuGetDeleter.cs
+++ b/src/Cake.Common/Tools/NuGet/Delete/NuGetDeleter.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Globalization;
 using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;

--- a/src/Cake.Common/Tools/NuGet/NuGetMSBuildVersion.cs
+++ b/src/Cake.Common/Tools/NuGet/NuGetMSBuildVersion.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace Cake.Common.Tools.NuGet
 {
     /// <summary>

--- a/src/Cake.Common/Tools/NuGet/Update/NuGetUpdateSettings.cs
+++ b/src/Cake.Common/Tools/NuGet/Update/NuGetUpdateSettings.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using Cake.Core.Tooling;
 

--- a/src/Cake.Common/Tools/OctopusDeploy/DeployReleaseArgumentBuilder.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/DeployReleaseArgumentBuilder.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Globalization;
 using Cake.Core;
 using Cake.Core.IO;

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverContext.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverContext.cs
@@ -3,10 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using Cake.Core;
-using Cake.Core.Configuration;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
-using Cake.Core.Tooling;
 
 namespace Cake.Common.Tools.OpenCover
 {

--- a/src/Cake.Common/Tools/OpenCover/OpenCoverHideSkippedOptionExtensions.cs
+++ b/src/Cake.Common/Tools/OpenCover/OpenCoverHideSkippedOptionExtensions.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
 namespace Cake.Common.Tools.OpenCover
 {
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Linq;
-
     /// <summary>
     /// Extensions class for <see cref="OpenCoverHideSkippedOption"/>.
     /// </summary>

--- a/src/Cake.Common/Tools/SpecFlow/SpecFlowContext.cs
+++ b/src/Cake.Common/Tools/SpecFlow/SpecFlowContext.cs
@@ -3,10 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using Cake.Core;
-using Cake.Core.Configuration;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
-using Cake.Core.Tooling;
 
 namespace Cake.Common.Tools.SpecFlow
 {

--- a/src/Cake.Common/Tools/VSTest/VSTestSettings.cs
+++ b/src/Cake.Common/Tools/VSTest/VSTestSettings.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
 

--- a/src/Cake.Core/CakeConsole.cs
+++ b/src/Cake.Core/CakeConsole.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Cake.Core.Configuration;
 using Cake.Core.Diagnostics;
 
 namespace Cake.Core

--- a/src/Cake.Core/CakeEngine.cs
+++ b/src/Cake.Core/CakeEngine.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
-using System.Net;
 using System.Reflection;
 using System.Threading.Tasks;
 using Cake.Core.Diagnostics;

--- a/src/Cake.Core/Configuration/CakeConfigurationProvider.cs
+++ b/src/Cake.Core/Configuration/CakeConfigurationProvider.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using Cake.Core.Configuration.Parser;
 using Cake.Core.IO;

--- a/src/Cake.Core/Diagnostics/Formatting/FormatParser.cs
+++ b/src/Cake.Core/Diagnostics/Formatting/FormatParser.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Text;
 

--- a/src/Cake.Core/Extensions/CakeArgumentsExtensions.cs
+++ b/src/Cake.Core/Extensions/CakeArgumentsExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 
 namespace Cake.Core
 {

--- a/src/Cake.Core/IO/Globbing/Nodes/UncRootNode.cs
+++ b/src/Cake.Core/IO/Globbing/Nodes/UncRootNode.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
 
 namespace Cake.Core.IO.Globbing.Nodes

--- a/src/Cake.Core/IO/IGlobber.cs
+++ b/src/Cake.Core/IO/IGlobber.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace Cake.Core.IO

--- a/src/Cake.Core/IO/ProcessRunner.cs
+++ b/src/Cake.Core/IO/ProcessRunner.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using Cake.Core.Configuration;
 using Cake.Core.Diagnostics;

--- a/src/Cake.Core/Modules/CoreModule.cs
+++ b/src/Cake.Core/Modules/CoreModule.cs
@@ -9,7 +9,6 @@ using Cake.Core.IO.NuGet;
 using Cake.Core.Reflection;
 using Cake.Core.Scripting;
 using Cake.Core.Scripting.Analysis;
-using Cake.Core.Scripting.Processors;
 using Cake.Core.Scripting.Processors.Loading;
 using Cake.Core.Tooling;
 

--- a/src/Cake.Core/Packaging/PackageReference.cs
+++ b/src/Cake.Core/Packaging/PackageReference.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 
 namespace Cake.Core.Packaging

--- a/src/Cake.Core/Polyfill/EnvironmentHelper.cs
+++ b/src/Cake.Core/Polyfill/EnvironmentHelper.cs
@@ -3,11 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
-using Cake.Core.IO;
 
 namespace Cake.Core.Polyfill
 {

--- a/src/Cake.Core/Reflection/AssemblyLoader.cs
+++ b/src/Cake.Core/Reflection/AssemblyLoader.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;
-using Cake.Core.Configuration;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.Core.Polyfill;

--- a/src/Cake.Core/Reflection/IAssemblyLoader.cs
+++ b/src/Cake.Core/Reflection/IAssemblyLoader.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;
-using Cake.Core.Configuration;
 using Cake.Core.IO;
 
 namespace Cake.Core.Reflection

--- a/src/Cake.Core/Reflection/IAssemblyVerifier.cs
+++ b/src/Cake.Core/Reflection/IAssemblyVerifier.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;
-using Cake.Core.Configuration;
 
 namespace Cake.Core.Reflection
 {

--- a/src/Cake.Core/Scripting/Analysis/ScriptAnalyzer.cs
+++ b/src/Cake.Core/Scripting/Analysis/ScriptAnalyzer.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;

--- a/src/Cake.Core/Scripting/IScriptProcessor.cs
+++ b/src/Cake.Core/Scripting/IScriptProcessor.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using Cake.Core.IO;
 using Cake.Core.Packaging;
-using Cake.Core.Scripting.Analysis;
 
 namespace Cake.Core.Scripting
 {

--- a/src/Cake.Core/Scripting/IScriptRunner.cs
+++ b/src/Cake.Core/Scripting/IScriptRunner.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using System.Linq;
 using Cake.Core.IO;
 
 namespace Cake.Core.Scripting

--- a/src/Cake.Core/Scripting/Processors/DefineDirectiveProcessor.cs
+++ b/src/Cake.Core/Scripting/Processors/DefineDirectiveProcessor.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Linq;
 using Cake.Core.Scripting.Analysis;
 
 namespace Cake.Core.Scripting.Processors

--- a/src/Cake.Core/Scripting/ScriptHost.cs
+++ b/src/Cake.Core/Scripting/ScriptHost.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Cake.Core.Diagnostics;
 
 namespace Cake.Core.Scripting
 {

--- a/src/Cake.Core/Tooling/Tool.cs
+++ b/src/Cake.Core/Tooling/Tool.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using Cake.Core.IO;

--- a/src/Cake.Frosting/FrostingSetup.cs
+++ b/src/Cake.Frosting/FrostingSetup.cs
@@ -4,7 +4,6 @@
 
 using System;
 using Cake.Core;
-using Cake.Frosting;
 
 namespace Cake.Frosting
 {

--- a/src/Cake.Frosting/FrostingTaskSetup.cs
+++ b/src/Cake.Frosting/FrostingTaskSetup.cs
@@ -4,7 +4,6 @@
 
 using System;
 using Cake.Core;
-using Cake.Frosting;
 
 namespace Cake.Frosting
 {

--- a/src/Cake.Frosting/FrostingTaskTeardown.cs
+++ b/src/Cake.Frosting/FrostingTaskTeardown.cs
@@ -4,7 +4,6 @@
 
 using System;
 using Cake.Core;
-using Cake.Frosting;
 
 namespace Cake.Frosting
 {

--- a/src/Cake.Frosting/FrostingTeardown.cs
+++ b/src/Cake.Frosting/FrostingTeardown.cs
@@ -4,7 +4,6 @@
 
 using System;
 using Cake.Core;
-using Cake.Frosting;
 
 namespace Cake.Frosting
 {

--- a/src/Cake.Frosting/Internal/Commands/DefaultCommand.cs
+++ b/src/Cake.Frosting/Internal/Commands/DefaultCommand.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Cake.Cli;
 using Cake.Cli.Infrastructure;

--- a/src/Cake.NuGet/Installers/OutOfProcessInstaller.cs
+++ b/src/Cake.NuGet/Installers/OutOfProcessInstaller.cs
@@ -11,7 +11,6 @@ using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.Core.IO.NuGet;
 using Cake.Core.Packaging;
-using NuGet.Versioning;
 
 using IFileSystem = Cake.Core.IO.IFileSystem;
 using PackageReference = Cake.Core.Packaging.PackageReference;

--- a/src/Shared.msbuild
+++ b/src/Shared.msbuild
@@ -17,6 +17,7 @@
     <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
     <DebugType>portable</DebugType>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     
     <!-- 
       While .NET 9 not released don't warn, remove as soon as non RC binaries shipped.


### PR DESCRIPTION
- Add IDE0005 severity as error in .editorconfig
- Remove unused using directives across Cake.Common, Cake.Core, Cake.Frosting, and Cake.NuGet
- Enable EnforceCodeStyleInBuild in Shared.msbuild
- Clean up imports in 50+ files to improve code quality and reduce compilation warnings
- fixes #4617
