### PR TITLE
GH4635: Fix DotCover no longer works with version 2025.2

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotCover/Cover/DotCoverCovererTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotCover/Cover/DotCoverCovererTests.cs
@@ -4,6 +4,7 @@
 
 using Cake.Common.Tests.Fixtures.Tools.DotCover.Cover;
 using Cake.Common.Tools.DotCover;
+using Cake.Common.Tools.DotCover.Cover;
 using Cake.Common.Tools.NUnit;
 using Cake.Common.Tools.XUnit;
 using Cake.Core.IO;
@@ -96,9 +97,9 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("Cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
-                             "/TargetArguments=\"-argument\" " +
-                             "/Output=\"/Working/result.dcvr\"", result.Args);
+                Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
+                             "--target-arguments \"-argument\" " +
+                             "--snapshot-output \"/Working/result.dcvr\"", result.Args);
             }
 
             [Theory]
@@ -122,8 +123,8 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("Cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
-                             "/Output=\"/Working/result.dcvr\"", result.Args);
+                Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
+                             "--snapshot-output \"/Working/result.dcvr\"", result.Args);
             }
 
             [Fact]
@@ -137,10 +138,10 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("Cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
-                             "/TargetArguments=\"-argument\" " +
-                             "/Output=\"/Working/result.dcvr\" " +
-                             "/TargetWorkingDir=\"/Working\"", result.Args);
+                Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
+                             "--target-arguments \"-argument\" " +
+                             "--snapshot-output \"/Working/result.dcvr\" " +
+                             "--target-working-directory \"/Working\"", result.Args);
             }
 
             [Fact]
@@ -155,9 +156,9 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("Cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
-                             "/TargetArguments=\"-argument\" " +
-                             "/Output=\"/Working/result.dcvr\" " +
+                Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
+                             "--target-arguments \"-argument\" " +
+                             "--snapshot-output \"/Working/result.dcvr\" " +
                              "/Scope=\"/Working/*.dll;/Some/**/Other/*.dll\"", result.Args);
             }
 
@@ -173,9 +174,9 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("Cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
-                             "/TargetArguments=\"-argument\" " +
-                             "/Output=\"/Working/result.dcvr\" " +
+                Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
+                             "--target-arguments \"-argument\" " +
+                             "--snapshot-output \"/Working/result.dcvr\" " +
                              "/Filters=\"+:module=Test.*;-:myassembly\"", result.Args);
             }
 
@@ -191,9 +192,9 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("Cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
-                             "/TargetArguments=\"-argument\" " +
-                             "/Output=\"/Working/result.dcvr\" " +
+                Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
+                             "--target-arguments \"-argument\" " +
+                             "--snapshot-output \"/Working/result.dcvr\" " +
                              "/AttributeFilters=\"filter1;filter2\"", result.Args);
             }
 
@@ -208,9 +209,9 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("Cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
-                             "/TargetArguments=\"-argument\" " +
-                             "/Output=\"/Working/result.dcvr\" " +
+                Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
+                             "--target-arguments \"-argument\" " +
+                             "--snapshot-output \"/Working/result.dcvr\" " +
                              "/DisableDefaultFilters", result.Args);
             }
 
@@ -226,9 +227,9 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("Cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
-                             "/TargetArguments=\"-argument\" " +
-                             "/Output=\"/Working/result.dcvr\" " +
+                Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
+                             "--target-arguments \"-argument\" " +
+                             "--snapshot-output \"/Working/result.dcvr\" " +
                              "/ProcessFilters=\"+:test.exe;-:sqlservr.exe\"", result.Args);
             }
 
@@ -249,9 +250,9 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("Cover /TargetExecutable=\"/Working/tools/xunit.console.exe\" " +
-                             "/TargetArguments=\"\\\"/Working/Test.dll\\\" -noshadow\" " +
-                             "/Output=\"/Working/result.dcvr\"", result.Args);
+                Assert.Equal("cover --target-executable \"/Working/tools/xunit.console.exe\" " +
+                             "--target-arguments \"\\\"/Working/Test.dll\\\" -noshadow\" " +
+                             "--snapshot-output \"/Working/result.dcvr\"", result.Args);
             }
 
             [Fact]
@@ -271,9 +272,9 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("Cover /TargetExecutable=\"/Working/tools/nunit-console.exe\" " +
-                             "/TargetArguments=\"\\\"/Working/Test.dll\\\" -noshadow\" " +
-                             "/Output=\"/Working/result.dcvr\"", result.Args);
+                Assert.Equal("cover --target-executable \"/Working/tools/nunit-console.exe\" " +
+                             "--target-arguments \"\\\"/Working/Test.dll\\\" -noshadow\" " +
+                             "--snapshot-output \"/Working/result.dcvr\"", result.Args);
             }
 
             [Fact]
@@ -287,9 +288,251 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("Cover \"/Working/config.xml\" /TargetExecutable=\"/Working/tools/Test.exe\" " +
+                Assert.Equal("cover \"/Working/config.xml\" --target-executable \"/Working/tools/Test.exe\" " +
+                             "--target-arguments \"-argument\" " +
+                             "--snapshot-output \"/Working/result.dcvr\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_ExcludeAssemblies()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.WithExcludeAssembly("*.Tests")
+                    .WithExcludeAssembly("Test.*");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
+                             "--target-arguments \"-argument\" " +
+                             "--snapshot-output \"/Working/result.dcvr\" " +
+                             "--exclude-assemblies \"*.Tests,Test.*\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_ExcludeAttributes()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.WithExcludeAttribute("System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute")
+                    .WithExcludeAttribute("Custom.*Attribute");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
+                             "--target-arguments \"-argument\" " +
+                             "--snapshot-output \"/Working/result.dcvr\" " +
+                             "--exclude-attributes \"System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute,Custom.*Attribute\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_ExcludeProcesses()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.WithExcludeProcess("test.exe")
+                    .WithExcludeProcess("*.vshost.exe");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
+                             "--target-arguments \"-argument\" " +
+                             "--snapshot-output \"/Working/result.dcvr\" " +
+                             "--exclude-processes \"test.exe,*.vshost.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_JsonReportOutput()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.WithJsonReportOutput(new FilePath("/Working/coverage.json"));
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
+                             "--target-arguments \"-argument\" " +
+                             "--snapshot-output \"/Working/result.dcvr\" " +
+                             "--json-report-output \"/Working/coverage.json\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_JsonReportCoveringTestsScope()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.WithJsonReportCoveringTestsScope(DotCoverReportScope.Method);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
+                             "--target-arguments \"-argument\" " +
+                             "--snapshot-output \"/Working/result.dcvr\" " +
+                             "--json-report-covering-tests-scope \"method\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_XmlReportOutput()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.WithXmlReportOutput(new FilePath("/Working/coverage.xml"));
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
+                             "--target-arguments \"-argument\" " +
+                             "--snapshot-output \"/Working/result.dcvr\" " +
+                             "--xml-report-output \"/Working/coverage.xml\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_XmlReportCoveringTestsScope()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.WithXmlReportCoveringTestsScope(DotCoverReportScope.Statement);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
+                             "--target-arguments \"-argument\" " +
+                             "--snapshot-output \"/Working/result.dcvr\" " +
+                             "--xml-report-covering-tests-scope \"statement\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_TemporaryDirectory()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.WithTemporaryDirectory(new DirectoryPath("/Working/temp"));
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
+                             "--target-arguments \"-argument\" " +
+                             "--snapshot-output \"/Working/result.dcvr\" " +
+                             "--temporary-directory \"/Working/temp\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_UseApi()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.WithUseApi();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
+                             "--target-arguments \"-argument\" " +
+                             "--snapshot-output \"/Working/result.dcvr\" " +
+                             "--use-api", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_NoNGen()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.WithNoNGen();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
+                             "--target-arguments \"-argument\" " +
+                             "--snapshot-output \"/Working/result.dcvr\" " +
+                             "--no-ngen", result.Args);
+            }
+
+            [Fact]
+            public void Should_Use_Legacy_Syntax_When_Enabled()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.WithLegacySyntax();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
                              "/TargetArguments=\"-argument\" " +
                              "/Output=\"/Working/result.dcvr\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Use_New_Syntax_By_Default()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                // Don't set UseLegacySyntax - should default to false
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
+                             "--target-arguments \"-argument\" " +
+                             "--snapshot-output \"/Working/result.dcvr\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Support_New_Features_In_Legacy_Mode()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.WithLegacySyntax()
+                    .WithJsonReportOutput(new FilePath("/Working/report.json"))
+                    .WithExcludeAssembly("*.Tests");
+
+                // When
+                var result = fixture.Run();
+
+                // Then - New format features should not appear in legacy mode
+                Assert.Equal("cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
+                             "/TargetArguments=\"-argument\" " +
+                             "/Output=\"/Working/result.dcvr\"", result.Args);
+                Assert.DoesNotContain("--json-report-output", result.Args);
+                Assert.DoesNotContain("--exclude-assemblies", result.Args);
+            }
+
+            [Fact]
+            public void Should_Support_New_Features_In_New_Mode()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.WithJsonReportOutput(new FilePath("/Working/report.json"))
+                    .WithExcludeAssembly("*.Tests");
+
+                // When
+                var result = fixture.Run();
+
+                // Then - New format features should appear
+                Assert.Contains("--json-report-output \"/Working/report.json\"", result.Args);
+                Assert.Contains("--exclude-assemblies \"*.Tests\"", result.Args);
+                Assert.Contains("--snapshot-output", result.Args);
             }
         }
     }

--- a/src/Cake.Common/Tools/DotCover/Cover/DotCoverCoverSettings.cs
+++ b/src/Cake.Common/Tools/DotCover/Cover/DotCoverCoverSettings.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Core.IO;
+
 namespace Cake.Common.Tools.DotCover.Cover
 {
     /// <summary>
@@ -9,5 +11,54 @@ namespace Cake.Common.Tools.DotCover.Cover
     /// </summary>
     public sealed class DotCoverCoverSettings : DotCoverCoverageSettings
     {
+        /// <summary>
+        /// Gets or sets the path to save formatted JSON report.
+        /// This represents the <c>--json-report-output</c> option.
+        /// </summary>
+        public FilePath JsonReportOutput { get; set; }
+
+        /// <summary>
+        /// Gets or sets the granularity for including covering tests in JSON reports.
+        /// This represents the <c>--json-report-covering-tests-scope</c> option.
+        /// </summary>
+        public DotCoverReportScope? JsonReportCoveringTestsScope { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to save formatted XML report.
+        /// This represents the <c>--xml-report-output</c> option.
+        /// </summary>
+        public FilePath XmlReportOutput { get; set; }
+
+        /// <summary>
+        /// Gets or sets the granularity for including covering tests in XML reports.
+        /// This represents the <c>--xml-report-covering-tests-scope</c> option.
+        /// </summary>
+        public DotCoverReportScope? XmlReportCoveringTestsScope { get; set; }
+
+        /// <summary>
+        /// Gets or sets the directory for temporary files.
+        /// This represents the <c>--temporary-directory</c> option.
+        /// </summary>
+        public DirectoryPath TemporaryDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to control the coverage session using the profiler API.
+        /// This represents the <c>--use-api</c> option.
+        /// </summary>
+        public bool UseApi { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to disable loading of NGen images during coverage.
+        /// This represents the <c>--no-ngen</c> option.
+        /// </summary>
+        public bool NoNGen { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use the legacy command syntax.
+        /// When true, uses old format like '/TargetExecutable="/path"'.
+        /// When false, uses new format like '--target-executable "/path"'.
+        /// Default is false (new format).
+        /// </summary>
+        public bool UseLegacySyntax { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotCover/Cover/DotCoverCoverSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/DotCover/Cover/DotCoverCoverSettingsExtensions.cs
@@ -1,0 +1,119 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotCover.Cover
+{
+    /// <summary>
+    /// Contains extensions for <see cref="DotCoverCoverSettings"/>.
+    /// </summary>
+    public static class DotCoverCoverSettingsExtensions
+    {
+        /// <summary>
+        /// Sets the JSON report output path.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="outputPath">The JSON report output path.</param>
+        /// <returns>The same <see cref="DotCoverCoverSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotCoverCoverSettings WithJsonReportOutput(this DotCoverCoverSettings settings, FilePath outputPath)
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+            settings.JsonReportOutput = outputPath;
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the JSON report covering tests scope.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="scope">The granularity for including covering tests in JSON reports.</param>
+        /// <returns>The same <see cref="DotCoverCoverSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotCoverCoverSettings WithJsonReportCoveringTestsScope(this DotCoverCoverSettings settings, DotCoverReportScope scope)
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+            settings.JsonReportCoveringTestsScope = scope;
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the XML report output path.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="outputPath">The XML report output path.</param>
+        /// <returns>The same <see cref="DotCoverCoverSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotCoverCoverSettings WithXmlReportOutput(this DotCoverCoverSettings settings, FilePath outputPath)
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+            settings.XmlReportOutput = outputPath;
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the XML report covering tests scope.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="scope">The granularity for including covering tests in XML reports.</param>
+        /// <returns>The same <see cref="DotCoverCoverSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotCoverCoverSettings WithXmlReportCoveringTestsScope(this DotCoverCoverSettings settings, DotCoverReportScope scope)
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+            settings.XmlReportCoveringTestsScope = scope;
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the temporary directory for files.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="directory">The temporary directory path.</param>
+        /// <returns>The same <see cref="DotCoverCoverSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotCoverCoverSettings WithTemporaryDirectory(this DotCoverCoverSettings settings, DirectoryPath directory)
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+            settings.TemporaryDirectory = directory;
+            return settings;
+        }
+
+        /// <summary>
+        /// Enables control of the coverage session using the profiler API.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="useApi">Whether to use the API.</param>
+        /// <returns>The same <see cref="DotCoverCoverSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotCoverCoverSettings WithUseApi(this DotCoverCoverSettings settings, bool useApi = true)
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+            settings.UseApi = useApi;
+            return settings;
+        }
+
+        /// <summary>
+        /// Disables loading of NGen images during coverage.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="noNGen">Whether to disable NGen.</param>
+        /// <returns>The same <see cref="DotCoverCoverSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotCoverCoverSettings WithNoNGen(this DotCoverCoverSettings settings, bool noNGen = true)
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+            settings.NoNGen = noNGen;
+            return settings;
+        }
+
+        /// <summary>
+        /// Configures whether to use legacy command syntax.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="useLegacySyntax">Whether to use legacy syntax. Default is false (new syntax).</param>
+        /// <returns>The same <see cref="DotCoverCoverSettings"/> instance so that multiple calls can be chained.</returns>
+        public static DotCoverCoverSettings WithLegacySyntax(this DotCoverCoverSettings settings, bool useLegacySyntax = true)
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+            settings.UseLegacySyntax = useLegacySyntax;
+            return settings;
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotCover/Cover/DotCoverCoverer.cs
+++ b/src/Cake.Common/Tools/DotCover/Cover/DotCoverCoverer.cs
@@ -61,23 +61,163 @@ namespace Cake.Common.Tools.DotCover.Cover
         {
             var builder = new ProcessArgumentBuilder();
 
-            builder.Append("Cover");
+            // Command name - always lowercase 'cover' for both formats
+            builder.Append("cover");
 
             // Set configuration file if exists.
             GetConfigurationFileArgument(settings).CopyTo(builder);
 
-            // Get Target executable arguments
-            GetTargetArguments(context, action).CopyTo(builder);
+            if (settings.UseLegacySyntax)
+            {
+                // Use legacy format
+                GetTargetArguments(context, action).CopyTo(builder);
+                // Set the output file - legacy format
+                outputPath = outputPath.MakeAbsolute(_environment);
+                builder.AppendSwitch("/Output", "=", outputPath.FullPath.Quote());
+                // Get Coverage arguments - legacy format
+                GetCoverageArguments(settings).CopyTo(builder);
+                // Get base arguments - legacy format
+                GetArguments(settings).CopyTo(builder);
+            }
+            else
+            {
+                // Use new format
+                GetCoverTargetArguments(context, action).CopyTo(builder);
+                // Set the output file - new format
+                outputPath = outputPath.MakeAbsolute(_environment);
+                builder.AppendSwitch("--snapshot-output", outputPath.FullPath.Quote());
+                // Get Coverage arguments - new format
+                GetCoverCoverageArguments(settings).CopyTo(builder);
+                // New report options (only available in new format)
+                if (settings.JsonReportOutput != null)
+                {
+                    builder.AppendSwitch("--json-report-output", settings.JsonReportOutput.MakeAbsolute(_environment).FullPath.Quote());
+                }
 
-            // Set the output file.
-            outputPath = outputPath.MakeAbsolute(_environment);
-            builder.AppendSwitch("/Output", "=", outputPath.FullPath.Quote());
+                if (settings.JsonReportCoveringTestsScope.HasValue)
+                {
+                    builder.AppendSwitch("--json-report-covering-tests-scope", settings.JsonReportCoveringTestsScope.Value.ToString().ToLowerInvariant().Quote());
+                }
 
-            // Get Coverage arguments
-            GetCoverageArguments(settings).CopyTo(builder);
+                if (settings.XmlReportOutput != null)
+                {
+                    builder.AppendSwitch("--xml-report-output", settings.XmlReportOutput.MakeAbsolute(_environment).FullPath.Quote());
+                }
 
-            // Get base arguments
-            GetArguments(settings).CopyTo(builder);
+                if (settings.XmlReportCoveringTestsScope.HasValue)
+                {
+                    builder.AppendSwitch("--xml-report-covering-tests-scope", settings.XmlReportCoveringTestsScope.Value.ToString().ToLowerInvariant().Quote());
+                }
+
+                if (settings.TemporaryDirectory != null)
+                {
+                    builder.AppendSwitch("--temporary-directory", settings.TemporaryDirectory.MakeAbsolute(_environment).FullPath.Quote());
+                }
+
+                if (settings.UseApi)
+                {
+                    builder.Append("--use-api");
+                }
+
+                if (settings.NoNGen)
+                {
+                    builder.Append("--no-ngen");
+                }
+
+                // Get base arguments - new format
+                GetCoverArguments(settings).CopyTo(builder);
+            }
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Get arguments from coverage settings for Cover command (using new format).
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The process arguments.</returns>
+        private ProcessArgumentBuilder GetCoverCoverageArguments(DotCoverCoverageSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            // TargetWorkingDir - using new format for Cover command
+            if (settings.TargetWorkingDir != null)
+            {
+                builder.AppendSwitch("--target-working-directory", settings.TargetWorkingDir.MakeAbsolute(_environment).FullPath.Quote());
+            }
+
+            // New filtering options (only available in new format)
+            if (settings.ExcludeAssemblies.Count > 0)
+            {
+                var excludeAssemblies = string.Join(',', settings.ExcludeAssemblies);
+                builder.AppendSwitch("--exclude-assemblies", excludeAssemblies.Quote());
+            }
+
+            if (settings.ExcludeAttributes.Count > 0)
+            {
+                var excludeAttributes = string.Join(',', settings.ExcludeAttributes);
+                builder.AppendSwitch("--exclude-attributes", excludeAttributes.Quote());
+            }
+
+            if (settings.ExcludeProcesses.Count > 0)
+            {
+                var excludeProcesses = string.Join(',', settings.ExcludeProcesses);
+                builder.AppendSwitch("--exclude-processes", excludeProcesses.Quote());
+            }
+
+            // Legacy filtering options (maintain backward compatibility with old format)
+            // Scope
+            if (settings.Scope.Count > 0)
+            {
+                var scope = string.Join(';', settings.Scope);
+                builder.AppendSwitch("/Scope", "=", scope.Quote());
+            }
+
+            // Filters
+            if (settings.Filters.Count > 0)
+            {
+                var filters = string.Join(';', settings.Filters);
+                builder.AppendSwitch("/Filters", "=", filters.Quote());
+            }
+
+            // AttributeFilters
+            if (settings.AttributeFilters.Count > 0)
+            {
+                var attributeFilters = string.Join(';', settings.AttributeFilters);
+                builder.AppendSwitch("/AttributeFilters", "=", attributeFilters.Quote());
+            }
+
+            // ProcessFilters
+            if (settings.ProcessFilters.Count > 0)
+            {
+                var processFilters = string.Join(';', settings.ProcessFilters);
+                builder.AppendSwitch("/ProcessFilters", "=", processFilters.Quote());
+            }
+
+            // DisableDefaultFilters
+            if (settings.DisableDefaultFilters)
+            {
+                builder.Append("/DisableDefaultFilters");
+            }
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Get arguments from global settings for Cover command (using new format).
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The process arguments.</returns>
+        private ProcessArgumentBuilder GetCoverArguments(DotCoverSettings settings)
+        {
+            var builder = new ProcessArgumentBuilder();
+
+            // LogFile - using new format for Cover command
+            if (settings.LogFile != null)
+            {
+                var logFilePath = settings.LogFile.MakeAbsolute(_environment);
+                builder.AppendSwitch("--log-file", logFilePath.FullPath.Quote());
+            }
 
             return builder;
         }

--- a/src/Cake.Common/Tools/DotCover/DotCoverCoverageSettings.cs
+++ b/src/Cake.Common/Tools/DotCover/DotCoverCoverageSettings.cs
@@ -17,10 +17,13 @@ namespace Cake.Common.Tools.DotCover
         private readonly HashSet<string> _filters;
         private readonly HashSet<string> _processFilters;
         private readonly HashSet<string> _attributeFilters;
+        private readonly HashSet<string> _excludeAssemblies;
+        private readonly HashSet<string> _excludeAttributes;
+        private readonly HashSet<string> _excludeProcesses;
 
         /// <summary>
         /// Gets or sets program working directory
-        /// This represents the <c>/TargetWorkingDir</c> option.
+        /// This represents the <c>--target-working-directory</c> option for Cover command, <c>/TargetWorkingDir</c> for others.
         /// </summary>
         public DirectoryPath TargetWorkingDir { get; set; }
 
@@ -66,6 +69,34 @@ namespace Cake.Common.Tools.DotCover
         }
 
         /// <summary>
+        /// Gets assembly names to exclude from analysis. Wildcards (*) allowed.
+        /// This represents the <c>--exclude-assemblies</c> option.
+        /// </summary>
+        public ISet<string> ExcludeAssemblies
+        {
+            get { return _excludeAssemblies; }
+        }
+
+        /// <summary>
+        /// Gets fully qualified attribute names to exclude from analysis. Wildcards (*) allowed.
+        /// Code marked with these attributes will be excluded from coverage.
+        /// This represents the <c>--exclude-attributes</c> option.
+        /// </summary>
+        public ISet<string> ExcludeAttributes
+        {
+            get { return _excludeAttributes; }
+        }
+
+        /// <summary>
+        /// Gets process names to ignore during analysis. Wildcards (*) allowed.
+        /// This represents the <c>--exclude-processes</c> option.
+        /// </summary>
+        public ISet<string> ExcludeProcesses
+        {
+            get { return _excludeProcesses; }
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating whether the default (automatically added) filters should be disabled
         /// This represents the <c>/DisableDefaultFilters</c> option.
         /// </summary>
@@ -80,6 +111,9 @@ namespace Cake.Common.Tools.DotCover
             _filters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             _attributeFilters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             _processFilters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _excludeAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _excludeAttributes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _excludeProcesses = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Cake.Common/Tools/DotCover/DotCoverCoverageSettingsExtensions.cs
+++ b/src/Cake.Common/Tools/DotCover/DotCoverCoverageSettingsExtensions.cs
@@ -66,5 +66,47 @@ namespace Cake.Common.Tools.DotCover
             settings.ProcessFilters.Add(filter);
             return settings;
         }
+
+        /// <summary>
+        /// Adds an assembly name to exclude from analysis.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="assemblyName">The assembly name to exclude. Wildcards (*) are allowed.</param>
+        /// <typeparam name="T">The settings type, derived from <see cref="DotCoverCoverageSettings"/>.</typeparam>
+        /// <returns>The same <see cref="DotCoverCoverageSettings"/> instance so that multiple calls can be chained.</returns>
+        public static T WithExcludeAssembly<T>(this T settings, string assemblyName) where T : DotCoverCoverageSettings
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+            settings.ExcludeAssemblies.Add(assemblyName);
+            return settings;
+        }
+
+        /// <summary>
+        /// Adds a fully qualified attribute name to exclude from analysis.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="attributeName">The fully qualified attribute name. Wildcards (*) are allowed.</param>
+        /// <typeparam name="T">The settings type, derived from <see cref="DotCoverCoverageSettings"/>.</typeparam>
+        /// <returns>The same <see cref="DotCoverCoverageSettings"/> instance so that multiple calls can be chained.</returns>
+        public static T WithExcludeAttribute<T>(this T settings, string attributeName) where T : DotCoverCoverageSettings
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+            settings.ExcludeAttributes.Add(attributeName);
+            return settings;
+        }
+
+        /// <summary>
+        /// Adds a process name to ignore during analysis.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="processName">The process name to ignore. Wildcards (*) are allowed.</param>
+        /// <typeparam name="T">The settings type, derived from <see cref="DotCoverCoverageSettings"/>.</typeparam>
+        /// <returns>The same <see cref="DotCoverCoverageSettings"/> instance so that multiple calls can be chained.</returns>
+        public static T WithExcludeProcess<T>(this T settings, string processName) where T : DotCoverCoverageSettings
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+            settings.ExcludeProcesses.Add(processName);
+            return settings;
+        }
     }
 }

--- a/src/Cake.Common/Tools/DotCover/DotCoverCoverageTool.cs
+++ b/src/Cake.Common/Tools/DotCover/DotCoverCoverageTool.cs
@@ -34,6 +34,35 @@ namespace Cake.Common.Tools.DotCover
         }
 
         /// <summary>
+        /// Get arguments from the target executable for Cover command (using new format).
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="action">The action to run DotCover for.</param>
+        /// <returns>The process arguments.</returns>
+        protected ProcessArgumentBuilder GetCoverTargetArguments(ICakeContext context, Action<ICakeContext> action)
+        {
+            // Run the tool using the interceptor.
+            var targetContext = InterceptAction(context, action);
+
+            var builder = new ProcessArgumentBuilder();
+            // The target application to call.
+            builder.AppendSwitch("--target-executable", targetContext.FilePath.FullPath.Quote());
+
+            // The arguments to the target application.
+            if (targetContext.Settings != null && targetContext.Settings.Arguments != null)
+            {
+                var arguments = targetContext.Settings.Arguments.Render();
+                if (!string.IsNullOrWhiteSpace(arguments))
+                {
+                    arguments = arguments.Replace("\"", "\\\"");
+                    builder.AppendSwitch("--target-arguments", arguments.Quote());
+                }
+            }
+
+            return builder;
+        }
+
+        /// <summary>
         /// Get arguments from the target executable.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -99,7 +128,7 @@ namespace Cake.Common.Tools.DotCover
                 builder.AppendSwitch("/AttributeFilters", "=", attributeFilters.Quote());
             }
 
-            // Filters
+            // ProcessFilters
             if (settings.ProcessFilters.Count > 0)
             {
                 var processFilters = string.Join(';', settings.ProcessFilters);

--- a/src/Cake.Common/Tools/DotCover/DotCoverReportScope.cs
+++ b/src/Cake.Common/Tools/DotCover/DotCoverReportScope.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Tools.DotCover
+{
+    /// <summary>
+    /// Represents the granularity for including covering tests in reports.
+    /// </summary>
+    public enum DotCoverReportScope
+    {
+        /// <summary>
+        /// No covering tests included.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Include covering tests at assembly level.
+        /// </summary>
+        Assembly,
+
+        /// <summary>
+        /// Include covering tests at type level.
+        /// </summary>
+        Type,
+
+        /// <summary>
+        /// Include covering tests at method level.
+        /// </summary>
+        Method,
+
+        /// <summary>
+        /// Include covering tests at statement level.
+        /// </summary>
+        Statement
+    }
+}

--- a/src/Cake.Common/Tools/DotCover/DotCoverTool.cs
+++ b/src/Cake.Common/Tools/DotCover/DotCoverTool.cs
@@ -49,7 +49,7 @@ namespace Cake.Common.Tools.DotCover
         /// <returns>The tool executable name.</returns>
         protected override IEnumerable<string> GetToolExecutableNames()
         {
-            return new[] { "dotCover.exe" };
+            return new[] { "dotCover.exe", "dotCover", "dotcover" };
         }
 
         /// <summary>


### PR DESCRIPTION
* **Update DotCover implementation to use new command format and add support for new options**
* **Add alternative executable names for DotCover tool**
* **Fixes #4635**
