### PR TITLE
Added SupportedOSPlatform property to AssemblyInfoSettings.

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/AssemblyInfoParserFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/AssemblyInfoParserFixture.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -27,6 +27,7 @@ namespace Cake.Common.Tests.Fixtures
         public string Guid { get; set; }
         public string InformationalVersion { get; set; }
         public List<string> InternalsVisibleTo { get; set; }
+        public List<string> SupportedOSPlatform { get; set; }
         public string Product { get; set; }
         public string Title { get; set; }
         public string Trademark { get; set; }
@@ -100,6 +101,10 @@ namespace Cake.Common.Tests.Fixtures
             if (InternalsVisibleTo != null)
             {
                 settings.InternalsVisibleTo = InternalsVisibleTo;
+            }
+            if (SupportedOSPlatform != null)
+            {
+                settings.SupportedOSPlatform = SupportedOSPlatform;
             }
             if (Product != null)
             {

--- a/src/Cake.Common.Tests/Fixtures/AssemblyInfoParserFixture_VB.cs
+++ b/src/Cake.Common.Tests/Fixtures/AssemblyInfoParserFixture_VB.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -27,6 +27,7 @@ namespace Cake.Common.Tests.Fixtures
         public string Guid { get; set; }
         public string InformationalVersion { get; set; }
         public List<string> InternalsVisibleTo { get; set; }
+        public List<string> SupportedOSPlatform { get; set; }
         public string Product { get; set; }
         public string Title { get; set; }
         public string Trademark { get; set; }
@@ -100,6 +101,10 @@ namespace Cake.Common.Tests.Fixtures
             if (InternalsVisibleTo != null)
             {
                 settings.InternalsVisibleTo = InternalsVisibleTo;
+            }
+            if (SupportedOSPlatform != null)
+            {
+                settings.SupportedOSPlatform = SupportedOSPlatform;
             }
             if (Product != null)
             {

--- a/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoCreatorTests.cs
+++ b/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoCreatorTests.cs
@@ -318,6 +318,38 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
             }
 
             [Fact]
+            public void Should_Add_SupportedOSPlatform_Attribute_If_Set()
+            {
+                // Given
+                var fixture = new AssemblyInfoFixture();
+                fixture.Settings.SupportedOSPlatform = new List<string> { "windows" };
+
+                // When
+                var result = fixture.CreateAndReturnContent();
+
+                // Then
+                Assert.Contains("using System.Runtime.Versioning;", result);
+                Assert.Contains("[assembly: SupportedOSPlatform(\"windows\")]", result);
+            }
+
+            [Fact]
+            public void Should_Add_Multiple_SupportedOSPlatform_Attribute_If_Set()
+            {
+                // Given
+                var fixture = new AssemblyInfoFixture();
+                fixture.Settings.SupportedOSPlatform = new Collection<string> { "windows", "linux", "macos" };
+
+                // When
+                var result = fixture.CreateAndReturnContent();
+
+                // Then
+                Assert.Contains("using System.Runtime.Versioning;", result);
+                Assert.Contains("[assembly: SupportedOSPlatform(\"windows\")]", result);
+                Assert.Contains("[assembly: SupportedOSPlatform(\"linux\")]", result);
+                Assert.Contains("[assembly: SupportedOSPlatform(\"macos\")]", result);
+            }
+
+            [Fact]
             public void Should_Add_Configuration_Attribute_If_Set()
             {
                 // Given

--- a/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoParserTests.cs
+++ b/src/Cake.Common.Tests/Unit/Solution/Project/Properties/AssemblyInfoParserTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -299,6 +299,44 @@ namespace Cake.Common.Tests.Unit.Solution.Project.Properties
                 Assert.Equal(2, result.InternalsVisibleTo.Count);
                 Assert.Equal("Cake.Core.Tests", result.InternalsVisibleTo.ElementAt(0));
                 Assert.Equal("Cake.Common.Tests", result.InternalsVisibleTo.ElementAt(1));
+            }
+
+            [Theory]
+            [InlineData(true)]
+            [InlineData(false)]
+            public void Should_Read_SupportedOSPlatform(bool extraWhiteSpaces)
+            {
+                // Given
+                var fixture = new AssemblyInfoParserFixture();
+                fixture.ExtraWhiteSpaces = extraWhiteSpaces;
+                fixture.SupportedOSPlatform = new List<string> { "windows" };
+
+                // When
+                var result = fixture.Parse();
+
+                // Then
+                Assert.Single(result.SupportedOSPlatform, x => x == "windows");
+            }
+
+            [Theory]
+            [InlineData(true)]
+            [InlineData(false)]
+            public void Should_Read_Multiple_SupportedOSPlatform(bool extraWhiteSpaces)
+            {
+                // Given
+                var fixture = new AssemblyInfoParserFixture();
+                fixture.ExtraWhiteSpaces = extraWhiteSpaces;
+                fixture.SupportedOSPlatform = new List<string> { "windows", "linux", "macos" };
+
+                // When
+                var result = fixture.Parse();
+
+                // Then
+                Assert.Collection(
+                    result.SupportedOSPlatform,
+                    item => Assert.Equal("windows", item),
+                    item => Assert.Equal("linux", item),
+                    item => Assert.Equal("macos", item));
             }
 
             [Theory]

--- a/src/Cake.Common/Solution/Project/Properties/AssemblyInfoCreator.cs
+++ b/src/Cake.Common/Solution/Project/Properties/AssemblyInfoCreator.cs
@@ -126,6 +126,14 @@ namespace Cake.Common.Solution.Project.Properties
                     writer.WriteLine();
                 }
 
+                if (data.SupportedOSPlatform.Count > 0)
+                {
+                    foreach (var attribute in data.SupportedOSPlatform)
+                    {
+                        writer.WriteLine(string.Format(attributeFormat, attribute));
+                    }
+                }
+
                 if (data.CustomAttributes.Count > 0)
                 {
                     writer.WriteLine(comment + " Custom Attributes");

--- a/src/Cake.Common/Solution/Project/Properties/AssemblyInfoCreatorData.cs
+++ b/src/Cake.Common/Solution/Project/Properties/AssemblyInfoCreatorData.cs
@@ -17,6 +17,7 @@ namespace Cake.Common.Solution.Project.Properties
         private readonly Dictionary<string, string> _metadatattributes;
         private readonly HashSet<string> _namespaces;
         private readonly HashSet<string> _internalVisibleTo;
+        private readonly HashSet<string> _supportedOSPlatform;
         private readonly string _trueStringValue;
         private readonly string _falseStringValue;
 
@@ -30,6 +31,8 @@ namespace Cake.Common.Solution.Project.Properties
 
         public ISet<string> InternalVisibleTo => _internalVisibleTo;
 
+        public ISet<string> SupportedOSPlatform => _supportedOSPlatform;
+
         public AssemblyInfoCreatorData(AssemblyInfoSettings settings, bool isVisualBasicAssemblyInfoFile)
         {
             _dictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -37,6 +40,7 @@ namespace Cake.Common.Solution.Project.Properties
             _metadatattributes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             _namespaces = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             _internalVisibleTo = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _supportedOSPlatform = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             _falseStringValue = isVisualBasicAssemblyInfoFile ? "False" : "false";
             _trueStringValue = isVisualBasicAssemblyInfoFile ? "True" : "true";
@@ -66,6 +70,18 @@ namespace Cake.Common.Solution.Project.Properties
                 if (_internalVisibleTo.Count > 0)
                 {
                     _namespaces.Add("System.Runtime.CompilerServices");
+                }
+            }
+            if (settings.SupportedOSPlatform != null)
+            {
+                foreach (var item in settings.SupportedOSPlatform.Where(item => item != null))
+                {
+                    _supportedOSPlatform.Add(string.Concat("SupportedOSPlatform(\"", item.UnQuote(), "\")"));
+                }
+
+                if (_supportedOSPlatform.Count > 0)
+                {
+                    _namespaces.Add("System.Runtime.Versioning");
                 }
             }
             if (settings.CustomAttributes != null)

--- a/src/Cake.Common/Solution/Project/Properties/AssemblyInfoParseResult.cs
+++ b/src/Cake.Common/Solution/Project/Properties/AssemblyInfoParseResult.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -13,6 +13,7 @@ namespace Cake.Common.Solution.Project.Properties
     public sealed class AssemblyInfoParseResult
     {
         private readonly List<string> _internalsVisibleTo;
+        private readonly List<string> _supportedOSPlatform;
 
         /// <summary>
         /// Gets a value indicating whether the assembly is CLS compliant.
@@ -103,6 +104,12 @@ namespace Cake.Common.Solution.Project.Properties
         public ICollection<string> InternalsVisibleTo => _internalsVisibleTo;
 
         /// <summary>
+        /// Gets the operating system(s) or platform(s) which this assembly supports.
+        /// </summary>
+        /// <value>The name(s), and optional version(s), of the supported platform(s).</value>
+        public ICollection<string> SupportedOSPlatform => _supportedOSPlatform;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="AssemblyInfoParseResult"/> class.
         /// </summary>
         /// <param name="clsCompliant">Whether the assembly is CLS compliant.</param>
@@ -119,6 +126,7 @@ namespace Cake.Common.Solution.Project.Properties
         /// <param name="trademark">The assembly trademark attribute.</param>
         /// <param name="assemblyVersion">The assembly version.</param>
         /// <param name="internalsVisibleTo">The assemblies that internals are visible to.</param>
+        /// <param name="supportedOSPlatform">The operating system(s) or platform(s) which this assembly supports.</param>
         public AssemblyInfoParseResult(string clsCompliant,
             string company,
             string comVisible,
@@ -132,7 +140,8 @@ namespace Cake.Common.Solution.Project.Properties
             string title,
             string trademark,
             string assemblyVersion,
-            IEnumerable<string> internalsVisibleTo)
+            IEnumerable<string> internalsVisibleTo,
+            IEnumerable<string> supportedOSPlatform)
         {
             ClsCompliant = !string.IsNullOrWhiteSpace(clsCompliant) && bool.Parse(clsCompliant);
             Company = company ?? string.Empty;
@@ -148,6 +157,7 @@ namespace Cake.Common.Solution.Project.Properties
             Trademark = trademark ?? string.Empty;
             AssemblyVersion = assemblyVersion ?? string.Empty;
             _internalsVisibleTo = new List<string>(internalsVisibleTo ?? Enumerable.Empty<string>());
+            _supportedOSPlatform = new List<string>(supportedOSPlatform ?? Enumerable.Empty<string>());
         }
     }
 }

--- a/src/Cake.Common/Solution/Project/Properties/AssemblyInfoParser.cs
+++ b/src/Cake.Common/Solution/Project/Properties/AssemblyInfoParser.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -88,7 +88,8 @@ namespace Cake.Common.Solution.Project.Properties
                     ParseSingle(quotedPattern, "AssemblyTitle", content),
                     ParseSingle(quotedPattern, "AssemblyTrademark", content),
                     ParseSingle(quotedPattern, "AssemblyVersion", content) ?? DefaultVersion,
-                    ParseMultiple(quotedPattern, "InternalsVisibleTo", content));
+                    ParseMultiple(quotedPattern, "InternalsVisibleTo", content),
+                    ParseMultiple(quotedPattern, "SupportedOSPlatform", content));
             }
         }
 

--- a/src/Cake.Common/Solution/Project/Properties/AssemblyInfoSettings.cs
+++ b/src/Cake.Common/Solution/Project/Properties/AssemblyInfoSettings.cs
@@ -90,6 +90,12 @@ namespace Cake.Common.Solution.Project.Properties
         public ICollection<string> InternalsVisibleTo { get; set; }
 
         /// <summary>
+        /// Gets or sets the operating system(s) or platform(s) which this assembly supports.
+        /// </summary>
+        /// <value>The name(s), and optional version(s), of the supported platform(s).</value>
+        public ICollection<string> SupportedOSPlatform { get; set; }
+
+        /// <summary>
         /// Gets or sets the configuration of the assembly.
         /// </summary>
         /// <value>The configuration.</value>

--- a/tests/integration/Cake.Common/Solution/Project/Properties/AssemblyInfoAliases.cake
+++ b/tests/integration/Cake.Common/Solution/Project/Properties/AssemblyInfoAliases.cake
@@ -28,7 +28,8 @@ Task("Cake.Common.Solution.Project.Properties.AssemblyInfoAliases.ParseAssemblyI
                             "Miny",
                             "Moe",
                             "Spacey"
-                       }
+                       },
+                       supportedOSPlatform: new string[] { }
                 );
 
     // When
@@ -49,6 +50,7 @@ Task("Cake.Common.Solution.Project.Properties.AssemblyInfoAliases.ParseAssemblyI
     Assert.Equal(expect.Trademark, result.Trademark);
     Assert.Equal(expect.AssemblyVersion, result.AssemblyVersion);
     Assert.Equal(expect.InternalsVisibleTo, result.InternalsVisibleTo);
+    Assert.Equal(expect.SupportedOSPlatform, result.SupportedOSPlatform);
 });
 
 Task("Cake.Common.Solution.Project.Properties.AssemblyInfoAliases.CreateAssemblyInfo")
@@ -89,6 +91,58 @@ Task("Cake.Common.Solution.Project.Properties.AssemblyInfoAliases.CreateAssembly
     Assert.True(FileHashEquals(expectFile, file));
 });
 
+Task("Cake.Common.Solution.Project.Properties.AssemblyInfoAliases.CreateAssemblyInfoWithSupportedOSPlatform")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Solution/Project/Properties/SupportedOSPlatform");
+    var file = path.CombineWithFilePath("AssemblyInfoWithSupportedOSPlatform.cs");
+    EnsureDirectoryExist(path);
+    var settings = new AssemblyInfoSettings {
+        Company = "The Company",
+        Product = "The Product",
+        Version = "1.0",
+        SupportedOSPlatform = new [] { "windows" }
+    };
+
+    // When
+    CreateAssemblyInfo(file, settings);
+
+    // Then
+    Assert.True(System.IO.File.Exists(file.FullPath));
+    var content = System.IO.File.ReadAllText(file.FullPath);
+    Assert.Contains("using System.Runtime.Versioning;", content);
+    Assert.Contains("[assembly: SupportedOSPlatform(\"windows\")]", content);
+});
+
+Task("Cake.Common.Solution.Project.Properties.AssemblyInfoAliases.CreateAssemblyInfoWithMultipleSupportedOSPlatform")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Solution/Project/Properties/MultipleSupportedOSPlatform");
+    var file = path.CombineWithFilePath("AssemblyInfoWithMultipleSupportedOSPlatform.cs");
+    EnsureDirectoryExist(path);
+    var settings = new AssemblyInfoSettings {
+        Company = "The Company",
+        Product = "The Product",
+        Version = "1.0",
+        SupportedOSPlatform = new [] { "windows", "linux", "macos" }
+    };
+
+    // When
+    CreateAssemblyInfo(file, settings);
+
+    // Then
+    Assert.True(System.IO.File.Exists(file.FullPath));
+    var content = System.IO.File.ReadAllText(file.FullPath);
+    Assert.Contains("using System.Runtime.Versioning;", content);
+    Assert.Contains("[assembly: SupportedOSPlatform(\"windows\")]", content);
+    Assert.Contains("[assembly: SupportedOSPlatform(\"linux\")]", content);
+    Assert.Contains("[assembly: SupportedOSPlatform(\"macos\")]", content);
+});
+
 Task("Cake.Common.Solution.Project.Properties.AssemblyInfoAliases")
     .IsDependentOn("Cake.Common.Solution.Project.Properties.AssemblyInfoAliases.ParseAssemblyInfo")
-    .IsDependentOn("Cake.Common.Solution.Project.Properties.AssemblyInfoAliases.CreateAssemblyInfo");
+    .IsDependentOn("Cake.Common.Solution.Project.Properties.AssemblyInfoAliases.CreateAssemblyInfo")
+    .IsDependentOn("Cake.Common.Solution.Project.Properties.AssemblyInfoAliases.CreateAssemblyInfoWithSupportedOSPlatform")
+    .IsDependentOn("Cake.Common.Solution.Project.Properties.AssemblyInfoAliases.CreateAssemblyInfoWithMultipleSupportedOSPlatform");


### PR DESCRIPTION
This fixes #4071 by introducing a new property to [AssemblyInfoSettings](https://github.com/cake-build/cake/blob/develop/src/Cake.Common/Solution/Project/Properties/AssemblyInfoSettings.cs).

It seemed more correct to introduce a new property rather than trying to alter the behavior of how `CustomAttributes` are handled, but I'm not dead set on this implementation if there is a better suggestion.

My main reasoning is that this will not break any existing setup which uses `CustomAttributes` to apply the SupportedOSPlatform attribute, but it enables what I need (to specify multiple platforms).