### PR TITLE
GH4656: Change GitLab CI ID properties from int to long

### DIFF
--- a/src/Cake.Common/Build/GitLabCI/Data/GitLabCIBuildInfo.cs
+++ b/src/Cake.Common/Build/GitLabCI/Data/GitLabCIBuildInfo.cs
@@ -26,7 +26,7 @@ namespace Cake.Common.Build.GitLabCI.Data
         /// <value>
         /// The build ID.
         /// </value>
-        public int Id => GetEnvironmentInteger("CI_JOB_ID", "CI_BUILD_ID");
+        public long Id => GetEnvironmentLong("CI_JOB_ID", "CI_BUILD_ID");
 
         /// <summary>
         /// Gets the commit revision for which project is built.
@@ -106,7 +106,7 @@ namespace Cake.Common.Build.GitLabCI.Data
         /// <value>
         /// The unique build ID.
         /// </value>
-        public int PipelineId => GetEnvironmentInteger("CI_PIPELINE_ID");
+        public long PipelineId => GetEnvironmentLong("CI_PIPELINE_ID");
 
         /// <summary>
         /// Gets the unique id of the current pipeline scoped to the project.
@@ -114,7 +114,7 @@ namespace Cake.Common.Build.GitLabCI.Data
         /// <value>
         /// The unique build ID.
         /// </value>
-        public int PipelineIId => GetEnvironmentInteger("CI_PIPELINE_IID");
+        public long PipelineIId => GetEnvironmentLong("CI_PIPELINE_IID");
 
         /// <summary>
         /// Gets the id of the user who started the build.
@@ -122,7 +122,7 @@ namespace Cake.Common.Build.GitLabCI.Data
         /// <value>
         /// The user ID.
         /// </value>
-        public int UserId => GetEnvironmentInteger("GITLAB_USER_ID");
+        public long UserId => GetEnvironmentLong("GITLAB_USER_ID");
 
         /// <summary>
         /// Gets the email of the user who started the build.

--- a/src/Cake.Common/Build/GitLabCI/Data/GitLabCIProjectInfo.cs
+++ b/src/Cake.Common/Build/GitLabCI/Data/GitLabCIProjectInfo.cs
@@ -26,7 +26,7 @@ namespace Cake.Common.Build.GitLabCI.Data
         /// <value>
         /// The project ID.
         /// </value>
-        public int Id => GetEnvironmentInteger("CI_PROJECT_ID");
+        public long Id => GetEnvironmentLong("CI_PROJECT_ID");
 
         /// <summary>
         /// Gets the project name that is currently being built.

--- a/src/Cake.Common/Build/GitLabCI/Data/GitLabCIPullRequestInfo.cs
+++ b/src/Cake.Common/Build/GitLabCI/Data/GitLabCIPullRequestInfo.cs
@@ -34,7 +34,7 @@ namespace Cake.Common.Build.GitLabCI.Data
         /// <value>
         ///   The pull request id.
         /// </value>
-        public int Id => GetEnvironmentInteger("CI_MERGE_REQUEST_ID");
+        public long Id => GetEnvironmentLong("CI_MERGE_REQUEST_ID");
 
         /// <summary>
         /// Gets the pull request id scoped to the project.
@@ -42,7 +42,7 @@ namespace Cake.Common.Build.GitLabCI.Data
         /// <value>
         ///   The pull request id.
         /// </value>
-        public int IId => GetEnvironmentInteger("CI_MERGE_REQUEST_IID");
+        public long IId => GetEnvironmentLong("CI_MERGE_REQUEST_IID");
 
         /// <summary>
         /// Gets the source branch of the pull request.

--- a/src/Cake.Common/Build/GitLabCI/Data/GitLabCIRunnerInfo.cs
+++ b/src/Cake.Common/Build/GitLabCI/Data/GitLabCIRunnerInfo.cs
@@ -27,7 +27,7 @@ namespace Cake.Common.Build.GitLabCI.Data
         /// <value>
         /// The unique id of runner being used.
         /// </value>
-        public int Id => GetEnvironmentInteger("CI_RUNNER_ID");
+        public long Id => GetEnvironmentLong("CI_RUNNER_ID");
 
         /// <summary>
         /// Gets the description of the runner as saved in GitLab.

--- a/src/Cake.Common/Build/GitLabCI/GitLabCIInfo.cs
+++ b/src/Cake.Common/Build/GitLabCI/GitLabCIInfo.cs
@@ -145,5 +145,34 @@ namespace Cake.Common.Build.GitLabCI
 
             return null;
         }
+
+        /// <summary>
+        /// Gets an environment variable as a <see cref="System.Int64"/>.
+        /// </summary>
+        /// <param name="variable">The environment variable name.</param>
+        /// <returns>The environment variable.</returns>
+        protected long GetEnvironmentLong(string variable)
+        {
+            var value = GetEnvironmentString(variable);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                if (long.TryParse(value, out long result))
+                {
+                    return result;
+                }
+            }
+            return 0;
+        }
+
+        /// <summary>
+        /// Gets an environment variable as a <see cref="System.Int64"/>.
+        /// </summary>
+        /// <param name="primaryVariable">The primary environment variable name.</param>
+        /// <param name="secondaryVariable">The secondary environment variable name.</param>
+        /// <returns>The environment variable.</returns>
+        protected long GetEnvironmentLong(string primaryVariable, string secondaryVariable)
+        {
+            return GetEnvironmentLong(primaryVariable) != 0 ? GetEnvironmentLong(primaryVariable) : GetEnvironmentLong(secondaryVariable);
+        }
     }
 }


### PR DESCRIPTION
- GitLab CI IDs (e.g. CI_PIPELINE_ID, CI_JOB_ID) can exceed int max on gitlab.com
- Use long and GetEnvironmentLong for Id, PipelineId, PipelineIId, UserId in GitLabCIBuildInfo
- Use long and GetEnvironmentLong for Id in GitLabCIProjectInfo and GitLabCIRunnerInfo
- Use long and GetEnvironmentLong for Id and IId in GitLabCIPullRequestInfo
- Add GetEnvironmentLong(string) and GetEnvironmentLong(string, string) to GitLabCIInfo
- fixes #4656
