### PR TITLE
GH4687: Trim leading hyphens from command-line argument keys in FrostingConfiguration

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -374,13 +374,17 @@ Task("Frosting-Integration-Tests")
         DotNetRun(test.Project.FullPath,
             new ProcessArgumentBuilder()
                 .AppendSwitchQuoted("--verbosity", "=", "quiet")
-                .AppendSwitchQuoted("--name", "=", "world"),
+                .AppendSwitchQuoted("--name", "=", "nothing"),
             new DotNetRunSettings
             {
                 Configuration = parameters.Configuration,
                 Framework = test.Framework,
                 NoRestore = true,
-                NoBuild = true
+                NoBuild = true,
+                EnvironmentVariables = new Dictionary<string, string>
+                {
+                    ["CAKE_NAME"] = "world",
+                }
             });
     }
     catch(Exception ex)

--- a/build.cake
+++ b/build.cake
@@ -373,8 +373,9 @@ Task("Frosting-Integration-Tests")
 
         DotNetRun(test.Project.FullPath,
             new ProcessArgumentBuilder()
-                .AppendSwitchQuoted("--verbosity", "=", "quiet")
-                .AppendSwitchQuoted("--name", "=", "nothing"),
+                .AppendSwitchQuoted("--verbosity", "=", Argument("integration-tests-verbosity", "quiet"))
+                .AppendSwitchQuoted("--name", "=", "World")
+                .AppendSwitchQuoted("--IntegrationTest_Argument", "=", bool.TrueString),
             new DotNetRunSettings
             {
                 Configuration = parameters.Configuration,
@@ -383,7 +384,7 @@ Task("Frosting-Integration-Tests")
                 NoBuild = true,
                 EnvironmentVariables = new Dictionary<string, string>
                 {
-                    ["CAKE_NAME"] = "world",
+                    ["CAKE_INTEGRATIONTEST_ENVIRONMENT"] = bool.TrueString,
                 }
             });
     }

--- a/src/Cake.Frosting.Template/Cake.Frosting.Template.csproj
+++ b/src/Cake.Frosting.Template/Cake.Frosting.Template.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>Cake.Frosting.Template</AssemblyName>
     <Title>Cake.Frosting templates for the .NET SDK.</Title>
     <Description>Cake.Frosting templates for the .NET SDK.</Description>
-    <TargetFramework>net8.0</TargetFramework>
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>content</ContentTargetFolders>
@@ -21,7 +20,7 @@
     <Compile Remove="**\*" />
   </ItemGroup>
 
-  <Target Name="VersionBuild" BeforeTargets="PrepareForBuild" Condition="'$(TemplateVersion)'!=''">
+  <Target Name="VersionBuild" BeforeTargets="DispatchToInnerBuilds" Condition="'$(TemplateVersion)'!=''">
    <XmlPoke XmlInputPath="templates\cakefrosting\build\Build.csproj" Query="Project/ItemGroup/PackageReference/@Version" Value="$(TemplateVersion)" />
   </Target>
 

--- a/src/Cake.Frosting.Tests/Cake.Frosting.Tests.csproj
+++ b/src/Cake.Frosting.Tests/Cake.Frosting.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Cake.Frosting\Cake.Frosting.csproj" />
     <ProjectReference Include="..\Cake.Testing\Cake.Testing.csproj" />
+    <ProjectReference Include="..\Cake.Testing.Xunit.v3\Cake.Testing.Xunit.v3.csproj" />
     <ProjectReference Include="..\Cake.Frosting.Tests.Tasks\Cake.Frosting.Tests.Tasks.csproj" />
   </ItemGroup>
 

--- a/src/Cake.Frosting.Tests/Unit/Internal/FrostingConfigurationTests.cs
+++ b/src/Cake.Frosting.Tests/Unit/Internal/FrostingConfigurationTests.cs
@@ -1,0 +1,484 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Frosting.Internal;
+using Cake.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Frosting.Tests.Unit.Internal
+{
+    public sealed class FrostingConfigurationTests
+    {
+        public sealed class TheConstructor
+        {
+            [Fact]
+            public void Should_Throw_If_Values_Is_Null()
+            {
+                // Given
+                var fileSystem = new FakeFileSystem(FakeEnvironment.CreateUnixEnvironment());
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+                var arguments = Substitute.For<ICakeArguments>();
+                arguments.GetArguments().Returns(new Dictionary<string, ICollection<string>>());
+
+                // When
+                var result = Record.Exception(() => new FrostingConfiguration(null, fileSystem, environment, arguments));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "values");
+            }
+
+            [Fact]
+            public void Should_Throw_If_FileSystem_Is_Null()
+            {
+                // Given
+                var values = new List<FrostingConfigurationValue>();
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+                var arguments = Substitute.For<ICakeArguments>();
+                arguments.GetArguments().Returns(new Dictionary<string, ICollection<string>>());
+
+                // When
+                var result = Record.Exception(() => new FrostingConfiguration(values, null, environment, arguments));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "fileSystem");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Environment_Is_Null()
+            {
+                // Given
+                var values = new List<FrostingConfigurationValue>();
+                var fileSystem = new FakeFileSystem(FakeEnvironment.CreateUnixEnvironment());
+                var arguments = Substitute.For<ICakeArguments>();
+                arguments.GetArguments().Returns(new Dictionary<string, ICollection<string>>());
+
+                // When
+                var result = Record.Exception(() => new FrostingConfiguration(values, fileSystem, null, arguments));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "environment");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Arguments_Is_Null()
+            {
+                // Given
+                var values = new List<FrostingConfigurationValue>();
+                var fileSystem = new FakeFileSystem(FakeEnvironment.CreateUnixEnvironment());
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+
+                // When
+                var result = Record.Exception(() => new FrostingConfiguration(values, fileSystem, environment, null));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "arguments");
+            }
+
+            [Fact]
+            public void Should_Create_Configuration_With_Empty_Values()
+            {
+                // Given
+                var values = new List<FrostingConfigurationValue>();
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+                var fileSystem = new FakeFileSystem(environment);
+                var arguments = Substitute.For<ICakeArguments>();
+                arguments.GetArguments().Returns(new Dictionary<string, ICollection<string>>());
+
+                // When
+                var result = new FrostingConfiguration(values, fileSystem, environment, arguments);
+
+                // Then
+                Assert.NotNull(result);
+            }
+
+            [Fact]
+            public void Should_Initialize_With_Provided_FrostingConfigurationValue_Values()
+            {
+                // Given
+                var values = new List<FrostingConfigurationValue>
+                {
+                    new FrostingConfigurationValue("TestKey1", "TestValue1"),
+                    new FrostingConfigurationValue("TestKey2", "TestValue2")
+                };
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+                var fileSystem = new FakeFileSystem(environment);
+                var arguments = Substitute.For<ICakeArguments>();
+                arguments.GetArguments().Returns(new Dictionary<string, ICollection<string>>());
+
+                // When
+                var result = new FrostingConfiguration(values, fileSystem, environment, arguments);
+
+                // Then
+                Assert.Equal("TestValue1", result.GetValue("TestKey1"));
+                Assert.Equal("TestValue2", result.GetValue("TestKey2"));
+            }
+        }
+
+        public sealed class TheGetValueMethod
+        {
+            [Fact]
+            public void Should_Return_Value_From_FrostingConfigurationValue()
+            {
+                // Given
+                var values = new List<FrostingConfigurationValue>
+                {
+                    new FrostingConfigurationValue("MyKey", "MyValue")
+                };
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+                var fileSystem = new FakeFileSystem(environment);
+                var arguments = Substitute.For<ICakeArguments>();
+                arguments.GetArguments().Returns(new Dictionary<string, ICollection<string>>());
+
+                var configuration = new FrostingConfiguration(values, fileSystem, environment, arguments);
+
+                // When
+                var result = configuration.GetValue("MyKey");
+
+                // Then
+                Assert.Equal("MyValue", result);
+            }
+
+            [Fact]
+            public void Should_Return_Value_Regardless_Of_Casing()
+            {
+                // Given
+                var values = new List<FrostingConfigurationValue>
+                {
+                    new FrostingConfigurationValue("MyKey", "MyValue")
+                };
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+                var fileSystem = new FakeFileSystem(environment);
+                var arguments = Substitute.For<ICakeArguments>();
+                arguments.GetArguments().Returns(new Dictionary<string, ICollection<string>>());
+
+                var configuration = new FrostingConfiguration(values, fileSystem, environment, arguments);
+
+                // When
+                var result = configuration.GetValue("mykey");
+
+                // Then
+                Assert.Equal("MyValue", result);
+            }
+
+            [Fact]
+            public void Should_Return_Null_For_Non_Existent_Key()
+            {
+                // Given
+                var values = new List<FrostingConfigurationValue>();
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+                var fileSystem = new FakeFileSystem(environment);
+                var arguments = Substitute.For<ICakeArguments>();
+                arguments.GetArguments().Returns(new Dictionary<string, ICollection<string>>());
+
+                var configuration = new FrostingConfiguration(values, fileSystem, environment, arguments);
+
+                // When
+                var result = configuration.GetValue("NonExistentKey");
+
+                // Then
+                Assert.Null(result);
+            }
+
+            [Fact]
+            public void Should_Return_Value_From_Environment_Variables()
+            {
+                // Given
+                var values = new List<FrostingConfigurationValue>();
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+                environment.SetEnvironmentVariable("CAKE_FOO", "BarFromEnv");
+                var fileSystem = new FakeFileSystem(environment);
+                var arguments = Substitute.For<ICakeArguments>();
+                arguments.GetArguments().Returns(new Dictionary<string, ICollection<string>>());
+
+                var configuration = new FrostingConfiguration(values, fileSystem, environment, arguments);
+
+                // When
+                var result = configuration.GetValue("FOO");
+
+                // Then
+                Assert.Equal("BarFromEnv", result);
+            }
+
+            [Fact]
+            public void Should_Return_Value_From_Configuration_File()
+            {
+                // Given
+                var values = new List<FrostingConfigurationValue>();
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+                var fileSystem = new FakeFileSystem(environment);
+                fileSystem.CreateFile("/Working/cake.config").SetContent("ConfigKey=ConfigValue");
+                var arguments = Substitute.For<ICakeArguments>();
+                arguments.GetArguments().Returns(new Dictionary<string, ICollection<string>>());
+
+                var configuration = new FrostingConfiguration(values, fileSystem, environment, arguments);
+
+                // When
+                var result = configuration.GetValue("ConfigKey");
+
+                // Then
+                Assert.Equal("ConfigValue", result);
+            }
+
+            [Fact]
+            public void Should_Return_Value_From_Arguments()
+            {
+                // Given
+                var values = new List<FrostingConfigurationValue>();
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+                var fileSystem = new FakeFileSystem(environment);
+                var arguments = Substitute.For<ICakeArguments>();
+                var argumentDict = new Dictionary<string, ICollection<string>>
+                {
+                    { "ArgKey", new List<string> { "ArgValue" } }
+                };
+                arguments.GetArguments().Returns(argumentDict);
+
+                var configuration = new FrostingConfiguration(values, fileSystem, environment, arguments);
+
+                // When
+                var result = configuration.GetValue("ArgKey");
+
+                // Then
+                Assert.Equal("ArgValue", result);
+            }
+
+            [Fact]
+            public void Should_Handle_Empty_String_Argument_Value()
+            {
+                // Given
+                var values = new List<FrostingConfigurationValue>();
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+                var fileSystem = new FakeFileSystem(environment);
+                var arguments = Substitute.For<ICakeArguments>();
+                var argumentDict = new Dictionary<string, ICollection<string>>
+                {
+                    { "EmptyKey", new List<string>() }
+                };
+                arguments.GetArguments().Returns(argumentDict);
+
+                var configuration = new FrostingConfiguration(values, fileSystem, environment, arguments);
+
+                // When
+                var result = configuration.GetValue("EmptyKey");
+
+                // Then
+                Assert.Equal(string.Empty, result);
+            }
+
+            [Fact]
+            public void Should_Handle_Null_Argument_Value()
+            {
+                // Given
+                var values = new List<FrostingConfigurationValue>();
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+                var fileSystem = new FakeFileSystem(environment);
+                var arguments = Substitute.For<ICakeArguments>();
+                var argumentDict = new Dictionary<string, ICollection<string>>
+                {
+                    { "NullKey", new List<string> { null } }
+                };
+                arguments.GetArguments().Returns(argumentDict);
+
+                var configuration = new FrostingConfiguration(values, fileSystem, environment, arguments);
+
+                // When
+                var result = configuration.GetValue("NullKey");
+
+                // Then
+                Assert.Equal(string.Empty, result);
+            }
+
+            [Fact]
+            public void Should_Use_FrostingConfigurationValue_When_No_Other_Source_Provides_Value()
+            {
+                // Given
+                var values = new List<FrostingConfigurationValue>
+                {
+                    new FrostingConfigurationValue("OnlyInBase", "BaseValue")
+                };
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+                var fileSystem = new FakeFileSystem(environment);
+                var arguments = Substitute.For<ICakeArguments>();
+                arguments.GetArguments().Returns(new Dictionary<string, ICollection<string>>());
+
+                var configuration = new FrostingConfiguration(values, fileSystem, environment, arguments);
+
+                // When
+                var result = configuration.GetValue("OnlyInBase");
+
+                // Then
+                Assert.Equal("BaseValue", result);
+            }
+
+            [Fact]
+            public void Should_Override_FrostingConfigurationValue_With_Environment_Variable()
+            {
+                // Given
+                var values = new List<FrostingConfigurationValue>
+                {
+                    new FrostingConfigurationValue("OverrideKey", "BaseValue")
+                };
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+                environment.SetEnvironmentVariable("CAKE_OverrideKey", "EnvValue");
+                var fileSystem = new FakeFileSystem(environment);
+                var arguments = Substitute.For<ICakeArguments>();
+                arguments.GetArguments().Returns(new Dictionary<string, ICollection<string>>());
+
+                var configuration = new FrostingConfiguration(values, fileSystem, environment, arguments);
+
+                // When
+                var result = configuration.GetValue("OverrideKey");
+
+                // Then
+                Assert.Equal("EnvValue", result);
+            }
+
+            [Fact]
+            public void Should_Override_FrostingConfigurationValue_And_Environment_Variable_With_Config_File()
+            {
+                // Given
+                var values = new List<FrostingConfigurationValue>
+                {
+                    new FrostingConfigurationValue("OverrideKey", "BaseValue")
+                };
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+                environment.SetEnvironmentVariable("CAKE_OverrideKey", "EnvValue");
+                var fileSystem = new FakeFileSystem(environment);
+                fileSystem.CreateFile("/Working/cake.config").SetContent("OverrideKey=ConfigValue");
+                var arguments = Substitute.For<ICakeArguments>();
+                arguments.GetArguments().Returns(new Dictionary<string, ICollection<string>>());
+
+                var configuration = new FrostingConfiguration(values, fileSystem, environment, arguments);
+
+                // When
+                var result = configuration.GetValue("OverrideKey");
+
+                // Then
+                Assert.Equal("ConfigValue", result);
+            }
+
+            [Fact]
+            public void Should_Override_All_Other_Sources_With_Argument()
+            {
+                // Given
+                var values = new List<FrostingConfigurationValue>
+                {
+                    new FrostingConfigurationValue("OverrideKey", "BaseValue")
+                };
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+                environment.SetEnvironmentVariable("CAKE_OverrideKey", "EnvValue");
+                var fileSystem = new FakeFileSystem(environment);
+                fileSystem.CreateFile("/Working/cake.config").SetContent("OverrideKey=ConfigValue");
+                var arguments = Substitute.For<ICakeArguments>();
+                var argumentDict = new Dictionary<string, ICollection<string>>
+                {
+                    { "OverrideKey", new List<string> { "ArgValue" } }
+                };
+                arguments.GetArguments().Returns(argumentDict);
+
+                var configuration = new FrostingConfiguration(values, fileSystem, environment, arguments);
+
+                // When
+                var result = configuration.GetValue("OverrideKey");
+
+                // Then
+                Assert.Equal("ArgValue", result);
+            }
+
+            [Fact]
+            public void Should_Handle_Multiple_FrostingConfigurationValue_Values()
+            {
+                // Given
+                var values = new List<FrostingConfigurationValue>
+                {
+                    new FrostingConfigurationValue("Key1", "Value1"),
+                    new FrostingConfigurationValue("Key2", "Value2"),
+                    new FrostingConfigurationValue("Key3", "Value3")
+                };
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+                var fileSystem = new FakeFileSystem(environment);
+                var arguments = Substitute.For<ICakeArguments>();
+                arguments.GetArguments().Returns(new Dictionary<string, ICollection<string>>());
+
+                var configuration = new FrostingConfiguration(values, fileSystem, environment, arguments);
+
+                // When & Then
+                Assert.Equal("Value1", configuration.GetValue("Key1"));
+                Assert.Equal("Value2", configuration.GetValue("Key2"));
+                Assert.Equal("Value3", configuration.GetValue("Key3"));
+            }
+
+            [Fact]
+            public void Should_Use_Last_Value_When_FrostingConfigurationValue_Has_Duplicate_Keys()
+            {
+                // Given
+                var values = new List<FrostingConfigurationValue>
+                {
+                    new FrostingConfigurationValue("DuplicateKey", "FirstValue"),
+                    new FrostingConfigurationValue("DuplicateKey", "SecondValue")
+                };
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+                var fileSystem = new FakeFileSystem(environment);
+                var arguments = Substitute.For<ICakeArguments>();
+                arguments.GetArguments().Returns(new Dictionary<string, ICollection<string>>());
+
+                var configuration = new FrostingConfiguration(values, fileSystem, environment, arguments);
+
+                // When
+                var result = configuration.GetValue("DuplicateKey");
+
+                // Then
+                Assert.Equal("SecondValue", result);
+            }
+
+            [Fact]
+            public void Should_Handle_Configuration_With_Sections_From_File()
+            {
+                // Given
+                var values = new List<FrostingConfigurationValue>();
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+                var fileSystem = new FakeFileSystem(environment);
+                fileSystem.CreateFile("/Working/cake.config").SetContent("[Section]\nKey=Value");
+                var arguments = Substitute.For<ICakeArguments>();
+                arguments.GetArguments().Returns(new Dictionary<string, ICollection<string>>());
+
+                var configuration = new FrostingConfiguration(values, fileSystem, environment, arguments);
+
+                // When
+                var result = configuration.GetValue("Section_Key");
+
+                // Then
+                Assert.Equal("Value", result);
+            }
+
+            [Fact]
+            public void Should_Take_First_Argument_Value_When_Multiple_Values_Provided()
+            {
+                // Given
+                var values = new List<FrostingConfigurationValue>();
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+                var fileSystem = new FakeFileSystem(environment);
+                var arguments = Substitute.For<ICakeArguments>();
+                var argumentDict = new Dictionary<string, ICollection<string>>
+                {
+                    { "MultiKey", new List<string> { "FirstValue", "SecondValue", "ThirdValue" } }
+                };
+                arguments.GetArguments().Returns(argumentDict);
+
+                var configuration = new FrostingConfiguration(values, fileSystem, environment, arguments);
+
+                // When
+                var result = configuration.GetValue("MultiKey");
+
+                // Then
+                Assert.Equal("FirstValue", result);
+            }
+        }
+    }
+}

--- a/src/Cake.Frosting/Internal/FrostingConfiguration.cs
+++ b/src/Cake.Frosting/Internal/FrostingConfiguration.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using Cake.Core;
 using Cake.Core.Configuration;
 using Cake.Core.IO;
-using Spectre.Console.Cli;
 
 namespace Cake.Frosting.Internal
 {
@@ -16,13 +15,15 @@ namespace Cake.Frosting.Internal
     {
         private readonly ICakeConfiguration _cakeConfiguration;
 
-        public FrostingConfiguration(IEnumerable<FrostingConfigurationValue> values, IFileSystem fileSystem, ICakeEnvironment environment, IRemainingArguments remainingArguments)
+        public FrostingConfiguration(IEnumerable<FrostingConfigurationValue> values, IFileSystem fileSystem, ICakeEnvironment environment, ICakeArguments arguments)
         {
             ArgumentNullException.ThrowIfNull(values);
 
             ArgumentNullException.ThrowIfNull(fileSystem);
 
             ArgumentNullException.ThrowIfNull(environment);
+
+            ArgumentNullException.ThrowIfNull(arguments);
 
             var baseConfiguration = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             foreach (var value in values)
@@ -31,7 +32,7 @@ namespace Cake.Frosting.Internal
             }
 
             var provider = new CakeConfigurationProvider(fileSystem, environment);
-            var args = remainingArguments.Parsed.ToDictionary(x => x.Key, x => x.FirstOrDefault() ?? string.Empty);
+            var args = arguments.GetArguments().ToDictionary(x => x.Key, x => x.Value?.FirstOrDefault() ?? string.Empty);
 
             _cakeConfiguration = provider.CreateConfiguration(environment.WorkingDirectory, baseConfiguration, args);
         }

--- a/src/Cake.Frosting/Properties/AssemblyInfo.cs
+++ b/src/Cake.Frosting/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Cake.Frosting.Tests")]

--- a/tests/integration/Cake.Frosting/build/Build.csproj
+++ b/tests/integration/Cake.Frosting/build/Build.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Cake.Frosting\Cake.Frosting.csproj" />
+    <PackageReference Include="xunit.v3.assert" Version="3.2.1" />
   </ItemGroup>
 
 </Project>

--- a/tests/integration/Cake.Frosting/build/Program.cs
+++ b/tests/integration/Cake.Frosting/build/Program.cs
@@ -14,6 +14,6 @@ public class Program : IFrostingStartup
         services.UseContext<Context>();
         services.UseLifetime<Lifetime>();
         services.UseTool(new System.Uri("nuget:?package=xunit.runner.console"));
-        services.UseWorkingDirectory("..");
+        services.UseWorkingDirectory(".");
     }
 }

--- a/tests/integration/Cake.Frosting/build/Tasks/Config.cs
+++ b/tests/integration/Cake.Frosting/build/Tasks/Config.cs
@@ -1,0 +1,38 @@
+using Cake.Common.Diagnostics;
+using Cake.Frosting;
+using Xunit;
+
+[TaskName(nameof(Config))]
+public sealed class Config : FrostingTask<Context>
+{
+    private const string IntegrationTestEnvironment = "IntegrationTest_Environment";
+    private const string IntegrationTestIniFile = "IntegrationTest_IniFile";
+    private const string IntegrationTestArgument = "IntegrationTest_Argument";
+
+    public override void Run(Context context)
+    {
+        // Given / When
+        var result = IntegrationTest.FromContext(context);
+        context.Verbose(logAction=>logAction("IntegrationTest: {0}", result));
+
+        // Then
+        Assert.Equal(IntegrationTest.Expected, result);
+    }
+
+    public record IntegrationTest(string Environment, string IniFile, string Argument)
+    {
+        public static IntegrationTest Expected {get; } = new IntegrationTest(
+            bool.TrueString,
+            bool.TrueString,
+            bool.TrueString
+            );
+        public static IntegrationTest FromContext(Context context)
+        {
+            return new IntegrationTest(
+                context.Configuration.GetValue(IntegrationTestEnvironment),
+                context.Configuration.GetValue(IntegrationTestIniFile),
+                context.Configuration.GetValue(IntegrationTestArgument)
+            );
+        }
+    }
+}

--- a/tests/integration/Cake.Frosting/build/Tasks/Default.cs
+++ b/tests/integration/Cake.Frosting/build/Tasks/Default.cs
@@ -1,7 +1,7 @@
 using Cake.Frosting;
 
 [IsDependentOn(typeof(Hello))]
-[IsDependentOn(typeof(ConfigurationFromArguments))]
+[IsDependentOn(typeof(Config))]
 public sealed class Default : FrostingTask<Context>
 {
 }

--- a/tests/integration/Cake.Frosting/build/Tasks/Default.cs
+++ b/tests/integration/Cake.Frosting/build/Tasks/Default.cs
@@ -1,6 +1,7 @@
 using Cake.Frosting;
 
 [IsDependentOn(typeof(Hello))]
+[IsDependentOn(typeof(ConfigurationFromArguments))]
 public sealed class Default : FrostingTask<Context>
 {
 }

--- a/tests/integration/Cake.Frosting/build/Tasks/Hello.cs
+++ b/tests/integration/Cake.Frosting/build/Tasks/Hello.cs
@@ -2,7 +2,7 @@ using Cake.Common;
 using Cake.Common.Diagnostics;
 using Cake.Frosting;
 
-[TaskName("Hello")]
+[TaskName(nameof(Hello))]
 public sealed class Hello : FrostingTask<Context>
 {
     public override void Run(Context context)

--- a/tests/integration/Cake.Frosting/cake.config
+++ b/tests/integration/Cake.Frosting/cake.config
@@ -1,2 +1,5 @@
 [Paths]
 Tools=../tools/frostingtools
+
+[IntegrationTest]
+IniFile=True


### PR DESCRIPTION
Trim leading hyphens from command-line argument keys in the
`FrostingConfiguration.cs` file to ensure consistent key
formatting when processing arguments. This change improves
compatibility and standardization in the `args` dictionary.

Addresses https://github.com/orgs/cake-build/discussions/4665
