### PR TITLE
GH-4639: Enable Spectre.Console report printer by default

### DIFF
--- a/src/Cake.Cli/Infrastructure/CakeSpectreReportPrinter.cs
+++ b/src/Cake.Cli/Infrastructure/CakeSpectreReportPrinter.cs
@@ -44,7 +44,7 @@ namespace Cake.Cli
             table.AddColumn(
                 new TableColumn(
                     new Text("Duration", rowStyle)).Footer(
-                        new Text(FormatTime(GetTotalTime(report)), rowStyle)));
+                        new Text(FormatTime(GetTotalTime(report)).EscapeMarkup(), rowStyle)));
 
             table.AddColumn(
                 new TableColumn(
@@ -61,16 +61,16 @@ namespace Cake.Cli
 
                 if (includeSkippedReasonColumn)
                 {
-                    table.AddRow(new Markup(item.TaskName, itemStyle),
-                                new Markup(FormatDuration(item), itemStyle),
-                                new Markup(item.ExecutionStatus.ToString(), itemStyle),
-                                new Markup(item.SkippedMessage, itemStyle));
+                    table.AddRow(new Markup(item.TaskName.EscapeMarkup(), itemStyle),
+                                new Markup(FormatDuration(item).EscapeMarkup(), itemStyle),
+                                new Markup(item.ExecutionStatus.ToString().EscapeMarkup(), itemStyle),
+                                new Markup(item.SkippedMessage.EscapeMarkup(), itemStyle));
                 }
                 else
                 {
-                    table.AddRow(new Markup(item.TaskName, itemStyle),
-                                new Markup(FormatDuration(item), itemStyle),
-                                new Markup(item.ExecutionStatus.ToString(), itemStyle));
+                    table.AddRow(new Markup(item.TaskName.EscapeMarkup(), itemStyle),
+                                new Markup(FormatDuration(item).EscapeMarkup(), itemStyle),
+                                new Markup(item.ExecutionStatus.ToString().EscapeMarkup(), itemStyle));
                 }
             }
 
@@ -88,7 +88,7 @@ namespace Cake.Cli
 
             var table = new Table().Border(DoubleBorder.Shared);
             table.Width(100);
-            table.AddColumn(name);
+            table.AddColumn(name.EscapeMarkup());
             _console.Write(new Padder(table).Padding(0, 1, 0, 0));
         }
 
@@ -104,7 +104,7 @@ namespace Cake.Cli
 
             var table = new Table().Border(SingleBorder.Shared);
             table.Width(100);
-            table.AddColumn(name);
+            table.AddColumn(name.EscapeMarkup());
             _console.Write(table);
         }
 
@@ -118,9 +118,12 @@ namespace Cake.Cli
 
             _console.WriteLine();
 
-            var table = new Table().Border(DoubleBorder.Shared);
+            var table = new Table()
+                .Border(DoubleBorder.Shared)
+                .BorderStyle(new Style(ConsoleColor.Gray));
+
             table.Width(100);
-            table.AddColumn(name);
+            table.AddColumn(name.EscapeMarkup());
             _console.Write(table);
         }
 

--- a/src/Cake.Cli/Infrastructure/DoubleBorder.cs
+++ b/src/Cake.Cli/Infrastructure/DoubleBorder.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+#nullable enable
 
 using Spectre.Console;
 using Spectre.Console.Rendering;
@@ -15,7 +16,10 @@ namespace Cake.Cli
         /// <summary>
         /// Gets a single instance of the DoubleBorder class.
         /// </summary>
-        public static DoubleBorder Shared { get; } = new DoubleBorder();
+        public static TableBorder Shared { get; } = new DoubleBorder();
+
+        /// <inheritdoc/>
+        public override TableBorder? SafeBorder => new Safe();
 
         /// <summary>
         /// Get information about the custom border.
@@ -26,10 +30,31 @@ namespace Cake.Cli
         {
             return part switch
             {
-                TableBorderPart.HeaderTop => "=",
-                TableBorderPart.FooterBottom => "=",
+                TableBorderPart.HeaderTopLeft => "═",
+                TableBorderPart.HeaderTop => "═",
+                TableBorderPart.HeaderTopRight => "═",
+                TableBorderPart.FooterBottomLeft => "═",
+                TableBorderPart.FooterBottom => "═",
+                TableBorderPart.FooterBottomRight => "═",
                 _ => string.Empty,
             };
+        }
+
+        private sealed class Safe : TableBorder
+        {
+            public override string GetPart(TableBorderPart part)
+            {
+                return part switch
+                {
+                    TableBorderPart.HeaderTopLeft => "=",
+                    TableBorderPart.HeaderTop => "=",
+                    TableBorderPart.HeaderTopRight => "=",
+                    TableBorderPart.FooterBottomLeft => "=",
+                    TableBorderPart.FooterBottom => "=",
+                    TableBorderPart.FooterBottomRight => "=",
+                    _ => string.Empty,
+                };
+            }
         }
     }
 }

--- a/src/Cake.Cli/Infrastructure/SingleBorder.cs
+++ b/src/Cake.Cli/Infrastructure/SingleBorder.cs
@@ -17,6 +17,9 @@ namespace Cake.Cli
         /// </summary>
         public static SingleBorder Shared { get; } = new SingleBorder();
 
+        /// <inheritdoc/>
+        public override TableBorder SafeBorder { get; } = new Safe();
+
         /// <summary>
         /// Get information about the custom border.
         /// </summary>
@@ -26,10 +29,31 @@ namespace Cake.Cli
         {
             return part switch
             {
-                TableBorderPart.HeaderTop => "-",
-                TableBorderPart.FooterBottom => "-",
+                TableBorderPart.HeaderTopLeft => "─",
+                TableBorderPart.HeaderTop => "─",
+                TableBorderPart.HeaderTopRight => "─",
+                TableBorderPart.FooterBottomLeft => "─",
+                TableBorderPart.FooterBottom => "─",
+                TableBorderPart.FooterBottomRight => "─",
                 _ => string.Empty,
             };
+        }
+
+        private sealed class Safe : TableBorder
+        {
+            public override string GetPart(TableBorderPart part)
+            {
+                return part switch
+                {
+                    TableBorderPart.HeaderTopLeft => "-",
+                    TableBorderPart.HeaderTop => "-",
+                    TableBorderPart.HeaderTopRight => "-",
+                    TableBorderPart.FooterBottomLeft => "-",
+                    TableBorderPart.FooterBottom => "-",
+                    TableBorderPart.FooterBottomRight => "-",
+                    _ => string.Empty,
+                };
+            }
         }
     }
 }

--- a/src/Cake/Infrastructure/ContainerConfigurator.cs
+++ b/src/Cake/Infrastructure/ContainerConfigurator.cs
@@ -57,19 +57,21 @@ namespace Cake.Infrastructure
 
             // Misc registrations.
             registrar.RegisterType<CakeReportPrinter>().As<ICakeReportPrinter>().Singleton();
-
-            registrar.RegisterInstance(AnsiConsole.Console).As<IAnsiConsole>().Singleton();
-
-            var useSpectreConsoleForConsoleOutputString = configuration.GetValue(Constants.Settings.UseSpectreConsoleForConsoleOutput);
-            var useSpectreConsoleForConsoleOutput = useSpectreConsoleForConsoleOutputString != null && useSpectreConsoleForConsoleOutputString.Equals("true", StringComparison.OrdinalIgnoreCase);
-
-            if (useSpectreConsoleForConsoleOutput)
-            {
-                registrar.RegisterType<CakeSpectreReportPrinter>().As<ICakeReportPrinter>().Singleton();
-            }
+            RegisterSpectreConsole(registrar, configuration);
 
             registrar.RegisterType<CakeConsole>().As<IConsole>().Singleton();
             registrar.RegisterInstance(configuration).As<ICakeConfiguration>().Singleton();
+        }
+
+        private static void RegisterSpectreConsole(ICakeContainerRegistrar registrar, ICakeConfiguration configuration)
+        {
+            registrar.RegisterInstance(AnsiConsole.Console).As<IAnsiConsole>().Singleton();
+
+            var useSpectre = configuration.GetValue(Constants.Settings.UseSpectreConsoleForConsoleOutput) ?? "true";
+            if (useSpectre.Equals("true", StringComparison.OrdinalIgnoreCase))
+            {
+                registrar.RegisterType<CakeSpectreReportPrinter>().As<ICakeReportPrinter>().Singleton();
+            }
         }
     }
 }


### PR DESCRIPTION
Also fixes some bugs with the initial implementation, as well as making sure that the borders have a safe (non-unicode) fallback.

Closes #4639
