### PR TITLE
fix: preserve Unix file permissions when creating zip archives (#2592)

### DIFF
--- a/src/Cake.Common.Tests/Unit/IO/ZipperTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/ZipperTests.cs
@@ -197,6 +197,33 @@ namespace Cake.Common.Tests.Unit.IO
                 Assert.True(archive.GetEntry("Dir2/Dir3/File5.txt")?.Length == 5);
             }
 
+            [Fact]
+            public void Should_Preserve_Unix_File_Permissions_In_Zip()
+            {
+                // Given
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+                var fileSystem = new FakeFileSystem(environment);
+                var executableMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                    | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+                    | UnixFileMode.OtherRead | UnixFileMode.OtherExecute;
+                fileSystem.CreateFile("/d/test.sh")
+                    .SetContent("#!/bin/bash")
+                    .SetUnixFileMode(executableMode);
+                var log = Substitute.For<ICakeLog>();
+                var zipper = new Zipper(fileSystem, environment, log);
+
+                // When
+                zipper.Zip("/d", "/out.zip", new FilePath[] { "/d/test.sh" });
+
+                // Then
+                var archive = new ZipArchive(fileSystem.GetFile("/out.zip").Open(FileMode.Open, FileAccess.Read, FileShare.Read));
+                var entry = archive.GetEntry("test.sh");
+                Assert.NotNull(entry);
+                const int UnixRegularFileType = 0x8000;
+                int expectedAttributes = ((int)executableMode & 0x1FF | UnixRegularFileType) << 16;
+                Assert.Equal(expectedAttributes, entry.ExternalAttributes);
+            }
+
             [WindowsFact("Investigate why this fail on Mono 4.2.1.")]
             public void Zipped_File_Should_Contain_Correct_Content()
             {

--- a/src/Cake.Common/IO/Zipper.cs
+++ b/src/Cake.Common/IO/Zipper.cs
@@ -87,6 +87,7 @@ namespace Cake.Common.IO
                         var directory = _fileSystem.GetDirectory(absoluteDirectoryPath);
                         var entry = archive.CreateEntry(relativeDirectoryPath + "/");
                         entry.LastWriteTime = (directory as Directory)?.LastWriteTime ?? DateTimeOffset.Now;
+                        ApplyUnixEntryAttributes(entry, directory);
                         directories.Add(relativeDirectoryPath);
                     }
 
@@ -99,6 +100,7 @@ namespace Cake.Common.IO
                         {
                             var entry = archive.CreateEntry(relativeFilePath);
                             entry.LastWriteTime = (file as File)?.LastWriteTime ?? DateTimeOffset.Now;
+                            ApplyUnixEntryAttributes(entry, file);
                             using (var entryStream = entry.Open())
                             {
                                 fileStream.CopyTo(entryStream);
@@ -151,6 +153,7 @@ namespace Cake.Common.IO
                         var directory = _fileSystem.GetDirectory(absoluteDirectoryPath);
                         var entry = archive.CreateEntry(relativeDirectoryPath + "/");
                         entry.LastWriteTime = GetValidZipDateTimeOffset((directory as Directory)?.LastWriteTime);
+                        ApplyUnixEntryAttributes(entry, directory);
                         directories.Add(relativeDirectoryPath);
                     }
 
@@ -161,6 +164,7 @@ namespace Cake.Common.IO
                     {
                         var entry = archive.CreateEntry(relativeFilePath);
                         entry.LastWriteTime = GetValidZipDateTimeOffset((file as File)?.LastWriteTime);
+                        ApplyUnixEntryAttributes(entry, file);
                         using (var entryStream = entry.Open())
                         {
                             fileStream.CopyTo(entryStream);
@@ -217,6 +221,39 @@ namespace Cake.Common.IO
             }
 
             return InvalidZipDateIndicator;
+        }
+
+        private void ApplyUnixEntryAttributes(ZipArchiveEntry entry, IFileSystemInfo fileSystemInfo)
+        {
+            if (!_environment.Platform.IsUnix())
+            {
+                return;
+            }
+
+            bool isDirectory = entry.FullName.EndsWith("/", StringComparison.Ordinal);
+            UnixFileMode mode = fileSystemInfo.UnixFileMode ?? GetDefaultUnixFileMode(isDirectory);
+            entry.ExternalAttributes = GetUnixExternalAttributes(mode, isDirectory);
+        }
+
+        private static UnixFileMode GetDefaultUnixFileMode(bool isDirectory)
+        {
+            if (isDirectory)
+            {
+                return UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                    | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+                    | UnixFileMode.OtherRead | UnixFileMode.OtherExecute;
+            }
+
+            return UnixFileMode.UserRead | UnixFileMode.UserWrite
+                | UnixFileMode.GroupRead | UnixFileMode.OtherRead;
+        }
+
+        private static int GetUnixExternalAttributes(UnixFileMode mode, bool isDirectory)
+        {
+            const int UnixRegularFileType = 0x8000;
+            const int UnixDirectoryFileType = 0x4000;
+            int fileType = isDirectory ? UnixDirectoryFileType : UnixRegularFileType;
+            return ((int)mode & 0x1FF | fileType) << 16;
         }
     }
 }


### PR DESCRIPTION
## Summary

- On Unix platforms, copy each zipped file/directory `UnixFileMode` into `ZipArchiveEntry.ExternalAttributes` (including the Unix file-type bits).
- Fall back to `755` for directories and `644` for files when no mode is available from the file system abstraction.

This allows `unzip -Zl` to show preserved permission flags (e.g. executable shell scripts) on Linux, matching behavior of the native `zip` tool.

## Test plan

- [x] `Should_Preserve_Unix_File_Permissions_In_Zip` unit test (FakeFileSystem + Unix environment)
- [ ] Manual: `chmod a+x d/test.sh`, `Zip(Directory("d"), File("test.zip"))`, `unzip -Zl test.zip` shows `rwx` permissions

CI not run locally (no .NET SDK in contributor environment).

Fixes #2592