### PR TITLE
GH4575: Use AppContext.BaseDirectory for ApplicationRoot

### DIFF
--- a/src/Cake.Core.Tests/Unit/CakeEnvironmentTests.cs
+++ b/src/Cake.Core.Tests/Unit/CakeEnvironmentTests.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core.IO;
+using Xunit;
+
+namespace Cake.Core.Tests.Unit
+{
+    /// <summary>
+    /// Tests for <see cref="CakeEnvironment"/>.
+    /// </summary>
+    public sealed class CakeEnvironmentTests
+    {
+        /// <summary>
+        /// Tests that ApplicationRoot is set to a valid rooted path when the environment is created.
+        /// When Assembly.Location is empty (e.g. single-file publish, AOT), ApplicationRoot falls back to AppContext.BaseDirectory.
+        /// </summary>
+        [Fact]
+        public void ApplicationRoot_Should_Be_Valid_Rooted_Path()
+        {
+            // Given
+            var platform = new CakePlatform();
+            var runtime = new CakeRuntime();
+
+            // When
+            var environment = new CakeEnvironment(platform, runtime);
+
+            // Then - ApplicationRoot must be set and rooted so script loading and tool resolution work
+            Assert.NotNull(environment.ApplicationRoot);
+            Assert.NotNull(environment.ApplicationRoot.FullPath);
+            Assert.False(string.IsNullOrWhiteSpace(environment.ApplicationRoot.FullPath));
+            Assert.True(environment.ApplicationRoot.IsRelative == false, "ApplicationRoot should be an absolute path.");
+        }
+    }
+}

--- a/src/Cake.Core/CakeEnvironment.cs
+++ b/src/Cake.Core/CakeEnvironment.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -43,9 +43,7 @@ namespace Cake.Core
             Runtime = runtime;
 
             // Get the application root.
-            var assembly = AssemblyHelper.GetExecutingAssembly();
-            var path = PathHelper.GetDirectoryName(assembly.Location);
-            ApplicationRoot = new DirectoryPath(path);
+            ApplicationRoot = new DirectoryPath(AppContext.BaseDirectory);
 
             // Get the working directory.
             WorkingDirectory = new DirectoryPath(System.IO.Directory.GetCurrentDirectory());

--- a/tests/integration/Cake.Core/CakeEnvironment.cake
+++ b/tests/integration/Cake.Core/CakeEnvironment.cake
@@ -1,0 +1,25 @@
+#load "./../../utilities/xunit.cake"
+
+//////////////////////////////////////////////////////////////////////////////
+// Integration tests for CakeEnvironment (ApplicationRoot from AppContext.BaseDirectory).
+// When Assembly.Location is empty (e.g. single-file publish, AOT), ApplicationRoot
+// must still be a valid rooted path so script loading and tool resolution work.
+//////////////////////////////////////////////////////////////////////////////
+
+Task("Cake.Core.CakeEnvironment.ApplicationRoot.ValidRootedPath")
+    .Does(() =>
+{
+    // Given - Context.Environment is the real CakeEnvironment used at runtime
+    var applicationRoot = Context.Environment.ApplicationRoot;
+
+    // Then - ApplicationRoot must be set and rooted so script loading and tool resolution work
+    Assert.NotNull(applicationRoot);
+    Assert.NotNull(applicationRoot.FullPath);
+    Assert.False(string.IsNullOrWhiteSpace(applicationRoot.FullPath));
+    Assert.False(applicationRoot.IsRelative);
+});
+
+//////////////////////////////////////////////////////////////////////////////
+
+Task("Cake.Core.CakeEnvironment")
+    .IsDependentOn("Cake.Core.CakeEnvironment.ApplicationRoot.ValidRootedPath");

--- a/tests/integration/build.cake
+++ b/tests/integration/build.cake
@@ -42,6 +42,7 @@
 #load "./Cake.Core/Scripting/SpectreConsole.cake"
 #load "./Cake.Core/Tooling/ToolLocator.cake"
 #load "./Cake.Core/CakeAliases.cake"
+#load "./Cake.Core/CakeEnvironment.cake"
 #load "./Cake.DotNetTool.Module/Cake.DotNetTool.Module.cake"
 #load "./Cake.NuGet/InProcessInstaller.cake"
 
@@ -59,6 +60,7 @@ Task("Cake")
     .IsDependentOn("Cake.ScriptCache");
 
 Task("Cake.Core")
+    .IsDependentOn("Cake.Core.CakeEnvironment")
     .IsDependentOn("Cake.Core.Diagnostics")
     .IsDependentOn("Cake.Core.IO.Path")
     .IsDependentOn("Cake.Core.Scripting.AddinDirective")


### PR DESCRIPTION
* Set CakeEnvironment.ApplicationRoot from AppContext.BaseDirectory instead of Assembly.Location so it works when Location is empty (e.g. single-file publish, AOT)
* Add unit test ensuring ApplicationRoot is a valid rooted path
* Add integration test for ApplicationRoot in real Cake runs
* Register CakeEnvironment integration test in build.cake
* fixes #4575
