### PR TITLE
GH4667: Make DotNetSlnList locale-independent

### DIFF
--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.Sln.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.Sln.cs
@@ -99,10 +99,7 @@ namespace Cake.Common.Tools.DotNet
         {
             ArgumentNullException.ThrowIfNull(context);
 
-            if (settings is null)
-            {
-                settings = new DotNetSlnListSettings();
-            }
+            settings ??= new DotNetSlnListSettings();
 
             var lister = new DotNetSlnLister(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             return lister.List(solution, settings);

--- a/src/Cake.Common/Tools/DotNet/Sln/List/DotNetSlnLister.cs
+++ b/src/Cake.Common/Tools/DotNet/Sln/List/DotNetSlnLister.cs
@@ -46,7 +46,11 @@ namespace Cake.Common.Tools.DotNet.Sln.List
 
             var processSettings = new ProcessSettings
             {
-                RedirectStandardOutput = true
+                RedirectStandardOutput = true,
+                EnvironmentVariables = new Dictionary<string, string>(settings.EnvironmentVariables)
+                                        {
+                                            { "DOTNET_CLI_UI_LANGUAGE",  "en" }
+                                        }
             };
 
             IEnumerable<string> result = null;


### PR DESCRIPTION
- Force dotnet CLI to use English output via `DOTNET_CLI_UI_LANGUAGE=en` so project list parsing works on non-English locales
- fixes #4667