### PR TITLE
feat: dotnet test support for slnx

### DIFF
--- a/src/Cake.Common/Tools/DotNet/Test/DotNetTester.cs
+++ b/src/Cake.Common/Tools/DotNet/Test/DotNetTester.cs
@@ -231,7 +231,7 @@ namespace Cake.Common.Tools.DotNet.Test
             var extension = FilePath.FromString(project).GetExtension().ToLowerInvariant();
             return extension switch
             {
-                ".sln" => DotNetTestPathType.Solution,
+                ".sln" or ".slnx" => DotNetTestPathType.Solution,
                 ".csproj" or ".vbproj" or ".fsproj" or ".vcxproj" => DotNetTestPathType.Project,
                 _ => DotNetTestPathType.None // Default to legacy behavior for unknown extensions
             };


### PR DESCRIPTION
Hello there!
It seems that autodetecting PathType in dotnet test lacks support of slnx files.
Adding it.