### PR TITLE
GH4454: Support dotnet package search --exact-match JSON version property

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/DotNet/Package/Search/DotNetPackageSearcherFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/DotNet/Package/Search/DotNetPackageSearcherFixture.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -41,6 +41,35 @@ namespace Cake.Common.Tests.Fixtures.Tools.DotNet.Package.Search
                 "        {",
                 "          \"id\": \"Cake.CoreCLR\",",
                 "          \"latestVersion\": \"0.22.2\"",
+                "        }",
+                "      ]",
+                "    }",
+                "  ]",
+                "}",
+            });
+        }
+
+        /// <summary>
+        /// Sets standard output to exact-match format (uses "version" instead of "latestVersion" per package).
+        /// </summary>
+        internal void GivenExactMatchPackageResult()
+        {
+            ProcessRunner.Process.SetStandardOutput(new string[]
+            {
+                "{",
+                "  \"version\": 2,",
+                "  \"problems\": [],",
+                "  \"searchResult\": [",
+                "    {",
+                "      \"sourceName\": \"nuget.org\",",
+                "      \"packages\": [",
+                "        {",
+                "          \"id\": \"Refit.Newtonsoft.Json\",",
+                "          \"version\": \"7.0.0\"",
+                "        },",
+                "        {",
+                "          \"id\": \"Refit.Newtonsoft.Json\",",
+                "          \"version\": \"6.3.0\"",
                 "        }",
                 "      ]",
                 "    }",

--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Package/Search/DotNetPackageSearcherTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Package/Search/DotNetPackageSearcherTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -166,6 +166,32 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Package.Search
                     {
                         Assert.Equal(item.Name, "Cake.CoreCLR");
                         Assert.Equal(item.Version, "0.22.2");
+                    });
+            }
+
+            [Fact]
+            public void Should_Return_Versions_When_ExactMatch_Json_Uses_Version_Property()
+            {
+                // Given: dotnet package search --exact-match --format json returns "version" not "latestVersion"
+                var fixture = new DotNetPackageSearcherFixture();
+                fixture.SearchTerm = "Refit.Newtonsoft.Json";
+                fixture.Settings.ExactMatch = true;
+                fixture.GivenExactMatchPackageResult();
+
+                // When
+                fixture.Run();
+
+                // Then: Version must be populated from "version" property (issue #4454)
+                Assert.Collection(fixture.Result,
+                    item =>
+                    {
+                        Assert.Equal("Refit.Newtonsoft.Json", item.Name);
+                        Assert.Equal("7.0.0", item.Version);
+                    },
+                    item =>
+                    {
+                        Assert.Equal("Refit.Newtonsoft.Json", item.Name);
+                        Assert.Equal("6.3.0", item.Version);
                     });
             }
         }

--- a/src/Cake.Common/Tools/DotNet/Package/Search/DotNetPackageSearcher.cs
+++ b/src/Cake.Common/Tools/DotNet/Package/Search/DotNetPackageSearcher.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -135,7 +135,7 @@ namespace Cake.Common.Tools.DotNet.Package.Search
                 {
                     foreach (var package in searchResult.Packages)
                     {
-                        yield return new DotNetPackageSearchItem { Name = package.Id, Version = package.LatestVersion };
+                        yield return new DotNetPackageSearchItem { Name = package.Id, Version = package.LatestVersion ?? package.Version };
                     }
                 }
             }
@@ -153,9 +153,14 @@ namespace Cake.Common.Tools.DotNet.Package.Search
 
         private sealed class Package
         {
+            /// <summary>Gets or sets the package identifier.</summary>
             public string Id { get; set; }
 
+            /// <summary>Gets or sets the latest version. Used when not using --exact-match; one entry per package with latest version.</summary>
             public string LatestVersion { get; set; }
+
+            /// <summary>Gets or sets the version. Used when using --exact-match; one entry per package version (property name "version" in JSON).</summary>
+            public string Version { get; set; }
         }
     }
 }

--- a/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
+++ b/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
@@ -473,6 +473,27 @@ Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSearchPackage")
     Assert.Contains(package, result.Select(x => x.Name));
 });
 
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSearchPackage.ExactMatch")
+    .Does(() =>
+{
+    // Given: exact-match returns "version" in JSON (not "latestVersion"); see issue #4454
+    var package = "Refit.Newtonsoft.Json";
+
+    // When
+    var result = DotNetSearchPackage(package, new DotNetPackageSearchSettings { ExactMatch = true });
+
+    // Then: every item must have non-null Version (fix for dotnet package search --exact-match --format json)
+    Assert.NotNull(result);
+    var list = result.ToList();
+    Assert.NotEmpty(list);
+    foreach (var item in list)
+    {
+        Assert.NotNull(item.Name);
+        Assert.NotNull(item.Version);
+        Assert.Equal(package, item.Name);
+    }
+});
+
 Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetListPackage")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRestore")
     .Does(() =>
@@ -551,6 +572,7 @@ Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetBuildServerShutdown")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetAddPackage")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRemovePackage")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSearchPackage")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSearchPackage.ExactMatch")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetListPackage")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetAddReference")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRemoveReference")


### PR DESCRIPTION
- Parse both "latestVersion" and "version" in DotNetPackageSearcher so exact-match output is handled correctly
- Add Version property and XML docs to Package DTO in DotNetPackageSearcher
- Add GivenExactMatchPackageResult fixture and unit test for exact-match parsing
- Add DotNetSearchPackage.ExactMatch integration test task
- fixes #4454