### PR TITLE
GH4658: Add support for MSBuild 18 and VS2026.

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/MSBuildRunnerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/MSBuildRunnerFixture.cs
@@ -40,6 +40,8 @@ namespace Cake.Common.Tests.Fixtures.Tools
                 "/Program86/Microsoft Visual Studio/2019/Professional/MSBuild/Current/Bin/amd64/MSBuild.exe",
                 "/Program/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin/MSBuild.exe",
                 "/Program/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin/amd64/MSBuild.exe",
+                "/Program/Microsoft Visual Studio/18/Enterprise/MSBuild/Current/Bin/MSBuild.exe",
+                "/Program/Microsoft Visual Studio/18/Enterprise/MSBuild/Current/Bin/amd64/MSBuild.exe",
                 "/usr/bin/msbuild",
                 "/Library/Frameworks/Mono.framework/Versions/Current/Commands/msbuild"
             };

--- a/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/MSBuild/MSBuildRunnerTests.cs
@@ -233,6 +233,82 @@ namespace Cake.Common.Tests.Unit.Tools.MSBuild
             }
 
             [Theory]
+            [InlineData(MSBuildToolVersion.VS2026, PlatformTarget.x64, PlatformFamily.Windows, false, "/Program/Microsoft Visual Studio/18/Enterprise/MSBuild/Current/Bin/amd64/MSBuild.exe")]
+            [InlineData(MSBuildToolVersion.VS2026, PlatformTarget.x86, PlatformFamily.Windows, false, "/Program/Microsoft Visual Studio/18/Enterprise/MSBuild/Current/Bin/MSBuild.exe")]
+            [InlineData(MSBuildToolVersion.VS2026, PlatformTarget.x64, PlatformFamily.Linux, false, "/usr/bin/msbuild")]
+            [InlineData(MSBuildToolVersion.VS2026, PlatformTarget.x64, PlatformFamily.OSX, false, "/Library/Frameworks/Mono.framework/Versions/Current/Commands/msbuild")]
+            public void Should_Get_Correct_Path_To_MSBuild_Version_18(MSBuildToolVersion version, PlatformTarget target, PlatformFamily family, bool is64BitOperativeSystem, string expected)
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(is64BitOperativeSystem, family);
+                fixture.Settings.ToolVersion = version;
+                fixture.Settings.PlatformTarget = target;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Path.FullPath);
+            }
+
+            [Theory]
+            [InlineData(MSBuildToolVersion.VS2026, PlatformTarget.x64, PlatformFamily.Windows, false, "/Program86/Microsoft Visual Studio/18/BuildTools/MSBuild/Current/Bin/amd64/MSBuild.exe")]
+            [InlineData(MSBuildToolVersion.VS2026, PlatformTarget.x86, PlatformFamily.Windows, false, "/Program86/Microsoft Visual Studio/18/BuildTools/MSBuild/Current/Bin/MSBuild.exe")]
+            public void Should_Get_Correct_Path_To_MSBuild_Version_18_When_Only_Build_Tools_Are_Installed(MSBuildToolVersion version, PlatformTarget target, PlatformFamily family, bool is64BitOperativeSystem, string expected)
+            {
+                // Given
+                var fixture = new MSBuildRunnerFixture(is64BitOperativeSystem, family);
+                fixture.Settings.ToolVersion = version;
+                fixture.Settings.PlatformTarget = target;
+
+                fixture.GivenDefaultToolDoNotExist();
+                fixture.GivenMSBuildIsNotInstalled();
+                fixture.FileSystem.CreateFile("/Program86/Microsoft Visual Studio/18/BuildTools/MSBuild/Current/Bin/amd64/MSBuild.exe");
+                fixture.FileSystem.CreateFile("/Program86/Microsoft Visual Studio/18/BuildTools/MSBuild/Current/Bin/MSBuild.exe");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Path.FullPath);
+            }
+
+            [Theory]
+            [InlineData(MSBuildToolVersion.VS2026, PlatformTarget.x64, PlatformFamily.Windows, true)]
+            [InlineData(MSBuildToolVersion.VS2026, PlatformTarget.x86, PlatformFamily.Windows, true)]
+            [InlineData(MSBuildToolVersion.VS2026, PlatformTarget.x64, PlatformFamily.Windows, false)]
+            [InlineData(MSBuildToolVersion.VS2026, PlatformTarget.x86, PlatformFamily.Windows, false)]
+            public void Should_Get_Correct_Path_To_MSBuild_Version_18Insider_When_Preview_Is_Set(MSBuildToolVersion version, PlatformTarget target, PlatformFamily family, bool allowPreview)
+            {
+                // Given
+                var is64BitOperativeSystem = target == PlatformTarget.x64;
+                var fixture = new MSBuildRunnerFixture(is64BitOperativeSystem, family);
+                fixture.Settings.ToolVersion = version;
+                fixture.Settings.PlatformTarget = target;
+                fixture.Settings.AllowPreviewVersion = allowPreview;
+
+                fixture.GivenDefaultToolDoNotExist();
+                fixture.GivenMSBuildIsNotInstalled();
+                fixture.FileSystem.CreateFile("/Program/Microsoft Visual Studio/18/Enterprise/MSBuild/Current/Bin/amd64/MSBuild.exe");
+                fixture.FileSystem.CreateFile("/Program/Microsoft Visual Studio/18/Enterprise/MSBuild/Current/Bin/MSBuild.exe");
+                fixture.FileSystem.CreateFile("/Program/Microsoft Visual Studio/18/Insiders/MSBuild/Current/Bin/amd64/MSBuild.exe");
+                fixture.FileSystem.CreateFile("/Program/Microsoft Visual Studio/18/Insiders/MSBuild/Current/Bin/MSBuild.exe");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                if (allowPreview)
+                {
+                    Assert.Contains("18/Insiders", result.Path.FullPath);
+                }
+                else
+                {
+                    Assert.DoesNotContain("18/Insiders", result.Path.FullPath);
+                }
+            }
+
+            [Theory]
             [InlineData(MSBuildToolVersion.NET40, PlatformTarget.MSIL, true, "/Windows/Microsoft.NET/Framework64/v4.0.30319/MSBuild.exe")]
             [InlineData(MSBuildToolVersion.NET40, PlatformTarget.MSIL, false, "/Windows/Microsoft.NET/Framework/v4.0.30319/MSBuild.exe")]
             [InlineData(MSBuildToolVersion.NET45, PlatformTarget.MSIL, true, "/Windows/Microsoft.NET/Framework64/v4.0.30319/MSBuild.exe")]

--- a/src/Cake.Common/Tools/DotNet/MSBuild/MSBuildArgumentBuilderExtensions.cs
+++ b/src/Cake.Common/Tools/DotNet/MSBuild/MSBuildArgumentBuilderExtensions.cs
@@ -308,6 +308,8 @@ namespace Cake.Common.Tools.DotNet.MSBuild
                     return "16.0";
                 case MSBuildVersion.MSBuild17:
                     return "17.0";
+                case MSBuildVersion.MSBuild18:
+                    return "18.0";
                 default:
                     throw new ArgumentOutOfRangeException(nameof(toolVersion), toolVersion, "Invalid value");
             }

--- a/src/Cake.Common/Tools/MSBuild/MSBuildResolver.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildResolver.cs
@@ -70,6 +70,7 @@ namespace Cake.Common.Tools.MSBuild
         {
             var versions = new[]
             {
+                MSBuildVersion.MSBuild18,
                 MSBuildVersion.MSBuild17,
                 MSBuildVersion.MSBuild16,
                 MSBuildVersion.MSBuild15,
@@ -101,6 +102,8 @@ namespace Cake.Common.Tools.MSBuild
         {
             switch (version)
             {
+                case MSBuildVersion.MSBuild18:
+                    return GetVisualStudio2026Path(fileSystem, environment, buildPlatform, allowPreview);
                 case MSBuildVersion.MSBuild17:
                     return GetVisualStudio2022Path(fileSystem, environment, buildPlatform, allowPreview);
                 case MSBuildVersion.MSBuild16:
@@ -234,6 +237,37 @@ namespace Cake.Common.Tools.MSBuild
             }
 
             return VisualStudio.GetYearAndEditionRootPath(environment, "2022", "Professional").Combine("MSBuild/Current/Bin");
+        }
+
+        private static DirectoryPath GetVisualStudio2026Path(IFileSystem fileSystem, ICakeEnvironment environment,
+            MSBuildPlatform buildPlatform, bool allowPreviewVersion)
+        {
+            foreach (var edition in allowPreviewVersion
+                         ? VisualStudio.Editions.All
+                         : VisualStudio.Editions.Stable)
+            {
+                // Get the bin path.
+                var binPath = VisualStudio.GetYearAndEditionRootPath(environment, "18", edition).Combine("MSBuild/Current/Bin");
+                if (fileSystem.Exist(binPath))
+                {
+                    if (buildPlatform == MSBuildPlatform.Automatic)
+                    {
+                        if (environment.Platform.Is64Bit)
+                        {
+                            binPath = binPath.Combine("amd64");
+                        }
+                    }
+
+                    if (buildPlatform == MSBuildPlatform.x64)
+                    {
+                        binPath = binPath.Combine("amd64");
+                    }
+
+                    return binPath;
+                }
+            }
+
+            return VisualStudio.GetYearAndEditionRootPath(environment, "18", "Professional").Combine("MSBuild/Current/Bin");
         }
 
         private static DirectoryPath GetFrameworkPath(ICakeEnvironment environment, MSBuildPlatform buildPlatform, string version)

--- a/src/Cake.Common/Tools/MSBuild/MSBuildToolVersion.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildToolVersion.cs
@@ -112,6 +112,11 @@ namespace Cake.Common.Tools.MSBuild
         /// <summary>
         /// MSBuild tool version: <c>Visual Studio 2022</c>
         /// </summary>
-        VS2022 = 10
+        VS2022 = 10,
+
+        /// <summary>
+        /// MSBuild tool version: <c>Visual Studio 2026</c>
+        /// </summary>
+        VS2026 = 11
     }
 }

--- a/src/Cake.Common/Tools/MSBuild/MSBuildVersion.cs
+++ b/src/Cake.Common/Tools/MSBuild/MSBuildVersion.cs
@@ -41,6 +41,9 @@ namespace Cake.Common.Tools.MSBuild
         MSBuildNETCustom = 9,
 
         /// <summary>Version 17.0</summary>
-        MSBuild17 = 10
+        MSBuild17 = 10,
+
+        /// <summary>Version 18.0</summary>
+        MSBuild18 = 11
     }
 }

--- a/src/Cake.Common/Tools/VisualStudio.cs
+++ b/src/Cake.Common/Tools/VisualStudio.cs
@@ -23,7 +23,8 @@ namespace Cake.Common.Tools
         {
             internal static ICollection<string> Preview { get; } = new[]
             {
-                "Preview"
+                "Preview",
+                "Insiders"
             };
 
             internal static ICollection<string> Stable { get; } = new[]
@@ -49,6 +50,8 @@ namespace Cake.Common.Tools
         {
             var programFiles = (year, edition) switch
             {
+                ("18", "BuildTools") => environment.GetSpecialPath(SpecialPath.ProgramFilesX86),
+                ("18", _) => environment.GetSpecialPath(SpecialPath.ProgramFiles),
                 ("2022", "BuildTools") => environment.GetSpecialPath(SpecialPath.ProgramFilesX86),
                 ("2022", _) => environment.GetSpecialPath(SpecialPath.ProgramFiles),
                 (_, _) => environment.GetSpecialPath(SpecialPath.ProgramFilesX86),


### PR DESCRIPTION
**As discussed [here](https://github.com/orgs/cake-build/discussions/4657), there are some differences between VS2022 and VS2026:**

- Visual Studio 2026 **Insiders** is located at:
  - `C:\Program Files\Microsoft Visual Studio\18\Insiders\`
- MSBuild 18 and Build Tools are located at:
  - `C:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin\amd64\MSBuild.exe`
  - `C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin\amd64\MSBuild.exe`

**Notes:**
- The internal `VisualStudio.GetYearAndEditionRootPath` method can be renamed to avoid confusion.
- The internal `VisualStudio.Editions.Preview` can be split between VS2022 and VS2026 but it feels unnecessary.
- Fixes: https://github.com/cake-build/cake/issues/4658

This PR is loosely based on: https://github.com/cake-build/cake/pull/3465