### PR TITLE
fix(dotnet): resolve DotNetRestore paths from WorkingDirectory (#1917)

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Restore/DotNetRestorerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Restore/DotNetRestorerTests.cs
@@ -103,6 +103,23 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Restore
             }
 
             [Fact]
+            public void Should_Resolve_Restore_Paths_Relative_To_WorkingDirectory()
+            {
+                // Given
+                var fixture = new DotNetRestorerFixture();
+                fixture.Settings.WorkingDirectory = "./source/MyProject";
+                fixture.Settings.PackagesDirectory = "./packages/";
+                fixture.Settings.ConfigFile = "./NuGet.config";
+                fixture.Settings.LockFilePath = "./obj/packages.lock.json";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("restore --packages \"/Working/source/MyProject/packages\" --configfile \"/Working/source/MyProject/NuGet.config\" --lock-file-path \"/Working/source/MyProject/obj/packages.lock.json\"", result.Args);
+            }
+
+            [Fact]
             public void Should_Add_Settings()
             {
                 // Given

--- a/src/Cake.Common/Tools/DotNet/DotNetTool.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetTool.cs
@@ -127,5 +127,46 @@ namespace Cake.Common.Tools.DotNet
 
             return builder;
         }
+        /// <summary>
+        /// Resolves a relative directory path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteDirectoryPath(DirectoryPath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).Combine(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative file path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static FilePath GetAbsoluteFilePath(FilePath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).CombineWithFilePath(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative output directory against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteOutputDirectory(DirectoryPath outputDirectory, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            return GetAbsoluteDirectoryPath(outputDirectory, settings, environment);
+        }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Restore/DotNetRestorer.cs
+++ b/src/Cake.Common/Tools/DotNet/Restore/DotNetRestorer.cs
@@ -71,7 +71,8 @@ namespace Cake.Common.Tools.DotNet.Restore
             if (settings.PackagesDirectory != null)
             {
                 builder.Append("--packages");
-                builder.AppendQuoted(settings.PackagesDirectory.MakeAbsolute(_environment).FullPath);
+                var packagesDirectory = GetAbsoluteDirectoryPath(settings.PackagesDirectory, settings, _environment);
+                builder.AppendQuoted(packagesDirectory.MakeAbsolute(_environment).FullPath);
             }
 
             // Sources
@@ -88,7 +89,8 @@ namespace Cake.Common.Tools.DotNet.Restore
             if (settings.ConfigFile != null)
             {
                 builder.Append("--configfile");
-                builder.AppendQuoted(settings.ConfigFile.MakeAbsolute(_environment).FullPath);
+                var configFile = GetAbsoluteFilePath(settings.ConfigFile, settings, _environment);
+                builder.AppendQuoted(configFile.MakeAbsolute(_environment).FullPath);
             }
 
             // Ignore failed sources
@@ -142,7 +144,8 @@ namespace Cake.Common.Tools.DotNet.Restore
             // Lock file path
             if (settings.LockFilePath != null)
             {
-                builder.AppendSwitchQuoted("--lock-file-path", " ", settings.LockFilePath.MakeAbsolute(_environment).FullPath);
+                var lockFilePath = GetAbsoluteFilePath(settings.LockFilePath, settings, _environment);
+                builder.AppendSwitchQuoted("--lock-file-path", " ", lockFilePath.MakeAbsolute(_environment).FullPath);
             }
 
             // Force Evaluate


### PR DESCRIPTION
## Summary

Related to #1917.

When `DotNetRestoreSettings.WorkingDirectory` is set, relative paths for restore artifacts were still resolved against the Cake script directory. This change resolves them against `WorkingDirectory` instead:

- `PackagesDirectory` (`--packages`)
- `ConfigFile` (`--configfile`)
- `LockFilePath` (`--lock-file-path`)

Adds shared `GetAbsoluteDirectoryPath` / `GetAbsoluteFilePath` helpers on `DotNetTool`.

Complements #4810 / #4811 / #4813.

## Test plan

- [x] Added unit test `Should_Resolve_Restore_Paths_Relative_To_WorkingDirectory`
- [ ] CI: `Cake.Common.Tests` (no local .NET SDK; relying on GitHub Actions)