### PR TITLE
Use inspectcode.sh on non-Windows platforms (#4313)

### DIFF
--- a/src/Cake.Common/Tools/InspectCode/InspectCodeRunner.cs
+++ b/src/Cake.Common/Tools/InspectCode/InspectCodeRunner.cs
@@ -225,7 +225,17 @@ namespace Cake.Common.Tools.InspectCode
         /// <returns>The tool executable name.</returns>
         protected override IEnumerable<string> GetToolExecutableNames(InspectCodeSettings settings)
         {
-            return new[] { settings != null && settings.UseX86Tool ? "inspectcode.x86.exe" : "inspectcode.exe" };
+            if (_environment.Platform.Family == PlatformFamily.Windows)
+            {
+                return new[] { settings != null && settings.UseX86Tool ? "inspectcode.x86.exe" : "inspectcode.exe" };
+            }
+
+            if (settings != null && settings.UseX86Tool)
+            {
+                return new[] { "inspectcode.x86.exe", "inspectcode.sh", "inspectcode.exe" };
+            }
+
+            return new[] { "inspectcode.sh", "inspectcode.exe" };
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #4313

On Linux/macOS installations of ReSharper Command Line Tools the entry point is
"inspectcode.sh", but Cake currently attempts to execute "inspectcode.exe".

This change prefers `inspectcode.sh` on non-Windows platforms while keeping
".exe" as fallback to preserve compatibility with existing setups and tests.