### PR TITLE
fix(dotnet): resolve DotNetFormat paths from WorkingDirectory (#1917)

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Format/DotNetFormatTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Format/DotNetFormatTests.cs
@@ -89,6 +89,23 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Format
             }
 
             [Fact]
+            public void Should_Resolve_Format_Paths_Relative_To_WorkingDirectory()
+            {
+                // Given
+                var fixture = new DotNetFormatterFixture();
+                fixture.Root = "./src/project";
+                fixture.Settings.WorkingDirectory = "./source/MyProject";
+                fixture.Settings.BinaryLog = "./temp/b.log";
+                fixture.Settings.Report = "./temp/report.json";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("format \"./src/project\" --binarylog \"/Working/source/MyProject/temp/b.log\" --report \"/Working/source/MyProject/temp/report.json\"", result.Args);
+            }
+
+            [Fact]
             public void Should_Add_Additional_Arguments()
             {
                 // Given

--- a/src/Cake.Common/Tools/DotNet/DotNetTool.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetTool.cs
@@ -127,5 +127,46 @@ namespace Cake.Common.Tools.DotNet
 
             return builder;
         }
+        /// <summary>
+        /// Resolves a relative directory path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteDirectoryPath(DirectoryPath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).Combine(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative file path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static FilePath GetAbsoluteFilePath(FilePath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).CombineWithFilePath(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative output directory against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteOutputDirectory(DirectoryPath outputDirectory, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            return GetAbsoluteDirectoryPath(outputDirectory, settings, environment);
+        }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Format/DotNetFormatter.cs
+++ b/src/Cake.Common/Tools/DotNet/Format/DotNetFormatter.cs
@@ -112,13 +112,15 @@ namespace Cake.Common.Tools.DotNet.Format
             // Binary Log
             if (settings.BinaryLog != null)
             {
-                builder.AppendSwitchQuoted($"--binarylog", settings.BinaryLog.MakeAbsolute(_environment).FullPath);
+                var binaryLog = GetAbsoluteFilePath(settings.BinaryLog, settings, _environment);
+                builder.AppendSwitchQuoted($"--binarylog", binaryLog.MakeAbsolute(_environment).FullPath);
             }
 
             // Report
             if (settings.Report != null)
             {
-                builder.AppendSwitchQuoted($"--report", settings.Report.MakeAbsolute(_environment).FullPath);
+                var report = GetAbsoluteFilePath(settings.Report, settings, _environment);
+                builder.AppendSwitchQuoted($"--report", report.MakeAbsolute(_environment).FullPath);
             }
 
             return builder;


### PR DESCRIPTION
## Summary

Related to #1917.

When `DotNetFormatSettings.WorkingDirectory` is set, relative `BinaryLog` and `Report` paths were still resolved against the Cake script directory. They are now resolved against `WorkingDirectory`.

Adds shared `GetAbsoluteDirectoryPath` / `GetAbsoluteFilePath` helpers on `DotNetTool`.

Complements #4810–#4814.

## Test plan

- [x] Added unit test `Should_Resolve_Format_Paths_Relative_To_WorkingDirectory`
- [ ] CI: `Cake.Common.Tests` (no local .NET SDK; relying on GitHub Actions)