### PR TITLE
fix(io): preserve backslash in paths on Unix (#2494)

### DIFF
--- a/src/Cake.Core.Tests/Unit/IO/PathTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/PathTests.cs
@@ -34,14 +34,27 @@ namespace Cake.Core.Tests.Unit.IO
                 Assert.Equal(string.Empty, path.FullPath);
             }
 
-            [Fact]
-            public void Will_Normalize_Path_Separators()
+            [WindowsTheory]
+            [InlineData("shaders\\basic", "shaders/basic")]
+            public void Will_Normalize_Path_Separators_On_Windows(string input, string expected)
             {
                 // Given, When
-                var path = new TestingPath("shaders\\basic");
+                var path = new TestingPath(input);
 
                 // Then
-                Assert.Equal("shaders/basic", path.FullPath);
+                Assert.Equal(expected, path.FullPath);
+            }
+
+            [NonWindowsTheory]
+            [InlineData("/users/source/bad\\file.txt", "/users/source/bad\\file.txt")]
+            [InlineData("shaders\\basic", "shaders\\basic")]
+            public void Will_Preserve_Backslash_In_Path_On_Unix(string input, string expected)
+            {
+                // Given, When
+                var path = new TestingPath(input);
+
+                // Then
+                Assert.Equal(expected, path.FullPath);
             }
 
             [Fact]
@@ -80,14 +93,24 @@ namespace Cake.Core.Tests.Unit.IO
 
             [Theory]
             [InlineData("/Hello/World/", "/Hello/World")]
-            [InlineData("\\Hello\\World\\", "/Hello/World")]
             [InlineData("file.txt/", "file.txt")]
-            [InlineData("file.txt\\", "file.txt")]
             [InlineData("Temp/file.txt/", "Temp/file.txt")]
-            [InlineData("Temp\\file.txt\\", "Temp/file.txt")]
             [InlineData(@"\\foo\bar\", @"\\foo\bar")]
             [InlineData(@"\\foo\bar/", @"\\foo\bar")]
             public void Should_Remove_Trailing_Slashes(string value, string expected)
+            {
+                // Given, When
+                var path = new TestingPath(value);
+
+                // Then
+                Assert.Equal(expected, path.FullPath);
+            }
+
+            [WindowsTheory]
+            [InlineData("\\Hello\\World\\", "/Hello/World")]
+            [InlineData("file.txt\\", "file.txt")]
+            [InlineData("Temp\\file.txt\\", "Temp/file.txt")]
+            public void Should_Remove_Trailing_Slashes_And_Normalize_Backslashes_On_Windows(string value, string expected)
             {
                 // Given, When
                 var path = new TestingPath(value);

--- a/src/Cake.Core/IO/Path.cs
+++ b/src/Cake.Core/IO/Path.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Cake.Core.Polyfill;
 
 namespace Cake.Core.IO
 {
@@ -64,7 +65,11 @@ namespace Cake.Core.IO
                 separatorToReplace = '/';
             }
 
-            FullPath = path.Replace(separatorToReplace, separatorToReplaceWith).Trim();
+            // On Unix, backslash is a valid filename character; do not treat it as a path separator (#2494).
+            var preserveBackslash = EnvironmentHelper.IsUnix() && !IsUNC;
+            FullPath = preserveBackslash
+                ? path.Trim()
+                : path.Replace(separatorToReplace, separatorToReplaceWith).Trim();
 
             // Relative paths are considered empty.
             FullPath = FullPath == "./" ? string.Empty : FullPath;
@@ -78,7 +83,9 @@ namespace Cake.Core.IO
             // Remove trailing slashes.
             if (FullPath.Length > 1)
             {
-                FullPath = FullPath.TrimEnd(Separator);
+                FullPath = preserveBackslash
+                    ? FullPath.TrimEnd('/', '\\')
+                    : FullPath.TrimEnd(Separator);
                 if (IsUNC && string.IsNullOrWhiteSpace(FullPath))
                 {
                     FullPath = @"\\";


### PR DESCRIPTION
## Summary

Fixes #2494.

On Unix/macOS, `\` is a valid character in file names. `Path` previously replaced all backslashes with `/`, which broke round-tripping for paths like `/users/source/bad\file.txt` and caused `CleanDirectories` to fail when deleting files whose names contain a backslash.

This change skips backslash-to-slash normalization on Unix (non-UNC paths) while keeping existing Windows and UNC behavior.

## Test plan

- [x] Added `NonWindowsTheory` tests for backslash preservation on Unix
- [x] Moved backslash normalization expectations to `WindowsTheory`
- [ ] CI: `Cake.Core.Tests` Path unit tests (no local .NET SDK in contributor environment; relying on GitHub Actions)