### PR TITLE
Use dotnet/install package for RWX integration test

### DIFF
--- a/.rwx/cake.yml
+++ b/.rwx/cake.yml
@@ -24,20 +24,25 @@ tasks:
       fetch-full-depth: true
       preserve-git-dir: true
 
-  - key: libicu-dev
-    run: |
-      sudo apt-get update
-      sudo apt-get install -y --no-install-recommends libicu-dev
+  - key: install-dotnet
+    use: code
+    call: dotnet/install 1.0.0
+    with:
+      dotnet-channels: '["8.0", "9.0"]'
+      global-json-file: global.json
+    filter:
+      - global.json
 
   - key: build
-    use: [code, libicu-dev]
+    use: [code, install-dotnet]
     run: |
       # We clone at a commit SHA, so HEAD is detached; GitVersion needs a named branch ref.
       # Use plumbing commands so the working tree (including any patched files) is untouched.
       git branch -f develop HEAD
       git symbolic-ref HEAD refs/heads/develop
 
-      ./build.sh --target=Rwx --integration-tests-target=Cake.Common.Build.RwxProvider
+      dotnet tool restore
+      dotnet cake --target=Rwx --integration-tests-target=Cake.Common.Build.RwxProvider
     env:
       CAKE_INSTALL_SUPPORTED_SDKS: "true"
       NuGetAudit: "false"


### PR DESCRIPTION
This applies the same changes from https://github.com/cake-build/generator/pull/135 to the RWX CI in this repo, following the introduction of the `dotnet/install` package in https://github.com/rwx-cloud/packages/pull/391.

More documentation on the `dotnet/install` package can be found at https://www.rwx.com/docs/packages/dotnet/install.