### PR TITLE
GH4794: Update NuGet client packages to 7.6.0 and PKCS pins

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
         "src"
     ],
     "sdk": {
-        "version": "10.0.201",
+        "version": "10.0.300",
         "rollForward": "latestFeature"
     },
     "test": {

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -20,13 +20,13 @@
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="18.4.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="NuGet.Common" Version="7.3.0" />
-    <PackageVersion Include="NuGet.Frameworks" Version="7.3.0" />
-    <PackageVersion Include="NuGet.Packaging" Version="7.3.0" />
-    <PackageVersion Include="NuGet.Protocol" Version="7.3.0" />
-    <PackageVersion Include="NuGet.Resolver" Version="7.3.0" />
-    <PackageVersion Include="NuGet.Versioning" Version="7.3.0" />
-    <PackageVersion Include="NuGet.Credentials" Version="7.3.0" />
+    <PackageVersion Include="NuGet.Common" Version="7.6.0" />
+    <PackageVersion Include="NuGet.Frameworks" Version="7.6.0" />
+    <PackageVersion Include="NuGet.Packaging" Version="7.6.0" />
+    <PackageVersion Include="NuGet.Protocol" Version="7.6.0" />
+    <PackageVersion Include="NuGet.Resolver" Version="7.6.0" />
+    <PackageVersion Include="NuGet.Versioning" Version="7.6.0" />
+    <PackageVersion Include="NuGet.Credentials" Version="7.6.0" />
     <PackageVersion Include="Spectre.Console" Version="0.55.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
     <PackageVersion Include="Spectre.Console.Testing" Version="0.55.0" />
@@ -45,13 +45,13 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <!-- Pin nuget transitive packages vulnerability issues NuGet.Packaging -->
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.5" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.8" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.14" />
     <!-- Pin nuget transitive packages vulnerability issues NuGet.Packaging -->
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.14" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.16" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
+++ b/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
@@ -284,7 +284,7 @@ Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTest.Fail")
     // Then
     Assert.NotNull(exception);
     Assert.IsType<CakeException>(exception);
-    Assert.Equal(exception.Message, ".NET CLI: Process returned an error (exit code 1).");
+    Assert.Equal(".NET CLI: Process returned an error (exit code 2).",exception.Message);
 });
 
 Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetFormat")


### PR DESCRIPTION
- Bump NuGet.Common, NuGet.Frameworks, NuGet.Packaging, NuGet.Protocol, NuGet.Resolver, NuGet.Versioning, and NuGet.Credentials from 7.3.0 to 7.6.0 in Directory.Packages.props
- Pin System.Security.Cryptography.Pkcs to 10.0.8 for net10.0 (was 10.0.5)
- Pin System.Security.Cryptography.Pkcs to 9.0.16 for net9.0 (was 9.0.14)
- Address transitive vulnerability issues related to NuGet.Packaging
- Update .NET SDK to 10.0.300
- fixes #4794
- fixes #4819 
