### PR TITLE
fix(dotnet): resolve DotNetTest paths from WorkingDirectory (#1917)

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Test/DotNetTesterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Test/DotNetTesterTests.cs
@@ -119,6 +119,26 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Test
             }
 
             [Fact]
+            public void Should_Resolve_Test_Paths_Relative_To_WorkingDirectory()
+            {
+                // Given
+                var fixture = new DotNetTesterFixture();
+                fixture.Settings.WorkingDirectory = "./source/MyProject";
+                fixture.Settings.OutputDirectory = "./artifacts/";
+                fixture.Settings.Settings = "./demo.runsettings";
+                fixture.Settings.DiagnosticFile = "./artifacts/logging/diagnostics.txt";
+                fixture.Settings.ResultsDirectory = "./tests/";
+                fixture.Settings.VSTestReportPath = "./tests/TestResults.xml";
+                fixture.Settings.TestAdapterPath = "./custom-test-adapter";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("test --settings \"/Working/source/MyProject/demo.runsettings\" --test-adapter-path \"/Working/source/MyProject/custom-test-adapter\" --output \"/Working/source/MyProject/artifacts\" --diag \"/Working/source/MyProject/artifacts/logging/diagnostics.txt\" --results-directory \"/Working/source/MyProject/tests\" --logger trx;LogFileName=\"/Working/source/MyProject/tests/TestResults.xml\"", result.Args);
+            }
+
+            [Fact]
             public void Should_Add_Additional_Settings()
             {
                 // Given

--- a/src/Cake.Common/Tools/DotNet/DotNetTool.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetTool.cs
@@ -127,5 +127,47 @@ namespace Cake.Common.Tools.DotNet
 
             return builder;
         }
+
+        /// <summary>
+        /// Resolves a relative directory path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteDirectoryPath(DirectoryPath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).Combine(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative file path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static FilePath GetAbsoluteFilePath(FilePath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).CombineWithFilePath(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative output directory against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteOutputDirectory(DirectoryPath outputDirectory, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            return GetAbsoluteDirectoryPath(outputDirectory, settings, environment);
+        }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Test/DotNetTester.cs
+++ b/src/Cake.Common/Tools/DotNet/Test/DotNetTester.cs
@@ -73,7 +73,8 @@ namespace Cake.Common.Tools.DotNet.Test
             if (settings.Settings != null)
             {
                 builder.Append("--settings");
-                builder.AppendQuoted(settings.Settings.MakeAbsolute(_environment).FullPath);
+                var settingsFile = GetAbsoluteFilePath(settings.Settings, settings, _environment);
+                builder.AppendQuoted(settingsFile.MakeAbsolute(_environment).FullPath);
             }
 
             // Filter
@@ -87,7 +88,8 @@ namespace Cake.Common.Tools.DotNet.Test
             if (settings.TestAdapterPath != null)
             {
                 builder.Append("--test-adapter-path");
-                builder.AppendQuoted(settings.TestAdapterPath.MakeAbsolute(_environment).FullPath);
+                var testAdapterPath = GetAbsoluteDirectoryPath(settings.TestAdapterPath, settings, _environment);
+                builder.AppendQuoted(testAdapterPath.MakeAbsolute(_environment).FullPath);
             }
 
             // Loggers
@@ -104,7 +106,8 @@ namespace Cake.Common.Tools.DotNet.Test
             if (settings.OutputDirectory != null)
             {
                 builder.Append("--output");
-                builder.AppendQuoted(settings.OutputDirectory.MakeAbsolute(_environment).FullPath);
+                var outputDirectory = GetAbsoluteOutputDirectory(settings.OutputDirectory, settings, _environment);
+                builder.AppendQuoted(outputDirectory.MakeAbsolute(_environment).FullPath);
             }
 
             // Frameworks
@@ -135,7 +138,8 @@ namespace Cake.Common.Tools.DotNet.Test
             if (settings.DiagnosticFile != null)
             {
                 builder.Append("--diag");
-                builder.AppendQuoted(settings.DiagnosticFile.MakeAbsolute(_environment).FullPath);
+                var diagnosticFile = GetAbsoluteFilePath(settings.DiagnosticFile, settings, _environment);
+                builder.AppendQuoted(diagnosticFile.MakeAbsolute(_environment).FullPath);
             }
 
             // No Build
@@ -159,12 +163,14 @@ namespace Cake.Common.Tools.DotNet.Test
             if (settings.ResultsDirectory != null)
             {
                 builder.Append("--results-directory");
-                builder.AppendQuoted(settings.ResultsDirectory.MakeAbsolute(_environment).FullPath);
+                var resultsDirectory = GetAbsoluteDirectoryPath(settings.ResultsDirectory, settings, _environment);
+                builder.AppendQuoted(resultsDirectory.MakeAbsolute(_environment).FullPath);
             }
 
             if (settings.VSTestReportPath != null)
             {
-                builder.AppendSwitchQuoted($"--logger trx;LogFileName", "=", settings.VSTestReportPath.MakeAbsolute(_environment).FullPath);
+                var vsTestReportPath = GetAbsoluteFilePath(settings.VSTestReportPath, settings, _environment);
+                builder.AppendSwitchQuoted($"--logger trx;LogFileName", "=", vsTestReportPath.MakeAbsolute(_environment).FullPath);
             }
 
             if (!string.IsNullOrEmpty(settings.Runtime))


### PR DESCRIPTION
## Summary

Related to #1917.

When `DotNetTestSettings.WorkingDirectory` is set, relative paths for test output and artifacts were still resolved against the Cake script directory. This change resolves them against `WorkingDirectory` instead:

- `OutputDirectory`
- `ResultsDirectory`
- `DiagnosticFile`
- `VSTestReportPath`
- `Settings` (runsettings file)
- `TestAdapterPath`

Adds shared `GetAbsoluteDirectoryPath` / `GetAbsoluteFilePath` helpers on `DotNetTool` (with `GetAbsoluteOutputDirectory` delegating to the directory helper).

Complements #4810 / #4811 for build/pack/publish/clean.

## Test plan

- [x] Added unit test `Should_Resolve_Test_Paths_Relative_To_WorkingDirectory`
- [ ] CI: `Cake.Common.Tests` (no local .NET SDK; relying on GitHub Actions)