### PR TITLE
GH2666: Fix GetFiles/GetDirectories/GetPaths when brace expansion is the only path segment

### DIFF
--- a/src/Cake.Core.Tests/Fixtures/GlobberFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/GlobberFixture.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -88,6 +88,7 @@ namespace Cake.Core.Tests.Fixtures
             filesystem.CreateDirectory("/Working/Foo");
             filesystem.CreateDirectory("/Working/Foo/Bar");
             filesystem.CreateDirectory("/Working/Bar");
+            filesystem.CreateDirectory("/Working/Project");
             filesystem.CreateDirectory("/Foo/Bar");
             filesystem.CreateDirectory("/Foo (Bar)");
             filesystem.CreateDirectory("/Foo@Bar/");
@@ -113,6 +114,10 @@ namespace Cake.Core.Tests.Fixtures
             filesystem.CreateFile("/Working/foobar.rs");
             filesystem.CreateFile("/Working/foobaz.rs");
             filesystem.CreateFile("/Working/foobax.rs");
+            filesystem.CreateFile("/Working/Project/package.json");
+            filesystem.CreateFile("/Working/Project/package-lock.json");
+            filesystem.CreateFile("/Working/Project/tsconfig.json");
+            filesystem.CreateFile("/Working/Project/.npmrc");
 
             return new GlobberFixture(filesystem, environment);
         }

--- a/src/Cake.Core.Tests/Unit/IO/Globbing/GlobberTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/Globbing/GlobberTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -126,7 +126,7 @@ namespace Cake.Core.Tests.Unit.IO.Globbing
                     var result = fixture.Match("./**/*.*", directoryPredicate, filePredicate);
 
                     // Then
-                    Assert.Equal(10, result.Length);
+                    Assert.Equal(14, result.Length);
                     AssertEx.ContainsFilePath(result, "/Working/Foo/Bar/Qux.c");
                     AssertEx.ContainsFilePath(result, "/Working/Foo/Bar/Qex.c");
                     AssertEx.ContainsFilePath(result, "/Working/Foo/Bar/Qux.h");
@@ -137,6 +137,10 @@ namespace Cake.Core.Tests.Unit.IO.Globbing
                     AssertEx.ContainsFilePath(result, "/Working/foobar.rs");
                     AssertEx.ContainsFilePath(result, "/Working/foobaz.rs");
                     AssertEx.ContainsFilePath(result, "/Working/foobax.rs");
+                    AssertEx.ContainsFilePath(result, "/Working/Project/package.json");
+                    AssertEx.ContainsFilePath(result, "/Working/Project/package-lock.json");
+                    AssertEx.ContainsFilePath(result, "/Working/Project/tsconfig.json");
+                    AssertEx.ContainsFilePath(result, "/Working/Project/.npmrc");
                 }
             }
 
@@ -314,12 +318,13 @@ namespace Cake.Core.Tests.Unit.IO.Globbing
                 var result = fixture.Match("/Working/**/*");
 
                 // Then
-                Assert.Equal(18, result.Length);
+                Assert.Equal(23, result.Length);
                 AssertEx.ContainsDirectoryPath(result, "/Working/Foo");
                 AssertEx.ContainsDirectoryPath(result, "/Working/Foo/Bar");
                 AssertEx.ContainsDirectoryPath(result, "/Working/Foo/Baz");
                 AssertEx.ContainsDirectoryPath(result, "/Working/Foo/Bar/Baz");
                 AssertEx.ContainsDirectoryPath(result, "/Working/Bar");
+                AssertEx.ContainsDirectoryPath(result, "/Working/Project");
                 AssertEx.ContainsFilePath(result, "/Working/Foo/Bar/Qux.c");
                 AssertEx.ContainsFilePath(result, "/Working/Foo/Bar/Qex.c");
                 AssertEx.ContainsFilePath(result, "/Working/Foo/Bar/Qux.h");
@@ -333,6 +338,10 @@ namespace Cake.Core.Tests.Unit.IO.Globbing
                 AssertEx.ContainsFilePath(result, "/Working/foobar.rs");
                 AssertEx.ContainsFilePath(result, "/Working/foobaz.rs");
                 AssertEx.ContainsFilePath(result, "/Working/foobax.rs");
+                AssertEx.ContainsFilePath(result, "/Working/Project/package.json");
+                AssertEx.ContainsFilePath(result, "/Working/Project/package-lock.json");
+                AssertEx.ContainsFilePath(result, "/Working/Project/tsconfig.json");
+                AssertEx.ContainsFilePath(result, "/Working/Project/.npmrc");
             }
 
             [Fact]
@@ -423,13 +432,14 @@ namespace Cake.Core.Tests.Unit.IO.Globbing
                 var result = fixture.Match("/Working/**");
 
                 // Then
-                Assert.Equal(6, result.Length);
+                Assert.Equal(7, result.Length);
                 AssertEx.ContainsDirectoryPath(result, "/Working");
                 AssertEx.ContainsDirectoryPath(result, "/Working/Foo");
                 AssertEx.ContainsDirectoryPath(result, "/Working/Foo/Bar");
                 AssertEx.ContainsDirectoryPath(result, "/Working/Foo/Baz");
                 AssertEx.ContainsDirectoryPath(result, "/Working/Foo/Bar/Baz");
                 AssertEx.ContainsDirectoryPath(result, "/Working/Bar");
+                AssertEx.ContainsDirectoryPath(result, "/Working/Project");
             }
 
             [Theory]
@@ -579,6 +589,37 @@ namespace Cake.Core.Tests.Unit.IO.Globbing
                 Assert.Equal(2, result.Length);
                 AssertEx.ContainsFilePath(result, "/Working/foobar.rs");
                 AssertEx.ContainsFilePath(result, "/Working/foobax.rs");
+            }
+
+            [Fact]
+            public void Should_Return_File_When_Brace_Expansion_Is_Only_Segment_Single_Alternative()
+            {
+                // Given (reproduces GitHub issue #2666: GetFiles with glob curly braces gave empty result)
+                var fixture = GlobberFixture.UnixLike();
+
+                // When
+                var result = fixture.Match("/Working/Project/{package.json}");
+
+                // Then
+                Assert.Single(result);
+                AssertEx.ContainsFilePath(result, "/Working/Project/package.json");
+            }
+
+            [Fact]
+            public void Should_Return_Files_When_Brace_Expansion_Is_Only_Segment_Multiple_Alternatives()
+            {
+                // Given (reproduces GitHub issue #2666: GetFiles with glob curly braces gave empty result)
+                var fixture = GlobberFixture.UnixLike();
+
+                // When
+                var result = fixture.Match("/Working/Project/{package.json,package-lock.json,tsconfig.json,.npmrc}");
+
+                // Then
+                Assert.Equal(4, result.Length);
+                AssertEx.ContainsFilePath(result, "/Working/Project/package.json");
+                AssertEx.ContainsFilePath(result, "/Working/Project/package-lock.json");
+                AssertEx.ContainsFilePath(result, "/Working/Project/tsconfig.json");
+                AssertEx.ContainsFilePath(result, "/Working/Project/.npmrc");
             }
 
             [Fact]

--- a/src/Cake.Core/IO/Globbing/GlobVisitor.cs
+++ b/src/Cake.Core/IO/Globbing/GlobVisitor.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -129,23 +129,22 @@ namespace Cake.Core.IO.Globbing
             }
             else
             {
-                if (node.Segments.Count > 1)
+                // Match using pattern (wildcards, brace expansion, bracket wildcards, etc.),
+                // including when the path segment is only a single non-literal segment (e.g. "{package.json}").
+                var path = context.FileSystem.GetDirectory(context.Path);
+                if (path.Exists)
                 {
-                    var path = context.FileSystem.GetDirectory(context.Path);
-                    if (path.Exists)
+                    foreach (var candidate in FindCandidates(path.Path, node, context, SearchScope.Current))
                     {
-                        foreach (var candidate in FindCandidates(path.Path, node, context, SearchScope.Current))
+                        if (node.Next != null)
                         {
-                            if (node.Next != null)
-                            {
-                                context.Push(candidate.Path.FullPath.Substring(path.Path.FullPath.Length + (path.Path.FullPath.Length > 1 ? 1 : 0)));
-                                node.Next.Accept(this, context);
-                                context.Pop();
-                            }
-                            else
-                            {
-                                context.AddResult(candidate);
-                            }
+                            context.Push(candidate.Path.FullPath.Substring(path.Path.FullPath.Length + (path.Path.FullPath.Length > 1 ? 1 : 0)));
+                            node.Next.Accept(this, context);
+                            context.Pop();
+                        }
+                        else
+                        {
+                            context.AddResult(candidate);
                         }
                     }
                 }

--- a/tests/integration/Cake.Common/IO/GlobbingAliases.cake
+++ b/tests/integration/Cake.Common/IO/GlobbingAliases.cake
@@ -291,6 +291,54 @@ Task("Cake.Common.IO.GlobbingAliases.GetPaths.BraceExpansion")
     paths.AssertPaths(foobaa, foobau, foobar, foobax);
 });
 
+Task("Cake.Common.IO.GlobbingAliases.GetFiles.BraceExpansionOnlySegment")
+    .Does(() =>
+{
+    // Given (GitHub issue #2666: GetFiles with glob curly braces as only path segment)
+    var root = EnsureDirectoryExist($"{Paths.Temp}/Cake.Common.IO.GlobbingAliases/braceexpansiononlysegment");
+    var packageJson = EnsureFileExist(root.CombineWithFilePath("package.json"));
+    var packageLock = EnsureFileExist(root.CombineWithFilePath("package-lock.json"));
+    var tsconfig = EnsureFileExist(root.CombineWithFilePath("tsconfig.json"));
+
+    // When
+    var files = GetFiles($"{root}/{{package.json,package-lock.json,tsconfig.json}}");
+
+    // Then
+    files.AssertFiles(packageJson, packageLock, tsconfig);
+});
+
+Task("Cake.Common.IO.GlobbingAliases.GetDirectories.BraceExpansionOnlySegment")
+    .Does(() =>
+{
+    // Given (GitHub issue #2666: GetDirectories with glob curly braces as only path segment)
+    var root = EnsureDirectoryExist($"{Paths.Temp}/Cake.Common.IO.GlobbingAliases/braceexpansiononlysegment");
+    var dir1 = EnsureDirectoryExist(root.Combine("config"));
+    var dir2 = EnsureDirectoryExist(root.Combine("src"));
+    var dir3 = EnsureDirectoryExist(root.Combine("tools"));
+
+    // When
+    var directories = GetDirectories($"{root}/{{config,src}}");
+
+    // Then
+    directories.AssertDirectories(dir1, dir2);
+});
+
+Task("Cake.Common.IO.GlobbingAliases.GetPaths.BraceExpansionOnlySegment")
+    .Does(() =>
+{
+    // Given (GitHub issue #2666: GetPaths with glob curly braces as only path segment)
+    var root = EnsureDirectoryExist($"{Paths.Temp}/Cake.Common.IO.GlobbingAliases/braceexpansiononlysegment");
+    var readme = EnsureFileExist(root.CombineWithFilePath("README.md"));
+    var license = EnsureFileExist(root.CombineWithFilePath("LICENSE"));
+    var docs = EnsureDirectoryExist(root.Combine("docs"));
+
+    // When
+    var paths = GetPaths($"{root}/{{README.md,LICENSE,docs}}");
+
+    // Then
+    paths.AssertPaths(readme, license, docs);
+});
+
 Task("Cake.Common.IO.GlobbingAliases.GetFiles.BraceExpansionNegation")
     .Does(() =>
 {
@@ -360,6 +408,9 @@ Task("Cake.Common.IO.GlobbingAliases")
     .IsDependentOn("Cake.Common.IO.GlobbingAliases.GetFiles.BraceExpansion")
     .IsDependentOn("Cake.Common.IO.GlobbingAliases.GetDirectories.BraceExpansion")
     .IsDependentOn("Cake.Common.IO.GlobbingAliases.GetPaths.BraceExpansion")
+    .IsDependentOn("Cake.Common.IO.GlobbingAliases.GetFiles.BraceExpansionOnlySegment")
+    .IsDependentOn("Cake.Common.IO.GlobbingAliases.GetDirectories.BraceExpansionOnlySegment")
+    .IsDependentOn("Cake.Common.IO.GlobbingAliases.GetPaths.BraceExpansionOnlySegment")
     .IsDependentOn("Cake.Common.IO.GlobbingAliases.GetFiles.BraceExpansionNegation")
     .IsDependentOn("Cake.Common.IO.GlobbingAliases.GetDirectories.BraceExpansionNegation")
     .IsDependentOn("Cake.Common.IO.GlobbingAliases.GetPaths.BraceExpansionNegation");


### PR DESCRIPTION
- In GlobVisitor, run FindCandidates for any non-identifier path segment so patterns like "Dir/{package.json}" or "Dir/{a,b,c}" are matched instead of skipped
- Extend GlobberFixture.UnixLike with /Working/Project and sample files for brace-expansion-only-segment tests
- Update existing globber tests that match under /Working to include the new fixture paths and counts
- Add unit tests for single and multiple alternatives when brace expansion is the only segment
- Add integration tests for GetFiles, GetDirectories, and GetPaths with brace-expansion-only-segment patterns
- fixes #2666
