### PR TITLE
fix(dotnet): resolve publish OutputDirectory from WorkingDirectory

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Publish/DotNetPublisherTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Publish/DotNetPublisherTests.cs
@@ -101,6 +101,21 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Publish
             }
 
             [Fact]
+            public void Should_Resolve_OutputDirectory_Relative_To_WorkingDirectory()
+            {
+                // Given
+                var fixture = new DotNetPublisherFixture();
+                fixture.Settings.WorkingDirectory = "./source/MyProject";
+                fixture.Settings.OutputDirectory = "./obj/Docker/publish";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("publish --output \"/Working/source/MyProject/obj/Docker/publish\"", result.Args);
+            }
+
+            [Fact]
             public void Should_Add_Settings()
             {
                 // Given

--- a/src/Cake.Common/Tools/DotNet/DotNetTool.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetTool.cs
@@ -127,5 +127,22 @@ namespace Cake.Common.Tools.DotNet
 
             return builder;
         }
+
+        /// <summary>
+        /// Resolves a relative output directory against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteOutputDirectory(DirectoryPath outputDirectory, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(outputDirectory);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && outputDirectory.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).Combine(outputDirectory);
+            }
+
+            return outputDirectory;
+        }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Publish/DotNetPublisher.cs
+++ b/src/Cake.Common/Tools/DotNet/Publish/DotNetPublisher.cs
@@ -61,7 +61,8 @@ namespace Cake.Common.Tools.DotNet.Publish
             if (settings.OutputDirectory != null)
             {
                 builder.Append("--output");
-                builder.AppendQuoted(settings.OutputDirectory.MakeAbsolute(_environment).FullPath);
+                var outputDirectory = GetAbsoluteOutputDirectory(settings.OutputDirectory, settings, _environment);
+                builder.AppendQuoted(outputDirectory.MakeAbsolute(_environment).FullPath);
             }
 
             // Runtime


### PR DESCRIPTION
## Summary

When `DotNetPublishSettings.OutputDirectory` is relative and `WorkingDirectory` is set, resolve the output path against the tool working directory (e.g. `./source/MyProject/obj/Docker/publish`) instead of only against the Cake script working directory.

Adds `DotNetTool.GetAbsoluteOutputDirectory` helper used by `DotNetPublisher`.

## Test plan

- [x] `DotNetPublisherTests.Should_Resolve_OutputDirectory_Relative_To_WorkingDirectory`
- [ ] CI (no local .NET SDK in contributor environment)

Fixes #1917