### PR TITLE
fix(logging): improve Debug palette contrast on dark terminals

### DIFF
--- a/src/Cake.Core.Tests/Unit/Diagnostics/CakeBuildLogTests.cs
+++ b/src/Cake.Core.Tests/Unit/Diagnostics/CakeBuildLogTests.cs
@@ -105,7 +105,7 @@ namespace Cake.Core.Tests.Unit.Diagnostics
                 [InlineData(LogLevel.Warning, "\u001b[33;1mHello, \u001b[0m\u001b[33;1mWorld\u001b[0m")]
                 [InlineData(LogLevel.Information, "\u001b[37;1mHello, \u001b[0m\u001b[44m\u001b[37;1mWorld\u001b[0m")]
                 [InlineData(LogLevel.Verbose, "\u001b[37mHello, \u001b[0m\u001b[37;1mWorld\u001b[0m")]
-                [InlineData(LogLevel.Debug, "\u001b[30;1mHello, \u001b[0m\u001b[37mWorld\u001b[0m")]
+                [InlineData(LogLevel.Debug, "\u001b[37mHello, \u001b[0m\u001b[37;1mWorld\u001b[0m")]
                 public void Should_Colorize_Tokens_Correctly(LogLevel level, string expected)
                 {
                     // Given
@@ -230,7 +230,7 @@ namespace Cake.Core.Tests.Unit.Diagnostics
                 [InlineData(LogLevel.Warning, "#[Black|Yellow]Hello, [/]#[Black|Yellow]World[/]")]
                 [InlineData(LogLevel.Information, "#[Black|White]Hello, [/]#[DarkBlue|White]World[/]")]
                 [InlineData(LogLevel.Verbose, "#[Black|Gray]Hello, [/]#[Black|White]World[/]")]
-                [InlineData(LogLevel.Debug, "#[Black|DarkGray]Hello, [/]#[Black|Gray]World[/]")]
+                [InlineData(LogLevel.Debug, "#[Black|Gray]Hello, [/]#[Black|White]World[/]")]
                 public void Should_Colorize_Tokens_Correctly(LogLevel level, string expected)
                 {
                     // Given
@@ -265,8 +265,8 @@ namespace Cake.Core.Tests.Unit.Diagnostics
                 }
 
                 [Theory]
-                [InlineData(false, "#[Black|DarkGray]Executing: if ($LASTEXITCODE -gt 0) { throw \"script failed with exit code $LASTEXITCODE\" }[/]")]
-                [InlineData(true, "\u001b[30;1mExecuting: if ($LASTEXITCODE -gt 0) { throw \"script failed with exit code $LASTEXITCODE\" }\u001b[0m")]
+                [InlineData(false, "#[Black|Gray]Executing: if ($LASTEXITCODE -gt 0) { throw \"script failed with exit code $LASTEXITCODE\" }[/]")]
+                [InlineData(true, "\u001b[37mExecuting: if ($LASTEXITCODE -gt 0) { throw \"script failed with exit code $LASTEXITCODE\" }\u001b[0m")]
                 public void Should_Output_Escaped_Tokens_Correctly(bool ansi, string expected)
                 {
                     // Given

--- a/src/Cake.Core/Diagnostics/Console/ConsolePalette.cs
+++ b/src/Cake.Core/Diagnostics/Console/ConsolePalette.cs
@@ -38,7 +38,7 @@ namespace Cake.Core.Diagnostics
                 { LogLevel.Warning, new ConsolePalette(background, ConsoleColor.Yellow, background, ConsoleColor.Yellow) },
                 { LogLevel.Information, new ConsolePalette(background, ConsoleColor.White, ConsoleColor.DarkBlue, ConsoleColor.White) },
                 { LogLevel.Verbose, new ConsolePalette(background, ConsoleColor.Gray, background, ConsoleColor.White) },
-                { LogLevel.Debug, new ConsolePalette(background, ConsoleColor.DarkGray, background, ConsoleColor.Gray) }
+                { LogLevel.Debug, new ConsolePalette(background, ConsoleColor.Gray, background, ConsoleColor.White) }
             };
         }
     }


### PR DESCRIPTION
## Summary

- Change Debug-level console palette from `DarkGray`/`Gray` to `Gray`/`White` so diagnostic output stays readable on dark CI backgrounds (GitHub Actions, Azure Pipelines, WSL).

## Motivation

Fixes #3245 — Debug/Diagnostic log text was nearly invisible when rendered with bright-black ANSI (`DarkGray`) on dark terminals.

## Test plan

- [x] Updated `CakeBuildLogTests` expected ANSI and console color tokens
- [ ] `dotnet test src/Cake.Core.Tests/Cake.Core.Tests.csproj --filter FullyQualifiedName~CakeBuildLogTests` (not run in this environment — no .NET SDK installed)