### PR TITLE
feat: expose stdout and stderr when a tool process fails (#2460)

### DIFF
--- a/src/Cake.Common/Tools/NUnit/NUnit3Runner.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnit3Runner.cs
@@ -248,6 +248,12 @@ namespace Cake.Common.Tools.NUnit
             return new[] { "nunit3-console.exe" };
         }
 
+        /// <inheritdoc />
+        protected override void ProcessExitCode(IProcess process)
+        {
+            ProcessExitCode(process.GetExitCode());
+        }
+
         /// <summary>
         /// Customized NUnit 3 exit code handling.
         /// Throws <see cref="CakeException"/> on non-zero exit code.

--- a/src/Cake.Common/Tools/NUnit/NUnitRunner.cs
+++ b/src/Cake.Common/Tools/NUnit/NUnitRunner.cs
@@ -181,6 +181,12 @@ namespace Cake.Common.Tools.NUnit
             return new[] { "nunit-console-x86.exe" };
         }
 
+        /// <inheritdoc />
+        protected override void ProcessExitCode(IProcess process)
+        {
+            ProcessExitCode(process.GetExitCode());
+        }
+
         /// <summary>
         /// Customized NUnit exit code handling.
         /// Throws <see cref="CakeException"/> on non-zero exit code.

--- a/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployDeploymentLister.cs
+++ b/src/Cake.Common/Tools/OctopusDeploy/OctopusDeployDeploymentLister.cs
@@ -71,7 +71,7 @@ namespace Cake.Common.Tools.OctopusDeploy
                 process.WaitForExit();
             }
 
-            ProcessExitCode(process.GetExitCode());
+            ProcessExitCode(process);
             var parser = new DeploymentQueryResultParser();
             return parser.ParseResults(process.GetStandardOutput());
         }

--- a/src/Cake.Core.Tests/Stubs/DummyTool.cs
+++ b/src/Cake.Core.Tests/Stubs/DummyTool.cs
@@ -28,14 +28,14 @@ namespace Cake.Core.Tests.Stubs
             Run(settings, new ProcessArgumentBuilder().Append("--foo"), new ProcessSettings(), null);
         }
 
-        protected override void ProcessExitCode(int exitCode)
+        protected override void ProcessExitCode(IProcess process)
         {
             if (_exitCodeValidation == null)
             {
-                base.ProcessExitCode(exitCode);
+                base.ProcessExitCode(process);
                 return;
             }
-            _exitCodeValidation(exitCode);
+            _exitCodeValidation(process.GetExitCode());
         }
 
         protected override string GetToolName()

--- a/src/Cake.Core.Tests/Unit/Tooling/ToolTests.cs
+++ b/src/Cake.Core.Tests/Unit/Tooling/ToolTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Linq;
 using Cake.Core.IO;
 using Cake.Core.Tests.Fixtures;
 using Cake.Testing;
@@ -100,7 +101,27 @@ namespace Cake.Core.Tests.Unit.Tooling
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, "dummy: Process returned an error (exit code 11).");
+                var exception = Assert.IsType<CakeProcessException>(result);
+                Assert.Equal("dummy: Process returned an error (exit code 11).", exception.Message);
+                Assert.Equal(11, exception.ExitCode);
+            }
+
+            [Fact]
+            public void Should_Include_Standard_Output_And_Error_On_NonZero_ExitCode()
+            {
+                // Given
+                var fixture = new DummyToolFixture();
+                fixture.GivenProcessExitsWithCode(1);
+                fixture.ProcessRunner.Process.SetStandardOutput(new[] { "stdout-line" });
+                fixture.ProcessRunner.Process.SetStandardError(new[] { "stderr-line" });
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                var exception = Assert.IsType<CakeProcessException>(result);
+                Assert.Equal("stdout-line", exception.StandardOutput.Single());
+                Assert.Equal("stderr-line", exception.StandardError.Single());
             }
 
             [Fact]

--- a/src/Cake.Core/CakeProcessException.cs
+++ b/src/Cake.Core/CakeProcessException.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Cake.Core
+{
+    /// <summary>
+    /// Represents an error that occurred while running an external tool process.
+    /// </summary>
+    public sealed class CakeProcessException : CakeException
+    {
+        /// <summary>
+        /// Gets the standard output captured from the process, if redirection was enabled.
+        /// </summary>
+        public IReadOnlyList<string> StandardOutput { get; }
+
+        /// <summary>
+        /// Gets the standard error captured from the process, if redirection was enabled.
+        /// </summary>
+        public IReadOnlyList<string> StandardError { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CakeProcessException"/> class.
+        /// </summary>
+        /// <param name="exitCode">The process exit code.</param>
+        /// <param name="message">The error message.</param>
+        /// <param name="standardOutput">The standard output lines.</param>
+        /// <param name="standardError">The standard error lines.</param>
+        public CakeProcessException(int exitCode, string message, IEnumerable<string> standardOutput, IEnumerable<string> standardError)
+            : base(exitCode, message)
+        {
+            StandardOutput = standardOutput?.ToArray() ?? Array.Empty<string>();
+            StandardError = standardError?.ToArray() ?? Array.Empty<string>();
+        }
+    }
+}

--- a/src/Cake.Core/Tooling/Tool.cs
+++ b/src/Cake.Core/Tooling/Tool.cs
@@ -90,7 +90,28 @@ namespace Cake.Core.Tooling
             var exitCode = process.GetExitCode();
             if (!settings.HandleExitCode?.Invoke(exitCode) ?? true)
             {
-                ProcessExitCode(process.GetExitCode());
+                ProcessExitCode(process);
+            }
+        }
+
+        /// <summary>
+        /// Customized exit code handling.
+        /// Standard behavior is to fail when non zero.
+        /// </summary>
+        /// <param name="process">The process that was run.</param>
+        protected virtual void ProcessExitCode(IProcess process)
+        {
+            ArgumentNullException.ThrowIfNull(process);
+
+            var exitCode = process.GetExitCode();
+            if (exitCode != 0)
+            {
+                const string message = "{0}: Process returned an error (exit code {1}).";
+                throw new CakeProcessException(
+                    exitCode,
+                    string.Format(CultureInfo.InvariantCulture, message, GetToolName(), exitCode),
+                    process.GetStandardOutput(),
+                    process.GetStandardError());
             }
         }
 


### PR DESCRIPTION
## Summary

- Add `CakeProcessException` (extends `CakeException`) with `StandardOutput` and `StandardError` line collections.
- `Tool.Run` now calls `ProcessExitCode(IProcess)` and throws `CakeProcessException` on non-zero exit codes when output redirection captured lines.
- NUnit runners keep custom exit-code mapping via the existing `ProcessExitCode(int)` override.

## Test plan

- [x] `Should_Throw_On_NonZero_ExitCode_Without_Custom_Validation` — expects `CakeProcessException`
- [x] `Should_Include_Standard_Output_And_Error_On_NonZero_ExitCode`
- [ ] Full Cake.Core / Cake.Common test suites (CI)

CI not run locally (no .NET SDK in contributor environment).

Fixes #2460