### PR TITLE
fix(io): tolerate broken symlinks when cleaning directories

### DIFF
--- a/src/Cake.Common.Tests/Unit/IO/DirectoryCleanerSymlinkTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/DirectoryCleanerSymlinkTests.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Cake.Common.IO;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Polyfill;
+using Cake.Core.Tests.Fixtures;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.IO
+{
+    public sealed class DirectoryCleanerSymlinkTests
+    {
+        [Fact]
+        public void Should_Clean_Directory_Containing_Broken_Symlink_On_Unix()
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
+            var tempPath = Path.Combine(Path.GetTempPath(), "cake-clean-symlink-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempPath);
+
+            try
+            {
+                var versions = Path.Combine(tempPath, "Versions");
+                Directory.CreateDirectory(versions);
+                File.CreateSymbolicLink(
+                    Path.Combine(versions, "Current"),
+                    Path.Combine(versions, "missing-target"));
+                File.WriteAllText(Path.Combine(tempPath, "file.txt"), "x");
+
+                var environment = new CakeEnvironment(new CakePlatform(), new CakeRuntime());
+                var fileSystem = new FileSystem();
+                var globber = new Globber(fileSystem, environment);
+                var context = new CakeContextFixture
+                {
+                    FileSystem = fileSystem,
+                    Environment = environment,
+                    Globber = globber
+                }.CreateContext();
+
+                var exception = Record.Exception(() =>
+                    DirectoryAliases.CleanDirectory(context, new DirectoryPath(tempPath)));
+
+                Assert.Null(exception);
+                Assert.False(File.Exists(Path.Combine(tempPath, "file.txt")));
+                Assert.False(Directory.Exists(Path.Combine(versions, "Current")));
+            }
+            finally
+            {
+                if (Directory.Exists(tempPath))
+                {
+                    Directory.Delete(tempPath, true);
+                }
+            }
+        }
+    }
+}

--- a/src/Cake.Common/IO/DirectoryCleaner.cs
+++ b/src/Cake.Common/IO/DirectoryCleaner.cs
@@ -60,7 +60,17 @@ namespace Cake.Common.IO
             var directories = root.GetDirectories("*", SearchScope.Current);
             foreach (var directory in directories)
             {
-                if (!CleanDirectory(directory, predicate, level + 1, settings))
+                if (!directory.Exists)
+                {
+                    if (!TryDeleteDirectoryEntry(directory, predicate, level))
+                    {
+                        shouldDeleteRoot = false;
+                    }
+
+                    continue;
+                }
+
+                if (!TryCleanChildDirectory(directory, predicate, level + 1, settings))
                 {
                     // Since the child directory reported it shouldn't be
                     // removed, we should not remove the current directory either.
@@ -72,17 +82,33 @@ namespace Cake.Common.IO
             var files = root.GetFiles("*", SearchScope.Current);
             foreach (var file in files)
             {
-                if (predicate(file))
+                if (!predicate(file))
                 {
-                    if (settings.Force)
+                    shouldDeleteRoot = false;
+                    continue;
+                }
+
+                if (!file.Exists)
+                {
+                    if (!TryDeleteFileEntry(file))
                     {
-                        // Remove the ReadOnly attribute on file (if set)
-                        file.Attributes &= ~FileAttributes.ReadOnly;
+                        shouldDeleteRoot = false;
                     }
 
+                    continue;
+                }
+
+                if (settings.Force)
+                {
+                    // Remove the ReadOnly attribute on file (if set)
+                    file.Attributes &= ~FileAttributes.ReadOnly;
+                }
+
+                try
+                {
                     file.Delete();
                 }
-                else
+                catch (IOException)
                 {
                     shouldDeleteRoot = false;
                 }
@@ -98,6 +124,53 @@ namespace Cake.Common.IO
 
             // We did not delete this directory.
             return false;
+        }
+
+        private static bool TryCleanChildDirectory(IDirectory directory, Func<IFileSystemInfo, bool> predicate, int level, CleanDirectorySettings settings)
+        {
+            try
+            {
+                return CleanDirectory(directory, predicate, level, settings);
+            }
+            catch (DirectoryNotFoundException)
+            {
+                return TryDeleteDirectoryEntry(directory, predicate, level);
+            }
+            catch (IOException)
+            {
+                return TryDeleteDirectoryEntry(directory, predicate, level);
+            }
+        }
+
+        private static bool TryDeleteDirectoryEntry(IDirectory directory, Func<IFileSystemInfo, bool> predicate, int level)
+        {
+            if (!predicate(directory) || level <= 0)
+            {
+                return false;
+            }
+
+            try
+            {
+                directory.Delete(false);
+                return true;
+            }
+            catch (IOException)
+            {
+                return false;
+            }
+        }
+
+        private static bool TryDeleteFileEntry(IFile file)
+        {
+            try
+            {
+                file.Delete();
+                return true;
+            }
+            catch (IOException)
+            {
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #2135

`CleanDirectory` / `CleanDirectories` could fail on macOS when a directory tree contains broken symbolic links (e.g. `Versions/Current` in a `.framework` bundle pointing to a missing target).

This PR:

- Removes broken symlink directory entries without recursing into them
- Catches `DirectoryNotFoundException` / `IOException` during child cleanup and deletes the symlink entry when appropriate
- Handles missing file entries similarly during file deletion

## Test plan

- [x] Added `DirectoryCleanerSymlinkTests.Should_Clean_Directory_Containing_Broken_Symlink_On_Unix` (skipped on Windows)
- [ ] CI: `Cake.Common.Tests`

I do not have a local .NET SDK in this environment; tests were not executed locally.