### PR TITLE
fix(dotnet): OutputDirectory from WorkingDirectory for build/pack/clean/test

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Build/DotNetBuilderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Build/DotNetBuilderTests.cs
@@ -125,6 +125,22 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Build
                 Assert.Equal("build \"./src/*\" --output \"/Working/artifacts\"", result.Args);
             }
 
+            [Fact]
+            public void Should_Resolve_OutputDirectory_Relative_To_WorkingDirectory()
+            {
+                // Given
+                var fixture = new DotNetBuilderFixture();
+                fixture.Settings.WorkingDirectory = "./source/MyProject";
+                fixture.Settings.OutputDirectory = "./obj/Docker/publish";
+                fixture.Project = "./src/*";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("build \"./src/*\" --output \"/Working/source/MyProject/obj/Docker/publish\"", result.Args);
+            }
+
             [Theory]
             [InlineData("./src/*", "build \"./src/*\"")]
             [InlineData("./src/cake build/", "build \"./src/cake build/\"")]

--- a/src/Cake.Common/Tools/DotNet/Build/DotNetBuilder.cs
+++ b/src/Cake.Common/Tools/DotNet/Build/DotNetBuilder.cs
@@ -62,7 +62,8 @@ namespace Cake.Common.Tools.DotNet.Build
             if (settings.OutputDirectory != null)
             {
                 builder.Append("--output");
-                builder.AppendQuoted(settings.OutputDirectory.MakeAbsolute(_environment).FullPath);
+                var outputDirectory = GetAbsoluteOutputDirectory(settings.OutputDirectory, settings, _environment);
+                builder.AppendQuoted(outputDirectory.MakeAbsolute(_environment).FullPath);
             }
 
             // Runtime

--- a/src/Cake.Common/Tools/DotNet/Clean/DotNetCleaner.cs
+++ b/src/Cake.Common/Tools/DotNet/Clean/DotNetCleaner.cs
@@ -61,7 +61,8 @@ namespace Cake.Common.Tools.DotNet.Clean
             if (settings.OutputDirectory != null)
             {
                 builder.Append("--output");
-                builder.AppendQuoted(settings.OutputDirectory.MakeAbsolute(_environment).FullPath);
+                var outputDirectory = GetAbsoluteOutputDirectory(settings.OutputDirectory, settings, _environment);
+                builder.AppendQuoted(outputDirectory.MakeAbsolute(_environment).FullPath);
             }
 
             // Framework

--- a/src/Cake.Common/Tools/DotNet/DotNetTool.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetTool.cs
@@ -127,5 +127,22 @@ namespace Cake.Common.Tools.DotNet
 
             return builder;
         }
+
+        /// <summary>
+        /// Resolves a relative output directory against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteOutputDirectory(DirectoryPath outputDirectory, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(outputDirectory);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && outputDirectory.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).Combine(outputDirectory);
+            }
+
+            return outputDirectory;
+        }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Pack/DotNetPacker.cs
+++ b/src/Cake.Common/Tools/DotNet/Pack/DotNetPacker.cs
@@ -61,7 +61,8 @@ namespace Cake.Common.Tools.DotNet.Pack
             if (settings.OutputDirectory != null)
             {
                 builder.Append("--output");
-                builder.AppendQuoted(settings.OutputDirectory.MakeAbsolute(_environment).FullPath);
+                var outputDirectory = GetAbsoluteOutputDirectory(settings.OutputDirectory, settings, _environment);
+                builder.AppendQuoted(outputDirectory.MakeAbsolute(_environment).FullPath);
             }
 
             // No build

--- a/src/Cake.Common/Tools/DotNet/Test/DotNetTester.cs
+++ b/src/Cake.Common/Tools/DotNet/Test/DotNetTester.cs
@@ -104,7 +104,8 @@ namespace Cake.Common.Tools.DotNet.Test
             if (settings.OutputDirectory != null)
             {
                 builder.Append("--output");
-                builder.AppendQuoted(settings.OutputDirectory.MakeAbsolute(_environment).FullPath);
+                var outputDirectory = GetAbsoluteOutputDirectory(settings.OutputDirectory, settings, _environment);
+                builder.AppendQuoted(outputDirectory.MakeAbsolute(_environment).FullPath);
             }
 
             // Frameworks


### PR DESCRIPTION
## Summary

Extends #1917-style output path resolution to `dotnet build`, `pack`, `clean`, and `test`: when `OutputDirectory` is relative and `WorkingDirectory` is set, resolve against the tool working directory.

Uses shared `DotNetTool.GetAbsoluteOutputDirectory` (publish is covered in #4810).

## Test plan

- [x] `DotNetBuilderTests.Should_Resolve_OutputDirectory_Relative_To_WorkingDirectory`
- [ ] CI (no local .NET SDK in contributor environment)

Related to #1917