### PR TITLE
feat: add redirected output handlers to ToolSettings (#2461)

### DIFF
--- a/src/Cake.Core.Tests/Unit/Tooling/ToolTests.cs
+++ b/src/Cake.Core.Tests/Unit/Tooling/ToolTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Linq;
 using Cake.Core.IO;
 using Cake.Core.Tests.Fixtures;
 using Cake.Testing;
@@ -100,7 +101,27 @@ namespace Cake.Core.Tests.Unit.Tooling
                 var result = Record.Exception(() => fixture.Run());
 
                 // Then
-                AssertEx.IsCakeException(result, "dummy: Process returned an error (exit code 11).");
+                var exception = Assert.IsType<CakeProcessException>(result);
+                Assert.Equal("dummy: Process returned an error (exit code 11).", exception.Message);
+                Assert.Equal(11, exception.ExitCode);
+            }
+
+            [Fact]
+            public void Should_Include_Standard_Output_And_Error_On_NonZero_ExitCode()
+            {
+                // Given
+                var fixture = new DummyToolFixture();
+                fixture.GivenProcessExitsWithCode(1);
+                fixture.ProcessRunner.Process.SetStandardOutput(new[] { "stdout-line" });
+                fixture.ProcessRunner.Process.SetStandardError(new[] { "stderr-line" });
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                var exception = Assert.IsType<CakeProcessException>(result);
+                Assert.Equal("stdout-line", exception.StandardOutput.Single());
+                Assert.Equal("stderr-line", exception.StandardError.Single());
             }
 
             [Fact]
@@ -176,6 +197,26 @@ namespace Cake.Core.Tests.Unit.Tooling
 
                 // Then
                 Assert.True(wasExecuted);
+            }
+
+            [Fact]
+            public void Should_Apply_Redirected_Output_Handlers_From_ToolSettings()
+            {
+                Func<string, string> outputHandler = line => line;
+                Func<string, string> errorHandler = line => line;
+
+                // Given
+                var fixture = new DummyToolFixture();
+                fixture.Settings.RedirectedStandardOutputHandler = outputHandler;
+                fixture.Settings.RedirectedStandardErrorHandler = errorHandler;
+                fixture.GivenProcessExitsWithCode(0);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Same(outputHandler, result.Process.RedirectedStandardOutputHandler);
+                Assert.Same(errorHandler, result.Process.RedirectedStandardErrorHandler);
             }
 
             [Fact]

--- a/src/Cake.Core/Tooling/Tool.cs
+++ b/src/Cake.Core/Tooling/Tool.cs
@@ -90,7 +90,28 @@ namespace Cake.Core.Tooling
             var exitCode = process.GetExitCode();
             if (!settings.HandleExitCode?.Invoke(exitCode) ?? true)
             {
-                ProcessExitCode(process.GetExitCode());
+                ProcessExitCode(process);
+            }
+        }
+
+        /// <summary>
+        /// Customized exit code handling.
+        /// Standard behavior is to fail when non zero.
+        /// </summary>
+        /// <param name="process">The process that was run.</param>
+        protected virtual void ProcessExitCode(IProcess process)
+        {
+            ArgumentNullException.ThrowIfNull(process);
+
+            var exitCode = process.GetExitCode();
+            if (exitCode != 0)
+            {
+                const string message = "{0}: Process returned an error (exit code {1}).";
+                throw new CakeProcessException(
+                    exitCode,
+                    string.Format(CultureInfo.InvariantCulture, message, GetToolName(), exitCode),
+                    process.GetStandardOutput(),
+                    process.GetStandardError());
             }
         }
 
@@ -179,6 +200,16 @@ namespace Cake.Core.Tooling
 
             // Want to opt out of using a working directory?
             info.NoWorkingDirectory = settings.NoWorkingDirectory;
+
+            if (info.RedirectedStandardOutputHandler == null && settings.RedirectedStandardOutputHandler != null)
+            {
+                info.RedirectedStandardOutputHandler = settings.RedirectedStandardOutputHandler;
+            }
+
+            if (info.RedirectedStandardErrorHandler == null && settings.RedirectedStandardErrorHandler != null)
+            {
+                info.RedirectedStandardErrorHandler = settings.RedirectedStandardErrorHandler;
+            }
 
             // Configure process settings
             settings.SetupProcessSettings?.Invoke(info);

--- a/src/Cake.Core/Tooling/ToolSettings.cs
+++ b/src/Cake.Core/Tooling/ToolSettings.cs
@@ -119,5 +119,17 @@ namespace Cake.Core.Tooling
         /// Gets or sets a delegate to configure the process settings.
         /// </summary>
         public Action<ProcessSettings> SetupProcessSettings { get; set; }
+
+        /// <summary>
+        /// Gets or sets a function that intercepts the error output before being redirected.
+        /// Use in conjunction with <see cref="ProcessSettings.RedirectStandardError"/> on the started process.
+        /// </summary>
+        public Func<string, string> RedirectedStandardErrorHandler { get; set; }
+
+        /// <summary>
+        /// Gets or sets a function that intercepts the standard output before being redirected.
+        /// Use in conjunction with <see cref="ProcessSettings.RedirectStandardOutput"/> on the started process.
+        /// </summary>
+        public Func<string, string> RedirectedStandardOutputHandler { get; set; }
     }
 }

--- a/src/Cake.Core/Tooling/ToolSettingsExtensions.cs
+++ b/src/Cake.Core/Tooling/ToolSettingsExtensions.cs
@@ -133,6 +133,28 @@ namespace Cake.Core.Tooling
             => toolSettings.WithToolSettings(toolSettings => toolSettings.SetupProcessSettings = setupProcessSettings);
 
         /// <summary>
+        /// Sets a function that intercepts the standard output before being redirected.
+        /// </summary>
+        /// <typeparam name="T">The ToolSettings type.</typeparam>
+        /// <param name="toolSettings">The tools settings.</param>
+        /// <param name="handler">The standard output handler.</param>
+        /// <returns>The tools settings.</returns>
+        public static T WithRedirectedStandardOutputHandler<T>(this T toolSettings, Func<string, string> handler)
+               where T : ToolSettings
+            => toolSettings.WithToolSettings(toolSettings => toolSettings.RedirectedStandardOutputHandler = handler);
+
+        /// <summary>
+        /// Sets a function that intercepts the standard error before being redirected.
+        /// </summary>
+        /// <typeparam name="T">The ToolSettings type.</typeparam>
+        /// <param name="toolSettings">The tools settings.</param>
+        /// <param name="handler">The standard error handler.</param>
+        /// <returns>The tools settings.</returns>
+        public static T WithRedirectedStandardErrorHandler<T>(this T toolSettings, Func<string, string> handler)
+               where T : ToolSettings
+            => toolSettings.WithToolSettings(toolSettings => toolSettings.RedirectedStandardErrorHandler = handler);
+
+        /// <summary>
         /// Sets expected exit code using <see cref="WithHandleExitCode{T}(T, Func{int, bool})"/>.
         /// </summary>
         /// <typeparam name="T">The ToolSettings type.</typeparam>


### PR DESCRIPTION
## Summary

- Add `RedirectedStandardOutputHandler` and `RedirectedStandardErrorHandler` to `ToolSettings`.
- Forward handlers to `ProcessSettings` when `Tool.RunProcess` starts a tool (unless already set on the passed `ProcessSettings`).
- Add `WithRedirectedStandardOutputHandler` / `WithRedirectedStandardErrorHandler` fluent extensions.

Complements #2460 by making it easier to configure output interception from tool settings without `SetupProcessSettings`.

## Test plan

- [x] `Should_Apply_Redirected_Output_Handlers_From_ToolSettings`
- [ ] Cake.Core.Tests (CI)

CI not run locally (no .NET SDK in contributor environment).

Fixes #2461