### PR TITLE
GH4675: Update Spectre.Console & Spectre.Console.Cli to 0.54.0 & 0.53.1

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -25,9 +25,9 @@
     <PackageVersion Include="NuGet.Protocol" Version="6.14.0" />
     <PackageVersion Include="NuGet.Resolver" Version="6.14.0" />
     <PackageVersion Include="NuGet.Versioning" Version="6.14.0" />
-    <PackageVersion Include="Spectre.Console" Version="0.53.0" />
-    <PackageVersion Include="Spectre.Console.Cli" Version="0.53.0" />
-    <PackageVersion Include="Spectre.Console.Testing" Version="0.53.0" />
+    <PackageVersion Include="Spectre.Console" Version="0.54.0" />
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.53.1" />
+    <PackageVersion Include="Spectre.Console.Testing" Version="0.54.0" />
     <PackageVersion Include="Spectre.Verify.Extensions" Version="28.16.0" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
     <PackageVersion Include="Verify.XunitV3" Version="31.8.0" />


### PR DESCRIPTION
* fixes #4675