### PR TITLE
fix(dotnet): resolve DotNetVSTest paths from WorkingDirectory (#1917)

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/VSTest/DotNetVSTesterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/VSTest/DotNetVSTesterTests.cs
@@ -109,6 +109,30 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.VSTest
             }
 
             [Fact]
+            public void Should_Resolve_VSTest_Paths_Relative_To_WorkingDirectory()
+            {
+                // Given
+                var fixture = new DotNetVSTesterFixture
+                {
+                    TestFiles = new[] { (FilePath)"./test/unit.tests.csproj" },
+                    Settings = new DotNetVSTestSettings
+                    {
+                        WorkingDirectory = "./source/MyProject",
+                        Settings = "./demo.runsettings",
+                        TestAdapterPath = "./custom-test-adapter",
+                        DiagnosticFile = "./artifacts/diagnostics.txt",
+                        ResultsDirectory = "./test-results"
+                    }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("vstest \"/Working/test/unit.tests.csproj\" --Settings:\"/Working/source/MyProject/demo.runsettings\" --TestAdapterPath:\"/Working/source/MyProject/custom-test-adapter\" --Diag:\"/Working/source/MyProject/artifacts/diagnostics.txt\" --ResultsDirectory:\"/Working/source/MyProject/test-results\"", result.Args);
+            }
+
+            [Fact]
             public void Should_Add_Settings_Argument()
             {
                 // Given

--- a/src/Cake.Common/Tools/DotNet/DotNetTool.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetTool.cs
@@ -127,5 +127,46 @@ namespace Cake.Common.Tools.DotNet
 
             return builder;
         }
+        /// <summary>
+        /// Resolves a relative directory path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteDirectoryPath(DirectoryPath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).Combine(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative file path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static FilePath GetAbsoluteFilePath(FilePath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).CombineWithFilePath(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative output directory against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteOutputDirectory(DirectoryPath outputDirectory, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            return GetAbsoluteDirectoryPath(outputDirectory, settings, environment);
+        }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/VSTest/DotNetVSTester.cs
+++ b/src/Cake.Common/Tools/DotNet/VSTest/DotNetVSTester.cs
@@ -67,7 +67,8 @@ namespace Cake.Common.Tools.DotNet.VSTest
             // Settings
             if (settings.Settings != null)
             {
-                builder.AppendSwitchQuoted("--Settings", ":", settings.Settings.MakeAbsolute(_environment).FullPath);
+                var settingsFile = GetAbsoluteFilePath(settings.Settings, settings, _environment);
+                builder.AppendSwitchQuoted("--Settings", ":", settingsFile.MakeAbsolute(_environment).FullPath);
             }
 
             // Tests to run
@@ -79,7 +80,8 @@ namespace Cake.Common.Tools.DotNet.VSTest
             // Path to custom test adapter
             if (settings.TestAdapterPath != null)
             {
-                builder.AppendSwitchQuoted("--TestAdapterPath", ":", settings.TestAdapterPath.MakeAbsolute(_environment).FullPath);
+                var testAdapterPath = GetAbsoluteDirectoryPath(settings.TestAdapterPath, settings, _environment);
+                builder.AppendSwitchQuoted("--TestAdapterPath", ":", testAdapterPath.MakeAbsolute(_environment).FullPath);
             }
 
             // Platform architecture to execute tests on
@@ -127,13 +129,15 @@ namespace Cake.Common.Tools.DotNet.VSTest
             // Write to Diagnostic file?
             if (settings.DiagnosticFile != null)
             {
-                builder.AppendSwitchQuoted("--Diag", ":", settings.DiagnosticFile.MakeAbsolute(_environment).FullPath);
+                var diagnosticFile = GetAbsoluteFilePath(settings.DiagnosticFile, settings, _environment);
+                builder.AppendSwitchQuoted("--Diag", ":", diagnosticFile.MakeAbsolute(_environment).FullPath);
             }
 
             // Path to output test results
             if (settings.ResultsDirectory != null)
             {
-                builder.AppendSwitchQuoted("--ResultsDirectory", ":", settings.ResultsDirectory.MakeAbsolute(_environment).FullPath);
+                var resultsDirectory = GetAbsoluteDirectoryPath(settings.ResultsDirectory, settings, _environment);
+                builder.AppendSwitchQuoted("--ResultsDirectory", ":", resultsDirectory.MakeAbsolute(_environment).FullPath);
             }
 
             // Extra arguments


### PR DESCRIPTION
## Summary

Related to #1917.

When `DotNetVSTestSettings.WorkingDirectory` is set, relative paths for vstest settings were still resolved against the Cake script directory. They are now resolved against `WorkingDirectory`:

- `Settings` (runsettings file)
- `TestAdapterPath`
- `DiagnosticFile`
- `ResultsDirectory`

Adds shared `GetAbsoluteDirectoryPath` / `GetAbsoluteFilePath` helpers on `DotNetTool`.

Complements #4810–#4816.

## Test plan

- [x] Added unit test `Should_Resolve_VSTest_Paths_Relative_To_WorkingDirectory`
- [ ] CI: `Cake.Common.Tests` (no local .NET SDK; relying on GitHub Actions)