### PR TITLE
GH4627: Add explicit path type support for .NET 10+ compatibility

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Test/DotNetTesterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Test/DotNetTesterTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Cake.Common.Tests.Fixtures.Tools.DotNet.Test;
+using Cake.Common.Tools.DotNet.Test;
 using Cake.Core;
 using Cake.Testing;
 using Xunit;
@@ -159,6 +160,132 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Test
 
                 // Then
                 Assert.Equal("--diagnostics test", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Project_Path_With_Explicit_Project_Type()
+            {
+                // Given
+                var fixture = new DotNetTesterFixture();
+                fixture.Project = "./test/Project.Tests.csproj";
+                fixture.Settings.PathType = DotNetTestPathType.Project;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("test --project \"./test/Project.Tests.csproj\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Solution_Path_With_Explicit_Solution_Type()
+            {
+                // Given
+                var fixture = new DotNetTesterFixture();
+                fixture.Project = "./test/TestSolution.sln";
+                fixture.Settings.PathType = DotNetTestPathType.Solution;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("test --solution \"./test/TestSolution.sln\"", result.Args);
+            }
+
+            [Theory]
+            [InlineData("./test/Project.csproj", "test --project \"./test/Project.csproj\"")]
+            [InlineData("./test/Project.vbproj", "test --project \"./test/Project.vbproj\"")]
+            [InlineData("./test/Project.fsproj", "test --project \"./test/Project.fsproj\"")]
+            [InlineData("./test/Project.vcxproj", "test --project \"./test/Project.vcxproj\"")]
+            public void Should_Auto_Detect_Project_Files(string projectPath, string expected)
+            {
+                // Given
+                var fixture = new DotNetTesterFixture();
+                fixture.Project = projectPath;
+                fixture.Settings.PathType = DotNetTestPathType.Auto;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Fact]
+            public void Should_Auto_Detect_Solution_Files()
+            {
+                // Given
+                var fixture = new DotNetTesterFixture();
+                fixture.Project = "./test/TestSolution.sln";
+                fixture.Settings.PathType = DotNetTestPathType.Auto;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("test --solution \"./test/TestSolution.sln\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Use_Legacy_Behavior_For_Unknown_Extensions_With_Auto()
+            {
+                // Given
+                var fixture = new DotNetTesterFixture();
+                fixture.Project = "./test/UnknownFile.xyz";
+                fixture.Settings.PathType = DotNetTestPathType.Auto;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("test \"./test/UnknownFile.xyz\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Use_Legacy_Behavior_When_PathType_Is_None()
+            {
+                // Given
+                var fixture = new DotNetTesterFixture();
+                fixture.Project = "./test/Project.csproj";
+                fixture.Settings.PathType = DotNetTestPathType.None;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("test \"./test/Project.csproj\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Use_Legacy_Behavior_When_PathType_Is_Default()
+            {
+                // Given
+                var fixture = new DotNetTesterFixture();
+                fixture.Project = "./test/Project.csproj";
+                // PathType defaults to None
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("test \"./test/Project.csproj\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Combine_PathType_With_Other_Settings()
+            {
+                // Given
+                var fixture = new DotNetTesterFixture();
+                fixture.Project = "./test/Project.csproj";
+                fixture.Settings.PathType = DotNetTestPathType.Project;
+                fixture.Settings.NoBuild = true;
+                fixture.Settings.Configuration = "Release";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("test --project \"./test/Project.csproj\" --configuration Release --no-build", result.Args);
             }
         }
     }

--- a/src/Cake.Common/Tools/DotNet/Test/DotNetTestPathType.cs
+++ b/src/Cake.Common/Tools/DotNet/Test/DotNetTestPathType.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Tools.DotNet.Test
+{
+    /// <summary>
+    /// Represents the path type for .NET test command.
+    /// </summary>
+    public enum DotNetTestPathType
+    {
+        /// <summary>
+        /// No explicit path type specified (default behavior).
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Automatically detect the path type based on the file extension.
+        /// </summary>
+        Auto,
+
+        /// <summary>
+        /// Explicitly specify the path as a project file.
+        /// </summary>
+        Project,
+
+        /// <summary>
+        /// Explicitly specify the path as a solution file.
+        /// </summary>
+        Solution
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/Test/DotNetTestSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Test/DotNetTestSettings.cs
@@ -116,5 +116,14 @@ namespace Cake.Common.Tools.DotNet.Test
         /// Gets or sets additional arguments to be passed to MSBuild.
         /// </summary>
         public DotNetMSBuildSettings MSBuildSettings { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path type for the test command.
+        /// When set to <see cref="DotNetTestPathType.Auto"/>, the path type will be automatically detected based on the file extension.
+        /// When set to <see cref="DotNetTestPathType.Project"/>, the path will be treated as a project file.
+        /// When set to <see cref="DotNetTestPathType.Solution"/>, the path will be treated as a solution file.
+        /// This is particularly useful for .NET 10+ where explicit --project or --solution parameters are required.
+        /// </summary>
+        public DotNetTestPathType PathType { get; set; } = DotNetTestPathType.None;
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Test/DotNetTester.cs
+++ b/src/Cake.Common/Tools/DotNet/Test/DotNetTester.cs
@@ -55,6 +55,17 @@ namespace Cake.Common.Tools.DotNet.Test
             // Specific path?
             if (project != null)
             {
+                // Handle path type for .NET 10+ compatibility
+                switch (DeterminePathType(project, settings.PathType))
+                {
+                    case DotNetTestPathType.Project:
+                        builder.Append("--project");
+                        break;
+                    case DotNetTestPathType.Solution:
+                        builder.Append("--solution");
+                        break;
+                }
+
                 builder.AppendQuoted(project);
             }
 
@@ -190,6 +201,40 @@ namespace Cake.Common.Tools.DotNet.Test
             }
 
             return builder;
+        }
+
+        /// <summary>
+        /// Determines the path type based on the project path and settings.
+        /// </summary>
+        /// <param name="project">The project path.</param>
+        /// <param name="pathType">The configured path type.</param>
+        /// <returns>The determined path type.</returns>
+        private static DotNetTestPathType DeterminePathType(string project, DotNetTestPathType pathType)
+        {
+            return pathType switch
+            {
+                DotNetTestPathType.None => DotNetTestPathType.None,
+                DotNetTestPathType.Project => DotNetTestPathType.Project,
+                DotNetTestPathType.Solution => DotNetTestPathType.Solution,
+                DotNetTestPathType.Auto => AutoDetectPathType(project),
+                _ => DotNetTestPathType.None
+            };
+        }
+
+        /// <summary>
+        /// Auto-detects the path type based on file extension.
+        /// </summary>
+        /// <param name="project">The project path.</param>
+        /// <returns>The detected path type.</returns>
+        private static DotNetTestPathType AutoDetectPathType(string project)
+        {
+            var extension = FilePath.FromString(project).GetExtension().ToLowerInvariant();
+            return extension switch
+            {
+                ".sln" => DotNetTestPathType.Solution,
+                ".csproj" or ".vbproj" or ".fsproj" or ".vcxproj" => DotNetTestPathType.Project,
+                _ => DotNetTestPathType.None // Default to legacy behavior for unknown extensions
+            };
         }
     }
 }


### PR DESCRIPTION
Adds DotNetTestPathType enum and PathType property to DotNetTestSettings to support explicit --project and --solution parameters required by .NET 10+.

Changes:
- Add DotNetTestPathType enum with None, Auto, Project, and Solution values
- Add PathType property to DotNetTestSettings (defaults to None for backward compatibility)
- Update DotNetTester to handle path type logic with switch expressions
- Add comprehensive unit tests covering all path type scenarios
- Support auto-detection based on file extensions (.sln, .csproj, .vbproj, .fsproj, .vcxproj)

fixes #4627
