### PR TITLE
GH4790: Update Microsoft.Testing.Extensions.CodeCoverage to 18.6.2

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -38,7 +38,7 @@
     <PackageVersion Include="xunit.v3.assert" Version="3.2.2" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
* fixes #4790