### PR TITLE
fix(io): use NullRegistry on non-Windows platforms

### DIFF
--- a/src/Cake.Core.Tests/Unit/IO/NullRegistryTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/NullRegistryTests.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core.IO;
+using Xunit;
+
+namespace Cake.Core.Tests.Unit.IO
+{
+    public sealed class NullRegistryTests
+    {
+        [Fact]
+        public void Registry_Properties_Should_Not_Throw()
+        {
+            var registry = new NullRegistry();
+
+            using (var currentUser = registry.CurrentUser)
+            using (var localMachine = registry.LocalMachine)
+            using (var classesRoot = registry.ClassesRoot)
+            using (var users = registry.Users)
+            using (var performanceData = registry.PerformanceData)
+            using (var currentConfig = registry.CurrentConfig)
+            {
+                Assert.Empty(currentUser.GetSubKeyNames());
+                Assert.Null(currentUser.OpenKey("test"));
+                Assert.Null(currentUser.GetValue("test"));
+            }
+        }
+    }
+}

--- a/src/Cake.Core/IO/NullRegistry.cs
+++ b/src/Cake.Core/IO/NullRegistry.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Core.IO
+{
+    /// <summary>
+    /// A no-op registry implementation for platforms without Windows registry support.
+    /// </summary>
+    internal sealed class NullRegistry : IRegistry
+    {
+        /// <inheritdoc/>
+        public IRegistryKey CurrentUser => NullRegistryKey.Instance;
+
+        /// <inheritdoc/>
+        public IRegistryKey LocalMachine => NullRegistryKey.Instance;
+
+        /// <inheritdoc/>
+        public IRegistryKey ClassesRoot => NullRegistryKey.Instance;
+
+        /// <inheritdoc/>
+        public IRegistryKey Users => NullRegistryKey.Instance;
+
+        /// <inheritdoc/>
+        public IRegistryKey PerformanceData => NullRegistryKey.Instance;
+
+        /// <inheritdoc/>
+        public IRegistryKey CurrentConfig => NullRegistryKey.Instance;
+    }
+}

--- a/src/Cake.Core/IO/NullRegistryKey.cs
+++ b/src/Cake.Core/IO/NullRegistryKey.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Cake.Core.IO
+{
+    internal sealed class NullRegistryKey : IRegistryKey
+    {
+        public static readonly NullRegistryKey Instance = new NullRegistryKey();
+
+        private NullRegistryKey()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public string[] GetSubKeyNames()
+        {
+            return Array.Empty<string>();
+        }
+
+        public IRegistryKey OpenKey(string name)
+        {
+            return null;
+        }
+
+        public object GetValue(string name)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Cake.Core/Modules/CoreModule.cs
+++ b/src/Cake.Core/Modules/CoreModule.cs
@@ -41,7 +41,14 @@ namespace Cake.Core.Modules
             registrar.RegisterType<Globber>().As<IGlobber>().Singleton();
             registrar.RegisterType<ProcessRunner>().As<IProcessRunner>().Singleton();
             registrar.RegisterType<NuGetToolResolver>().As<INuGetToolResolver>().Singleton();
-            registrar.RegisterType<WindowsRegistry>().As<IRegistry>().Singleton();
+            if (OperatingSystem.IsWindows())
+            {
+                registrar.RegisterType<WindowsRegistry>().As<IRegistry>().Singleton();
+            }
+            else
+            {
+                registrar.RegisterType<NullRegistry>().As<IRegistry>().Singleton();
+            }
 
             // Reflection
             registrar.RegisterType<AssemblyLoader>().As<IAssemblyLoader>().Singleton();


### PR DESCRIPTION
## Summary

Fixes #3829

On Linux/macOS, serializing `ICakeContext` (e.g. via `ToJson()`) failed when Newtonsoft.Json accessed `Registry.CurrentUser` because `WindowsRegistry` wraps `Microsoft.Win32.Registry`, which is not supported off Windows.

This PR registers a `NullRegistry` implementation on non-Windows platforms. All hive properties return a no-op `NullRegistryKey` that can be disposed and queried without throwing.

## Test plan

- [x] Added `NullRegistryTests` for no-op registry access
- [ ] CI: `Cake.Core.Tests`
- [ ] Manual: `context.ToJson()` on Linux Frosting setup should no longer throw on `Registry`

I do not have a local .NET SDK in this environment; tests were not executed locally.