### PR TITLE
GH4453: Add GitVersion 6+ compatibility with legacy property fallback

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/GitVersionRunnerFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/GitVersionRunnerFixture.cs
@@ -1,10 +1,8 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.IO;
-using System.Runtime.Serialization.Json;
 using Cake.Common.Tools.GitVersion;
 using Cake.Core.Diagnostics;
 using Cake.Testing.Fixtures;
@@ -16,32 +14,22 @@ namespace Cake.Common.Tests.Fixtures.Tools
     {
         public ICakeLog Log { get; set; }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
         public GitVersionRunnerFixture(ICollection<string> standardOutput = null)
              : base("GitVersion.exe")
         {
             if (standardOutput == null)
             {
-                var resultJson = new GitVersion
-                {
-                    Major = 1,
-                    Minor = 0,
-                    Patch = 0
-                };
-
-                var serializer = new DataContractJsonSerializer(typeof(GitVersion));
-                using (var memoryStream = new MemoryStream())
-                using (var reader = new StreamReader(memoryStream))
-                {
-                    serializer.WriteObject(memoryStream, resultJson);
-                    memoryStream.Position = 0;
-                    var output = new List<string>();
-                    while (!reader.EndOfStream)
-                    {
-                        output.Add(reader.ReadLine());
-                    }
-                    standardOutput = output;
-                }
+                // Minimal GitVersion-style JSON (string values match GitVersion CLI output).
+                standardOutput =
+                    [
+                        """
+                        {
+                            "Major":"1",
+                            "Minor":"0",
+                            "Patch":"0"
+                        }
+                        """
+                    ];
             }
 
             ProcessRunner.Process.SetStandardOutput(standardOutput);

--- a/src/Cake.Common.Tests/Unit/Tools/GitVersion/GitVersionRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/GitVersion/GitVersionRunnerTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -504,6 +504,46 @@ namespace Cake.Common.Tests.Unit.Tools.GitVersion
                 Assert.Equal(expect.CommitsSinceVersionSourcePadded, result.CommitsSinceVersionSourcePadded);
                 Assert.Equal(expect.UncommittedChanges, result.UncommittedChanges);
                 Assert.Equal(expect.CommitDate, result.CommitDate);
+            }
+
+            [Fact]
+            public void Should_Populate_Legacy_Properties_When_Not_Returned_By_GitVersion_6()
+            {
+                // GitVersion 6+ omits legacy output variables; Cake best-effort populates them from remaining properties.
+                var fixture = new GitVersionRunnerFixture(
+                    new[]
+                    {
+                        "{",
+                        "  \"Major\":6,",
+                        "  \"Minor\":1,",
+                        "  \"Patch\":0,",
+                        "  \"PreReleaseTag\":\"alpha.41\",",
+                        "  \"PreReleaseTagWithDash\":\"-alpha.41\",",
+                        "  \"PreReleaseLabel\":\"alpha\",",
+                        "  \"PreReleaseLabelWithDash\":\"-alpha\",",
+                        "  \"PreReleaseNumber\":\"41\",",
+                        "  \"BuildMetaData\":\"41.Branch.feature.Sha.abc123\",",
+                        "  \"MajorMinorPatch\":\"6.1.0\",",
+                        "  \"SemVer\":\"6.1.0-alpha.41\",",
+                        "  \"FullSemVer\":\"6.1.0-alpha.41+41\",",
+                        "  \"BranchName\":\"feature/gh-4575\",",
+                        "  \"Sha\":\"abc123def456\",",
+                        "  \"CommitsSinceVersionSource\":\"41\"",
+                        "}"
+                    });
+                fixture.Settings.OutputType = GitVersionOutput.Json;
+
+                var result = fixture.RunGitVersion();
+
+                Assert.Equal("6.1.0", result.MajorMinorPatch);
+                Assert.Equal("0041", result.CommitsSinceVersionSourcePadded);
+                Assert.Equal("0041", result.BuildMetaDataPadded);
+                Assert.Equal("6.1.0-alpha41", result.LegacySemVer);
+                Assert.Equal("6.1.0-alpha0041", result.LegacySemVerPadded);
+                Assert.Equal("6.1.0-alpha0041", result.NuGetVersionV2);
+                Assert.Equal("6.1.0-alpha0041", result.NuGetVersion);
+                Assert.Equal("-alpha", result.NuGetPreReleaseTagV2);
+                Assert.Equal("-alpha", result.NuGetPreReleaseTag);
             }
 
             [Theory]

--- a/src/Cake.Common/Tools/GitVersion/GitVersionInternal.cs
+++ b/src/Cake.Common/Tools/GitVersion/GitVersionInternal.cs
@@ -3,242 +3,244 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
-using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Cake.Common.Tools.GitVersion
 {
-    [DataContract(Name = "GitVersion")]
+    /// <summary>
+    /// Internal DTO for deserializing GitVersion JSON output. Property names match GitVersion CLI output (PascalCase).
+    /// </summary>
     internal class GitVersionInternal
     {
         private GitVersion _gitVersion;
 
         internal GitVersion GitVersion => _gitVersion ?? (_gitVersion = new GitVersion());
 
-        [DataMember]
+        [JsonPropertyName("Major")]
         public string Major
         {
             get => ToString(GitVersion.Major);
             set => GitVersion.Major = ToInt(value);
         }
 
-        [DataMember]
+        [JsonPropertyName("Minor")]
         public string Minor
         {
             get => ToString(GitVersion.Minor);
             set => GitVersion.Minor = ToInt(value);
         }
 
-        [DataMember]
+        [JsonPropertyName("Patch")]
         public string Patch
         {
             get => ToString(GitVersion.Patch);
             set => GitVersion.Patch = ToInt(value);
         }
 
-        [DataMember]
+        [JsonPropertyName("PreReleaseTag")]
         public string PreReleaseTag
         {
             get => GitVersion.PreReleaseTag;
             set => GitVersion.PreReleaseTag = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("PreReleaseTagWithDash")]
         public string PreReleaseTagWithDash
         {
             get => GitVersion.PreReleaseTagWithDash;
             set => GitVersion.PreReleaseTagWithDash = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("PreReleaseLabel")]
         public string PreReleaseLabel
         {
             get => GitVersion.PreReleaseLabel;
             set => GitVersion.PreReleaseLabel = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("PreReleaseLabelWithDash")]
         public string PreReleaseLabelWithDash
         {
             get => GitVersion.PreReleaseLabelWithDash;
             set => GitVersion.PreReleaseLabelWithDash = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("PreReleaseNumber")]
         public string PreReleaseNumber
         {
             get => ToString(GitVersion.PreReleaseNumber);
             set => GitVersion.PreReleaseNumber = ToNullableInt(value);
         }
 
-        [DataMember]
+        [JsonPropertyName("WeightedPreReleaseNumber")]
         public string WeightedPreReleaseNumber
         {
             get => ToString(GitVersion.WeightedPreReleaseNumber);
             set => GitVersion.WeightedPreReleaseNumber = ToNullableInt(value);
         }
 
-        [DataMember]
+        [JsonPropertyName("BuildMetaData")]
         public string BuildMetaData
         {
             get => GitVersion.BuildMetaData;
             set => GitVersion.BuildMetaData = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("BuildMetaDataPadded")]
         public string BuildMetaDataPadded
         {
             get => GitVersion.BuildMetaDataPadded;
             set => GitVersion.BuildMetaDataPadded = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("FullBuildMetaData")]
         public string FullBuildMetaData
         {
             get => GitVersion.FullBuildMetaData;
             set => GitVersion.FullBuildMetaData = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("MajorMinorPatch")]
         public string MajorMinorPatch
         {
             get => GitVersion.MajorMinorPatch;
             set => GitVersion.MajorMinorPatch = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("SemVer")]
         public string SemVer
         {
             get => GitVersion.SemVer;
             set => GitVersion.SemVer = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("LegacySemVer")]
         public string LegacySemVer
         {
             get => GitVersion.LegacySemVer;
             set => GitVersion.LegacySemVer = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("LegacySemVerPadded")]
         public string LegacySemVerPadded
         {
             get => GitVersion.LegacySemVerPadded;
             set => GitVersion.LegacySemVerPadded = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("AssemblySemVer")]
         public string AssemblySemVer
         {
             get => GitVersion.AssemblySemVer;
             set => GitVersion.AssemblySemVer = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("AssemblySemFileVer")]
         public string AssemblySemFileVer
         {
             get => GitVersion.AssemblySemFileVer;
             set => GitVersion.AssemblySemFileVer = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("FullSemVer")]
         public string FullSemVer
         {
             get => GitVersion.FullSemVer;
             set => GitVersion.FullSemVer = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("InformationalVersion")]
         public string InformationalVersion
         {
             get => GitVersion.InformationalVersion;
             set => GitVersion.InformationalVersion = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("BranchName")]
         public string BranchName
         {
             get => GitVersion.BranchName;
             set => GitVersion.BranchName = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("EscapedBranchName")]
         public string EscapedBranchName
         {
             get => GitVersion.EscapedBranchName;
             set => GitVersion.EscapedBranchName = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("Sha")]
         public string Sha
         {
             get => GitVersion.Sha;
             set => GitVersion.Sha = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("ShortSha")]
         public string ShortSha
         {
             get => GitVersion.ShortSha;
             set => GitVersion.ShortSha = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("NuGetVersionV2")]
         public string NuGetVersionV2
         {
             get => GitVersion.NuGetVersionV2;
             set => GitVersion.NuGetVersionV2 = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("NuGetVersion")]
         public string NuGetVersion
         {
             get => GitVersion.NuGetVersion;
             set => GitVersion.NuGetVersion = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("NuGetPreReleaseTagV2")]
         public string NuGetPreReleaseTagV2
         {
             get => GitVersion.NuGetPreReleaseTagV2;
             set => GitVersion.NuGetPreReleaseTagV2 = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("NuGetPreReleaseTag")]
         public string NuGetPreReleaseTag
         {
             get => GitVersion.NuGetPreReleaseTag;
             set => GitVersion.NuGetPreReleaseTag = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("VersionSourceSha")]
         public string VersionSourceSha
         {
             get => GitVersion.VersionSourceSha;
             set => GitVersion.VersionSourceSha = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("CommitsSinceVersionSource")]
         public string CommitsSinceVersionSource
         {
             get => ToString(GitVersion.CommitsSinceVersionSource);
             set => GitVersion.CommitsSinceVersionSource = ToNullableInt(value);
         }
 
-        [DataMember]
+        [JsonPropertyName("CommitsSinceVersionSourcePadded")]
         public string CommitsSinceVersionSourcePadded
         {
             get => GitVersion.CommitsSinceVersionSourcePadded;
             set => GitVersion.CommitsSinceVersionSourcePadded = value;
         }
 
-        [DataMember]
+        [JsonPropertyName("UncommittedChanges")]
         public string UncommittedChanges
         {
             get => ToString(GitVersion.UncommittedChanges);
             set => GitVersion.UncommittedChanges = ToNullableInt(value);
         }
 
-        [DataMember]
+        [JsonPropertyName("CommitDate")]
         public string CommitDate
         {
             get => GitVersion.CommitDate;

--- a/src/Cake.Common/Tools/GitVersion/GitVersionJsonContext.cs
+++ b/src/Cake.Common/Tools/GitVersion/GitVersionJsonContext.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Cake.Common.Tools.GitVersion
+{
+    /// <summary>
+    /// Source-generated JSON serializer context for GitVersion types.
+    /// Uses static options that include <see cref="JsonStringOrNumberConverter"/> so CLI number/string values deserialize to string properties.
+    /// </summary>
+    [JsonSerializable(typeof(GitVersionInternal))]
+    internal partial class GitVersionJsonContext : JsonSerializerContext
+    {
+        /// <summary>
+        /// Gets the static serializer options used for GitVersion JSON (includes <see cref="JsonStringOrNumberConverter"/>).
+        /// </summary>
+        public static JsonSerializerOptions SerializerOptions { get; } = new ()
+        {
+            Converters = { new JsonStringOrNumberConverter() }
+        };
+
+        /// <summary>
+        /// Gets the context instance with options that allow number-or-string for string properties (uses <see cref="SerializerOptions"/>).
+        /// Use this instead of <see cref="Default"/> when deserializing GitVersion CLI output.
+        /// </summary>
+        public static GitVersionJsonContext DefaultWithConverter { get; } = new (SerializerOptions);
+    }
+}

--- a/src/Cake.Common/Tools/GitVersion/GitVersionLegacyCompat.cs
+++ b/src/Cake.Common/Tools/GitVersion/GitVersionLegacyCompat.cs
@@ -1,0 +1,121 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+
+namespace Cake.Common.Tools.GitVersion
+{
+    /// <summary>
+    /// Best-effort population of legacy GitVersion properties removed in GitVersion 6.
+    /// When the tool omits these fields (e.g. GitVersion 6+), they are computed from
+    /// the properties that are still present so existing Cake scripts keep working.
+    /// </summary>
+    internal static class GitVersionLegacyCompat
+    {
+        private const int DefaultPadding = 4;
+
+        /// <summary>
+        /// Populates legacy properties on the given <see cref="GitVersion"/> instance when they are null.
+        /// Uses the same formulas as GitVersion 5 where possible (e.g. LegacySemVerPadded, NuGetVersion).
+        /// </summary>
+        /// <param name="version">The GitVersion instance to fill; not modified if null.</param>
+        public static void PopulateLegacyProperties(GitVersion version)
+        {
+            if (version == null)
+            {
+                return;
+            }
+
+            var majorMinorPatch = version.MajorMinorPatch ?? string.Empty;
+
+            if (string.IsNullOrEmpty(version.CommitsSinceVersionSourcePadded) && version.CommitsSinceVersionSource.HasValue)
+            {
+                version.CommitsSinceVersionSourcePadded = version.CommitsSinceVersionSource.Value.ToString("D" + DefaultPadding, CultureInfo.InvariantCulture);
+            }
+
+            if (string.IsNullOrEmpty(version.BuildMetaDataPadded))
+            {
+                version.BuildMetaDataPadded = version.CommitsSinceVersionSource.HasValue
+                    ? version.CommitsSinceVersionSource.Value.ToString("D" + DefaultPadding, CultureInfo.InvariantCulture)
+                    : (version.BuildMetaData ?? string.Empty);
+            }
+
+            if (string.IsNullOrEmpty(version.LegacySemVer))
+            {
+                version.LegacySemVer = GetLegacySemVer(majorMinorPatch, version.PreReleaseLabelWithDash, version.PreReleaseNumber);
+            }
+
+            if (string.IsNullOrEmpty(version.LegacySemVerPadded))
+            {
+                version.LegacySemVerPadded = GetLegacySemVerPadded(majorMinorPatch, version.PreReleaseLabelWithDash, version.PreReleaseNumber);
+            }
+
+            if (string.IsNullOrEmpty(version.NuGetVersionV2) || string.IsNullOrEmpty(version.NuGetVersion))
+            {
+                var nuGetVersion = version.LegacySemVerPadded ?? version.SemVer ?? majorMinorPatch;
+                if (string.IsNullOrEmpty(version.NuGetVersionV2))
+                {
+                    version.NuGetVersionV2 = nuGetVersion.ToLowerInvariant();
+                }
+
+                if (string.IsNullOrEmpty(version.NuGetVersion))
+                {
+                    version.NuGetVersion = version.NuGetVersionV2;
+                }
+            }
+
+            if (string.IsNullOrEmpty(version.NuGetPreReleaseTagV2) || string.IsNullOrEmpty(version.NuGetPreReleaseTag))
+            {
+                var nuGetPreRelease = (version.PreReleaseLabelWithDash ?? string.Empty).ToLowerInvariant();
+                if (string.IsNullOrEmpty(version.NuGetPreReleaseTagV2))
+                {
+                    version.NuGetPreReleaseTagV2 = nuGetPreRelease;
+                }
+
+                if (string.IsNullOrEmpty(version.NuGetPreReleaseTag))
+                {
+                    version.NuGetPreReleaseTag = nuGetPreRelease;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Legacy semantic version: {MajorMinorPatch}-{PreReleaseLabel}{PreReleaseNumber} (no dot between label and number).
+        /// </summary>
+        private static string GetLegacySemVer(string majorMinorPatch, string preReleaseLabelWithDash, int? preReleaseNumber)
+        {
+            if (string.IsNullOrEmpty(majorMinorPatch))
+            {
+                return string.Empty;
+            }
+
+            if (string.IsNullOrEmpty(preReleaseLabelWithDash) || !preReleaseNumber.HasValue)
+            {
+                return majorMinorPatch;
+            }
+
+            return majorMinorPatch + preReleaseLabelWithDash + preReleaseNumber.Value.ToString(CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Legacy semantic version with padded pre-release number (4 digits).
+        /// Format: {MajorMinorPatch}-{PreReleaseLabel}{PreReleaseNumber:D4}.
+        /// Example: 6.1.0-alpha0041.
+        /// </summary>
+        private static string GetLegacySemVerPadded(string majorMinorPatch, string preReleaseLabelWithDash, int? preReleaseNumber)
+        {
+            if (string.IsNullOrEmpty(majorMinorPatch))
+            {
+                return string.Empty;
+            }
+
+            if (string.IsNullOrEmpty(preReleaseLabelWithDash) || !preReleaseNumber.HasValue)
+            {
+                return majorMinorPatch;
+            }
+
+            return majorMinorPatch + preReleaseLabelWithDash + preReleaseNumber.Value.ToString("D" + DefaultPadding, CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/GitVersion/GitVersionRunner.cs
+++ b/src/Cake.Common/Tools/GitVersion/GitVersionRunner.cs
@@ -1,13 +1,11 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Runtime.Serialization.Json;
-using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using Cake.Core;
 using Cake.Core.Diagnostics;
@@ -67,11 +65,9 @@ namespace Cake.Common.Tools.GitVersion
                     }
                 });
 
-                var jsonSerializer = new DataContractJsonSerializer(typeof(GitVersionInternal));
-                using (var jsonStream = new MemoryStream(Encoding.UTF8.GetBytes(output)))
-                {
-                    return (jsonSerializer.ReadObject(jsonStream) as GitVersionInternal)?.GitVersion;
-                }
+                var result = JsonSerializer.Deserialize(output, GitVersionJsonContext.DefaultWithConverter.GitVersionInternal)?.GitVersion;
+                GitVersionLegacyCompat.PopulateLegacyProperties(result);
+                return result;
             }
 
             Run(settings, GetArguments(settings));

--- a/src/Cake.Common/Tools/GitVersion/JsonStringOrNumberConverter.cs
+++ b/src/Cake.Common/Tools/GitVersion/JsonStringOrNumberConverter.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Cake.Common.Tools.GitVersion
+{
+    /// <summary>
+    /// Allows deserializing JSON number or string values into a <see cref="string"/> property.
+    /// GitVersion CLI may output numeric values (e.g. Major: 6) or strings; this converter accepts both.
+    /// </summary>
+    internal sealed class JsonStringOrNumberConverter : JsonConverter<string>
+    {
+        /// <inheritdoc />
+        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return reader.TokenType switch
+            {
+                JsonTokenType.String => reader.GetString(),
+                JsonTokenType.Number => reader.TryGetInt64(out var n) ? n.ToString(CultureInfo.InvariantCulture) : reader.GetDouble().ToString(CultureInfo.InvariantCulture),
+                JsonTokenType.Null => null,
+                _ => throw new JsonException($"Unexpected token {reader.TokenType} when reading string.")
+            };
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                writer.WriteStringValue(value);
+            }
+        }
+    }
+}

--- a/tests/integration/Cake.Common/Tools/GitVersion/GitVersionAliases.cake
+++ b/tests/integration/Cake.Common/Tools/GitVersion/GitVersionAliases.cake
@@ -1,0 +1,80 @@
+#tool "dotnet:https://api.nuget.org/v3/index.json?package=GitVersion.Tool&version=6.6.0"
+#load "./../../../utilities/xunit.cake"
+#load "./../../../utilities/paths.cake"
+
+//////////////////////////////////////////////////////////////////////////////
+// Integration tests for GitVersion aliases.
+// Verifies GitVersion() runs with GitVersion.Tool 6+ and that legacy
+// properties (LegacySemVerPadded, NuGetVersion, etc.) are populated.
+// Skipped when CAKE_SKIP_GITVERSION is "True" (case-insensitive).
+//////////////////////////////////////////////////////////////////////////////
+
+public record GitVersionBuildData(bool SkipGitVersion);
+
+Setup<GitVersionBuildData>(setupContext =>
+{
+    var skipGitVersion = StringComparer.OrdinalIgnoreCase.Equals("True", EnvironmentVariable("CAKE_SKIP_GITVERSION"));
+    return new GitVersionBuildData(skipGitVersion);
+});
+
+Task("Cake.Common.Tools.GitVersion.GitVersionAliases.GitVersion.Default")
+    .WithCriteria<GitVersionBuildData>((context, data) => !data.SkipGitVersion)
+    .Does(() =>
+{
+    // When - run GitVersion with default settings (JSON output) in current repo
+    var result = GitVersion(new GitVersionSettings { OutputType = GitVersionOutput.Json });
+
+    // Then - core properties are set
+    Assert.NotNull(result);
+    Assert.True(result.Major >= 0, "Major should be non-negative");
+    Assert.True(result.Minor >= 0, "Minor should be non-negative");
+    Assert.True(result.Patch >= 0, "Patch should be non-negative");
+    Assert.NotNull(result.MajorMinorPatch);
+    Assert.NotNull(result.SemVer);
+});
+
+Task("Cake.Common.Tools.GitVersion.GitVersionAliases.GitVersion.LegacyPropertiesPopulated")
+    .WithCriteria<GitVersionBuildData>((context, data) => !data.SkipGitVersion)
+    .Does(() =>
+{
+    // When - run GitVersion (GitVersion 6+ omits legacy vars; Cake populates them)
+    var result = GitVersion(new GitVersionSettings { OutputType = GitVersionOutput.Json });
+
+    // Then - legacy properties are populated (best-effort when null from tool)
+    Assert.NotNull(result);
+    Assert.NotNull(result.LegacySemVer);
+    Assert.NotNull(result.LegacySemVerPadded);
+    Assert.NotNull(result.NuGetVersion);
+    Assert.NotNull(result.NuGetVersionV2);
+    Assert.NotNull(result.CommitsSinceVersionSourcePadded);
+    Assert.NotNull(result.BuildMetaDataPadded);
+    // NuGet pre-release can be empty for release versions
+    Assert.NotNull(result.NuGetPreReleaseTag);
+    Assert.NotNull(result.NuGetPreReleaseTagV2);
+});
+
+Task("Cake.Common.Tools.GitVersion.GitVersionAliases.GitVersion.LegacySemVerPadded.Format")
+    .WithCriteria<GitVersionBuildData>((context, data) => !data.SkipGitVersion)
+    .Does(() =>
+{
+    var result = GitVersion(new GitVersionSettings { OutputType = GitVersionOutput.Json });
+
+    // LegacySemVerPadded should equal SemVer when no pre-release, or match known format
+    Assert.NotNull(result.LegacySemVerPadded);
+    if (string.IsNullOrEmpty(result.PreReleaseLabel))
+    {
+        Assert.Equal(result.MajorMinorPatch, result.LegacySemVerPadded);
+    }
+    else
+    {
+        Assert.Contains(result.MajorMinorPatch, result.LegacySemVerPadded);
+    }
+});
+
+//////////////////////////////////////////////////////////////////////////////
+
+Task("Cake.Common.Tools.GitVersion.GitVersionAliases")
+    .WithCriteria<GitVersionBuildData>((context, data) => !data.SkipGitVersion)
+    .IsDependentOn("Cake.Common.Tools.GitVersion.GitVersionAliases.GitVersion.Default")
+    .IsDependentOn("Cake.Common.Tools.GitVersion.GitVersionAliases.GitVersion.LegacyPropertiesPopulated")
+    .IsDependentOn("Cake.Common.Tools.GitVersion.GitVersionAliases.GitVersion.LegacySemVerPadded.Format");

--- a/tests/integration/build.cake
+++ b/tests/integration/build.cake
@@ -27,6 +27,7 @@
 #load "./Cake.Common/Tools/Cake/CakeAliases.cake"
 #load "./Cake.Common/Tools/Command/CommandAliases.cake"
 #load "./Cake.Common/Tools/DotNet/DotNetAliases.cake"
+#load "./Cake.Common/Tools/GitVersion/GitVersionAliases.cake"
 #load "./Cake.Common/Tools/NuGet/NuGetAliases.cake"
 #load "./Cake.Common/Tools/Chocolatey/ChocolateyAliases.cake"
 #load "./Cake.Common/Tools/TextTransform/TextTransformAliases.cake"
@@ -95,6 +96,7 @@ Task("Cake.Common")
     .IsDependentOn("Cake.Common.Tools.Cake.CakeAliases")
     .IsDependentOn("Cake.Common.Tools.Command.CommandAliases")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases")
+    .IsDependentOn("Cake.Common.Tools.GitVersion.GitVersionAliases")
     .IsDependentOn("Cake.Common.Tools.NuGet.NuGetAliases")
     .IsDependentOn("Cake.Common.Tools.TextTransform.TextTransformAliases");
 


### PR DESCRIPTION
- Switch GitVersion JSON deserialization from DataContractSerializer to System.Text.Json
- Add JsonStringOrNumberConverter to support Major/Minor/Patch as number or string from CLI
- Add GitVersionJsonContext for source-generated deserialization with converter
- Add GitVersionLegacyCompat to populate legacy properties when GitVersion 6+ omits them (e.g. LegacySemVer, NuGetVersion, CommitsSinceVersionSourcePadded)
- Update GitVersionInternal to use JsonPropertyName attributes and document the DTO
- Simplify GitVersionRunnerFixture to use raw GitVersion-style JSON strings instead of DataContractJsonSerializer
- Add unit test for legacy property population when output lacks them (GitVersion 6 style)
- Include GitVersion aliases in integration build.cake
- fixes #4453
- Could also aid with sorting https://github.com/cake-contrib/Cake.Recipe/issues/1014