### PR TITLE
fix(dotnet): resolve DotNetPackageAdd directory from WorkingDirectory (#1917)

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Package/Add/DotNetPackageAdderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Package/Add/DotNetPackageAdderTests.cs
@@ -90,6 +90,22 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Package.Add
             }
 
             [Fact]
+            public void Should_Resolve_PackageDirectory_Relative_To_WorkingDirectory()
+            {
+                // Given
+                var fixture = new DotNetPackageAdderFixture();
+                fixture.PackageName = "Newtonsoft.Json";
+                fixture.Settings.WorkingDirectory = "./source/MyProject";
+                fixture.Settings.PackageDirectory = "./packages";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("add package Newtonsoft.Json --package-directory \"/Working/source/MyProject/packages\"", result.Args);
+            }
+
+            [Fact]
             public void Should_Add_Additional_Arguments()
             {
                 // Given

--- a/src/Cake.Common/Tools/DotNet/DotNetTool.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetTool.cs
@@ -127,5 +127,46 @@ namespace Cake.Common.Tools.DotNet
 
             return builder;
         }
+        /// <summary>
+        /// Resolves a relative directory path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteDirectoryPath(DirectoryPath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).Combine(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative file path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static FilePath GetAbsoluteFilePath(FilePath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).CombineWithFilePath(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative output directory against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteOutputDirectory(DirectoryPath outputDirectory, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            return GetAbsoluteDirectoryPath(outputDirectory, settings, environment);
+        }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Package/Add/DotNetPackageAdder.cs
+++ b/src/Cake.Common/Tools/DotNet/Package/Add/DotNetPackageAdder.cs
@@ -83,7 +83,8 @@ namespace Cake.Common.Tools.DotNet.Package.Add
             if (settings.PackageDirectory != null)
             {
                 builder.Append("--package-directory");
-                builder.AppendQuoted(settings.PackageDirectory.MakeAbsolute(_environment).FullPath);
+                var packageDirectory = GetAbsoluteDirectoryPath(settings.PackageDirectory, settings, _environment);
+                builder.AppendQuoted(packageDirectory.MakeAbsolute(_environment).FullPath);
             }
 
             // Prerelease


### PR DESCRIPTION
## Summary

Related to #1917.

When `DotNetPackageAddSettings.WorkingDirectory` is set, relative `PackageDirectory` was still resolved against the Cake script directory. It is now resolved against `WorkingDirectory`.

Adds shared `GetAbsoluteDirectoryPath` / `GetAbsoluteFilePath` helpers on `DotNetTool`.

Complements #4810–#4815.

## Test plan

- [x] Added unit test `Should_Resolve_PackageDirectory_Relative_To_WorkingDirectory`
- [ ] CI: `Cake.Common.Tests` (no local .NET SDK; relying on GitHub Actions)