### PR TITLE
fix(scripting): avoid duplicate missing #load warnings during bootstrap

### DIFF
--- a/src/Cake.Core.Tests/Fixtures/ScriptAnalyzerFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/ScriptAnalyzerFixture.cs
@@ -46,6 +46,11 @@ namespace Cake.Core.Tests.Fixtures
             return CreateAnalyzer().Analyze(script, new ScriptAnalyzerSettings());
         }
 
+        public ScriptAnalyzerResult AnalyzeModules(FilePath script)
+        {
+            return CreateAnalyzer().Analyze(script, new ScriptAnalyzerSettings { Mode = ScriptAnalyzerMode.Modules });
+        }
+
         public void GivenScriptExist(FilePath path, string content)
         {
             FileSystem.CreateFile(path).SetContent(content);

--- a/src/Cake.Core.Tests/Unit/Scripting/Analysis/ScriptAnalyzerTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/Analysis/ScriptAnalyzerTests.cs
@@ -3,8 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
+using Cake.Core.Diagnostics;
 using Cake.Core.Scripting.Processors.Loading;
 using Cake.Core.Tests.Fixtures;
+using Cake.Testing;
 using Xunit;
 
 namespace Cake.Core.Tests.Unit.Scripting.Analysis
@@ -398,6 +400,38 @@ namespace Cake.Core.Tests.Unit.Scripting.Analysis
                 // Then
                 Assert.Single(result.Script.Defines);
                 Assert.Equal("#define FOO", result.Script.Defines.ElementAt(0));
+            }
+
+            [Fact]
+            public void Should_Not_Warn_When_Missing_Load_Target_In_Modules_Mode()
+            {
+                // Given
+                var log = new FakeLog();
+                var fixture = new ScriptAnalyzerFixture { Log = log };
+                fixture.AddFileLoadDirectiveProvider();
+                fixture.GivenScriptExist("/Working/build.cake", "#load \"optional.cake\"");
+
+                // When
+                fixture.AnalyzeModules("/Working/build.cake");
+
+                // Then
+                Assert.DoesNotContain(log.Entries, entry => entry.Level == LogLevel.Warning);
+            }
+
+            [Fact]
+            public void Should_Warn_When_Missing_Load_Target_In_Everything_Mode()
+            {
+                // Given
+                var log = new FakeLog();
+                var fixture = new ScriptAnalyzerFixture { Log = log };
+                fixture.AddFileLoadDirectiveProvider();
+                fixture.GivenScriptExist("/Working/build.cake", "#load \"optional.cake\"");
+
+                // When
+                fixture.Analyze("/Working/build.cake");
+
+                // Then
+                Assert.Contains(log.Entries, entry => entry.Message.Contains("No scripts found at"));
             }
         }
     }

--- a/src/Cake.Core/Scripting/Analysis/IScriptAnalyzerContext.cs
+++ b/src/Cake.Core/Scripting/Analysis/IScriptAnalyzerContext.cs
@@ -23,6 +23,12 @@ namespace Cake.Core.Scripting.Analysis
         IScriptInformation Current { get; }
 
         /// <summary>
+        /// Gets a value indicating whether warnings for missing scripts referenced by
+        /// <c>#load</c> should be suppressed.
+        /// </summary>
+        bool SuppressMissingLoadScriptWarnings { get; }
+
+        /// <summary>
         /// Processes the specified script path using the same context.
         /// </summary>
         /// <param name="scriptPath">The script path to process.</param>

--- a/src/Cake.Core/Scripting/Analysis/ScriptAnalyzer.cs
+++ b/src/Cake.Core/Scripting/Analysis/ScriptAnalyzer.cs
@@ -83,7 +83,8 @@ namespace Cake.Core.Scripting.Analysis
             // Create a new context.
             var context = new ScriptAnalyzerContext(
                 _fileSystem, _environment,
-                _log, callback, path);
+                _log, callback, path,
+                settings.Mode == ScriptAnalyzerMode.Modules);
 
             // Analyze the script.
             context.Analyze(path);
@@ -104,7 +105,7 @@ namespace Cake.Core.Scripting.Analysis
             var lines = ReadLines(context.Current.Path);
             foreach (var line in lines)
             {
-                foreach (var processor in _defaultProcessors)
+                foreach (var processor in _moduleProcessors)
                 {
                     if (processor.Process(context, _environment.ExpandEnvironmentVariables(line), out var _))
                     {

--- a/src/Cake.Core/Scripting/Analysis/ScriptAnalyzerContext.cs
+++ b/src/Cake.Core/Scripting/Analysis/ScriptAnalyzerContext.cs
@@ -28,6 +28,8 @@ namespace Cake.Core.Scripting.Analysis
 
         public IScriptInformation Current => _current;
 
+        public bool SuppressMissingLoadScriptWarnings { get; }
+
         public IReadOnlyList<string> Lines => _lines;
 
         public IReadOnlyList<ScriptAnalyzerError> Errors => _errors;
@@ -37,13 +39,15 @@ namespace Cake.Core.Scripting.Analysis
             ICakeEnvironment environment,
             ICakeLog log,
             Action<IScriptAnalyzerContext> callback,
-            FilePath script)
+            FilePath script,
+            bool suppressMissingLoadScriptWarnings)
         {
             _fileSystem = fileSystem;
             _environment = environment;
             _log = log;
             _callback = callback;
             _script = script.MakeAbsolute(_environment);
+            SuppressMissingLoadScriptWarnings = suppressMissingLoadScriptWarnings;
             _processedScripts = new HashSet<FilePath>(new PathComparer(_environment));
             _stack = new Stack<ScriptInformation>();
             _lines = new List<string>();

--- a/src/Cake.Core/Scripting/Processors/Loading/FileLoadDirectiveProvider.cs
+++ b/src/Cake.Core/Scripting/Processors/Loading/FileLoadDirectiveProvider.cs
@@ -66,8 +66,11 @@ namespace Cake.Core.Scripting.Processors.Loading
 
             if (files.Length == 0)
             {
-                // No scripts found.
-                _log.Warning("No scripts found at {0}.", path);
+                if (!context.SuppressMissingLoadScriptWarnings)
+                {
+                    _log.Warning("No scripts found at {0}.", path);
+                }
+
                 return;
             }
 


### PR DESCRIPTION
## Summary

Fixes #2965

Since v1.0.0, bootstrapping and the build both analyze the main script. Missing optional `#load` targets (e.g. `#load "optional.cake"`) were warned twice because `ScriptAnalyzer.Analyze` ran in both phases.

This PR:

1. Uses `_moduleProcessors` (not `_defaultProcessors`) in `ModuleAnalyzeCallback`, so module discovery only processes `#load` and `#module` directives.
2. Suppresses missing-script warnings when `ScriptAnalyzerMode.Modules` is used (bootstrap), so users still see a single warning during the full build analysis.

## Test plan

- [x] Added unit tests for Modules vs Everything mode missing `#load` behavior
- [ ] CI: `Cake.Core.Tests` ScriptAnalyzer tests

I do not have a local .NET SDK in this environment; tests were not executed locally.