### PR TITLE
GH4662: Fix colorization of console log output

### DIFF
--- a/src/Cake.Core.Tests/Unit/Diagnostics/CakeBuildLogTests.cs
+++ b/src/Cake.Core.Tests/Unit/Diagnostics/CakeBuildLogTests.cs
@@ -98,7 +98,7 @@ namespace Cake.Core.Tests.Unit.Diagnostics
 
                     // Then
                     Assert.Single(console.Messages);
-                    Assert.Equal("Hello World", console.Messages[0]);
+                    Assert.Equal("\u001b[37;1mHello World\u001b[0m", console.Messages[0]);
                 }
 
                 [Theory]

--- a/src/Cake.Core/Diagnostics/Console/AnsiConsoleRenderer.cs
+++ b/src/Cake.Core/Diagnostics/Console/AnsiConsoleRenderer.cs
@@ -68,37 +68,25 @@ namespace Cake.Core.Diagnostics
         public void Render(LogLevel level, string format, params object[] args)
         {
             var palette = _palette[level];
-            var tokens = FormatParser.Parse(format);
-
-            var colorize = !"{0}".Equals(format, StringComparison.Ordinal);
+            var (tokens, tokenArgs) = "{0}".Equals(format, StringComparison.Ordinal)
+                            ? ([
+                                    new LiteralToken(string.Format(format, args))
+                                ],
+                                [])
+                            : (FormatParser.Parse(format), args);
 
             foreach (var token in tokens)
             {
-                if (colorize)
-                {
-                    var colorEscapeCode = GetColorEscapeCode(token, palette);
-                    var content = token.Render(args);
+                var colorEscapeCode = GetColorEscapeCode(token, palette);
+                var content = token.Render(tokenArgs);
 
-                    if (level > LogLevel.Error)
-                    {
-                        _console.Write("{0}", $"{colorEscapeCode}{content}{ResetEscapeCode}");
-                    }
-                    else
-                    {
-                        _console.WriteError("{0}", $"{colorEscapeCode}{content}{ResetEscapeCode}");
-                    }
+                if (level > LogLevel.Error)
+                {
+                    _console.Write("{0}", $"{colorEscapeCode}{content}{ResetEscapeCode}");
                 }
                 else
                 {
-                    // Render without colorization.
-                    if (level > LogLevel.Error)
-                    {
-                        _console.Write("{0}", token.Render(args));
-                    }
-                    else
-                    {
-                        _console.WriteError("{0}", token.Render(args));
-                    }
+                    _console.WriteError("{0}", $"{colorEscapeCode}{content}{ResetEscapeCode}");
                 }
             }
 


### PR DESCRIPTION
* background color should be added for single argument too
* fixes #4662

Before:
<img width="657" height="128" alt="image" src="https://github.com/user-attachments/assets/05a3cdcc-39a4-4693-9087-2d9316820286" />

After:
<img width="521" height="111" alt="image" src="https://github.com/user-attachments/assets/0b7cdf4f-d8f6-42b6-9cd2-1a9d63d910fc" />
