### PR TITLE
GH4698: Add FormattableString support to logging methods

### DIFF
--- a/src/Cake.Common/Diagnostics/LoggingAliases.Disposable.cs
+++ b/src/Cake.Common/Diagnostics/LoggingAliases.Disposable.cs
@@ -1,0 +1,164 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.Diagnostics;
+
+namespace Cake.Common.Diagnostics;
+
+public static partial class LoggingAliases
+{
+    /// <summary>
+    /// Sets the log verbosity to quiet and returns a disposable that restores the log verbosity on dispose.
+    /// </summary>
+    /// <param name="context">the context.</param>
+    /// <returns>A disposable that restores the log verbosity.</returns>
+    /// <example>
+    /// <code>
+    /// using (QuietVerbosity())
+    /// {
+    ///     Error("Show me.");
+    ///     Warning("Hide me.");
+    ///     Information("Hide me.");
+    ///     Verbose("Hide me.");
+    ///     Debug("Hide me.");
+    /// }
+    /// </code>
+    /// </example>
+    [CakeMethodAlias]
+    [CakeAliasCategory("Verbosity")]
+    public static IDisposable QuietVerbosity(this ICakeContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return context.Log.QuietVerbosity();
+    }
+
+    /// <summary>
+    /// Sets the log verbosity to minimal and returns a disposable that restores the log verbosity on dispose.
+    /// </summary>
+    /// <param name="context">the context.</param>
+    /// <returns>A disposable that restores the log verbosity.</returns>
+    /// <example>
+    /// <code>
+    /// using (MinimalVerbosity())
+    /// {
+    ///     Error("Show me.");
+    ///     Warning("Show me.");
+    ///     Information("Hide me.");
+    ///     Verbose("Hide me.");
+    ///     Debug("Hide me.");
+    /// }
+    /// </code>
+    /// </example>
+    [CakeMethodAlias]
+    [CakeAliasCategory("Verbosity")]
+    public static IDisposable MinimalVerbosity(this ICakeContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return context.Log.MinimalVerbosity();
+    }
+
+    /// <summary>
+    /// Sets the log verbosity to normal and returns a disposable that restores the log verbosity on dispose.
+    /// </summary>
+    /// <param name="context">the context.</param>
+    /// <returns>A disposable that restores the log verbosity.</returns>
+    /// <example>
+    /// <code>
+    /// using (NormalVerbosity())
+    /// {
+    ///     Error("Show me.");
+    ///     Warning("Show me.");
+    ///     Information("Show me.");
+    ///     Verbose("Hide me.");
+    ///     Debug("Hide me.");
+    /// }
+    /// </code>
+    /// </example>
+    [CakeMethodAlias]
+    [CakeAliasCategory("Verbosity")]
+    public static IDisposable NormalVerbosity(this ICakeContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return context.Log.NormalVerbosity();
+    }
+
+    /// <summary>
+    /// Sets the log verbosity to verbose and returns a disposable that restores the log verbosity on dispose.
+    /// </summary>
+    /// <param name="context">the context.</param>
+    /// <returns>A disposable that restores the log verbosity.</returns>
+    /// <example>
+    /// <code>
+    /// using (VerboseVerbosity())
+    /// {
+    ///     Error("Show me.");
+    ///     Warning("Show me.");
+    ///     Information("Show me.");
+    ///     Verbose("Show me.");
+    ///     Debug("Hide me.");
+    /// }
+    /// </code>
+    /// </example>
+    [CakeMethodAlias]
+    [CakeAliasCategory("Verbosity")]
+    public static IDisposable VerboseVerbosity(this ICakeContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return context.Log.VerboseVerbosity();
+    }
+
+    /// <summary>
+    /// Sets the log verbosity to diagnostic and returns a disposable that restores the log verbosity on dispose.
+    /// </summary>
+    /// <param name="context">the context.</param>
+    /// <returns>A disposable that restores the log verbosity.</returns>
+    /// <example>
+    /// <code>
+    /// using (DiagnosticVerbosity())
+    /// {
+    ///     Error("Show me.");
+    ///     Warning("Show me.");
+    ///     Information("Show me.");
+    ///     Verbose("Show me.");
+    ///     Debug("Show me.");
+    /// }
+    /// </code>
+    /// </example>
+    [CakeMethodAlias]
+    [CakeAliasCategory("Verbosity")]
+    public static IDisposable DiagnosticVerbosity(this ICakeContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return context.Log.DiagnosticVerbosity();
+    }
+
+    /// <summary>
+    /// Sets the log verbosity as specified and returns a disposable that restores the log verbosity on dispose.
+    /// </summary>
+    /// <param name="context">The context.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <returns>A disposable that restores the log verbosity.</returns>
+    /// <example>
+    /// <code>
+    /// using (DiagnosticVerbosity())
+    /// {
+    ///     Error("Show me.");
+    ///     Warning("Show me.");
+    ///     Information("Show me.");
+    ///     Verbose("Show me.");
+    ///     Debug("Show me.");
+    /// }
+    /// </code>
+    /// </example>
+    [CakeMethodAlias]
+    [CakeAliasCategory("Verbosity")]
+    public static IDisposable WithVerbosity(this ICakeContext context, Verbosity verbosity)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return context.Log.WithVerbosity(verbosity);
+    }
+}

--- a/src/Cake.Common/Diagnostics/LoggingAliases.Formattable.cs
+++ b/src/Cake.Common/Diagnostics/LoggingAliases.Formattable.cs
@@ -1,0 +1,189 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.Diagnostics;
+
+namespace Cake.Common.Diagnostics;
+
+public static partial class LoggingAliases
+{
+    /// <summary>
+    /// Writes an error message to the log using the specified format information.
+    /// </summary>
+    /// <param name="context">The context.</param>
+    /// <param name="formattable">The string to be formatted.</param>
+    /// <example>
+    /// <code>
+    /// Error($"Hello {"World"}! Today is an {DateTime.Now:dddd}");
+    /// </code>
+    /// </example>
+    [CakeMethodAlias]
+    [CakeAliasCategory("Error")]
+    public static void Error(this ICakeContext context, FormattableString formattable)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        context.Log.Error(formattable);
+    }
+
+    /// <summary>
+    /// Writes an warning message to the log using the specified format information.
+    /// </summary>
+    /// <param name="context">The context.</param>
+    /// <param name="formattable">The string to be formatted.</param>
+    /// <example>
+    /// <code>
+    /// Warning($"Hello {"World"}! Today is an {DateTime.Now:dddd}");
+    /// </code>
+    /// </example>
+    [CakeMethodAlias]
+    [CakeAliasCategory("Warning")]
+    public static void Warning(this ICakeContext context, FormattableString formattable)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        context.Log.Warning(formattable);
+    }
+
+    /// <summary>
+    /// Writes an informational message to the log using the specified formattable string.
+    /// </summary>
+    /// <param name="context">The context.</param>
+    /// <param name="formattable">The string to be formatted.</param>
+    /// <example>
+    /// <code>
+    /// Information($"Hello {"World"}! Today is an {DateTime.Now:dddd}");
+    /// </code>
+    /// </example>
+    [CakeMethodAlias]
+    [CakeAliasCategory("Information")]
+    public static void Information(this ICakeContext context, FormattableString formattable)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        context.Log.Information(formattable);
+    }
+
+    /// <summary>
+    /// Writes an verbose message to the log using the specified formattable string.
+    /// </summary>
+    /// <param name="context">The context.</param>
+    /// <param name="formattable">The string to be formatted.</param>
+    /// <example>
+    /// <code>
+    /// Verbose($"Hello {"World"}! Today is an {DateTime.Now:dddd}");
+    /// </code>
+    /// </example>
+    [CakeMethodAlias]
+    [CakeAliasCategory("Verbose")]
+    public static void Verbose(this ICakeContext context, FormattableString formattable)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        context.Log.Verbose(formattable);
+    }
+
+    /// <summary>
+    /// Writes an debug message to the log using the specified formattable string.
+    /// </summary>
+    /// <param name="context">The context.</param>
+    /// <param name="formattable">The string to be formatted.</param>
+    /// <example>
+    /// <code>
+    /// Debug($"Hello {"World"}! Today is an {DateTime.Now:dddd}");
+    /// </code>
+    /// </example>
+    [CakeMethodAlias]
+    [CakeAliasCategory("Debug")]
+    public static void Debug(this ICakeContext context, FormattableString formattable)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        context.Log.Debug(formattable);
+    }
+
+    /// <summary>
+    /// Writes an error message to the log using the specified format information.
+    /// </summary>
+    /// <param name="context">The context.</param>
+    /// <param name="formattableLogAction">The log action.</param>
+    /// <example>
+    /// <code>
+    /// Error(logAction => logAction($"Hello {"World"}! Today is an {DateTime.Now:dddd}"));
+    /// </code>
+    /// </example>
+    [CakeMethodAlias]
+    [CakeAliasCategory("Error")]
+    public static void Error(this ICakeContext context, FormattableLogAction formattableLogAction)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        context.Log.Error(formattableLogAction);
+    }
+
+    /// <summary>
+    /// Writes an warning message to the log using the specified format information.
+    /// </summary>
+    /// <param name="context">The context.</param>
+    /// <param name="formattableLogAction">The log action.</param>
+    /// <example>
+    /// <code>
+    /// Warning(logAction => logAction($"Hello {"World"}! Today is an {DateTime.Now:dddd}"));
+    /// </code>
+    /// </example>
+    [CakeMethodAlias]
+    [CakeAliasCategory("Warning")]
+    public static void Warning(this ICakeContext context, FormattableLogAction formattableLogAction)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        context.Log.Warning(formattableLogAction);
+    }
+
+    /// <summary>
+    /// Writes an informational message to the log using the specified formattable string.
+    /// </summary>
+    /// <param name="context">The context.</param>
+    /// <param name="formattableLogAction">The log action.</param>
+    /// <example>
+    /// <code>
+    /// Information(logAction => logAction($"Hello {"World"}! Today is an {DateTime.Now:dddd}"));
+    /// </code>
+    /// </example>
+    [CakeMethodAlias]
+    [CakeAliasCategory("Information")]
+    public static void Information(this ICakeContext context, FormattableLogAction formattableLogAction)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        context.Log.Information(formattableLogAction);
+    }
+
+    /// <summary>
+    /// Writes an verbose message to the log using the specified formattable string.
+    /// </summary>
+    /// <param name="context">The context.</param>
+    /// <param name="formattableLogAction">The log action.</param>
+    /// <example>
+    /// <code>
+    /// Verbose(logAction => logAction($"Hello {"World"}! Today is an {DateTime.Now:dddd}"));
+    /// </code>
+    /// </example>
+    [CakeMethodAlias]
+    [CakeAliasCategory("Verbose")]
+    public static void Verbose(this ICakeContext context, FormattableLogAction formattableLogAction)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        context.Log.Verbose(formattableLogAction);
+    }
+
+    /// <summary>
+    /// Writes an debug message to the log using the specified formattable string.
+    /// </summary>
+    /// <param name="context">The context.</param>
+    /// <param name="formattableLogAction">The log action.</param>
+    /// <example>
+    /// <code>
+    /// Debug(logAction => logAction($"Hello {"World"}! Today is an {DateTime.Now:dddd}"));
+    /// </code>
+    /// </example>
+    [CakeMethodAlias]
+    [CakeAliasCategory("Debug")]
+    public static void Debug(this ICakeContext context, FormattableLogAction formattableLogAction)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        context.Log.Debug(formattableLogAction);
+    }
+}

--- a/src/Cake.Common/Diagnostics/LoggingAliases.cs
+++ b/src/Cake.Common/Diagnostics/LoggingAliases.cs
@@ -13,7 +13,7 @@ namespace Cake.Common.Diagnostics
     /// Contains functionality related to logging.
     /// </summary>
     [CakeAliasCategory("Logging")]
-    public static class LoggingAliases
+    public static partial class LoggingAliases
     {
         /// <summary>
         /// Writes an error message to the log using the specified format information.
@@ -383,131 +383,6 @@ namespace Cake.Common.Diagnostics
         {
             ArgumentNullException.ThrowIfNull(context);
             context.Log.Debug(value);
-        }
-
-        /// <summary>
-        /// Sets the log verbosity to quiet and returns a disposable that restores the log verbosity on dispose.
-        /// </summary>
-        /// <param name="context">the context.</param>
-        /// <returns>A disposable that restores the log verbosity.</returns>
-        /// <example>
-        /// <code>
-        /// using (QuietVerbosity())
-        /// {
-        ///     Error("Show me.");
-        ///     Warning("Hide me.");
-        ///     Information("Hide me.");
-        ///     Verbose("Hide me.");
-        ///     Debug("Hide me.");
-        /// }
-        /// </code>
-        /// </example>
-        [CakeMethodAlias]
-        [CakeAliasCategory("Verbosity")]
-        public static IDisposable QuietVerbosity(this ICakeContext context)
-        {
-            ArgumentNullException.ThrowIfNull(context);
-            return context.Log.QuietVerbosity();
-        }
-
-        /// <summary>
-        /// Sets the log verbosity to minimal and returns a disposable that restores the log verbosity on dispose.
-        /// </summary>
-        /// <param name="context">the context.</param>
-        /// <returns>A disposable that restores the log verbosity.</returns>
-        /// <example>
-        /// <code>
-        /// using (MinimalVerbosity())
-        /// {
-        ///     Error("Show me.");
-        ///     Warning("Show me.");
-        ///     Information("Hide me.");
-        ///     Verbose("Hide me.");
-        ///     Debug("Hide me.");
-        /// }
-        /// </code>
-        /// </example>
-        [CakeMethodAlias]
-        [CakeAliasCategory("Verbosity")]
-        public static IDisposable MinimalVerbosity(this ICakeContext context)
-        {
-            ArgumentNullException.ThrowIfNull(context);
-            return context.Log.MinimalVerbosity();
-        }
-
-        /// <summary>
-        /// Sets the log verbosity to normal and returns a disposable that restores the log verbosity on dispose.
-        /// </summary>
-        /// <param name="context">the context.</param>
-        /// <returns>A disposable that restores the log verbosity.</returns>
-        /// <example>
-        /// <code>
-        /// using (NormalVerbosity())
-        /// {
-        ///     Error("Show me.");
-        ///     Warning("Show me.");
-        ///     Information("Show me.");
-        ///     Verbose("Hide me.");
-        ///     Debug("Hide me.");
-        /// }
-        /// </code>
-        /// </example>
-        [CakeMethodAlias]
-        [CakeAliasCategory("Verbosity")]
-        public static IDisposable NormalVerbosity(this ICakeContext context)
-        {
-            ArgumentNullException.ThrowIfNull(context);
-            return context.Log.NormalVerbosity();
-        }
-
-        /// <summary>
-        /// Sets the log verbosity to verbose and returns a disposable that restores the log verbosity on dispose.
-        /// </summary>
-        /// <param name="context">the context.</param>
-        /// <returns>A disposable that restores the log verbosity.</returns>
-        /// <example>
-        /// <code>
-        /// using (VerboseVerbosity())
-        /// {
-        ///     Error("Show me.");
-        ///     Warning("Show me.");
-        ///     Information("Show me.");
-        ///     Verbose("Show me.");
-        ///     Debug("Hide me.");
-        /// }
-        /// </code>
-        /// </example>
-        [CakeMethodAlias]
-        [CakeAliasCategory("Verbosity")]
-        public static IDisposable VerboseVerbosity(this ICakeContext context)
-        {
-            ArgumentNullException.ThrowIfNull(context);
-            return context.Log.VerboseVerbosity();
-        }
-
-        /// <summary>
-        /// Sets the log verbosity to diagnostic and returns a disposable that restores the log verbosity on dispose.
-        /// </summary>
-        /// <param name="context">the context.</param>
-        /// <returns>A disposable that restores the log verbosity.</returns>
-        /// <example>
-        /// <code>
-        /// using (DiagnosticVerbosity())
-        /// {
-        ///     Error("Show me.");
-        ///     Warning("Show me.");
-        ///     Information("Show me.");
-        ///     Verbose("Show me.");
-        ///     Debug("Show me.");
-        /// }
-        /// </code>
-        /// </example>
-        [CakeMethodAlias]
-        [CakeAliasCategory("Verbosity")]
-        public static IDisposable DiagnosticVerbosity(this ICakeContext context)
-        {
-            ArgumentNullException.ThrowIfNull(context);
-            return context.Log.DiagnosticVerbosity();
         }
     }
 }

--- a/src/Cake.Core.Tests/Unit/Diagnostics/LogExtensionsTests.Formattable.cs
+++ b/src/Cake.Core.Tests/Unit/Diagnostics/LogExtensionsTests.Formattable.cs
@@ -1,0 +1,279 @@
+﻿using System;
+using Cake.Core.Diagnostics;
+using Xunit;
+
+namespace Cake.Core.Tests.Unit.Diagnostics;
+
+public partial class LogExtensionsTests
+{
+    public class Formattable
+    {
+        private const string ExpectedMessage = "Hello World";
+        private static readonly FormattableString HelloWorld = $"{"Hello"} {"World"}";
+
+        public class TheDebugMethod
+        {
+            [Fact]
+            public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Default_Verbosity()
+            {
+                // Given, When
+                var result = Record.Exception(() => LogExtensions.Debug(null, HelloWorld));
+
+                // Then
+                Assert.Null(result);
+            }
+
+            [Fact]
+            public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Custom_Verbosity()
+            {
+                // Given, When
+                var result = Record.Exception(() => LogExtensions.Debug(null, Verbosity.Normal, HelloWorld));
+
+                // Then
+                Assert.Null(result);
+            }
+
+            [Fact]
+            public void Can_Write_Debug_Message_With_Default_Verbosity()
+            {
+                // Given
+                var log = new TestLog();
+
+                // When
+                log.Debug(HelloWorld);
+
+                // Then
+                Assert.Equal(Verbosity.Diagnostic, log.Verbosity);
+                Assert.Equal(LogLevel.Debug, log.Level);
+                Assert.Equal(ExpectedMessage, log.Message);
+            }
+
+            [Fact]
+            public void Can_Write_Debug_Message_With_Custom_Verbosity()
+            {
+                // Given
+                var log = new TestLog();
+
+                // When
+                log.Debug(Verbosity.Quiet, HelloWorld);
+
+                // Then
+                Assert.Equal(Verbosity.Quiet, log.Verbosity);
+                Assert.Equal(LogLevel.Debug, log.Level);
+                Assert.Equal(ExpectedMessage, log.Message);
+            }
+        }
+
+        public class TheVerboseMethod
+        {
+            [Fact]
+            public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Default_Verbosity()
+            {
+                // Given, When
+                var result = Record.Exception(() => LogExtensions.Verbose(null, HelloWorld));
+
+                // Then
+                Assert.Null(result);
+            }
+
+            [Fact]
+            public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Custom_Verbosity()
+            {
+                // Given, When
+                var result = Record.Exception(() => LogExtensions.Verbose(null, Verbosity.Normal, HelloWorld));
+
+                // Then
+                Assert.Null(result);
+            }
+
+            [Fact]
+            public void Can_Write_Verbose_Message_With_Default_Verbosity()
+            {
+                // Given
+                var log = new TestLog();
+
+                // When
+                log.Verbose(HelloWorld);
+
+                // Then
+                Assert.Equal(Verbosity.Verbose, log.Verbosity);
+                Assert.Equal(LogLevel.Verbose, log.Level);
+                Assert.Equal(ExpectedMessage, log.Message);
+            }
+
+            [Fact]
+            public void Can_Write_Verbose_Message_With_Custom_Verbosity()
+            {
+                // Given
+                var log = new TestLog();
+
+                // When
+                log.Verbose(Verbosity.Quiet, HelloWorld);
+
+                // Then
+                Assert.Equal(Verbosity.Quiet, log.Verbosity);
+                Assert.Equal(LogLevel.Verbose, log.Level);
+                Assert.Equal(ExpectedMessage, log.Message);
+            }
+        }
+
+        public class TheInformationMethod
+        {
+            [Fact]
+            public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Default_Verbosity()
+            {
+                // Given, When
+                var result = Record.Exception(() => LogExtensions.Information(null, HelloWorld));
+
+                // Then
+                Assert.Null(result);
+            }
+
+            [Fact]
+            public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Custom_Verbosity()
+            {
+                // Given, When
+                var result = Record.Exception(() => LogExtensions.Information(null, Verbosity.Normal, HelloWorld));
+
+                // Then
+                Assert.Null(result);
+            }
+
+            [Fact]
+            public void Can_Write_Informative_Message_With_Default_Verbosity()
+            {
+                // Given
+                var log = new TestLog();
+
+                // When
+                log.Information(HelloWorld);
+
+                // Then
+                Assert.Equal(Verbosity.Normal, log.Verbosity);
+                Assert.Equal(LogLevel.Information, log.Level);
+                Assert.Equal(ExpectedMessage, log.Message);
+            }
+
+            [Fact]
+            public void Can_Write_Informative_Message_With_Custom_Verbosity()
+            {
+                // Given
+                var log = new TestLog();
+
+                // When
+                log.Information(Verbosity.Quiet, HelloWorld);
+
+                // Then
+                Assert.Equal(Verbosity.Quiet, log.Verbosity);
+                Assert.Equal(LogLevel.Information, log.Level);
+                Assert.Equal(ExpectedMessage, log.Message);
+            }
+        }
+
+        public class TheWarningMethod
+        {
+            [Fact]
+            public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Default_Verbosity()
+            {
+                // Given, When
+                var result = Record.Exception(() => LogExtensions.Warning(null, HelloWorld));
+
+                // Then
+                Assert.Null(result);
+            }
+
+            [Fact]
+            public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Custom_Verbosity()
+            {
+                // Given, When
+                var result = Record.Exception(() => LogExtensions.Warning(null, Verbosity.Normal, HelloWorld));
+
+                // Then
+                Assert.Null(result);
+            }
+
+            [Fact]
+            public void Can_Write_Warning_Message_With_Default_Verbosity()
+            {
+                // Given
+                var log = new TestLog();
+
+                // When
+                log.Warning(HelloWorld);
+
+                // Then
+                Assert.Equal(Verbosity.Minimal, log.Verbosity);
+                Assert.Equal(LogLevel.Warning, log.Level);
+                Assert.Equal(ExpectedMessage, log.Message);
+            }
+
+            [Fact]
+            public void Can_Write_Warning_Message_With_Custom_Verbosity()
+            {
+                // Given
+                var log = new TestLog();
+
+                // When
+                log.Warning(Verbosity.Quiet, HelloWorld);
+
+                // Then
+                Assert.Equal(Verbosity.Quiet, log.Verbosity);
+                Assert.Equal(LogLevel.Warning, log.Level);
+                Assert.Equal(ExpectedMessage, log.Message);
+            }
+        }
+
+        public class TheErrorMethod
+        {
+            [Fact]
+            public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Default_Verbosity()
+            {
+                // Given, When
+                var result = Record.Exception(() => LogExtensions.Error(null, HelloWorld));
+
+                // Then
+                Assert.Null(result);
+            }
+
+            [Fact]
+            public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Custom_Verbosity()
+            {
+                // Given, When
+                var result = Record.Exception(() => LogExtensions.Error(null, Verbosity.Normal, HelloWorld));
+
+                // Then
+                Assert.Null(result);
+            }
+
+            [Fact]
+            public void Can_Write_Error_Message_With_Default_Verbosity()
+            {
+                // Given
+                var log = new TestLog();
+
+                // When
+                log.Error(HelloWorld);
+
+                // Then
+                Assert.Equal(Verbosity.Quiet, log.Verbosity);
+                Assert.Equal(LogLevel.Error, log.Level);
+                Assert.Equal(ExpectedMessage, log.Message);
+            }
+
+            [Fact]
+            public void Can_Write_Error_Message_With_Custom_Verbosity()
+            {
+                // Given
+                var log = new TestLog();
+
+                // When
+                log.Error(Verbosity.Diagnostic, HelloWorld);
+
+                // Then
+                Assert.Equal(Verbosity.Diagnostic, log.Verbosity);
+                Assert.Equal(LogLevel.Error, log.Level);
+                Assert.Equal(ExpectedMessage, log.Message);
+            }
+        }
+    }
+}

--- a/src/Cake.Core.Tests/Unit/Diagnostics/LogExtensionsTests.cs
+++ b/src/Cake.Core.Tests/Unit/Diagnostics/LogExtensionsTests.cs
@@ -5,511 +5,510 @@
 using Cake.Core.Diagnostics;
 using Xunit;
 
-namespace Cake.Core.Tests.Unit.Diagnostics
+namespace Cake.Core.Tests.Unit.Diagnostics;
+
+public partial class LogExtensionsTests
 {
-    public class LogExtensionsTests
+    private sealed class TestLog : ICakeLog
     {
-        private sealed class TestLog : ICakeLog
+        public Verbosity Verbosity { get; set; }
+
+        public LogLevel Level { get; private set; }
+
+        public string Message { get; private set; }
+
+        public void Write(Verbosity verbosity, LogLevel level, string format, params object[] args)
         {
-            public Verbosity Verbosity { get; set; }
+            Verbosity = verbosity;
+            Level = level;
+            Message = string.Format(format, args);
+        }
+    }
 
-            public LogLevel Level { get; private set; }
+    public class TheDebugMethod
+    {
+        [Fact]
+        public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Default_Verbosity()
+        {
+            // Given, When
+            var result = Record.Exception(() => LogExtensions.Debug(null, "Hello World"));
 
-            public string Message { get; private set; }
-
-            public void Write(Verbosity verbosity, LogLevel level, string format, params object[] args)
-            {
-                Verbosity = verbosity;
-                Level = level;
-                Message = string.Format(format, args);
-            }
+            // Then
+            Assert.Null(result);
         }
 
-        public class TheDebugMethod
+        [Fact]
+        public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Custom_Verbosity()
         {
-            [Fact]
-            public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Default_Verbosity()
-            {
-                // Given, When
-                var result = Record.Exception(() => LogExtensions.Debug(null, "Hello World"));
+            // Given, When
+            var result = Record.Exception(() => LogExtensions.Debug(null, Verbosity.Normal, "Hello World"));
 
-                // Then
-                Assert.Null(result);
-            }
-
-            [Fact]
-            public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Custom_Verbosity()
-            {
-                // Given, When
-                var result = Record.Exception(() => LogExtensions.Debug(null, Verbosity.Normal, "Hello World"));
-
-                // Then
-                Assert.Null(result);
-            }
-
-            [Fact]
-            public void Can_Write_Debug_Message_With_Default_Verbosity()
-            {
-                // Given
-                var log = new TestLog();
-
-                // When
-                log.Debug("Hello World");
-
-                // Then
-                Assert.Equal(Verbosity.Diagnostic, log.Verbosity);
-                Assert.Equal(LogLevel.Debug, log.Level);
-                Assert.Equal("Hello World", log.Message);
-            }
-
-            [Fact]
-            public void Can_Write_Debug_Message_With_Custom_Verbosity()
-            {
-                // Given
-                var log = new TestLog();
-
-                // When
-                log.Debug(Verbosity.Quiet, "Hello World");
-
-                // Then
-                Assert.Equal(Verbosity.Quiet, log.Verbosity);
-                Assert.Equal(LogLevel.Debug, log.Level);
-                Assert.Equal("Hello World", log.Message);
-            }
+            // Then
+            Assert.Null(result);
         }
 
-        public class TheVerboseMethod
+        [Fact]
+        public void Can_Write_Debug_Message_With_Default_Verbosity()
         {
-            [Fact]
-            public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Default_Verbosity()
-            {
-                // Given, When
-                var result = Record.Exception(() => LogExtensions.Verbose(null, "Hello World"));
+            // Given
+            var log = new TestLog();
 
-                // Then
-                Assert.Null(result);
-            }
+            // When
+            log.Debug("Hello World");
 
-            [Fact]
-            public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Custom_Verbosity()
-            {
-                // Given, When
-                var result = Record.Exception(() => LogExtensions.Verbose(null, Verbosity.Normal, "Hello World"));
-
-                // Then
-                Assert.Null(result);
-            }
-
-            [Fact]
-            public void Can_Write_Verbose_Message_With_Default_Verbosity()
-            {
-                // Given
-                var log = new TestLog();
-
-                // When
-                log.Verbose("Hello World");
-
-                // Then
-                Assert.Equal(Verbosity.Verbose, log.Verbosity);
-                Assert.Equal(LogLevel.Verbose, log.Level);
-                Assert.Equal("Hello World", log.Message);
-            }
-
-            [Fact]
-            public void Can_Write_Verbose_Message_With_Custom_Verbosity()
-            {
-                // Given
-                var log = new TestLog();
-
-                // When
-                log.Verbose(Verbosity.Quiet, "Hello World");
-
-                // Then
-                Assert.Equal(Verbosity.Quiet, log.Verbosity);
-                Assert.Equal(LogLevel.Verbose, log.Level);
-                Assert.Equal("Hello World", log.Message);
-            }
+            // Then
+            Assert.Equal(Verbosity.Diagnostic, log.Verbosity);
+            Assert.Equal(LogLevel.Debug, log.Level);
+            Assert.Equal("Hello World", log.Message);
         }
 
-        public class TheInformationMethod
+        [Fact]
+        public void Can_Write_Debug_Message_With_Custom_Verbosity()
         {
-            [Fact]
-            public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Default_Verbosity()
-            {
-                // Given, When
-                var result = Record.Exception(() => LogExtensions.Information(null, "Hello World"));
+            // Given
+            var log = new TestLog();
 
-                // Then
-                Assert.Null(result);
-            }
+            // When
+            log.Debug(Verbosity.Quiet, "Hello World");
 
-            [Fact]
-            public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Custom_Verbosity()
-            {
-                // Given, When
-                var result = Record.Exception(() => LogExtensions.Information(null, Verbosity.Normal, "Hello World"));
+            // Then
+            Assert.Equal(Verbosity.Quiet, log.Verbosity);
+            Assert.Equal(LogLevel.Debug, log.Level);
+            Assert.Equal("Hello World", log.Message);
+        }
+    }
 
-                // Then
-                Assert.Null(result);
-            }
+    public class TheVerboseMethod
+    {
+        [Fact]
+        public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Default_Verbosity()
+        {
+            // Given, When
+            var result = Record.Exception(() => LogExtensions.Verbose(null, "Hello World"));
 
-            [Fact]
-            public void Can_Write_Informative_Message_With_Default_Verbosity()
-            {
-                // Given
-                var log = new TestLog();
-
-                // When
-                log.Information("Hello World");
-
-                // Then
-                Assert.Equal(Verbosity.Normal, log.Verbosity);
-                Assert.Equal(LogLevel.Information, log.Level);
-                Assert.Equal("Hello World", log.Message);
-            }
-
-            [Fact]
-            public void Can_Write_Informative_Message_With_Custom_Verbosity()
-            {
-                // Given
-                var log = new TestLog();
-
-                // When
-                log.Information(Verbosity.Quiet, "Hello World");
-
-                // Then
-                Assert.Equal(Verbosity.Quiet, log.Verbosity);
-                Assert.Equal(LogLevel.Information, log.Level);
-                Assert.Equal("Hello World", log.Message);
-            }
+            // Then
+            Assert.Null(result);
         }
 
-        public class TheWarningMethod
+        [Fact]
+        public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Custom_Verbosity()
         {
-            [Fact]
-            public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Default_Verbosity()
-            {
-                // Given, When
-                var result = Record.Exception(() => LogExtensions.Warning(null, "Hello World"));
+            // Given, When
+            var result = Record.Exception(() => LogExtensions.Verbose(null, Verbosity.Normal, "Hello World"));
 
-                // Then
-                Assert.Null(result);
-            }
-
-            [Fact]
-            public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Custom_Verbosity()
-            {
-                // Given, When
-                var result = Record.Exception(() => LogExtensions.Warning(null, Verbosity.Normal, "Hello World"));
-
-                // Then
-                Assert.Null(result);
-            }
-
-            [Fact]
-            public void Can_Write_Warning_Message_With_Default_Verbosity()
-            {
-                // Given
-                var log = new TestLog();
-
-                // When
-                log.Warning("Hello World");
-
-                // Then
-                Assert.Equal(Verbosity.Minimal, log.Verbosity);
-                Assert.Equal(LogLevel.Warning, log.Level);
-                Assert.Equal("Hello World", log.Message);
-            }
-
-            [Fact]
-            public void Can_Write_Warning_Message_With_Custom_Verbosity()
-            {
-                // Given
-                var log = new TestLog();
-
-                // When
-                log.Warning(Verbosity.Quiet, "Hello World");
-
-                // Then
-                Assert.Equal(Verbosity.Quiet, log.Verbosity);
-                Assert.Equal(LogLevel.Warning, log.Level);
-                Assert.Equal("Hello World", log.Message);
-            }
+            // Then
+            Assert.Null(result);
         }
 
-        public class TheErrorMethod
+        [Fact]
+        public void Can_Write_Verbose_Message_With_Default_Verbosity()
         {
-            [Fact]
-            public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Default_Verbosity()
-            {
-                // Given, When
-                var result = Record.Exception(() => LogExtensions.Error(null, "Hello World"));
+            // Given
+            var log = new TestLog();
 
-                // Then
-                Assert.Null(result);
-            }
+            // When
+            log.Verbose("Hello World");
 
-            [Fact]
-            public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Custom_Verbosity()
-            {
-                // Given, When
-                var result = Record.Exception(() => LogExtensions.Error(null, Verbosity.Normal, "Hello World"));
-
-                // Then
-                Assert.Null(result);
-            }
-
-            [Fact]
-            public void Can_Write_Error_Message_With_Default_Verbosity()
-            {
-                // Given
-                var log = new TestLog();
-
-                // When
-                log.Error("Hello World");
-
-                // Then
-                Assert.Equal(Verbosity.Quiet, log.Verbosity);
-                Assert.Equal(LogLevel.Error, log.Level);
-                Assert.Equal("Hello World", log.Message);
-            }
-
-            [Fact]
-            public void Can_Write_Error_Message_With_Custom_Verbosity()
-            {
-                // Given
-                var log = new TestLog();
-
-                // When
-                log.Error(Verbosity.Diagnostic, "Hello World");
-
-                // Then
-                Assert.Equal(Verbosity.Diagnostic, log.Verbosity);
-                Assert.Equal(LogLevel.Error, log.Level);
-                Assert.Equal("Hello World", log.Message);
-            }
+            // Then
+            Assert.Equal(Verbosity.Verbose, log.Verbosity);
+            Assert.Equal(LogLevel.Verbose, log.Level);
+            Assert.Equal("Hello World", log.Message);
         }
 
-        public sealed class TheQuietVerbosityMethod
+        [Fact]
+        public void Can_Write_Verbose_Message_With_Custom_Verbosity()
         {
-            [Fact]
-            public void Should_Throw_If_Log_Null()
-            {
-                // When
-                var result = Record.Exception(() => LogExtensions.QuietVerbosity(null));
+            // Given
+            var log = new TestLog();
 
-                // Then
-                AssertEx.IsArgumentNullException(result, "log");
-            }
+            // When
+            log.Verbose(Verbosity.Quiet, "Hello World");
 
-            [Fact]
-            public void Should_Set_Log_Verbosity_To_Quiet()
-            {
-                // When
-                var log = new TestLog { Verbosity = Verbosity.Verbose };
-                log.QuietVerbosity();
+            // Then
+            Assert.Equal(Verbosity.Quiet, log.Verbosity);
+            Assert.Equal(LogLevel.Verbose, log.Level);
+            Assert.Equal("Hello World", log.Message);
+        }
+    }
 
-                // Then
-                Assert.Equal(Verbosity.Quiet, log.Verbosity);
-            }
+    public class TheInformationMethod
+    {
+        [Fact]
+        public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Default_Verbosity()
+        {
+            // Given, When
+            var result = Record.Exception(() => LogExtensions.Information(null, "Hello World"));
 
-            [Fact]
-            public void Should_Return_Disposable_That_Restores_Log_Verbosity()
-            {
-                // When
-                var log = new TestLog { Verbosity = Verbosity.Verbose };
-                using (log.QuietVerbosity())
-                {
-                }
-
-                // Then
-                Assert.Equal(Verbosity.Verbose, log.Verbosity);
-            }
+            // Then
+            Assert.Null(result);
         }
 
-        public sealed class TheMinimalVerbosityMethod
+        [Fact]
+        public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Custom_Verbosity()
         {
-            [Fact]
-            public void Should_Throw_If_Log_Null()
-            {
-                // When
-                var result = Record.Exception(() => LogExtensions.MinimalVerbosity(null));
+            // Given, When
+            var result = Record.Exception(() => LogExtensions.Information(null, Verbosity.Normal, "Hello World"));
 
-                // Then
-                AssertEx.IsArgumentNullException(result, "log");
-            }
-
-            [Fact]
-            public void Should_Set_Log_Verbosity_To_Minimal()
-            {
-                // When
-                var log = new TestLog { Verbosity = Verbosity.Quiet };
-                log.MinimalVerbosity();
-
-                // Then
-                Assert.Equal(Verbosity.Minimal, log.Verbosity);
-            }
-
-            [Fact]
-            public void Should_Return_Disposable_That_Restores_Log_Verbosity()
-            {
-                // When
-                var log = new TestLog { Verbosity = Verbosity.Quiet };
-                using (log.MinimalVerbosity())
-                {
-                }
-
-                // Then
-                Assert.Equal(Verbosity.Quiet, log.Verbosity);
-            }
+            // Then
+            Assert.Null(result);
         }
 
-        public sealed class TheNormalVerbosityMethod
+        [Fact]
+        public void Can_Write_Informative_Message_With_Default_Verbosity()
         {
-            [Fact]
-            public void Should_Throw_If_Log_Null()
-            {
-                // When
-                var result = Record.Exception(() => LogExtensions.NormalVerbosity(null));
+            // Given
+            var log = new TestLog();
 
-                // Then
-                AssertEx.IsArgumentNullException(result, "log");
-            }
+            // When
+            log.Information("Hello World");
 
-            [Fact]
-            public void Should_Set_Log_Verbosity_To_Normal()
-            {
-                // When
-                var log = new TestLog { Verbosity = Verbosity.Quiet };
-                log.NormalVerbosity();
-
-                // Then
-                Assert.Equal(Verbosity.Normal, log.Verbosity);
-            }
-
-            [Fact]
-            public void Should_Return_Disposable_That_Restores_Log_Verbosity()
-            {
-                // When
-                var log = new TestLog { Verbosity = Verbosity.Quiet };
-                using (log.NormalVerbosity())
-                {
-                }
-
-                // Then
-                Assert.Equal(Verbosity.Quiet, log.Verbosity);
-            }
+            // Then
+            Assert.Equal(Verbosity.Normal, log.Verbosity);
+            Assert.Equal(LogLevel.Information, log.Level);
+            Assert.Equal("Hello World", log.Message);
         }
 
-        public sealed class TheVerboseVerbosityMethod
+        [Fact]
+        public void Can_Write_Informative_Message_With_Custom_Verbosity()
         {
-            [Fact]
-            public void Should_Throw_If_Log_Null()
-            {
-                // When
-                var result = Record.Exception(() => LogExtensions.VerboseVerbosity(null));
+            // Given
+            var log = new TestLog();
 
-                // Then
-                AssertEx.IsArgumentNullException(result, "log");
-            }
+            // When
+            log.Information(Verbosity.Quiet, "Hello World");
 
-            [Fact]
-            public void Should_Set_Log_Verbosity_To_Verbose()
-            {
-                // When
-                var log = new TestLog { Verbosity = Verbosity.Quiet };
-                log.VerboseVerbosity();
+            // Then
+            Assert.Equal(Verbosity.Quiet, log.Verbosity);
+            Assert.Equal(LogLevel.Information, log.Level);
+            Assert.Equal("Hello World", log.Message);
+        }
+    }
 
-                // Then
-                Assert.Equal(Verbosity.Verbose, log.Verbosity);
-            }
+    public class TheWarningMethod
+    {
+        [Fact]
+        public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Default_Verbosity()
+        {
+            // Given, When
+            var result = Record.Exception(() => LogExtensions.Warning(null, "Hello World"));
 
-            [Fact]
-            public void Should_Return_Disposable_That_Restores_Log_Verbosity()
-            {
-                // When
-                var log = new TestLog { Verbosity = Verbosity.Quiet };
-                using (log.VerboseVerbosity())
-                {
-                }
-
-                // Then
-                Assert.Equal(Verbosity.Quiet, log.Verbosity);
-            }
+            // Then
+            Assert.Null(result);
         }
 
-        public sealed class TheDiagnosticVerbosityMethod
+        [Fact]
+        public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Custom_Verbosity()
         {
-            [Fact]
-            public void Should_Throw_If_Log_Null()
-            {
-                // When
-                var result = Record.Exception(() => LogExtensions.DiagnosticVerbosity(null));
+            // Given, When
+            var result = Record.Exception(() => LogExtensions.Warning(null, Verbosity.Normal, "Hello World"));
 
-                // Then
-                AssertEx.IsArgumentNullException(result, "log");
-            }
-
-            [Fact]
-            public void Should_Set_Log_Verbosity_To_Diagnostic()
-            {
-                // When
-                var log = new TestLog { Verbosity = Verbosity.Quiet };
-                log.DiagnosticVerbosity();
-
-                // Then
-                Assert.Equal(Verbosity.Diagnostic, log.Verbosity);
-            }
-
-            [Fact]
-            public void Should_Return_Disposable_That_Restores_Log_Verbosity()
-            {
-                // When
-                var log = new TestLog { Verbosity = Verbosity.Quiet };
-                using (log.DiagnosticVerbosity())
-                {
-                }
-
-                // Then
-                Assert.Equal(Verbosity.Quiet, log.Verbosity);
-            }
+            // Then
+            Assert.Null(result);
         }
 
-        public sealed class TheWithVerbosityMethod
+        [Fact]
+        public void Can_Write_Warning_Message_With_Default_Verbosity()
         {
-            [Fact]
-            public void Should_Throw_If_Log_Null()
-            {
-                // When
-                var result = Record.Exception(() => LogExtensions.WithVerbosity(null, Verbosity.Diagnostic));
+            // Given
+            var log = new TestLog();
 
-                // Then
-                AssertEx.IsArgumentNullException(result, "log");
+            // When
+            log.Warning("Hello World");
+
+            // Then
+            Assert.Equal(Verbosity.Minimal, log.Verbosity);
+            Assert.Equal(LogLevel.Warning, log.Level);
+            Assert.Equal("Hello World", log.Message);
+        }
+
+        [Fact]
+        public void Can_Write_Warning_Message_With_Custom_Verbosity()
+        {
+            // Given
+            var log = new TestLog();
+
+            // When
+            log.Warning(Verbosity.Quiet, "Hello World");
+
+            // Then
+            Assert.Equal(Verbosity.Quiet, log.Verbosity);
+            Assert.Equal(LogLevel.Warning, log.Level);
+            Assert.Equal("Hello World", log.Message);
+        }
+    }
+
+    public class TheErrorMethod
+    {
+        [Fact]
+        public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Default_Verbosity()
+        {
+            // Given, When
+            var result = Record.Exception(() => LogExtensions.Error(null, "Hello World"));
+
+            // Then
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Should_Not_Throw_If_Log_Is_Null_When_Logging_With_Custom_Verbosity()
+        {
+            // Given, When
+            var result = Record.Exception(() => LogExtensions.Error(null, Verbosity.Normal, "Hello World"));
+
+            // Then
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Can_Write_Error_Message_With_Default_Verbosity()
+        {
+            // Given
+            var log = new TestLog();
+
+            // When
+            log.Error("Hello World");
+
+            // Then
+            Assert.Equal(Verbosity.Quiet, log.Verbosity);
+            Assert.Equal(LogLevel.Error, log.Level);
+            Assert.Equal("Hello World", log.Message);
+        }
+
+        [Fact]
+        public void Can_Write_Error_Message_With_Custom_Verbosity()
+        {
+            // Given
+            var log = new TestLog();
+
+            // When
+            log.Error(Verbosity.Diagnostic, "Hello World");
+
+            // Then
+            Assert.Equal(Verbosity.Diagnostic, log.Verbosity);
+            Assert.Equal(LogLevel.Error, log.Level);
+            Assert.Equal("Hello World", log.Message);
+        }
+    }
+
+    public sealed class TheQuietVerbosityMethod
+    {
+        [Fact]
+        public void Should_Throw_If_Log_Null()
+        {
+            // When
+            var result = Record.Exception(() => LogExtensions.QuietVerbosity(null));
+
+            // Then
+            AssertEx.IsArgumentNullException(result, "log");
+        }
+
+        [Fact]
+        public void Should_Set_Log_Verbosity_To_Quiet()
+        {
+            // When
+            var log = new TestLog { Verbosity = Verbosity.Verbose };
+            log.QuietVerbosity();
+
+            // Then
+            Assert.Equal(Verbosity.Quiet, log.Verbosity);
+        }
+
+        [Fact]
+        public void Should_Return_Disposable_That_Restores_Log_Verbosity()
+        {
+            // When
+            var log = new TestLog { Verbosity = Verbosity.Verbose };
+            using (log.QuietVerbosity())
+            {
             }
 
-            [Fact]
-            public void Should_Set_Log_Verbosity_As_Specified()
-            {
-                // When
-                var log = new TestLog { Verbosity = Verbosity.Quiet };
-                log.WithVerbosity(Verbosity.Diagnostic);
+            // Then
+            Assert.Equal(Verbosity.Verbose, log.Verbosity);
+        }
+    }
 
-                // Then
-                Assert.Equal(Verbosity.Diagnostic, log.Verbosity);
+    public sealed class TheMinimalVerbosityMethod
+    {
+        [Fact]
+        public void Should_Throw_If_Log_Null()
+        {
+            // When
+            var result = Record.Exception(() => LogExtensions.MinimalVerbosity(null));
+
+            // Then
+            AssertEx.IsArgumentNullException(result, "log");
+        }
+
+        [Fact]
+        public void Should_Set_Log_Verbosity_To_Minimal()
+        {
+            // When
+            var log = new TestLog { Verbosity = Verbosity.Quiet };
+            log.MinimalVerbosity();
+
+            // Then
+            Assert.Equal(Verbosity.Minimal, log.Verbosity);
+        }
+
+        [Fact]
+        public void Should_Return_Disposable_That_Restores_Log_Verbosity()
+        {
+            // When
+            var log = new TestLog { Verbosity = Verbosity.Quiet };
+            using (log.MinimalVerbosity())
+            {
             }
 
-            [Fact]
-            public void Should_Return_Disposable_That_Restores_Log_Verbosity()
-            {
-                // When
-                var log = new TestLog { Verbosity = Verbosity.Quiet };
-                using (log.WithVerbosity(Verbosity.Diagnostic))
-                {
-                }
+            // Then
+            Assert.Equal(Verbosity.Quiet, log.Verbosity);
+        }
+    }
 
-                // Then
-                Assert.Equal(Verbosity.Quiet, log.Verbosity);
+    public sealed class TheNormalVerbosityMethod
+    {
+        [Fact]
+        public void Should_Throw_If_Log_Null()
+        {
+            // When
+            var result = Record.Exception(() => LogExtensions.NormalVerbosity(null));
+
+            // Then
+            AssertEx.IsArgumentNullException(result, "log");
+        }
+
+        [Fact]
+        public void Should_Set_Log_Verbosity_To_Normal()
+        {
+            // When
+            var log = new TestLog { Verbosity = Verbosity.Quiet };
+            log.NormalVerbosity();
+
+            // Then
+            Assert.Equal(Verbosity.Normal, log.Verbosity);
+        }
+
+        [Fact]
+        public void Should_Return_Disposable_That_Restores_Log_Verbosity()
+        {
+            // When
+            var log = new TestLog { Verbosity = Verbosity.Quiet };
+            using (log.NormalVerbosity())
+            {
             }
+
+            // Then
+            Assert.Equal(Verbosity.Quiet, log.Verbosity);
+        }
+    }
+
+    public sealed class TheVerboseVerbosityMethod
+    {
+        [Fact]
+        public void Should_Throw_If_Log_Null()
+        {
+            // When
+            var result = Record.Exception(() => LogExtensions.VerboseVerbosity(null));
+
+            // Then
+            AssertEx.IsArgumentNullException(result, "log");
+        }
+
+        [Fact]
+        public void Should_Set_Log_Verbosity_To_Verbose()
+        {
+            // When
+            var log = new TestLog { Verbosity = Verbosity.Quiet };
+            log.VerboseVerbosity();
+
+            // Then
+            Assert.Equal(Verbosity.Verbose, log.Verbosity);
+        }
+
+        [Fact]
+        public void Should_Return_Disposable_That_Restores_Log_Verbosity()
+        {
+            // When
+            var log = new TestLog { Verbosity = Verbosity.Quiet };
+            using (log.VerboseVerbosity())
+            {
+            }
+
+            // Then
+            Assert.Equal(Verbosity.Quiet, log.Verbosity);
+        }
+    }
+
+    public sealed class TheDiagnosticVerbosityMethod
+    {
+        [Fact]
+        public void Should_Throw_If_Log_Null()
+        {
+            // When
+            var result = Record.Exception(() => LogExtensions.DiagnosticVerbosity(null));
+
+            // Then
+            AssertEx.IsArgumentNullException(result, "log");
+        }
+
+        [Fact]
+        public void Should_Set_Log_Verbosity_To_Diagnostic()
+        {
+            // When
+            var log = new TestLog { Verbosity = Verbosity.Quiet };
+            log.DiagnosticVerbosity();
+
+            // Then
+            Assert.Equal(Verbosity.Diagnostic, log.Verbosity);
+        }
+
+        [Fact]
+        public void Should_Return_Disposable_That_Restores_Log_Verbosity()
+        {
+            // When
+            var log = new TestLog { Verbosity = Verbosity.Quiet };
+            using (log.DiagnosticVerbosity())
+            {
+            }
+
+            // Then
+            Assert.Equal(Verbosity.Quiet, log.Verbosity);
+        }
+    }
+
+    public sealed class TheWithVerbosityMethod
+    {
+        [Fact]
+        public void Should_Throw_If_Log_Null()
+        {
+            // When
+            var result = Record.Exception(() => LogExtensions.WithVerbosity(null, Verbosity.Diagnostic));
+
+            // Then
+            AssertEx.IsArgumentNullException(result, "log");
+        }
+
+        [Fact]
+        public void Should_Set_Log_Verbosity_As_Specified()
+        {
+            // When
+            var log = new TestLog { Verbosity = Verbosity.Quiet };
+            log.WithVerbosity(Verbosity.Diagnostic);
+
+            // Then
+            Assert.Equal(Verbosity.Diagnostic, log.Verbosity);
+        }
+
+        [Fact]
+        public void Should_Return_Disposable_That_Restores_Log_Verbosity()
+        {
+            // When
+            var log = new TestLog { Verbosity = Verbosity.Quiet };
+            using (log.WithVerbosity(Verbosity.Diagnostic))
+            {
+            }
+
+            // Then
+            Assert.Equal(Verbosity.Quiet, log.Verbosity);
         }
     }
 }

--- a/src/Cake.Core/Diagnostics/LogAction.cs
+++ b/src/Cake.Core/Diagnostics/LogAction.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 namespace Cake.Core.Diagnostics
 {
     /// <summary>
@@ -16,4 +18,16 @@ namespace Cake.Core.Diagnostics
     /// <param name="format">A composite format string.</param>
     /// <param name="args">An array of objects to write using format.</param>
     public delegate void LogActionEntry(string format, params object[] args);
+
+    /// <summary>
+    /// Delegate representing lazy formattable log action.
+    /// </summary>
+    /// <param name="actionEntry">Proxy to log.</param>
+    public delegate void FormattableLogAction(FormattableLogActionEntry actionEntry);
+
+    /// <summary>
+    /// Delegate representing lazy formattable log entry.
+    /// </summary>
+    /// <param name="formattable">The string to be formatted.</param>
+    public delegate void FormattableLogActionEntry(FormattableString formattable);
 }

--- a/src/Cake.Core/Diagnostics/LogExtensions.Disposable.cs
+++ b/src/Cake.Core/Diagnostics/LogExtensions.Disposable.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Cake.Core.Diagnostics;
+
+/// <summary>
+/// Contains extension methods for <see cref="ICakeLog"/>.
+/// </summary>
+public static partial class LogExtensions
+{
+    /// <summary>
+    /// Sets the log verbosity to quiet and returns a disposable that restores the log verbosity on dispose.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <returns>A disposable that restores the log verbosity.</returns>
+    public static IDisposable QuietVerbosity(this ICakeLog log)
+    {
+        return log.WithVerbosity(Verbosity.Quiet);
+    }
+
+    /// <summary>
+    /// Sets the log verbosity to minimal and returns a disposable that restores the log verbosity on dispose.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <returns>A disposable that restores the log verbosity.</returns>
+    public static IDisposable MinimalVerbosity(this ICakeLog log)
+    {
+        return log.WithVerbosity(Verbosity.Minimal);
+    }
+
+    /// <summary>
+    /// Sets the log verbosity to normal and returns a disposable that restores the log verbosity on dispose.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <returns>A disposable that restores the log verbosity.</returns>
+    public static IDisposable NormalVerbosity(this ICakeLog log)
+    {
+        return log.WithVerbosity(Verbosity.Normal);
+    }
+
+    /// <summary>
+    /// Sets the log verbosity to verbose and returns a disposable that restores the log verbosity on dispose.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <returns>A disposable that restores the log verbosity.</returns>
+    public static IDisposable VerboseVerbosity(this ICakeLog log)
+    {
+        return log.WithVerbosity(Verbosity.Verbose);
+    }
+
+    /// <summary>
+    /// Sets the log verbosity to diagnostic and returns a disposable that restores the log verbosity on dispose.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <returns>A disposable that restores the log verbosity.</returns>
+    public static IDisposable DiagnosticVerbosity(this ICakeLog log)
+    {
+        return log.WithVerbosity(Verbosity.Diagnostic);
+    }
+
+    /// <summary>
+    /// Sets the log verbosity as specified and returns a disposable that restores the log verbosity on dispose.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <returns>A disposable that restores the log verbosity.</returns>
+    public static IDisposable WithVerbosity(this ICakeLog log, Verbosity verbosity)
+    {
+        ArgumentNullException.ThrowIfNull(log);
+        var lastVerbosity = log.Verbosity;
+        log.Verbosity = verbosity;
+        return Disposable.Create(() => log.Verbosity = lastVerbosity);
+    }
+}

--- a/src/Cake.Core/Diagnostics/LogExtensions.Formattable.cs
+++ b/src/Cake.Core/Diagnostics/LogExtensions.Formattable.cs
@@ -1,0 +1,272 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Cake.Core.Diagnostics;
+
+/// <summary>
+/// Contains extension methods for <see cref="ICakeLog"/>.
+/// </summary>
+public static partial class LogExtensions
+{
+    /// <summary>
+    /// Writes the text representation of the formattable string to the
+    /// log using the specified verbosity, log level and format information.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <param name="level">The log level.</param>
+    /// <param name="formattable">The string to be formatted.</param>
+    public static void Write(this ICakeLog log, Verbosity verbosity, LogLevel level, FormattableString formattable)
+    {
+        log?.Write(verbosity, level, formattable.Format, formattable.GetArguments());
+    }
+
+    /// <summary>
+    /// Writes an formattable string error message to the log using the specified format information.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="formattable">The string to be formatted.</param>
+    public static void Error(this ICakeLog log, FormattableString formattable)
+    {
+        Error(log, Verbosity.Quiet, formattable);
+    }
+
+    /// <summary>
+    /// Writes an formattable string error message to the log using the specified format information.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <param name="formattable">The string to be formatted.</param>
+    public static void Error(this ICakeLog log, Verbosity verbosity, FormattableString formattable)
+    {
+        log?.Write(verbosity, LogLevel.Error, formattable);
+    }
+
+    /// <summary>
+    /// Writes an formattable string error message to the log using the specified verbosity and log message action.
+    /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <param name="formattableLogAction">The formattable log action.</param>
+    public static void Error(this ICakeLog log, Verbosity verbosity, FormattableLogAction formattableLogAction)
+    {
+        Write(log, verbosity, LogLevel.Error, formattableLogAction);
+    }
+
+    /// <summary>
+    /// Writes an formattable string error message to the log using the specified log message action.
+    /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="formattableLogAction">The log action.</param>
+    public static void Error(this ICakeLog log, FormattableLogAction formattableLogAction)
+    {
+        Error(log, Verbosity.Quiet, formattableLogAction);
+    }
+
+    /// <summary>
+    /// Writes a formattable string warning message to the log using the specified format information.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="formattable">The string to be formatted.</param>
+    public static void Warning(this ICakeLog log, FormattableString formattable)
+    {
+        Warning(log, Verbosity.Minimal, formattable);
+    }
+
+    /// <summary>
+    /// Writes a formattable string warning message to the log using the specified verbosity and format information.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <param name="formattable">The string to be formatted.</param>
+    public static void Warning(this ICakeLog log, Verbosity verbosity, FormattableString formattable)
+    {
+        log?.Write(verbosity, LogLevel.Warning, formattable);
+    }
+
+    /// <summary>
+    /// Writes a formattable string warning message to the log using the specified log message action.
+    /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="formattableLogAction">The formattable log action.</param>
+    public static void Warning(this ICakeLog log, FormattableLogAction formattableLogAction)
+    {
+        Warning(log, Verbosity.Minimal, formattableLogAction);
+    }
+
+    /// <summary>
+    /// Writes a formattable string warning message to the log using the specified verbosity and log message action.
+    /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <param name="formattableLogAction">The formattable log action.</param>
+    public static void Warning(this ICakeLog log, Verbosity verbosity, FormattableLogAction formattableLogAction)
+    {
+        Write(log, verbosity, LogLevel.Warning, formattableLogAction);
+    }
+
+    /// <summary>
+    /// Writes an formattable string informational message to the log using the specified format information.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="formattable">The string to be formatted.</param>
+    public static void Information(this ICakeLog log, FormattableString formattable)
+    {
+        Information(log, Verbosity.Normal, formattable);
+    }
+
+    /// <summary>
+    /// Writes an formattable string informational message to the log using the specified verbosity and format information.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <param name="formattable">The string to be formatted.</param>
+    public static void Information(this ICakeLog log, Verbosity verbosity, FormattableString formattable)
+    {
+        log?.Write(verbosity, LogLevel.Information, formattable);
+    }
+
+    /// <summary>
+    /// Writes an formattable string informational message to the log using the specified verbosity and log message action.
+    /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <param name="formattableLogAction">The formattable log action.</param>
+    public static void Information(this ICakeLog log, Verbosity verbosity, FormattableLogAction formattableLogAction)
+    {
+        Write(log, verbosity, LogLevel.Information, formattableLogAction);
+    }
+
+    /// <summary>
+    /// Writes an formattable string informational message to the log using the specified log message action.
+    /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="formattableLogAction">The formattable log action.</param>
+    public static void Information(this ICakeLog log, FormattableLogAction formattableLogAction)
+    {
+        Information(log, Verbosity.Normal, formattableLogAction);
+    }
+
+    /// <summary>
+    /// Writes a formattable string verbose message to the log using the specified format information.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="formattable">The string to be formatted.</param>
+    public static void Verbose(this ICakeLog log, FormattableString formattable)
+    {
+        Verbose(log, Verbosity.Verbose, formattable);
+    }
+
+    /// <summary>
+    /// Writes a formattable string verbose message to the log using the specified verbosity and format information.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <param name="formattable">The string to be formatted.</param>
+    public static void Verbose(this ICakeLog log, Verbosity verbosity, FormattableString formattable)
+    {
+        log?.Write(verbosity, LogLevel.Verbose, formattable);
+    }
+
+    /// <summary>
+    /// Writes a formattable string verbose message to the log using the specified log message action.
+    /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="formattableLogAction">The formattable log action.</param>
+    public static void Verbose(this ICakeLog log, FormattableLogAction formattableLogAction)
+    {
+        Verbose(log, Verbosity.Verbose, formattableLogAction);
+    }
+
+    /// <summary>
+    /// Writes a formattable string verbose message to the log using the specified verbosity and log message action.
+    /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <param name="formattableLogAction">The formattable log action.</param>
+    public static void Verbose(this ICakeLog log, Verbosity verbosity, FormattableLogAction formattableLogAction)
+    {
+        Write(log, verbosity, LogLevel.Verbose, formattableLogAction);
+    }
+
+    /// <summary>
+    /// Writes a formattable string debug message to the log using the specified format information.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="formattable">The string to be formatted.</param>
+    public static void Debug(this ICakeLog log, FormattableString formattable)
+    {
+        Debug(log, Verbosity.Diagnostic, formattable);
+    }
+
+    /// <summary>
+    /// Writes a formattable string debug message to the log using the specified verbosity and format information.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <param name="formattable">The string to be formatted.</param>
+    public static void Debug(this ICakeLog log, Verbosity verbosity, FormattableString formattable)
+    {
+        log?.Write(verbosity, LogLevel.Debug, formattable);
+    }
+
+    /// <summary>
+    /// Writes a formattable string debug message to the log using the specified log message action.
+    /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="formattableLogAction">The formattable log action.</param>
+    public static void Debug(this ICakeLog log, FormattableLogAction formattableLogAction)
+    {
+        Debug(log, Verbosity.Diagnostic, formattableLogAction);
+    }
+
+    /// <summary>
+    /// Writes a formattable string debug message to the log using the specified verbosity and log message action.
+    /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <param name="formattableLogAction">The formattable log action.</param>
+    public static void Debug(this ICakeLog log, Verbosity verbosity, FormattableLogAction formattableLogAction)
+    {
+        Write(log, verbosity, LogLevel.Debug, formattableLogAction);
+    }
+
+    /// <summary>
+    /// Writes a formattable string message to the log using the specified verbosity, log level and log action delegate.
+    /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <param name="level">The log level.</param>
+    /// <param name="formattableLogAction">The log action.</param>
+    public static void Write(this ICakeLog log, Verbosity verbosity, LogLevel level, FormattableLogAction formattableLogAction)
+    {
+        if (log == null || formattableLogAction == null)
+        {
+            return;
+        }
+
+        if (verbosity > log.Verbosity)
+        {
+            return;
+        }
+
+        void actionEntry(FormattableString formattable)
+            => log.Write(verbosity, level, formattable);
+
+        formattableLogAction(actionEntry);
+    }
+}

--- a/src/Cake.Core/Diagnostics/LogExtensions.cs
+++ b/src/Cake.Core/Diagnostics/LogExtensions.cs
@@ -2,431 +2,366 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+namespace Cake.Core.Diagnostics;
 
-namespace Cake.Core.Diagnostics
+/// <summary>
+/// Contains extension methods for <see cref="ICakeLog"/>.
+/// </summary>
+public static partial class LogExtensions
 {
     /// <summary>
-    /// Contains extension methods for <see cref="ICakeLog"/>.
+    /// Writes an error message to the log using the specified format information.
     /// </summary>
-    public static class LogExtensions
+    /// <param name="log">The log.</param>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write using format.</param>
+    public static void Error(this ICakeLog log, string format, params object[] args)
     {
-        /// <summary>
-        /// Writes an error message to the log using the specified format information.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write using format.</param>
-        public static void Error(this ICakeLog log, string format, params object[] args)
+        Error(log, Verbosity.Quiet, format, args);
+    }
+
+    /// <summary>
+    /// Writes an error message to the log using the specified verbosity and format information.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write using format.</param>
+    public static void Error(this ICakeLog log, Verbosity verbosity, string format, params object[] args)
+    {
+        log?.Write(verbosity, LogLevel.Error, format, args);
+    }
+
+    /// <summary>
+    /// Writes an error message to the log using the specified verbosity and log message action.
+    /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <param name="logAction">The log action.</param>
+    public static void Error(this ICakeLog log, Verbosity verbosity, LogAction logAction)
+    {
+        Write(log, verbosity, LogLevel.Error, logAction);
+    }
+
+    /// <summary>
+    /// Writes an error message to the log using the specified log message action.
+    /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="logAction">The log action.</param>
+    public static void Error(this ICakeLog log, LogAction logAction)
+    {
+        Error(log, Verbosity.Quiet, logAction);
+    }
+
+    /// <summary>
+    /// Writes an error message to the log using the specified value.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="value">The value.</param>
+    public static void Error(this ICakeLog log, object value)
+    {
+        log.Error("{0}", value);
+    }
+
+    /// <summary>
+    /// Writes an error message to the log using the specified string value.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="value">The value.</param>
+    public static void Error(this ICakeLog log, string value)
+    {
+        log.Error("{0}", value);
+    }
+
+    /// <summary>
+    /// Writes a warning message to the log using the specified format information.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write using format.</param>
+    public static void Warning(this ICakeLog log, string format, params object[] args)
+    {
+        Warning(log, Verbosity.Minimal, format, args);
+    }
+
+    /// <summary>
+    /// Writes a warning message to the log using the specified verbosity and format information.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write using format.</param>
+    public static void Warning(this ICakeLog log, Verbosity verbosity, string format, params object[] args)
+    {
+        log?.Write(verbosity, LogLevel.Warning, format, args);
+    }
+
+    /// <summary>
+    /// Writes a warning message to the log using the specified log message action.
+    /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="logAction">The log action.</param>
+    public static void Warning(this ICakeLog log, LogAction logAction)
+    {
+        Warning(log, Verbosity.Minimal, logAction);
+    }
+
+    /// <summary>
+    /// Writes a warning message to the log using the specified verbosity and log message action.
+    /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <param name="logAction">The log action.</param>
+    public static void Warning(this ICakeLog log, Verbosity verbosity, LogAction logAction)
+    {
+        Write(log, verbosity, LogLevel.Warning, logAction);
+    }
+
+    /// <summary>
+    /// Writes an warning message to the log using the specified value.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="value">The value.</param>
+    public static void Warning(this ICakeLog log, object value)
+    {
+        log.Warning("{0}", value);
+    }
+
+    /// <summary>
+    /// Writes an warning message to the log using the specified string value.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="value">The value.</param>
+    public static void Warning(this ICakeLog log, string value)
+    {
+        log.Warning("{0}", value);
+    }
+
+    /// <summary>
+    /// Writes an informational message to the log using the specified format information.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write using format.</param>
+    public static void Information(this ICakeLog log, string format, params object[] args)
+    {
+        Information(log, Verbosity.Normal, format, args);
+    }
+
+    /// <summary>
+    /// Writes an informational message to the log using the specified verbosity and format information.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write using format.</param>
+    public static void Information(this ICakeLog log, Verbosity verbosity, string format, params object[] args)
+    {
+        log?.Write(verbosity, LogLevel.Information, format, args);
+    }
+
+    /// <summary>
+    /// Writes an informational message to the log using the specified verbosity and log message action.
+    /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <param name="logAction">The log action.</param>
+    public static void Information(this ICakeLog log, Verbosity verbosity, LogAction logAction)
+    {
+        Write(log, verbosity, LogLevel.Information, logAction);
+    }
+
+    /// <summary>
+    /// Writes an informational message to the log using the specified log message action.
+    /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="logAction">The log action.</param>
+    public static void Information(this ICakeLog log, LogAction logAction)
+    {
+        Information(log, Verbosity.Normal, logAction);
+    }
+
+    /// <summary>
+    /// Writes an informational message to the log using the specified value.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="value">The value.</param>
+    public static void Information(this ICakeLog log, object value)
+    {
+        log.Information("{0}", value);
+    }
+
+    /// <summary>
+    /// Writes an informational message to the log using the specified string value.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="value">The value.</param>
+    public static void Information(this ICakeLog log, string value)
+    {
+        log.Information("{0}", value);
+    }
+
+    /// <summary>
+    /// Writes a verbose message to the log using the specified format information.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write using format.</param>
+    public static void Verbose(this ICakeLog log, string format, params object[] args)
+    {
+        Verbose(log, Verbosity.Verbose, format, args);
+    }
+
+    /// <summary>
+    /// Writes a verbose message to the log using the specified verbosity and format information.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write using format.</param>
+    public static void Verbose(this ICakeLog log, Verbosity verbosity, string format, params object[] args)
+    {
+        log?.Write(verbosity, LogLevel.Verbose, format, args);
+    }
+
+    /// <summary>
+    /// Writes a verbose message to the log using the specified log message action.
+    /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="logAction">The log action.</param>
+    public static void Verbose(this ICakeLog log, LogAction logAction)
+    {
+        Verbose(log, Verbosity.Verbose, logAction);
+    }
+
+    /// <summary>
+    /// Writes a verbose message to the log using the specified verbosity and log message action.
+    /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <param name="logAction">The log action.</param>
+    public static void Verbose(this ICakeLog log, Verbosity verbosity, LogAction logAction)
+    {
+        Write(log, verbosity, LogLevel.Verbose, logAction);
+    }
+
+    /// <summary>
+    /// Writes a verbose message to the log using the specified value.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="value">The value.</param>
+    public static void Verbose(this ICakeLog log, object value)
+    {
+        log.Verbose("{0}", value);
+    }
+
+    /// <summary>
+    /// Writes a verbose message to the log using the specified string value.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="value">The value.</param>
+    public static void Verbose(this ICakeLog log, string value)
+    {
+        log.Verbose("{0}", value);
+    }
+
+    /// <summary>
+    /// Writes a debug message to the log using the specified format information.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write using format.</param>
+    public static void Debug(this ICakeLog log, string format, params object[] args)
+    {
+        Debug(log, Verbosity.Diagnostic, format, args);
+    }
+
+    /// <summary>
+    /// Writes a debug message to the log using the specified verbosity and format information.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write using format.</param>
+    public static void Debug(this ICakeLog log, Verbosity verbosity, string format, params object[] args)
+    {
+        log?.Write(verbosity, LogLevel.Debug, format, args);
+    }
+
+    /// <summary>
+    /// Writes a debug message to the log using the specified log message action.
+    /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="logAction">The log action.</param>
+    public static void Debug(this ICakeLog log, LogAction logAction)
+    {
+        Debug(log, Verbosity.Diagnostic, logAction);
+    }
+
+    /// <summary>
+    /// Writes a debug message to the log using the specified verbosity and log message action.
+    /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <param name="logAction">The log action.</param>
+    public static void Debug(this ICakeLog log, Verbosity verbosity, LogAction logAction)
+    {
+        Write(log, verbosity, LogLevel.Debug, logAction);
+    }
+
+    /// <summary>
+    /// Writes a debug message to the log using the specified value.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="value">The value.</param>
+    public static void Debug(this ICakeLog log, object value)
+    {
+        log.Debug("{0}", value);
+    }
+
+    /// <summary>
+    /// Writes a debug message to the log using the specified string value.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="value">The value.</param>
+    public static void Debug(this ICakeLog log, string value)
+    {
+        log.Debug("{0}", value);
+    }
+
+    /// <summary>
+    /// Writes a message to the log using the specified verbosity, log level and log action delegate.
+    /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="verbosity">The verbosity.</param>
+    /// <param name="level">The log level.</param>
+    /// <param name="logAction">The log action.</param>
+    public static void Write(this ICakeLog log, Verbosity verbosity, LogLevel level, LogAction logAction)
+    {
+        if (log == null || logAction == null)
         {
-            Error(log, Verbosity.Quiet, format, args);
+            return;
         }
 
-        /// <summary>
-        /// Writes an error message to the log using the specified verbosity and format information.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="verbosity">The verbosity.</param>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write using format.</param>
-        public static void Error(this ICakeLog log, Verbosity verbosity, string format, params object[] args)
+        if (verbosity > log.Verbosity)
         {
-            log?.Write(verbosity, LogLevel.Error, format, args);
+            return;
         }
 
-        /// <summary>
-        /// Writes an error message to the log using the specified verbosity and log message action.
-        /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="verbosity">The verbosity.</param>
-        /// <param name="logAction">The log action.</param>
-        public static void Error(this ICakeLog log, Verbosity verbosity, LogAction logAction)
-        {
-            Write(log, verbosity, LogLevel.Error, logAction);
-        }
+        void actionEntry(string format, object[] args)
+            => log.Write(verbosity, level, format, args);
 
-        /// <summary>
-        /// Writes an error message to the log using the specified log message action.
-        /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="logAction">The log action.</param>
-        public static void Error(this ICakeLog log, LogAction logAction)
-        {
-            Error(log, Verbosity.Quiet, logAction);
-        }
-
-        /// <summary>
-        /// Writes an error message to the log using the specified value.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="value">The value.</param>
-        public static void Error(this ICakeLog log, object value)
-        {
-            log.Error("{0}", value);
-        }
-
-        /// <summary>
-        /// Writes an error message to the log using the specified string value.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="value">The value.</param>
-        public static void Error(this ICakeLog log, string value)
-        {
-            log.Error("{0}", value);
-        }
-
-        /// <summary>
-        /// Writes a warning message to the log using the specified format information.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write using format.</param>
-        public static void Warning(this ICakeLog log, string format, params object[] args)
-        {
-            Warning(log, Verbosity.Minimal, format, args);
-        }
-
-        /// <summary>
-        /// Writes a warning message to the log using the specified verbosity and format information.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="verbosity">The verbosity.</param>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write using format.</param>
-        public static void Warning(this ICakeLog log, Verbosity verbosity, string format, params object[] args)
-        {
-            log?.Write(verbosity, LogLevel.Warning, format, args);
-        }
-
-        /// <summary>
-        /// Writes a warning message to the log using the specified log message action.
-        /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="logAction">The log action.</param>
-        public static void Warning(this ICakeLog log, LogAction logAction)
-        {
-            Warning(log, Verbosity.Minimal, logAction);
-        }
-
-        /// <summary>
-        /// Writes a warning message to the log using the specified verbosity and log message action.
-        /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="verbosity">The verbosity.</param>
-        /// <param name="logAction">The log action.</param>
-        public static void Warning(this ICakeLog log, Verbosity verbosity, LogAction logAction)
-        {
-            Write(log, verbosity, LogLevel.Warning, logAction);
-        }
-
-        /// <summary>
-        /// Writes an warning message to the log using the specified value.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="value">The value.</param>
-        public static void Warning(this ICakeLog log, object value)
-        {
-            log.Warning("{0}", value);
-        }
-
-        /// <summary>
-        /// Writes an warning message to the log using the specified string value.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="value">The value.</param>
-        public static void Warning(this ICakeLog log, string value)
-        {
-            log.Warning("{0}", value);
-        }
-
-        /// <summary>
-        /// Writes an informational message to the log using the specified format information.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write using format.</param>
-        public static void Information(this ICakeLog log, string format, params object[] args)
-        {
-            Information(log, Verbosity.Normal, format, args);
-        }
-
-        /// <summary>
-        /// Writes an informational message to the log using the specified verbosity and format information.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="verbosity">The verbosity.</param>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write using format.</param>
-        public static void Information(this ICakeLog log, Verbosity verbosity, string format, params object[] args)
-        {
-            log?.Write(verbosity, LogLevel.Information, format, args);
-        }
-
-        /// <summary>
-        /// Writes an informational message to the log using the specified verbosity and log message action.
-        /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="verbosity">The verbosity.</param>
-        /// <param name="logAction">The log action.</param>
-        public static void Information(this ICakeLog log, Verbosity verbosity, LogAction logAction)
-        {
-            Write(log, verbosity, LogLevel.Information, logAction);
-        }
-
-        /// <summary>
-        /// Writes an informational message to the log using the specified log message action.
-        /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="logAction">The log action.</param>
-        public static void Information(this ICakeLog log, LogAction logAction)
-        {
-            Information(log, Verbosity.Normal, logAction);
-        }
-
-        /// <summary>
-        /// Writes an informational message to the log using the specified value.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="value">The value.</param>
-        public static void Information(this ICakeLog log, object value)
-        {
-            log.Information("{0}", value);
-        }
-
-        /// <summary>
-        /// Writes an informational message to the log using the specified string value.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="value">The value.</param>
-        public static void Information(this ICakeLog log, string value)
-        {
-            log.Information("{0}", value);
-        }
-
-        /// <summary>
-        /// Writes a verbose message to the log using the specified format information.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write using format.</param>
-        public static void Verbose(this ICakeLog log, string format, params object[] args)
-        {
-            Verbose(log, Verbosity.Verbose, format, args);
-        }
-
-        /// <summary>
-        /// Writes a verbose message to the log using the specified verbosity and format information.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="verbosity">The verbosity.</param>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write using format.</param>
-        public static void Verbose(this ICakeLog log, Verbosity verbosity, string format, params object[] args)
-        {
-            log?.Write(verbosity, LogLevel.Verbose, format, args);
-        }
-
-        /// <summary>
-        /// Writes a verbose message to the log using the specified log message action.
-        /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="logAction">The log action.</param>
-        public static void Verbose(this ICakeLog log, LogAction logAction)
-        {
-            Verbose(log, Verbosity.Verbose, logAction);
-        }
-
-        /// <summary>
-        /// Writes a verbose message to the log using the specified verbosity and log message action.
-        /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="verbosity">The verbosity.</param>
-        /// <param name="logAction">The log action.</param>
-        public static void Verbose(this ICakeLog log, Verbosity verbosity, LogAction logAction)
-        {
-            Write(log, verbosity, LogLevel.Verbose, logAction);
-        }
-
-        /// <summary>
-        /// Writes a verbose message to the log using the specified value.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="value">The value.</param>
-        public static void Verbose(this ICakeLog log, object value)
-        {
-            log.Verbose("{0}", value);
-        }
-
-        /// <summary>
-        /// Writes a verbose message to the log using the specified string value.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="value">The value.</param>
-        public static void Verbose(this ICakeLog log, string value)
-        {
-            log.Verbose("{0}", value);
-        }
-
-        /// <summary>
-        /// Writes a debug message to the log using the specified format information.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write using format.</param>
-        public static void Debug(this ICakeLog log, string format, params object[] args)
-        {
-            Debug(log, Verbosity.Diagnostic, format, args);
-        }
-
-        /// <summary>
-        /// Writes a debug message to the log using the specified verbosity and format information.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="verbosity">The verbosity.</param>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write using format.</param>
-        public static void Debug(this ICakeLog log, Verbosity verbosity, string format, params object[] args)
-        {
-            log?.Write(verbosity, LogLevel.Debug, format, args);
-        }
-
-        /// <summary>
-        /// Writes a debug message to the log using the specified log message action.
-        /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="logAction">The log action.</param>
-        public static void Debug(this ICakeLog log, LogAction logAction)
-        {
-            Debug(log, Verbosity.Diagnostic, logAction);
-        }
-
-        /// <summary>
-        /// Writes a debug message to the log using the specified verbosity and log message action.
-        /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="verbosity">The verbosity.</param>
-        /// <param name="logAction">The log action.</param>
-        public static void Debug(this ICakeLog log, Verbosity verbosity, LogAction logAction)
-        {
-            Write(log, verbosity, LogLevel.Debug, logAction);
-        }
-
-        /// <summary>
-        /// Writes a debug message to the log using the specified value.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="value">The value.</param>
-        public static void Debug(this ICakeLog log, object value)
-        {
-            log.Debug("{0}", value);
-        }
-
-        /// <summary>
-        /// Writes a debug message to the log using the specified string value.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="value">The value.</param>
-        public static void Debug(this ICakeLog log, string value)
-        {
-            log.Debug("{0}", value);
-        }
-
-        /// <summary>
-        /// Writes a message to the log using the specified verbosity, log level and log action delegate.
-        /// Evaluates log message only if the verbosity is equal to or more verbose than the log's verbosity.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="verbosity">The verbosity.</param>
-        /// <param name="level">The log level.</param>
-        /// <param name="logAction">The log action.</param>
-        public static void Write(this ICakeLog log, Verbosity verbosity, LogLevel level, LogAction logAction)
-        {
-            if (log == null || logAction == null)
-            {
-                return;
-            }
-
-            if (verbosity > log.Verbosity)
-            {
-                return;
-            }
-
-            LogActionEntry actionEntry = (format, args) => log.Write(verbosity, level, format, args);
-            logAction(actionEntry);
-        }
-
-        /// <summary>
-        /// Sets the log verbosity to quiet and returns a disposable that restores the log verbosity on dispose.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <returns>A disposable that restores the log verbosity.</returns>
-        public static IDisposable QuietVerbosity(this ICakeLog log)
-        {
-            return log.WithVerbosity(Verbosity.Quiet);
-        }
-
-        /// <summary>
-        /// Sets the log verbosity to minimal and returns a disposable that restores the log verbosity on dispose.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <returns>A disposable that restores the log verbosity.</returns>
-        public static IDisposable MinimalVerbosity(this ICakeLog log)
-        {
-            return log.WithVerbosity(Verbosity.Minimal);
-        }
-
-        /// <summary>
-        /// Sets the log verbosity to normal and returns a disposable that restores the log verbosity on dispose.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <returns>A disposable that restores the log verbosity.</returns>
-        public static IDisposable NormalVerbosity(this ICakeLog log)
-        {
-            return log.WithVerbosity(Verbosity.Normal);
-        }
-
-        /// <summary>
-        /// Sets the log verbosity to verbose and returns a disposable that restores the log verbosity on dispose.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <returns>A disposable that restores the log verbosity.</returns>
-        public static IDisposable VerboseVerbosity(this ICakeLog log)
-        {
-            return log.WithVerbosity(Verbosity.Verbose);
-        }
-
-        /// <summary>
-        /// Sets the log verbosity to diagnostic and returns a disposable that restores the log verbosity on dispose.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <returns>A disposable that restores the log verbosity.</returns>
-        public static IDisposable DiagnosticVerbosity(this ICakeLog log)
-        {
-            return log.WithVerbosity(Verbosity.Diagnostic);
-        }
-
-        /// <summary>
-        /// Sets the log verbosity as specified and returns a disposable that restores the log verbosity on dispose.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="verbosity">The verbosity.</param>
-        /// <returns>A disposable that restores the log verbosity.</returns>
-        public static IDisposable WithVerbosity(this ICakeLog log, Verbosity verbosity)
-        {
-            ArgumentNullException.ThrowIfNull(log);
-            var lastVerbosity = log.Verbosity;
-            log.Verbosity = verbosity;
-            return Disposable.Create(() => log.Verbosity = lastVerbosity);
-        }
+        logAction(actionEntry);
     }
 }

--- a/tests/integration/Cake.Common/Diagnostics/LoggingAliases.cake
+++ b/tests/integration/Cake.Common/Diagnostics/LoggingAliases.cake
@@ -20,6 +20,22 @@ var logActionMethods = new [] {
     new { Name = "Debug", Action = new Action<LogAction>(Debug), Verbosity = Verbosity.Diagnostic }
 };
 
+var logFormattableStringMethods = new [] {
+    new { Name = "Error", Action = new Action<FormattableString>(Error)},
+    new { Name = "Warning", Action = new Action<FormattableString>(Warning)},
+    new { Name = "Information", Action = new Action<FormattableString>(Information)},
+    new { Name = "Verbose", Action = new Action<FormattableString>(Verbose)},
+    new { Name = "Debug", Action = new Action<FormattableString>(Debug)}
+};
+
+var logFormattableLogActionMethods = new [] {
+    new { Name = "Error", Action = new Action<FormattableLogAction>(Error), Verbosity = Verbosity.Quiet },
+    new { Name = "Warning", Action = new Action<FormattableLogAction>(Warning), Verbosity = Verbosity.Minimal },
+    new { Name = "Information", Action = new Action<FormattableLogAction>(Information), Verbosity = Verbosity.Normal },
+    new { Name = "Verbose", Action = new Action<FormattableLogAction>(Verbose), Verbosity = Verbosity.Verbose },
+    new { Name = "Debug", Action = new Action<FormattableLogAction>(Debug), Verbosity = Verbosity.Diagnostic }
+};
+
 var logStringMethods = new [] {
     new { Name = "Error", Action = new Action<string>(Error)},
     new { Name = "Warning", Action = new Action<string>(Warning)},
@@ -47,18 +63,11 @@ Array.ForEach(
                                     Task(string.Format("Cake.Common.Diagnostics.LoggingAliases.StringFormat.{0}.{1}", verbosity, logStringFormatMethod.Name))
                                         .Does(() =>
                                     {
-                                        var originalVerbosity = Context.Log.Verbosity;
-                                        try
+                                        // Given
+                                        using (Context.WithVerbosity(verbosity))
                                         {
-                                            // Given
-                                            Context.Log.Verbosity = verbosity;
-
                                             // When
                                             logStringFormatMethod.Action("Cake.Common.Diagnostics.LoggingAliases.StringFormat.{0}.{1}", new object[] { verbosity, logStringFormatMethod.Name });
-                                        }
-                                        finally
-                                        {
-                                            Context.Log.Verbosity = originalVerbosity;
                                         }
                                     }).Task.Name
                         ))
@@ -72,11 +81,9 @@ Array.ForEach(
                                     Task(string.Format("Cake.Common.Diagnostics.LoggingAliases.LogAction.{0}.{1}", verbosity, logActionMethod.Name))
                                         .Does(() =>
                                     {
-                                        var originalVerbosity = Context.Log.Verbosity;
-                                        try
+                                        // Given
+                                        using (Context.WithVerbosity(verbosity))
                                         {
-                                            // Given
-                                            Context.Log.Verbosity = verbosity;
                                             bool called = false;
                                             LogAction action = entry=>{
                                                 called = true;
@@ -87,10 +94,6 @@ Array.ForEach(
 
                                             // Then
                                             Assert.True(called || verbosity<logActionMethod.Verbosity);
-                                        }
-                                        finally
-                                        {
-                                            Context.Log.Verbosity = originalVerbosity;
                                         }
                                     }).Task.Name
                         ))
@@ -104,18 +107,11 @@ Array.ForEach(
                                     Task(string.Format("Cake.Common.Diagnostics.LoggingAliases.String.{0}.{1}", verbosity, logStringMethod.Name))
                                         .Does(() =>
                                     {
-                                        var originalVerbosity = Context.Log.Verbosity;
-                                        try
+                                        // Given
+                                        using (Context.WithVerbosity(verbosity))
                                         {
-                                            // Given
-                                            Context.Log.Verbosity = verbosity;
-
                                             // When
                                             logStringMethod.Action(string.Format("Cake.Common.Diagnostics.LoggingAliases.String.{0}.{1}: {2}", verbosity, logStringMethod.Name, "{Bon}jour"));
-                                        }
-                                        finally
-                                        {
-                                            Context.Log.Verbosity = originalVerbosity;
                                         }
                                     }).Task.Name
                         ))
@@ -129,18 +125,55 @@ Array.ForEach(
                                     Task(string.Format("Cake.Common.Diagnostics.LoggingAliases.Object.{0}.{1}", verbosity, logObjectMethod.Name))
                                         .Does(() =>
                                     {
-                                        var originalVerbosity = Context.Log.Verbosity;
-                                        try
+                                        // Given
+                                        using (Context.WithVerbosity(verbosity))
                                         {
-                                            // Given
-                                            Context.Log.Verbosity = verbosity;
-
                                             // When
                                             logObjectMethod.Action(new { Test = "Cake.Common.Diagnostics.LoggingAliases.Object", Verbosity = verbosity, Name = logObjectMethod.Name });
                                         }
-                                        finally
+                                    }).Task.Name
+                        ))
+);
+
+Array.ForEach(
+    verbosities,
+    verbosity => Array.ForEach(
+                            logFormattableStringMethods,
+                            logFormattableStringMethod => loggingAliasesTask.IsDependentOn(
+                                    Task(string.Format("Cake.Common.Diagnostics.LoggingAliases.FormattableString.{0}.{1}", verbosity, logFormattableStringMethod.Name))
+                                        .Does(() =>
+                                    {
+                                        // Given
+                                        using (Context.WithVerbosity(verbosity))
                                         {
-                                            Context.Log.Verbosity = originalVerbosity;
+                                            // When
+                                            logFormattableStringMethod.Action($"Cake.Common.Diagnostics.LoggingAliases.FormattableString.{verbosity}.{logFormattableStringMethod.Name}: {"Bon"}jour");
+                                        }
+                                    }).Task.Name
+                        ))
+);
+
+Array.ForEach(
+    verbosities,
+    verbosity => Array.ForEach(
+                            logFormattableLogActionMethods,
+                            logFormattableLogActionMethod => loggingAliasesTask.IsDependentOn(
+                                    Task(string.Format("Cake.Common.Diagnostics.LoggingAliases.FormattableLogAction.{0}.{1}", verbosity, logFormattableLogActionMethod.Name))
+                                        .Does(() =>
+                                    {
+                                        // Given
+                                        using (Context.WithVerbosity(verbosity))
+                                        {
+                                            bool called = false;
+                                            FormattableLogAction action = entry => {
+                                                called = true;
+                                            };
+
+                                            // When
+                                            logFormattableLogActionMethod.Action(action);
+
+                                            // Then
+                                            Assert.True(called || verbosity < logFormattableLogActionMethod.Verbosity);
                                         }
                                     }).Task.Name
                         ))


### PR DESCRIPTION
- Add FormattableString and FormattableLogAction overloads to all logging methods (`Error`, `Warning`, `Information`, `Verbose`, `Debug`)
- Refactor LoggingAliases and LogExtensions into partial classes for better organization
- Move verbosity control methods to separate partial class files
- Add FormattableLogAction and FormattableLogActionEntry delegates
- Add comprehensive tests for formattable string logging
- Update integration tests to use disposable verbosity control
- fixes #4698