### PR TITLE
GH4834: Use --source for dotnet tool install on .NET 9+

### DIFF
--- a/src/Cake.DotNetTool.Module/DotNetToolPackageInstaller.cs
+++ b/src/Cake.DotNetTool.Module/DotNetToolPackageInstaller.cs
@@ -246,7 +246,11 @@ namespace Cake.DotNetTool.Module
             {
                 if (definition.Address != null)
                 {
+#if NET9_0_OR_GREATER
+                    arguments.Append("--source");
+#else
                     arguments.Append("--add-source");
+#endif
                     arguments.AppendQuoted(definition.Address.AbsoluteUri);
                 }
 

--- a/tests/integration/Cake.DotNetTool.Module/Cake.DotNetTool.Module.cake
+++ b/tests/integration/Cake.DotNetTool.Module/Cake.DotNetTool.Module.cake
@@ -33,7 +33,46 @@ Task("Cake.DotNetTool.Module.Update")
     CakeExecuteScript(scriptPath);
 });
 
+Task("Cake.DotNetTool.Module.Source.Setup")
+    .Does(() =>
+{
+    var path = Paths.Temp.Combine("./Cake.DotNetTool.Module.Source");
+    CleanDirectory(path);
+});
+
+Task("Cake.DotNetTool.Module.Source.Install")
+    .IsDependentOn("Cake.DotNetTool.Module.Source.Setup")
+    .Does(() =>
+{
+    // Given — explicit NuGet source (see https://github.com/cake-build/cake/issues/4834)
+    var scriptPath = Paths.Temp.Combine("./Cake.DotNetTool.Module.Source/").CombineWithFilePath("build.cake");
+    var script = "#tool \"dotnet:https://api.nuget.org/v3/index.json?package=GitVersion.Tool&version=6.6.2\"";
+    System.IO.File.WriteAllText(scriptPath.FullPath, script);
+
+    // When
+    CakeExecuteScript(scriptPath);
+});
+
+Task("Cake.DotNetTool.Module.Source.Update")
+    .IsDependentOn("Cake.DotNetTool.Module.Source.Install")
+    .Does(() =>
+{
+    // Given — same source, newer tool version (see https://cakebuild.net/docs/writing-builds/tools/installing-tools)
+    var scriptPath = Paths.Temp.Combine("./Cake.DotNetTool.Module.Source/").CombineWithFilePath("build.cake");
+    var script = "#tool \"dotnet:https://api.nuget.org/v3/index.json?package=GitVersion.Tool&version=6.7.0\"";
+    System.IO.File.WriteAllText(scriptPath.FullPath, script);
+
+    // When
+    CakeExecuteScript(scriptPath);
+});
+
+Task("Cake.DotNetTool.Module.Source")
+    .IsDependentOn("Cake.DotNetTool.Module.Source.Setup")
+    .IsDependentOn("Cake.DotNetTool.Module.Source.Install")
+    .IsDependentOn("Cake.DotNetTool.Module.Source.Update");
+
 Task("Cake.DotNetTool.Module")
     .IsDependentOn("Cake.DotNetTool.Module.Setup")
     .IsDependentOn("Cake.DotNetTool.Module.Install")
-    .IsDependentOn("Cake.DotNetTool.Module.Update");
+    .IsDependentOn("Cake.DotNetTool.Module.Update")
+    .IsDependentOn("Cake.DotNetTool.Module.Source");


### PR DESCRIPTION
- Emit `--source` instead of `--add-source` when installing tools with an explicit NuGet feed on net9.0/net10.0 builds (`NET9_0_OR_GREATER`)
- Keep `--add-source` for net8.0 for backward compatibility
- Add integration tests that install and update `GitVersion.Tool` via `dotnet:https://api.nuget.org/v3/index.json`
- fixes #4834