### PR TITLE
fix: preserve folder structure when glob matches only subdirectories (#2102)

### DIFF
--- a/src/Cake.Common.Tests/Unit/IO/FileCopierTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/FileCopierTests.cs
@@ -147,6 +147,23 @@ namespace Cake.Common.Tests.Unit.IO
             }
 
             [Fact]
+            public void Should_Preserve_Subdirectory_Structure_When_Only_Subdirectory_Files_Match_Glob()
+            {
+                const string dstPath = "./dst";
+
+                // Given
+                var fixture = new FileCopierFixture();
+                fixture.EnsureFileExists("./src/sub/file3.dat");
+                fixture.EnsureDirectoryExists(dstPath);
+
+                // When
+                FileCopier.CopyFiles(fixture.Context, "./src/**/*.dat", new DirectoryPath(dstPath), true);
+
+                // Then
+                Assert.True(fixture.ExistsFile($"{dstPath}/sub/file3.dat"));
+            }
+
+            [Fact]
             public void Should_Throw_If_Context_Is_Null()
             {
                 // When

--- a/src/Cake.Common/IO/FileCopier.cs
+++ b/src/Cake.Common/IO/FileCopier.cs
@@ -54,10 +54,14 @@ namespace Cake.Common.IO
                 return;
             }
 
-            CopyFiles(context, files, targetDirectoryPath, preserverFolderStructure);
+            var structureBaseDirectory = preserverFolderStructure ? GetGlobPatternBaseDirectory(pattern) : null;
+            CopyFiles(context, files, targetDirectoryPath, preserverFolderStructure, structureBaseDirectory);
         }
 
         public static void CopyFiles(ICakeContext context, IEnumerable<FilePath> filePaths, DirectoryPath targetDirectoryPath, bool preserverFolderStructure)
+            => CopyFiles(context, filePaths, targetDirectoryPath, preserverFolderStructure, null);
+
+        private static void CopyFiles(ICakeContext context, IEnumerable<FilePath> filePaths, DirectoryPath targetDirectoryPath, bool preserverFolderStructure, DirectoryPath structureBaseDirectory)
         {
             ArgumentNullException.ThrowIfNull(context);
             ArgumentNullException.ThrowIfNull(filePaths);
@@ -78,7 +82,13 @@ namespace Cake.Common.IO
 
             if (preserverFolderStructure)
             {
+                var structureBasePath = structureBaseDirectory?.MakeAbsolute(context.Environment).FullPath;
                 var commonPath = string.Empty;
+                if (!string.IsNullOrEmpty(structureBasePath) && context.DirectoryExists(structureBasePath))
+                {
+                    commonPath = structureBasePath;
+                }
+
                 var separatedPath = absoluteFilePaths
                     .First(str => str.ToString().Length == absoluteFilePaths.Max(st2 => st2.ToString().Length)).ToString()
                     .Split(new[] { "/" }, StringSplitOptions.RemoveEmptyEntries)
@@ -86,6 +96,11 @@ namespace Cake.Common.IO
 
                 foreach (string pathSegment in separatedPath)
                 {
+                    if (!string.IsNullOrEmpty(structureBasePath))
+                    {
+                        break;
+                    }
+
                     if (commonPath.Length == 0 && absoluteFilePaths.All(str => str.ToString().StartsWith(pathSegment)))
                     {
                         commonPath = pathSegment;
@@ -100,7 +115,9 @@ namespace Cake.Common.IO
                     }
                 }
 
-                if (absoluteFilePaths.Count == 1 && absoluteFilePaths.First().FullPath.Contains(context.Environment.WorkingDirectory.FullPath))
+                if (string.IsNullOrEmpty(structureBasePath)
+                    && absoluteFilePaths.Count == 1
+                    && absoluteFilePaths.First().FullPath.Contains(context.Environment.WorkingDirectory.FullPath))
                 {
                     var relativePath = absoluteFilePaths.First().FullPath.Remove(0, context.Environment.WorkingDirectory.FullPath.Length + 1);
                     var relativePathParts = relativePath.Split('/').ToList();
@@ -175,6 +192,26 @@ namespace Cake.Common.IO
                 context.Log.Verbose("Copying file {0} to {1}", absoluteFilePath.GetFilename(), absoluteTargetPath);
                 file.Copy(absoluteTargetPath, true);
             }
+        }
+
+        private static DirectoryPath GetGlobPatternBaseDirectory(GlobPattern pattern)
+        {
+            ArgumentNullException.ThrowIfNull(pattern);
+
+            var patternText = pattern.Pattern;
+            int wildcardIndex = patternText.IndexOfAny(new[] { '*', '?', '{' });
+            if (wildcardIndex > 0)
+            {
+                patternText = patternText.Substring(0, wildcardIndex);
+            }
+
+            patternText = patternText.TrimEnd('/', '\\');
+            if (string.IsNullOrWhiteSpace(patternText))
+            {
+                return null;
+            }
+
+            return new DirectoryPath(patternText);
         }
     }
 }


### PR DESCRIPTION
## Summary

- When `CopyFiles` is called with `preserveFolderStructure: true` and a glob pattern, derive the structure base directory from the pattern prefix (text before the first `*`, `?`, or `{`).
- Use that base (e.g. `src` from `src/**/*.dat`) instead of inferring a common path only from matched file paths, which failed when every match lived in a subdirectory.

## Test plan

- [x] `Should_Preserve_Subdirectory_Structure_When_Only_Subdirectory_Files_Match_Glob` — single `src/sub/file3.dat` via `./src/**/*.dat` lands at `dst/sub/file3.dat`
- [ ] Existing `FileCopierTests` (CI)

CI not run locally (no .NET SDK in contributor environment).

Fixes #2102