### PR TITLE
GH4737: Update Microsoft.Extensions.DependencyInjection to 9.0.13 & 10.0.3

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -40,21 +40,21 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
     <!-- Pin nuget transitive packages vulnerability issues NuGet.Packaging -->
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.3" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.13" />
     <!-- Pin nuget transitive packages vulnerability issues NuGet.Packaging -->
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.3" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.13" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <!-- Pin nuget transitive packages vulnerability issues NuGet.Packaging -->
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.3" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
* Update Microsoft.Extensions.DependencyInjection to 9.0.13 (net9.0)
* Update Microsoft.Extensions.DependencyInjection to 10.0.3 (net10.0)
* Align System.Security.Cryptography.Pkcs correctly
* fixes #4737
