### PR TITLE
GH4456: DotNetMSBuild Use MSBuild /verbosity not dotnet --verbosity

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/MSBuild/DotNetMSBuildBuilderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/MSBuild/DotNetMSBuildBuilderTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -909,6 +909,26 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.MSBuild
 
                 // Then
                 Assert.Equal("--diagnostics msbuild", result.Args);
+            }
+
+            [Theory]
+            [InlineData(DotNetVerbosity.Quiet, "/verbosity:quiet")]
+            [InlineData(DotNetVerbosity.Minimal, "/verbosity:minimal")]
+            [InlineData(DotNetVerbosity.Normal, "/verbosity:normal")]
+            [InlineData(DotNetVerbosity.Detailed, "/verbosity:detailed")]
+            [InlineData(DotNetVerbosity.Diagnostic, "/verbosity:diagnostic")]
+            public void Should_Use_MSBuild_Verbosity_Not_DotNet_Verbosity_When_Verbosity_Is_Specified(DotNetVerbosity verbosity, string expectedMsBuildVerbosity)
+            {
+                // Given: DotNetMSBuildSettings.Verbosity (not ConsoleLoggerSettings) causes MSB1016 if passed as dotnet --verbosity
+                var fixture = new DotNetMSBuildBuilderFixture();
+                fixture.Settings.Verbosity = verbosity;
+
+                // When
+                var result = fixture.Run();
+
+                // Then: must use MSBuild /verbosity switch, not dotnet --verbosity (see https://github.com/cake-build/cake/issues/4456)
+                Assert.Contains(expectedMsBuildVerbosity, result.Args);
+                Assert.DoesNotContain("--verbosity", result.Args);
             }
 
             [Fact]

--- a/src/Cake.Common/Tools/DotNet/MSBuild/DotNetMSBuildBuilder.cs
+++ b/src/Cake.Common/Tools/DotNet/MSBuild/DotNetMSBuildBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -13,6 +13,10 @@ namespace Cake.Common.Tools.DotNet.MSBuild
     /// <summary>
     /// .NET Core project builder.
     /// </summary>
+    /// <remarks>
+    /// Verbosity is passed as MSBuild /verbosity (not dotnet --verbosity) because dotnet msbuild forwards
+    /// arguments to MSBuild, which does not accept the dotnet CLI --verbosity form and fails with MSB1016.
+    /// </remarks>
     public sealed class DotNetMSBuildBuilder : DotNetTool<DotNetMSBuildSettings>
     {
         private readonly ICakeEnvironment _environment;
@@ -39,13 +43,18 @@ namespace Cake.Common.Tools.DotNet.MSBuild
         /// <param name="projectOrDirectory">The target project path.</param>
         /// <param name="settings">The settings.</param>
         /// <param name="standardOutputAction">The action to invoke with the standard output.</param>
+        /// <remarks>
+        /// Calls Run directly so that dotnet --verbosity is not appended (it would cause MSB1016);
+        /// verbosity is passed as MSBuild /verbosity in the arguments instead.
+        /// </remarks>
         public void Build(string projectOrDirectory, DotNetMSBuildSettings settings, Action<IEnumerable<string>> standardOutputAction)
         {
             ArgumentNullException.ThrowIfNull(settings);
 
-            RunCommand(
+            var arguments = GetArguments(projectOrDirectory, settings);
+            Run(
                 settings,
-                GetArguments(projectOrDirectory, settings),
+                arguments,
                 standardOutputAction == null ? null : new ProcessSettings { RedirectStandardOutput = true },
                 standardOutputAction == null ? null : new Action<IProcess>(process => standardOutputAction(process.GetStandardOutput())));
         }

--- a/src/Cake.Common/Tools/DotNet/MSBuild/MSBuildArgumentBuilderExtensions.cs
+++ b/src/Cake.Common/Tools/DotNet/MSBuild/MSBuildArgumentBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -40,6 +40,12 @@ namespace Cake.Common.Tools.DotNet.MSBuild
             ArgumentNullException.ThrowIfNull(builder);
 
             var msBuilder = new ProcessArgumentBuilder();
+
+            // Verbosity: use MSBuild /verbosity switch (dotnet msbuild does not support --verbosity; it forwards to MSBuild which expects /verbosity:x)
+            if (settings.Verbosity.HasValue)
+            {
+                msBuilder.AppendMSBuildSwitch("verbosity", GetMSBuildVerbosityValue(settings.Verbosity.Value));
+            }
 
             // Got any targets?
             if (settings.Targets.Any())
@@ -287,6 +293,20 @@ namespace Cake.Common.Tools.DotNet.MSBuild
             var counter = index == 0 ? string.Empty : index.ToString();
             return $"/fileLogger{counter} /fileloggerparameters{counter}:{parameters}";
         }
+
+        /// <summary>
+        /// Maps <see cref="DotNet.DotNetVerbosity"/> to MSBuild verbosity string (quiet, minimal, normal, detailed, diagnostic).
+        /// </summary>
+        private static string GetMSBuildVerbosityValue(DotNet.DotNetVerbosity verbosity)
+            => verbosity switch
+            {
+                DotNet.DotNetVerbosity.Quiet => "quiet",
+                DotNet.DotNetVerbosity.Minimal => "minimal",
+                DotNet.DotNetVerbosity.Normal => "normal",
+                DotNet.DotNetVerbosity.Detailed => "detailed",
+                DotNet.DotNetVerbosity.Diagnostic => "diagnostic",
+                _ => throw new ArgumentOutOfRangeException(nameof(verbosity), verbosity, "Invalid value"),
+            };
 
         private static string GetToolVersionValue(MSBuildVersion toolVersion)
         {

--- a/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
+++ b/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
@@ -216,8 +216,8 @@ Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetMSBuild")
     var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
     var assembly = path.CombineWithFilePath("hwapp/bin/Debug/net10.0/hwapp.dll");
 
-    // When
-    DotNetMSBuild(project.FullPath);
+    // When (Verbosity.Quiet exercises MSBuild /verbosity, not dotnet --verbosity; see https://github.com/cake-build/cake/issues/4456)
+    DotNetMSBuild(project.FullPath, new DotNetMSBuildSettings { Verbosity = DotNetVerbosity.Quiet });
 
     // Then
     Assert.True(System.IO.File.Exists(assembly.FullPath));


### PR DESCRIPTION
Use MSBuild /verbosity switch instead of dotnet --verbosity for DotNetMSBuild, since dotnet msbuild forwards arguments to MSBuild, which does not accept --verbosity and fails with MSB1016.

- Add verbosity to MSBuild args in AppendMSBuildSettings via GetMSBuildVerbosityValue (quiet, minimal, normal, detailed, diagnostic)
- Call Run() directly from DotNetMSBuildBuilder.Build() so AppendCommonArguments (and thus --verbosity) is not appended
- Add unit test that verbosity is emitted as /verbosity:x and not --verbosity
- Use Verbosity.Quiet in DotNetMSBuild integration task to cover the fix
- fixes #4456
