### PR TITLE
feat(tooling): RedirectStandardOutput/Error on ToolSettings

### DIFF
--- a/src/Cake.Core.Tests/Unit/Tooling/ToolSettingsExtensionsTests.cs
+++ b/src/Cake.Core.Tests/Unit/Tooling/ToolSettingsExtensionsTests.cs
@@ -168,6 +168,36 @@ namespace Cake.Core.Tests.Unit.Tooling
         }
 
         [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Should_Set_RedirectStandardOutput(bool redirect)
+        {
+            // Given
+            var fixture = new DummyToolFixture();
+
+            // When
+            fixture.Settings.WithRedirectStandardOutput(redirect);
+
+            // Then
+            Assert.Equal(redirect, fixture.Settings.RedirectStandardOutput);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Should_Set_RedirectStandardError(bool redirect)
+        {
+            // Given
+            var fixture = new DummyToolFixture();
+
+            // When
+            fixture.Settings.WithRedirectStandardError(redirect);
+
+            // Then
+            Assert.Equal(redirect, fixture.Settings.RedirectStandardError);
+        }
+
+        [Theory]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(2)]

--- a/src/Cake.Core.Tests/Unit/Tooling/ToolTests.cs
+++ b/src/Cake.Core.Tests/Unit/Tooling/ToolTests.cs
@@ -179,6 +179,23 @@ namespace Cake.Core.Tests.Unit.Tooling
             }
 
             [Fact]
+            public void Should_Apply_Redirect_Standard_Output_And_Error_From_ToolSettings()
+            {
+                // Given
+                var fixture = new DummyToolFixture();
+                fixture.Settings.RedirectStandardOutput = true;
+                fixture.Settings.RedirectStandardError = true;
+                fixture.GivenProcessExitsWithCode(0);
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.True(result.Process.RedirectStandardOutput);
+                Assert.True(result.Process.RedirectStandardError);
+            }
+
+            [Fact]
             public void Executes_SetupProcessSettings()
             {
                 var wasExecuted = false;

--- a/src/Cake.Core/Tooling/Tool.cs
+++ b/src/Cake.Core/Tooling/Tool.cs
@@ -180,6 +180,16 @@ namespace Cake.Core.Tooling
             // Want to opt out of using a working directory?
             info.NoWorkingDirectory = settings.NoWorkingDirectory;
 
+            if (settings.RedirectStandardOutput is bool redirectStandardOutput)
+            {
+                info.RedirectStandardOutput = redirectStandardOutput;
+            }
+
+            if (settings.RedirectStandardError is bool redirectStandardError)
+            {
+                info.RedirectStandardError = redirectStandardError;
+            }
+
             // Configure process settings
             settings.SetupProcessSettings?.Invoke(info);
 

--- a/src/Cake.Core/Tooling/ToolSettings.cs
+++ b/src/Cake.Core/Tooling/ToolSettings.cs
@@ -119,5 +119,17 @@ namespace Cake.Core.Tooling
         /// Gets or sets a delegate to configure the process settings.
         /// </summary>
         public Action<ProcessSettings> SetupProcessSettings { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the tool process redirects standard output.
+        /// When set, the value is applied to <see cref="ProcessSettings.RedirectStandardOutput"/>.
+        /// </summary>
+        public bool? RedirectStandardOutput { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the tool process redirects standard error.
+        /// When set, the value is applied to <see cref="ProcessSettings.RedirectStandardError"/>.
+        /// </summary>
+        public bool? RedirectStandardError { get; set; }
     }
 }

--- a/src/Cake.Core/Tooling/ToolSettingsExtensions.cs
+++ b/src/Cake.Core/Tooling/ToolSettingsExtensions.cs
@@ -133,6 +133,28 @@ namespace Cake.Core.Tooling
             => toolSettings.WithToolSettings(toolSettings => toolSettings.SetupProcessSettings = setupProcessSettings);
 
         /// <summary>
+        /// Sets whether the tool process redirects standard output.
+        /// </summary>
+        /// <typeparam name="T">The ToolSettings type.</typeparam>
+        /// <param name="toolSettings">The tools settings.</param>
+        /// <param name="redirect">Whether to redirect standard output.</param>
+        /// <returns>The tools settings.</returns>
+        public static T WithRedirectStandardOutput<T>(this T toolSettings, bool redirect = true)
+               where T : ToolSettings
+            => toolSettings.WithToolSettings(toolSettings => toolSettings.RedirectStandardOutput = redirect);
+
+        /// <summary>
+        /// Sets whether the tool process redirects standard error.
+        /// </summary>
+        /// <typeparam name="T">The ToolSettings type.</typeparam>
+        /// <param name="toolSettings">The tools settings.</param>
+        /// <param name="redirect">Whether to redirect standard error.</param>
+        /// <returns>The tools settings.</returns>
+        public static T WithRedirectStandardError<T>(this T toolSettings, bool redirect = true)
+               where T : ToolSettings
+            => toolSettings.WithToolSettings(toolSettings => toolSettings.RedirectStandardError = redirect);
+
+        /// <summary>
         /// Sets expected exit code using <see cref="WithHandleExitCode{T}(T, Func{int, bool})"/>.
         /// </summary>
         /// <typeparam name="T">The ToolSettings type.</typeparam>


### PR DESCRIPTION
## Summary

- Adds nullable `RedirectStandardOutput` and `RedirectStandardError` on `ToolSettings`.
- Forwards those values to `ProcessSettings` in `Tool.RunProcess` before `SetupProcessSettings`.
- Adds `WithRedirectStandardOutput` / `WithRedirectStandardError` fluent helpers and unit tests.

Related to #2461: enables stream redirection from tool settings without `SetupProcessSettings` boilerplate (pairs with redirect handler support in #4807).

## Test plan

- [x] `ToolTests.Should_Apply_Redirect_Standard_Output_And_Error_From_ToolSettings`
- [x] `ToolSettingsExtensionsTests` for both fluent helpers
- [ ] CI (no local .NET SDK in contributor environment)