### PR TITLE
GH4771: Update System.Security.Cryptography.Pkcs to 9.0.14 & 10.0.5 (net9.0&net10.0)

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -42,13 +42,13 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <!-- Pin nuget transitive packages vulnerability issues NuGet.Packaging -->
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.3" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.5" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.14" />
     <!-- Pin nuget transitive packages vulnerability issues NuGet.Packaging -->
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.13" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.14" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">


### PR DESCRIPTION
* fixes #4771
