### PR TITLE
GH4720: Use non-boolean self-contained arguments for dotnet publish.

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Publish/DotNetPublisherTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Publish/DotNetPublisherTests.cs
@@ -123,7 +123,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Publish
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("publish --output \"/Working/artifacts\" --runtime runtime1 --framework dnxcore50 --configuration Release --version-suffix rc1 --no-build --no-dependencies --no-restore --nologo --force --self-contained true --source \"https://api.nuget.org/v3/index.json\" --verbosity minimal", result.Args);
+                Assert.Equal("publish --output \"/Working/artifacts\" --runtime runtime1 --framework dnxcore50 --configuration Release --version-suffix rc1 --no-build --no-dependencies --no-restore --nologo --force --self-contained --source \"https://api.nuget.org/v3/index.json\" --verbosity minimal", result.Args);
             }
 
             [Fact]
@@ -147,7 +147,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Publish
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("publish --output \"/Working/artifacts\" --runtime runtime1 --framework dnxcore50 --configuration Release --version-suffix rc1 --no-dependencies --no-restore --force --self-contained false --source \"https://api.nuget.org/v3/index.json\" --verbosity minimal", result.Args);
+                Assert.Equal("publish --output \"/Working/artifacts\" --runtime runtime1 --framework dnxcore50 --configuration Release --version-suffix rc1 --no-dependencies --no-restore --force --no-self-contained --source \"https://api.nuget.org/v3/index.json\" --verbosity minimal", result.Args);
             }
 
             [Fact]

--- a/src/Cake.Common/Tools/DotNet/Publish/DotNetPublisher.cs
+++ b/src/Cake.Common/Tools/DotNet/Publish/DotNetPublisher.cs
@@ -125,14 +125,13 @@ namespace Cake.Common.Tools.DotNet.Publish
             // Self contained
             if (settings.SelfContained.HasValue)
             {
-                builder.Append("--self-contained");
                 if (settings.SelfContained.Value)
                 {
-                    builder.Append("true");
+                    builder.Append("--self-contained");
                 }
                 else
                 {
-                    builder.Append("false");
+                    builder.Append("--no-self-contained");
                 }
             }
 


### PR DESCRIPTION
This PR replaces the boolean self-contained arguments with their non-boolean counterparts:

| Value | Before | After |
|--------|--------|--------|
| `SelfContained = true` | `--self-contained true`  | `--self-contained` |
| `SelfContained = false` | `--self-contained false` | `--no-self-contained` |

Closes: #4720