### PR TITLE
GH4696: Update GitVersion.Tool to 6 & migrate config

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,18 +1,8 @@
+workflow: GitFlow/v1
 next-version: 6.0.0
 branches:
-  master:
-    regex: main
-    mode: ContinuousDelivery
-    tag:
-    increment: Patch
-    prevent-increment-of-merged-branch-version: true
-    track-merge-target: false
-  develop:
-    mode: ContinuousDeployment
-    tag: alpha
-    increment: Minor
-    prevent-increment-of-merged-branch-version: false
-    track-merge-target: true
+  main:
+    label: beta
 ignore:
   sha:
     - 2a4757b270f7946122ba6622e3d2e72b2b2808a7

--- a/build.cake
+++ b/build.cake
@@ -2,7 +2,7 @@
 #addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Twitter&version=6.0.0"
 
 // Install .NET Core Global tools.
-#tool "dotnet:https://api.nuget.org/v3/index.json?package=GitVersion.Tool&version=5.12.0"
+#tool "dotnet:https://api.nuget.org/v3/index.json?package=GitVersion.Tool&version=6.6.0"
 #tool "dotnet:https://api.nuget.org/v3/index.json?package=GitReleaseManager.Tool&version=0.20.0"
 #tool "dotnet:https://api.nuget.org/v3/index.json?package=sign&version=0.9.1-beta.25379.1&prerelease"
 

--- a/build/version.cake
+++ b/build/version.cake
@@ -44,7 +44,11 @@ public record BuildVersion(
                 });
 
                 version = context.EnvironmentVariable("GitVersion_MajorMinorPatch");
-                semVersion = context.EnvironmentVariable("GitVersion_LegacySemVerPadded");
+                var preReleaseNumberStr = context.EnvironmentVariable("GitVersion_PreReleaseNumber");
+                semVersion = GetLegacySemVerPadded(
+                    context.EnvironmentVariable("GitVersion_MajorMinorPatch"),
+                    context.EnvironmentVariable("GitVersion_PreReleaseLabel"),
+                    !string.IsNullOrEmpty(preReleaseNumberStr) && int.TryParse(preReleaseNumberStr, out int num) ? num : (int?)null);
                 milestone = string.Concat("v", version);
             }
 
@@ -58,7 +62,10 @@ public record BuildVersion(
             });
 
             version = assertedVersions.MajorMinorPatch;
-            semVersion = assertedVersions.LegacySemVerPadded;
+            semVersion = GetLegacySemVerPadded(
+                assertedVersions.MajorMinorPatch,
+                assertedVersions.PreReleaseLabel,
+                assertedVersions.PreReleaseNumber);
             milestone = string.Concat("v", version);
             branchName = assertedVersions.BranchName;
 
@@ -85,6 +92,28 @@ public record BuildVersion(
             CakeVersion: cakeVersion,
             BranchName: branchName
         );
+    }
+
+    /// <summary>
+    /// Constructs the LegacySemVerPadded format that was removed in GitVersion 6.0.0.
+    /// Format: {MajorMinorPatch}-{PreReleaseLabel}{PreReleaseNumber:D4}
+    /// Example: 6.1.0-alpha-0041
+    /// </summary>
+    private static string GetLegacySemVerPadded(string majorMinorPatch, string preReleaseLabel, int? preReleaseNumber)
+    {
+        if (string.IsNullOrEmpty(majorMinorPatch))
+        {
+            return string.Empty;
+        }
+
+        // If no pre-release label or number, return just the version
+        if (string.IsNullOrEmpty(preReleaseLabel) || !preReleaseNumber.HasValue)
+        {
+            return majorMinorPatch;
+        }
+
+        // Format with 4-digit padding
+        return $"{majorMinorPatch}-{preReleaseLabel}{preReleaseNumber.Value:D4}";
     }
 
     public static string ReadSolutionInfoVersion(ICakeContext context)


### PR DESCRIPTION
- Update GitVersion.Tool from 5.12.0 to 6.6.0
- Migrate GitVersion.yml for v6 compatibility (per PR feedback):
  * Set workflow: GitFlow/v1 and only override repo-specific values
  * Keep next-version: 6.0.0 and ignore.sha list
  * Override main branch with label: beta for untagged main builds
  * Remove previous branch config (master/develop) and deprecated
    properties (prevent-increment-of-merged-branch-version,
    track-merge-target); rely on GitFlow/v1 defaults
- Reconstruct LegacySemVerPadded format removed in GitVersion 6.0.0:
  * Add GetLegacySemVerPadded helper in build/version.cake
  * Format: {MajorMinorPatch}-{PreReleaseLabel}{PreReleaseNumber:D4}
    (e.g. 6.1.0-alpha0041)

- fixes #4696