### PR TITLE
Add FindFilesInDirectory alias to FileAliases

### DIFF
--- a/src/Cake.Common.Tests/Unit/IO/FileAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/FileAliasesTests.cs
@@ -1279,5 +1279,75 @@ namespace Cake.Common.Tests.Unit.IO
                 Assert.Equal("/bar/baz.qux", result.FullPath);
             }
         }
+
+        public sealed class TheFindFilesInDirectory
+        {
+            [Fact]
+            public void Should_Throw_If_Context_Is_Null()
+            {
+                // Given
+                var directory = new DirectoryPath("./tests");
+
+                // when
+                var result = Record.Exception(() =>
+                    FileAliases.FindFilesInDirectory(null, directory, "*.csproj"));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "context");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Directory_Path_Is_Null()
+            {
+                // Given
+                var context = Substitute.For<ICakeContext>();
+
+                // When
+                var result = Record.Exception(() =>
+                    FileAliases.FindFilesInDirectory(context, null, "*.csproj"));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "directoryPath");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Pattern_Is_Null()
+            {
+                // Given
+                var context = Substitute.For<ICakeContext>();
+                var directory = new DirectoryPath("./tests");
+
+                // When
+                var result = Record.Exception(() =>
+                    FileAliases.FindFilesInDirectory(context, directory, null));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "pattern");
+            }
+
+            [Fact]
+            public void Should_Return_Files_Matching_Pattern()
+            {
+                // Given
+                var environment = FakeEnvironment.CreateUnixEnvironment();
+                var fileSystem = new FakeFileSystem(environment);
+                fileSystem.CreateFile("/Working/tests/project.csproj");
+                fileSystem.CreateFile("/Working/tests/other.txt");
+
+                var context = Substitute.For<ICakeContext>();
+                context.FileSystem.Returns(fileSystem);
+                context.Environment.Returns(environment);
+
+                // When
+                var result = FileAliases.FindFilesInDirectory(
+                    context,
+                    new DirectoryPath("/Working/tests"),
+                    "*.csproj").ToList();
+
+                // Then
+                Assert.Single(result);
+                Assert.Equal("/Working/tests/project.csproj", result[0].FullPath);
+            }
+        }
     }
 }

--- a/src/Cake.Common/IO/FileAliases.cs
+++ b/src/Cake.Common/IO/FileAliases.cs
@@ -428,5 +428,36 @@ namespace Cake.Common.IO
 
             return filePath.ExpandEnvironmentVariables(context.Environment);
         }
+
+        ///<summary>
+        /// Finds all files mactching the specified pattern within a directory
+        /// </summary>
+        /// <param name="Context">The context.</param>
+        /// <param name="directoryPath">The directory path to search in.</param>
+        /// <param name="pattern">The file pattern to match (eg:"*.csproj").</param>
+        /// <parma name= "scope">The search scope (current directory or recursive).</parma>
+        /// <returns>List of files matching the  pattern.</returns>
+        /// <example>
+        /// <code>
+        /// var files = FindFilesInDirectory("./src", "*.csproj", SearchScope.Recursive);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Find")]
+        public static IEnumerable<FilePath> FindFilesInDirectory(
+            this ICakeContext context,
+            DirectoryPath directoryPath,
+            string pattern,
+            SearchScope scope = SearchScope.Recursive)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(directoryPath);
+            ArgumentNullException.ThrowIfNull(pattern);
+
+            var directory = context.FileSystem.GetDirectory(
+                directoryPath.MakeAbsolute(context.Environment));
+
+            return directory.GetFiles(pattern, scope).Select(f => f.Path);
+        } 
     }
 }


### PR DESCRIPTION

## Summary
Adds a new `FindFilesInDirectory` alias to `FileAliases` that allows users 
to easily search for files matching a pattern within a directory.

## Changes
- Added `FindFilesInDirectory` method to `FileAliases.cs`
- Added unit tests for the new method

## Related Issue
Closes #2056

## Example Usage
```csharp
var testProjects = FindFilesInDirectory(
    "./tests", 
    "*.csproj", 
    SearchScope.Recursive);

foreach (var project in testProjects)
{
    DotNetTest(project.FullPath);
}
```