### PR TITLE
fix(nuget): discover NuGet.config from working directory

### DIFF
--- a/src/Cake.NuGet.Tests/Unit/NuGetConfigPathResolverTests.cs
+++ b/src/Cake.NuGet.Tests/Unit/NuGetConfigPathResolverTests.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Cake.Core.Configuration;
+using Cake.Testing;
+using Xunit;
+
+namespace Cake.NuGet.Tests.Unit
+{
+    public sealed class NuGetConfigPathResolverTests
+    {
+        [Fact]
+        public void Should_Use_Working_Directory_When_Config_File_Not_Specified()
+        {
+            // Given
+            var environment = FakeEnvironment.CreateUnixEnvironment();
+            environment.WorkingDirectory = "/project/src";
+            var fileSystem = new FakeFileSystem(environment);
+            var config = new CakeConfiguration(new Dictionary<string, string>());
+
+            // When
+            var result = NuGetConfigPathResolver.GetPath(environment, config, fileSystem);
+
+            // Then
+            Assert.Equal("/project/src", result.Item1.FullPath);
+            Assert.Null(result.Item2);
+        }
+
+        [Fact]
+        public void Should_Use_Explicit_Config_File_When_Specified()
+        {
+            // Given
+            var environment = FakeEnvironment.CreateUnixEnvironment();
+            var fileSystem = new FakeFileSystem(environment);
+            var configPath = environment.WorkingDirectory.CombineWithFilePath("NuGet.config");
+            fileSystem.CreateFile(configPath).Dispose();
+            var config = new CakeConfiguration(new Dictionary<string, string>
+            {
+                [Constants.NuGet.ConfigFile] = "./NuGet.config",
+            });
+
+            // When
+            var result = NuGetConfigPathResolver.GetPath(environment, config, fileSystem);
+
+            // Then
+            Assert.Equal("/Working", result.Item1.FullPath);
+            Assert.Equal("NuGet.config", result.Item2.FullPath);
+        }
+    }
+}

--- a/src/Cake.NuGet/Installers/InProcessInstaller.cs
+++ b/src/Cake.NuGet/Installers/InProcessInstaller.cs
@@ -77,13 +77,13 @@ namespace Cake.NuGet
             _currentFramework = NuGetFramework.Parse(_environment.Runtime.BuiltFramework.FullName, DefaultFrameworkNameProvider.Instance);
             _nugetLogger = new NuGetLogger(_log);
 
-            var nugetConfig = GetNuGetConfigPath(_environment, _config, _fileSystem);
+            var nugetConfig = NuGetConfigPathResolver.GetPath(_environment, _config, _fileSystem);
             var nugetConfigDirectoryPath = nugetConfig.Item1;
             var nugetConfigFilePath = nugetConfig.Item2;
 
             _log.Debug(nugetConfigFilePath != null
                 ? $"Found NuGet Config at: {nugetConfigDirectoryPath}/{nugetConfigFilePath}"
-                : "NuGet Config not specified. Will use NuGet default mechanism for resolving it.");
+                : $"NuGet Config not specified. Searching from working directory: {nugetConfigDirectoryPath}");
 
             _nugetSettings = Settings.LoadDefaultSettings(
                 nugetConfigDirectoryPath.FullPath,
@@ -335,33 +335,6 @@ namespace Cake.NuGet
                 // If we have already found package we can return here. No need to enumerate the other sources.
                 return;
             }
-        }
-
-        private static Tuple<DirectoryPath, FilePath> GetNuGetConfigPath(ICakeEnvironment environment, ICakeConfiguration config, IFileSystem fileSystem)
-        {
-            DirectoryPath rootPath;
-            FilePath filePath;
-
-            var nugetConfigFile = config.GetValue(Constants.NuGet.ConfigFile);
-            if (!string.IsNullOrEmpty(nugetConfigFile))
-            {
-                var configFilePath = new FilePath(nugetConfigFile).MakeAbsolute(environment);
-
-                if (!fileSystem.Exist(configFilePath))
-                {
-                    throw new System.IO.FileNotFoundException("NuGet Config file not found.", configFilePath.FullPath);
-                }
-
-                rootPath = configFilePath.GetDirectory();
-                filePath = configFilePath.GetFilename();
-            }
-            else
-            {
-                rootPath = GetToolPath(environment, config);
-                filePath = null;
-            }
-
-            return Tuple.Create(rootPath, filePath);
         }
 
         public void Dispose()

--- a/src/Cake.NuGet/NuGetConfigPathResolver.cs
+++ b/src/Cake.NuGet/NuGetConfigPathResolver.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Cake.Core;
+using Cake.Core.Configuration;
+using Cake.Core.IO;
+
+namespace Cake.NuGet
+{
+    internal static class NuGetConfigPathResolver
+    {
+        internal static Tuple<DirectoryPath, FilePath> GetPath(ICakeEnvironment environment, ICakeConfiguration config, IFileSystem fileSystem)
+        {
+            ArgumentNullException.ThrowIfNull(environment);
+            ArgumentNullException.ThrowIfNull(config);
+            ArgumentNullException.ThrowIfNull(fileSystem);
+
+            DirectoryPath rootPath;
+            FilePath filePath;
+
+            var nugetConfigFile = config.GetValue(Constants.NuGet.ConfigFile);
+            if (!string.IsNullOrEmpty(nugetConfigFile))
+            {
+                var configFilePath = new FilePath(nugetConfigFile).MakeAbsolute(environment);
+
+                if (!fileSystem.Exist(configFilePath))
+                {
+                    throw new System.IO.FileNotFoundException("NuGet Config file not found.", configFilePath.FullPath);
+                }
+
+                rootPath = configFilePath.GetDirectory();
+                filePath = configFilePath.GetFilename();
+            }
+            else
+            {
+                rootPath = environment.WorkingDirectory.MakeAbsolute(environment);
+                filePath = null;
+            }
+
+            return Tuple.Create(rootPath, filePath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

When `NuGet_ConfigFile` is not set, Cake now passes the script **working directory** (not the `tools` folder) as the root to `Settings.LoadDefaultSettings`. NuGet then walks parent directories and applies the standard config hierarchy (`NuGet.config` in repo, user profile, machine-wide, etc.).

Extracted `NuGetConfigPathResolver` for clarity and unit testing.

## Test plan

- [x] `NuGetConfigPathResolverTests.Should_Use_Working_Directory_When_Config_File_Not_Specified`
- [x] `NuGetConfigPathResolverTests.Should_Use_Explicit_Config_File_When_Specified`
- [ ] CI (no local .NET SDK in contributor environment)

Fixes #2160