### PR TITLE
GH4890: Add typed Cake aliases for dotnet tool subcommands

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -379,13 +379,14 @@ Task("Frosting-Integration-Tests")
         },
         (parameters, test, context) =>
 {
+    string defaultVerbosity = EnvironmentVariable("RUNNER_DEBUG", "0") == "1" ? "diagnostic" : "quiet";
     try
     {
         Information("Testing: {0}", test.Framework);
 
         DotNetRun(test.Project.FullPath,
             new ProcessArgumentBuilder()
-                .AppendSwitchQuoted("--verbosity", "=", Argument("integration-tests-verbosity", "quiet"))
+                .AppendSwitchQuoted("--verbosity", "=", Argument("integration-tests-verbosity", defaultVerbosity))
                 .AppendSwitchQuoted("--name", "=", "World")
                 .AppendSwitchQuoted("--IntegrationTest_Argument", "=", bool.TrueString),
             new DotNetRunSettings
@@ -414,16 +415,21 @@ Task("Run-Integration-Tests")
     .IsDependentOn("Prepare-Integration-Tests")
     .IsDependentOn("Frosting-Integration-Tests")
     .DeferOnError()
-    .DoesForEach<BuildParameters, FilePath>(
-        parameters => new[] {
-            GetFiles($"{parameters.Paths.Directories.IntegrationTestsBinTool.FullPath}/**/net8.0/**/Cake.dll").Single(),
-            GetFiles($"{parameters.Paths.Directories.IntegrationTestsBinTool.FullPath}/**/net9.0/**/Cake.dll").Single(),
-            GetFiles($"{parameters.Paths.Directories.IntegrationTestsBinTool.FullPath}/**/net10.0/**/Cake.dll").Single()
+    .DoesForEach<BuildParameters, (FilePath CakeAssembly, string Verbosity)>(
+        parameters => {
+            string defaultVerbosity = EnvironmentVariable("RUNNER_DEBUG", "0") == "1" ? "diagnostic" : "quiet";
+            return [
+                (GetFiles($"{parameters.Paths.Directories.IntegrationTestsBinTool.FullPath}/**/net8.0/**/Cake.dll").Single(), defaultVerbosity),
+                (GetFiles($"{parameters.Paths.Directories.IntegrationTestsBinTool.FullPath}/**/net9.0/**/Cake.dll").Single(), defaultVerbosity),
+                (GetFiles($"{parameters.Paths.Directories.IntegrationTestsBinTool.FullPath}/**/net10.0/**/Cake.dll").Single(), defaultVerbosity)
+            ];
         },
-        (parameters, cakeAssembly, context) =>
+        (parameters, test, context) =>
 {
+    var (cakeAssembly, verbosity) = test;
     try
     {
+        
         Information("Testing: {0}", cakeAssembly);
         CakeExecuteScript("./tests/integration/build.cake",
             new CakeSettings {
@@ -434,7 +440,7 @@ Task("Run-Integration-Tests")
                 },
                 ArgumentCustomization = args => args
                     .AppendSwitchQuoted("--target", " ", Argument("integration-tests-target", "Run-All-Tests"))
-                    .AppendSwitchQuoted("--verbosity", " ", Argument("integration-tests-verbosity", "quiet"))
+                    .AppendSwitchQuoted("--verbosity", " ", Argument("integration-tests-verbosity", verbosity))
                     .AppendSwitchQuoted("--platform", " ", parameters.IsRunningOnWindows ? "windows" : "posix")
                     .AppendSwitchQuoted("--customarg", " ", "hello")
                     .AppendSwitchQuoted("--multipleargs", "=", "a")

--- a/build/paths.cake
+++ b/build/paths.cake
@@ -40,7 +40,7 @@ public record BuildPaths(
             integrationTestsBinTool);
 
         FilePath signClientPath = null;
-        if (context.IsRunningOnWindows())
+        if (context.IsRunningOnWindows() && context.GitHubActions().IsRunningOnGitHubActions)
         {
             signClientPath = context.Tools.Resolve("sign.exe");
 

--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Tool/DotNetToolCommandTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Tool/DotNetToolCommandTests.cs
@@ -1,0 +1,677 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cake.Common.Tests.Fixtures.Tools.DotNet;
+using Cake.Common.Tools.DotNet;
+using Cake.Common.Tools.DotNet.Tool;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Common.Tests.Unit.Tools.DotNet.Tool
+{
+    public sealed class DotNetToolCommandTests
+    {
+        public sealed class TheToolCommandAliases
+        {
+            public static IEnumerable<object[]> DotNetToolExecuteOverloadCases()
+            {
+                yield return new object[] { nameof(DotNetToolCommandInvocation.ExecutePackageOnly), "\"tool\" exec dotnetsay@1.2.3" };
+                yield return new object[] { nameof(DotNetToolCommandInvocation.ExecutePackageWithArguments), "\"tool\" exec dotnetsay@1.2.3 -- --tool-option tool-value" };
+                yield return new object[] { nameof(DotNetToolCommandInvocation.ExecutePackageWithSettings), "\"tool\" exec dotnetsay@1.2.3 --verbosity minimal" };
+                yield return new object[] { nameof(DotNetToolCommandInvocation.ExecutePackageWithArgumentsAndSettings), "\"tool\" exec dotnetsay@1.2.3 --verbosity minimal -- --tool-option tool-value" };
+            }
+
+            public static IEnumerable<object[]> DotNetToolCommandCases()
+            {
+                yield return new object[] { nameof(DotNetToolCommandInvocation.ExecutePackageWithArgumentsAndSettings), "dotnetsay@1.2.3", "\"tool\" exec dotnetsay@1.2.3 --verbosity minimal -- --tool-option tool-value", false };
+                yield return new object[] { nameof(DotNetToolCommandInvocation.InstallFull), "dotnetsay", "\"tool\" install dotnetsay --global --verbosity minimal", false };
+                yield return new object[] { nameof(DotNetToolCommandInvocation.ListFull), "dotnetsay", "\"tool\" list dotnetsay --global", false };
+                yield return new object[] { nameof(DotNetToolCommandInvocation.ListSettings), null, "\"tool\" list --global", false };
+                yield return new object[] { nameof(DotNetToolCommandInvocation.ListPackageSettings), "dotnetsay", "\"tool\" list dotnetsay --global", false };
+                yield return new object[] { nameof(DotNetToolCommandInvocation.RestoreFull), null, "\"tool\" restore --disable-parallel --verbosity minimal", false };
+                yield return new object[] { nameof(DotNetToolCommandInvocation.RestoreSettings), null, "\"tool\" restore --disable-parallel --verbosity minimal", false };
+                yield return new object[] { nameof(DotNetToolCommandInvocation.RunFull), "dotnetsay", "\"tool\" run dotnetsay -- Hello --name World", false };
+                yield return new object[] { nameof(DotNetToolCommandInvocation.RunCommandArguments), "dotnetsay", "\"tool\" run dotnetsay -- Hello --name World", false };
+                yield return new object[] { nameof(DotNetToolCommandInvocation.RunCommandArgumentsAndSettings), "dotnetsay", "\"tool\" run dotnetsay -- Hello --name World", false };
+                yield return new object[] { nameof(DotNetToolCommandInvocation.RunCommandSettings), "dotnetsay", "\"tool\" run dotnetsay", false };
+                yield return new object[] { nameof(DotNetToolCommandInvocation.SearchFull), "cake", "\"tool\" search cake --detail", false };
+                yield return new object[] { nameof(DotNetToolCommandInvocation.UninstallFull), "dotnetsay", "\"tool\" uninstall dotnetsay --global", false };
+                yield return new object[] { nameof(DotNetToolCommandInvocation.UpdateFull), "dotnetsay", "\"tool\" update dotnetsay --global --verbosity minimal", false };
+            }
+
+            public static IEnumerable<object[]> RequiredCommandArgumentCases()
+            {
+                var commandArgumentCases = new[]
+                {
+                    new { InvocationName = nameof(DotNetToolCommandInvocation.ExecutePackageWithSettings), ParameterName = "packageId" },
+                    new { InvocationName = nameof(DotNetToolCommandInvocation.InstallFull), ParameterName = "packageId" },
+                    new { InvocationName = nameof(DotNetToolCommandInvocation.RunFull), ParameterName = "commandName" },
+                    new { InvocationName = nameof(DotNetToolCommandInvocation.SearchFull), ParameterName = "searchTerm" },
+                    new { InvocationName = nameof(DotNetToolCommandInvocation.UninstallFull), ParameterName = "packageId" }
+                };
+
+                var invalidArguments = new[] { null, string.Empty, " " };
+                foreach (var commandArgumentCase in commandArgumentCases)
+                {
+                    foreach (var invalidArgument in invalidArguments)
+                    {
+                        yield return new object[] { commandArgumentCase.InvocationName, commandArgumentCase.ParameterName, invalidArgument };
+                    }
+                }
+            }
+
+            [Fact]
+            public void DotNetToolInstall_WithDefaultSettings_RendersCakeToolsPath()
+            {
+                // Given
+                var fixture = new DotNetToolCommandFixture
+                {
+                    Invocation = DotNetToolCommandInvocation.InstallFull,
+                    CommandArgument = "dotnetsay"
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("\"tool\" install dotnetsay --tool-path \"/Working/tools\"", result.Args);
+            }
+
+            [Fact]
+            public void DotNetToolInstall_WithToolPathScopeAndWorkingDirectory_RendersToolsPathRelativeToWorkingDirectory()
+            {
+                // Given
+                var fixture = new DotNetToolCommandFixture
+                {
+                    Invocation = DotNetToolCommandInvocation.InstallFull,
+                    CommandArgument = "dotnetsay"
+                };
+                fixture.InstallSettings.WorkingDirectory = "./temp";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("\"tool\" install dotnetsay --tool-path \"/Working/temp/tools\"", result.Args);
+            }
+
+            [Theory]
+            [InlineData(DotNetToolInstallationScope.Global, "--global")]
+            [InlineData(DotNetToolInstallationScope.Local, "--local")]
+            [InlineData(DotNetToolInstallationScope.ToolPath, "--tool-path \"/Working/tools\"")]
+            public void DotNetToolInstall_WithInstallationScope_RendersSingleScopeFlag(DotNetToolInstallationScope scope, string expectedScopeArgument)
+            {
+                // Given
+                var fixture = new DotNetToolCommandFixture
+                {
+                    Invocation = DotNetToolCommandInvocation.InstallFull,
+                    CommandArgument = "dotnetsay"
+                };
+                fixture.InstallSettings.InstallationScope = scope;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal($"\"tool\" install dotnetsay {expectedScopeArgument}", result.Args);
+            }
+
+            [Fact]
+            public void DotNetToolExecute_WithDefaultSettings_RendersExpectedCommand()
+            {
+                // Given
+                var fixture = new DotNetToolCommandFixture
+                {
+                    Invocation = DotNetToolCommandInvocation.ExecutePackageWithSettings,
+                    CommandArgument = "dotnetsay"
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("\"tool\" exec dotnetsay", result.Args);
+            }
+
+            [Theory]
+            [MemberData(nameof(RequiredCommandArgumentCases))]
+            public void DotNetToolCommand_WithInvalidRequiredArgument_ThrowsArgumentNullException(string invocationName, string parameterName, string commandArgument)
+            {
+                // Given
+                var fixture = new DotNetToolCommandFixture
+                {
+                    Invocation = Enum.Parse<DotNetToolCommandInvocation>(invocationName),
+                    CommandArgument = commandArgument
+                };
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, parameterName);
+            }
+
+            [Fact]
+            public void DotNetToolExecute_WithNullSettings_UsesDefaultSettings()
+            {
+                // Given
+                var fixture = new DotNetToolCommandFixture
+                {
+                    Invocation = DotNetToolCommandInvocation.ExecutePackageWithSettings,
+                    CommandArgument = "dotnetsay",
+                    ExecuteSettings = null
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("\"tool\" exec dotnetsay", result.Args);
+            }
+
+            [Fact]
+            public void DotNetToolExecute_WhenProcessCannotStart_ThrowsCakeException()
+            {
+                // Given
+                var fixture = new DotNetToolCommandFixture
+                {
+                    Invocation = DotNetToolCommandInvocation.ExecutePackageWithSettings,
+                    CommandArgument = "dotnetsay"
+                };
+                fixture.GivenProcessCannotStart();
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, ".NET CLI: Process was not started.");
+            }
+
+            [Fact]
+            public void DotNetToolExecute_WhenProcessHasNonZeroExitCode_ThrowsCakeException()
+            {
+                // Given
+                var fixture = new DotNetToolCommandFixture
+                {
+                    Invocation = DotNetToolCommandInvocation.ExecutePackageWithSettings,
+                    CommandArgument = "dotnetsay"
+                };
+                fixture.GivenProcessExitsWithCode(1);
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1).");
+            }
+
+            [Theory]
+            [MemberData(nameof(DotNetToolExecuteOverloadCases))]
+            public void DotNetToolExecute_AllOverloads_RenderDotNetToolExecCommand(string invocationName, string expectedArguments)
+            {
+                // Given
+                var fixture = new DotNetToolCommandFixture
+                {
+                    Invocation = Enum.Parse<DotNetToolCommandInvocation>(invocationName),
+                    CommandArgument = "dotnetsay@1.2.3"
+                };
+                fixture.ConfigureCommonSettings();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expectedArguments, result.Args);
+            }
+
+            [Theory]
+            [MemberData(nameof(DotNetToolCommandCases))]
+            public void DotNetToolCommands_RenderExpectedArguments(string invocationName, string commandArgument, string expectedArguments, bool usesProjectPath)
+            {
+                // Given
+                var fixture = new DotNetToolCommandFixture
+                {
+                    Invocation = Enum.Parse<DotNetToolCommandInvocation>(invocationName),
+                    ProjectPath = "./src/project.csproj",
+                    CommandArgument = commandArgument
+                };
+                fixture.ConfigureCommonSettings();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expectedArguments, result.Args);
+                if (usesProjectPath)
+                {
+                    Assert.Equal(fixture.ProjectPath.GetDirectory().FullPath, result.Process.WorkingDirectory.FullPath);
+                }
+            }
+
+            [Fact]
+            public void DotNetToolCommands_RenderCommandSpecificSettings()
+            {
+                // Given
+                var fixture = new DotNetToolCommandFixture
+                {
+                    Invocation = DotNetToolCommandInvocation.InstallFull,
+                    CommandArgument = "dotnetsay"
+                };
+                fixture.InstallSettings.InstallationScope = DotNetToolInstallationScope.ToolPath;
+                fixture.InstallSettings.ToolInstallationPath = "./tools";
+                fixture.InstallSettings.Version = "1.2.3";
+                fixture.InstallSettings.ConfigFile = "./nuget.config";
+                fixture.InstallSettings.ToolManifest = "./.config/dotnet-tools.json";
+                fixture.InstallSettings.AddSource.Add("https://example.com/add-source");
+                fixture.InstallSettings.Source.Add("https://example.com/source");
+                fixture.InstallSettings.Framework = "net10.0";
+                fixture.InstallSettings.Prerelease = true;
+                fixture.InstallSettings.DisableParallel = true;
+                fixture.InstallSettings.IgnoreFailedSources = true;
+                fixture.InstallSettings.NoHttpCache = true;
+                fixture.InstallSettings.Interactive = true;
+                fixture.InstallSettings.AllowDowngrade = true;
+                fixture.InstallSettings.Architecture = "x64";
+                fixture.InstallSettings.CreateManifestIfNeeded = true;
+                fixture.InstallSettings.AllowRollForward = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                var expected = "\"tool\" install dotnetsay --tool-path \"/Working/tools\" --version \"1.2.3\" --configfile \"/Working/nuget.config\" --source \"https://example.com/source\" --add-source \"https://example.com/add-source\" --prerelease --tool-manifest \"/Working/.config/dotnet-tools.json\" --framework \"net10.0\" --disable-parallel --ignore-failed-sources --no-http-cache --interactive --allow-downgrade --arch \"x64\" --create-manifest-if-needed --allow-roll-forward";
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Fact]
+            public void DotNetToolExecute_RenderCommandSpecificSettings()
+            {
+                // Given
+                var fixture = new DotNetToolCommandFixture
+                {
+                    Invocation = DotNetToolCommandInvocation.ExecutePackageWithSettings,
+                    CommandArgument = "dotnetsay"
+                };
+                fixture.ExecuteSettings.Version = "1.2.3";
+                fixture.ExecuteSettings.ConfigFile = "./nuget.config";
+                fixture.ExecuteSettings.Source.Add("https://example.com/source");
+                fixture.ExecuteSettings.AddSource.Add("https://example.com/add-source");
+                fixture.ExecuteSettings.Prerelease = true;
+                fixture.ExecuteSettings.AllowRollForward = true;
+                fixture.ExecuteSettings.DisableParallel = true;
+                fixture.ExecuteSettings.IgnoreFailedSources = true;
+                fixture.ExecuteSettings.NoHttpCache = true;
+                fixture.ExecuteSettings.Interactive = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                var expected = "\"tool\" exec dotnetsay --version \"1.2.3\" --configfile \"/Working/nuget.config\" --source \"https://example.com/source\" --add-source \"https://example.com/add-source\" --prerelease --allow-roll-forward --disable-parallel --ignore-failed-sources --no-http-cache --interactive";
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Fact]
+            public void DotNetToolList_RenderCommandSpecificSettings()
+            {
+                // Given
+                var fixture = new DotNetToolCommandFixture
+                {
+                    Invocation = DotNetToolCommandInvocation.ListFull,
+                    CommandArgument = "dotnetsay"
+                };
+                fixture.ListSettings.InstallationScope = DotNetToolInstallationScope.Local;
+                fixture.ListSettings.Format = DotNetToolListFormat.Json;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                var expected = "\"tool\" list dotnetsay --local --format json";
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Fact]
+            public void DotNetToolRestore_RenderCommandSpecificSettings()
+            {
+                // Given
+                var fixture = new DotNetToolCommandFixture
+                {
+                    Invocation = DotNetToolCommandInvocation.RestoreFull
+                };
+                fixture.RestoreSettings.ConfigFile = "./nuget.config";
+                fixture.RestoreSettings.AddSource.Add("https://example.com/add-source");
+                fixture.RestoreSettings.ToolManifest = "./.config/dotnet-tools.json";
+                fixture.RestoreSettings.DisableParallel = true;
+                fixture.RestoreSettings.IgnoreFailedSources = true;
+                fixture.RestoreSettings.NoHttpCache = true;
+                fixture.RestoreSettings.Interactive = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                var expected = "\"tool\" restore --configfile \"/Working/nuget.config\" --add-source \"https://example.com/add-source\" --tool-manifest \"/Working/.config/dotnet-tools.json\" --disable-parallel --ignore-failed-sources --no-http-cache --interactive";
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Fact]
+            public void DotNetToolRun_RenderCommandSpecificSettings()
+            {
+                // Given
+                var fixture = new DotNetToolCommandFixture
+                {
+                    Invocation = DotNetToolCommandInvocation.RunFull,
+                    CommandArgument = "dotnetsay"
+                };
+                fixture.RunSettings.AllowRollForward = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                var expected = "\"tool\" run dotnetsay --allow-roll-forward";
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Fact]
+            public void DotNetToolRun_WithArgumentCustomization_RestoresOriginalCustomization()
+            {
+                // Given
+                Func<ProcessArgumentBuilder, ProcessArgumentBuilder> addInteractive = arguments => arguments.Append("--interactive");
+                var fixture = new DotNetToolCommandFixture
+                {
+                    Invocation = DotNetToolCommandInvocation.RunCommandArgumentsAndSettings,
+                    CommandArgument = "dotnetsay"
+                };
+                fixture.RunArguments = Arguments("--tool-option");
+                fixture.RunSettings.ArgumentCustomization = addInteractive;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("\"tool\" run dotnetsay --interactive -- --tool-option", result.Args);
+                Assert.Same(addInteractive, fixture.RunSettings.ArgumentCustomization);
+            }
+
+            [Fact]
+            public void DotNetToolSearch_RenderCommandSpecificSettings()
+            {
+                // Given
+                var fixture = new DotNetToolCommandFixture
+                {
+                    Invocation = DotNetToolCommandInvocation.SearchFull,
+                    CommandArgument = "cake"
+                };
+                fixture.SearchSettings.Detail = true;
+                fixture.SearchSettings.Skip = 10;
+                fixture.SearchSettings.Take = 20;
+                fixture.SearchSettings.Prerelease = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                var expected = "\"tool\" search cake --detail --skip 10 --take 20 --prerelease";
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Fact]
+            public void DotNetToolUninstall_RenderCommandSpecificSettings()
+            {
+                // Given
+                var fixture = new DotNetToolCommandFixture
+                {
+                    Invocation = DotNetToolCommandInvocation.UninstallFull,
+                    CommandArgument = "dotnetsay"
+                };
+                fixture.UninstallSettings.InstallationScope = DotNetToolInstallationScope.Local;
+                fixture.UninstallSettings.ToolManifest = "./.config/dotnet-tools.json";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                var expected = "\"tool\" uninstall dotnetsay --local --tool-manifest \"/Working/.config/dotnet-tools.json\"";
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Fact]
+            public void DotNetToolUpdate_RenderCommandSpecificSettings()
+            {
+                // Given
+                var fixture = new DotNetToolCommandFixture
+                {
+                    Invocation = DotNetToolCommandInvocation.UpdateFull,
+                    CommandArgument = null
+                };
+                fixture.UpdateSettings.InstallationScope = DotNetToolInstallationScope.Global;
+                fixture.UpdateSettings.Version = "1.2.3";
+                fixture.UpdateSettings.ConfigFile = "./nuget.config";
+                fixture.UpdateSettings.Source.Add("https://example.com/source");
+                fixture.UpdateSettings.AddSource.Add("https://example.com/add-source");
+                fixture.UpdateSettings.Prerelease = true;
+                fixture.UpdateSettings.ToolManifest = "./.config/dotnet-tools.json";
+                fixture.UpdateSettings.Framework = "net10.0";
+                fixture.UpdateSettings.DisableParallel = true;
+                fixture.UpdateSettings.IgnoreFailedSources = true;
+                fixture.UpdateSettings.NoHttpCache = true;
+                fixture.UpdateSettings.Interactive = true;
+                fixture.UpdateSettings.AllowDowngrade = true;
+                fixture.UpdateSettings.All = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                var expected = "\"tool\" update --global --version \"1.2.3\" --configfile \"/Working/nuget.config\" --source \"https://example.com/source\" --add-source \"https://example.com/add-source\" --prerelease --tool-manifest \"/Working/.config/dotnet-tools.json\" --framework \"net10.0\" --disable-parallel --ignore-failed-sources --no-http-cache --interactive --allow-downgrade --all";
+                Assert.Equal(expected, result.Args);
+            }
+
+            [Fact]
+            public void DotNetToolExecute_WithArgumentCustomization_RestoresOriginalCustomization()
+            {
+                // Given
+                Func<ProcessArgumentBuilder, ProcessArgumentBuilder> addInteractive = arguments => arguments.Append("--interactive");
+                var fixture = new DotNetToolCommandFixture
+                {
+                    Invocation = DotNetToolCommandInvocation.ExecutePackageWithArgumentsAndSettings,
+                    CommandArgument = "dotnetsay"
+                };
+                fixture.ExecuteArguments = Arguments("--tool-option");
+                fixture.ExecuteSettings.ArgumentCustomization = addInteractive;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("\"tool\" exec dotnetsay --interactive -- --tool-option", result.Args);
+                Assert.Same(addInteractive, fixture.ExecuteSettings.ArgumentCustomization);
+            }
+
+            private static ProcessArgumentBuilder Arguments(params string[] arguments)
+            {
+                var builder = new ProcessArgumentBuilder();
+                foreach (var argument in arguments)
+                {
+                    builder.Append(argument);
+                }
+
+                return builder;
+            }
+        }
+
+        private enum DotNetToolCommandInvocation
+        {
+            ExecutePackageWithSettings,
+            ExecutePackageOnly,
+            ExecutePackageWithArguments,
+            ExecutePackageWithArgumentsAndSettings,
+            InstallFull,
+            ListFull,
+            ListSettings,
+            ListPackageSettings,
+            RestoreFull,
+            RestoreSettings,
+            RunFull,
+            RunCommandArguments,
+            RunCommandArgumentsAndSettings,
+            RunCommandSettings,
+            SearchFull,
+            UninstallFull,
+            UpdateFull
+        }
+
+        private sealed class DotNetToolCommandFixture : DotNetFixture<DotNetToolSettings>
+        {
+            public FilePath ProjectPath { get; set; }
+
+            public string CommandArgument { get; set; }
+
+            public DotNetToolCommandInvocation Invocation { get; set; }
+
+            public DotNetToolExecuteSettings ExecuteSettings { get; set; } = new DotNetToolExecuteSettings();
+
+            public ProcessArgumentBuilder ExecuteArguments { get; set; } = new ProcessArgumentBuilder();
+
+            public DotNetToolInstallSettings InstallSettings { get; set; } = new DotNetToolInstallSettings();
+
+            public DotNetToolListSettings ListSettings { get; set; } = new DotNetToolListSettings();
+
+            public DotNetToolRestoreSettings RestoreSettings { get; set; } = new DotNetToolRestoreSettings();
+
+            public DotNetToolRunSettings RunSettings { get; set; } = new DotNetToolRunSettings();
+
+            public ProcessArgumentBuilder RunArguments { get; set; } = new ProcessArgumentBuilder();
+
+            public DotNetToolSearchSettings SearchSettings { get; set; } = new DotNetToolSearchSettings();
+
+            public DotNetToolUninstallSettings UninstallSettings { get; set; } = new DotNetToolUninstallSettings();
+
+            public DotNetToolUpdateSettings UpdateSettings { get; set; } = new DotNetToolUpdateSettings();
+
+            public void ConfigureCommonSettings()
+            {
+                ExecuteSettings.Verbosity = DotNetVerbosity.Minimal;
+                ExecuteArguments = Arguments("--tool-option", "tool-value");
+
+                InstallSettings.Verbosity = DotNetVerbosity.Minimal;
+                InstallSettings.InstallationScope = DotNetToolInstallationScope.Global;
+
+                ListSettings.Verbosity = DotNetVerbosity.Minimal;
+                ListSettings.InstallationScope = DotNetToolInstallationScope.Global;
+
+                RestoreSettings.Verbosity = DotNetVerbosity.Minimal;
+                RestoreSettings.DisableParallel = true;
+
+                RunSettings.Verbosity = DotNetVerbosity.Minimal;
+                RunArguments = Arguments("Hello", "--name", "World");
+
+                SearchSettings.Verbosity = DotNetVerbosity.Minimal;
+                SearchSettings.Detail = true;
+
+                UninstallSettings.Verbosity = DotNetVerbosity.Minimal;
+                UninstallSettings.InstallationScope = DotNetToolInstallationScope.Global;
+
+                UpdateSettings.Verbosity = DotNetVerbosity.Minimal;
+                UpdateSettings.InstallationScope = DotNetToolInstallationScope.Global;
+            }
+
+            protected override void RunTool()
+            {
+                var context = CreateContext();
+
+                switch (Invocation)
+                {
+                    case DotNetToolCommandInvocation.ExecutePackageOnly:
+                        context.DotNetToolExecute(CommandArgument);
+                        break;
+                    case DotNetToolCommandInvocation.ExecutePackageWithArguments:
+                        context.DotNetToolExecute(CommandArgument, ExecuteArguments);
+                        break;
+                    case DotNetToolCommandInvocation.ExecutePackageWithArgumentsAndSettings:
+                        context.DotNetToolExecute(CommandArgument, ExecuteArguments, ExecuteSettings);
+                        break;
+                    case DotNetToolCommandInvocation.ExecutePackageWithSettings:
+                        context.DotNetToolExecute(CommandArgument, ExecuteSettings);
+                        break;
+                    case DotNetToolCommandInvocation.InstallFull:
+                        context.DotNetToolInstall(CommandArgument, InstallSettings);
+                        break;
+                    case DotNetToolCommandInvocation.ListFull:
+                        context.DotNetToolList(CommandArgument, ListSettings);
+                        break;
+                    case DotNetToolCommandInvocation.ListSettings:
+                        context.DotNetToolList(ListSettings);
+                        break;
+                    case DotNetToolCommandInvocation.ListPackageSettings:
+                        context.DotNetToolList(CommandArgument, ListSettings);
+                        break;
+                    case DotNetToolCommandInvocation.RestoreFull:
+                        context.DotNetToolRestore(RestoreSettings);
+                        break;
+                    case DotNetToolCommandInvocation.RestoreSettings:
+                        context.DotNetToolRestore(RestoreSettings);
+                        break;
+                    case DotNetToolCommandInvocation.RunFull:
+                        context.DotNetToolRun(CommandArgument, RunArguments, RunSettings);
+                        break;
+                    case DotNetToolCommandInvocation.RunCommandArguments:
+                        context.DotNetToolRun(CommandArgument, RunArguments);
+                        break;
+                    case DotNetToolCommandInvocation.RunCommandArgumentsAndSettings:
+                        context.DotNetToolRun(CommandArgument, RunArguments, RunSettings);
+                        break;
+                    case DotNetToolCommandInvocation.RunCommandSettings:
+                        context.DotNetToolRun(CommandArgument, RunSettings);
+                        break;
+                    case DotNetToolCommandInvocation.SearchFull:
+                        context.DotNetToolSearch(CommandArgument, SearchSettings);
+                        break;
+                    case DotNetToolCommandInvocation.UninstallFull:
+                        context.DotNetToolUninstall(CommandArgument, UninstallSettings);
+                        break;
+                    case DotNetToolCommandInvocation.UpdateFull:
+                        context.DotNetToolUpdate(CommandArgument, UpdateSettings);
+                        break;
+                }
+            }
+
+            private static ProcessArgumentBuilder Arguments(params string[] arguments)
+            {
+                var builder = new ProcessArgumentBuilder();
+                foreach (var argument in arguments)
+                {
+                    builder.Append(argument);
+                }
+
+                return builder;
+            }
+
+            private ICakeContext CreateContext()
+            {
+                var arguments = new CakeArguments(Enumerable.Empty<string>().ToLookup(argument => argument, StringComparer.Ordinal));
+
+                return new CakeContext(
+                    FileSystem,
+                    Environment,
+                    Globber,
+                    new FakeLog(),
+                    arguments,
+                    ProcessRunner,
+                    Substitute.For<IRegistry>(),
+                    Tools,
+                    Substitute.For<ICakeDataService>(),
+                    Configuration);
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.Tool.Common.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.Tool.Common.cs
@@ -1,0 +1,308 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Cake.Common.Tools.DotNet.Tool;
+using Cake.Core;
+using Cake.Core.Configuration;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotNet
+{
+    /// <summary>
+    /// <para>Contains functionality related to <see href="https://github.com/dotnet/cli">.NET CLI</see>.</para>
+    /// <para>
+    /// In order to use the commands for this alias, the .NET CLI tools will need to be installed on the machine where
+    /// the Cake script is being executed.  See this <see href="https://www.microsoft.com/net/core">page</see> for information
+    /// on how to install.
+    /// </para>
+    /// </summary>
+    public static partial class DotNetAliases
+    {
+        private static void RunDotNetToolCommand(
+            ICakeContext context,
+            FilePath projectPath,
+            ProcessArgumentBuilder arguments,
+            DotNetToolSettings settings)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(arguments);
+            ArgumentNullException.ThrowIfNull(settings);
+
+            context.DotNetTool(projectPath, "tool", arguments, settings);
+        }
+
+        private static void RunDotNetToolCommandWithoutVerbosity(
+            ICakeContext context,
+            FilePath projectPath,
+            ProcessArgumentBuilder arguments,
+            DotNetToolSettings settings)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(arguments);
+            ArgumentNullException.ThrowIfNull(settings);
+
+            var verbosity = settings.Verbosity;
+            settings.Verbosity = null;
+
+            try
+            {
+                context.DotNetTool(projectPath, "tool", arguments, settings);
+            }
+            finally
+            {
+                settings.Verbosity = verbosity;
+            }
+        }
+
+        private static void RunDotNetToolCommandWithForwardedArguments(
+            ICakeContext context,
+            FilePath projectPath,
+            ProcessArgumentBuilder arguments,
+            ProcessArgumentBuilder forwardedArguments,
+            DotNetToolSettings settings)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(arguments);
+            ArgumentNullException.ThrowIfNull(settings);
+
+            if (forwardedArguments.IsNullOrEmpty())
+            {
+                context.DotNetTool(projectPath, "tool", arguments, settings);
+                return;
+            }
+
+            var argumentCustomization = settings.ArgumentCustomization;
+            settings.ArgumentCustomization = dotnetArguments =>
+            {
+                var customizedArguments = argumentCustomization?.Invoke(dotnetArguments) ?? dotnetArguments;
+                customizedArguments.Append("--");
+                forwardedArguments.CopyTo(customizedArguments);
+                return customizedArguments;
+            };
+
+            try
+            {
+                context.DotNetTool(projectPath, "tool", arguments, settings);
+            }
+            finally
+            {
+                settings.ArgumentCustomization = argumentCustomization;
+            }
+        }
+
+        private static void RunDotNetToolCommandWithForwardedArgumentsWithoutVerbosity(
+            ICakeContext context,
+            FilePath projectPath,
+            ProcessArgumentBuilder arguments,
+            ProcessArgumentBuilder forwardedArguments,
+            DotNetToolSettings settings)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(arguments);
+            ArgumentNullException.ThrowIfNull(settings);
+
+            var verbosity = settings.Verbosity;
+            settings.Verbosity = null;
+
+            try
+            {
+                RunDotNetToolCommandWithForwardedArguments(context, projectPath, arguments, forwardedArguments, settings);
+            }
+            finally
+            {
+                settings.Verbosity = verbosity;
+            }
+        }
+
+        private static void AppendToolExecuteSettings(ProcessArgumentBuilder builder, DotNetToolExecuteSettings settings, ICakeEnvironment environment)
+        {
+            AppendPackageResolutionSettings(builder, settings.Version, settings.ConfigFile, settings.Source, settings.AddSource, settings.Prerelease, environment);
+            AppendSwitch(builder, "--allow-roll-forward", settings.AllowRollForward);
+            AppendRestoreSettings(builder, settings.DisableParallel, settings.IgnoreFailedSources, settings.NoHttpCache, settings.Interactive);
+        }
+
+        private static void AppendToolInstallSettings(ProcessArgumentBuilder builder, DotNetToolInstallSettings settings, ICakeConfiguration configuration, ICakeEnvironment environment)
+        {
+            AppendInstallationScope(builder, settings.InstallationScope, settings.ToolInstallationPath, settings.WorkingDirectory, configuration, environment);
+            AppendPackageResolutionSettings(builder, settings.Version, settings.ConfigFile, settings.Source, settings.AddSource, settings.Prerelease, environment);
+            AppendFilePath(builder, "--tool-manifest", settings.ToolManifest, environment);
+            AppendString(builder, "--framework", settings.Framework);
+            AppendRestoreSettings(builder, settings.DisableParallel, settings.IgnoreFailedSources, settings.NoHttpCache, settings.Interactive);
+            AppendSwitch(builder, "--allow-downgrade", settings.AllowDowngrade);
+            AppendString(builder, "--arch", settings.Architecture);
+            AppendSwitch(builder, "--create-manifest-if-needed", settings.CreateManifestIfNeeded);
+            AppendSwitch(builder, "--allow-roll-forward", settings.AllowRollForward);
+        }
+
+        private static void AppendToolListSettings(ProcessArgumentBuilder builder, DotNetToolListSettings settings, ICakeConfiguration configuration, ICakeEnvironment environment)
+        {
+            AppendInstallationScope(builder, settings.InstallationScope, settings.ToolInstallationPath, settings.WorkingDirectory, configuration, environment);
+
+            if (settings.Format.HasValue)
+            {
+                builder.AppendSwitch("--format", settings.Format.Value == DotNetToolListFormat.Json ? "json" : "table");
+            }
+        }
+
+        private static void AppendToolRestoreSettings(ProcessArgumentBuilder builder, DotNetToolRestoreSettings settings, ICakeEnvironment environment)
+        {
+            AppendFilePath(builder, "--configfile", settings.ConfigFile, environment);
+            AppendSources(builder, "--add-source", settings.AddSource);
+            AppendFilePath(builder, "--tool-manifest", settings.ToolManifest, environment);
+            AppendRestoreSettings(builder, settings.DisableParallel, settings.IgnoreFailedSources, settings.NoHttpCache, settings.Interactive);
+        }
+
+        private static void AppendToolRunSettings(ProcessArgumentBuilder builder, DotNetToolRunSettings settings)
+        {
+            AppendSwitch(builder, "--allow-roll-forward", settings.AllowRollForward);
+        }
+
+        private static void AppendToolSearchSettings(ProcessArgumentBuilder builder, DotNetToolSearchSettings settings)
+        {
+            AppendSwitch(builder, "--detail", settings.Detail);
+
+            if (settings.Skip.HasValue)
+            {
+                builder.AppendSwitch("--skip", settings.Skip.Value.ToString());
+            }
+
+            if (settings.Take.HasValue)
+            {
+                builder.AppendSwitch("--take", settings.Take.Value.ToString());
+            }
+
+            AppendSwitch(builder, "--prerelease", settings.Prerelease);
+        }
+
+        private static void AppendToolUninstallSettings(ProcessArgumentBuilder builder, DotNetToolUninstallSettings settings, ICakeConfiguration configuration, ICakeEnvironment environment)
+        {
+            AppendInstallationScope(builder, settings.InstallationScope, settings.ToolInstallationPath, settings.WorkingDirectory, configuration, environment);
+            AppendFilePath(builder, "--tool-manifest", settings.ToolManifest, environment);
+        }
+
+        private static void AppendToolUpdateSettings(ProcessArgumentBuilder builder, DotNetToolUpdateSettings settings, ICakeConfiguration configuration, ICakeEnvironment environment)
+        {
+            AppendInstallationScope(builder, settings.InstallationScope, settings.ToolInstallationPath, settings.WorkingDirectory, configuration, environment);
+            AppendPackageResolutionSettings(builder, settings.Version, settings.ConfigFile, settings.Source, settings.AddSource, settings.Prerelease, environment);
+            AppendFilePath(builder, "--tool-manifest", settings.ToolManifest, environment);
+            AppendString(builder, "--framework", settings.Framework);
+            AppendRestoreSettings(builder, settings.DisableParallel, settings.IgnoreFailedSources, settings.NoHttpCache, settings.Interactive);
+            AppendSwitch(builder, "--allow-downgrade", settings.AllowDowngrade);
+            AppendSwitch(builder, "--all", settings.All);
+        }
+
+        private static void AppendInstallationScope(
+            ProcessArgumentBuilder builder,
+            DotNetToolInstallationScope scope,
+            DirectoryPath toolInstallationPath,
+            DirectoryPath settingsWorkingDirectory,
+            ICakeConfiguration configuration,
+            ICakeEnvironment environment)
+        {
+            switch (scope)
+            {
+                case DotNetToolInstallationScope.Global:
+                    builder.Append("--global");
+                    break;
+                case DotNetToolInstallationScope.Local:
+                    builder.Append("--local");
+                    break;
+                case DotNetToolInstallationScope.ToolPath:
+                    var root = settingsWorkingDirectory ?? environment.WorkingDirectory;
+                    var path = toolInstallationPath ?? configuration.GetToolPath(root, environment);
+                    AppendDirectoryPath(builder, "--tool-path", path, environment);
+                    break;
+            }
+        }
+
+        private static void AppendPackageResolutionSettings(
+            ProcessArgumentBuilder builder,
+            string version,
+            FilePath configFile,
+            ICollection<string> source,
+            ICollection<string> addSource,
+            bool prerelease,
+            ICakeEnvironment environment)
+        {
+            AppendString(builder, "--version", version);
+            AppendFilePath(builder, "--configfile", configFile, environment);
+            AppendSources(builder, "--source", source);
+            AppendSources(builder, "--add-source", addSource);
+            AppendSwitch(builder, "--prerelease", prerelease);
+        }
+
+        private static void AppendRestoreSettings(ProcessArgumentBuilder builder, bool disableParallel, bool ignoreFailedSources, bool noHttpCache, bool interactive)
+        {
+            AppendSwitch(builder, "--disable-parallel", disableParallel);
+            AppendSwitch(builder, "--ignore-failed-sources", ignoreFailedSources);
+            AppendSwitch(builder, "--no-http-cache", noHttpCache);
+            AppendSwitch(builder, "--interactive", interactive);
+        }
+
+        private static void AppendRequiredArgument(ProcessArgumentBuilder builder, string argument, string parameterName)
+        {
+            if (string.IsNullOrWhiteSpace(argument))
+            {
+                throw new ArgumentNullException(parameterName);
+            }
+
+            builder.Append(argument);
+        }
+
+        private static void AppendOptionalArgument(ProcessArgumentBuilder builder, string argument)
+        {
+            if (!string.IsNullOrWhiteSpace(argument))
+            {
+                builder.Append(argument);
+            }
+        }
+
+        private static void AppendSwitch(ProcessArgumentBuilder builder, string switchName, bool value)
+        {
+            if (value)
+            {
+                builder.Append(switchName);
+            }
+        }
+
+        private static void AppendString(ProcessArgumentBuilder builder, string switchName, string value)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                builder.AppendSwitchQuoted(switchName, value);
+            }
+        }
+
+        private static void AppendFilePath(ProcessArgumentBuilder builder, string switchName, FilePath value, ICakeEnvironment environment)
+        {
+            if (value != null)
+            {
+                builder.AppendSwitchQuoted(switchName, value.MakeAbsolute(environment).FullPath);
+            }
+        }
+
+        private static void AppendDirectoryPath(ProcessArgumentBuilder builder, string switchName, DirectoryPath value, ICakeEnvironment environment)
+        {
+            if (value != null)
+            {
+                builder.AppendSwitchQuoted(switchName, value.MakeAbsolute(environment).FullPath);
+            }
+        }
+
+        private static void AppendSources(ProcessArgumentBuilder builder, string switchName, ICollection<string> sources)
+        {
+            if (sources == null)
+            {
+                return;
+            }
+
+            foreach (var source in sources)
+            {
+                AppendString(builder, switchName, source);
+            }
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.Tool.Execute.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.Tool.Execute.cs
@@ -1,0 +1,109 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNet.Tool;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotNet
+{
+    /// <summary>
+    /// <para>Contains functionality related to <see href="https://github.com/dotnet/cli">.NET CLI</see>.</para>
+    /// <para>
+    /// In order to use the commands for this alias, the .NET CLI tools will need to be installed on the machine where
+    /// the Cake script is being executed.  See this <see href="https://www.microsoft.com/net/core">page</see> for information
+    /// on how to install.
+    /// </para>
+    /// </summary>
+    public static partial class DotNetAliases
+    {
+        /// <summary>
+        /// Executes a .NET tool package with <c>dotnet tool exec</c>.
+        /// </summary>
+        /// <remarks>For more information, see <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-exec">dotnet tool exec</see>.</remarks>
+        /// <param name="context">The context.</param>
+        /// <param name="packageId">The package ID to execute. Use the <c>package@version</c> syntax to request a specific version.</param>
+        /// <example>
+        /// <code>
+        /// DotNetToolExecute("DPI");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Tool")]
+        public static void DotNetToolExecute(this ICakeContext context, string packageId)
+        {
+            context.DotNetToolExecute(packageId, (ProcessArgumentBuilder)null, null);
+        }
+
+        /// <inheritdoc cref="DotNetToolExecute(ICakeContext,string)" />
+        /// <remarks>For more information, see <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-exec">dotnet tool exec</see>.</remarks>
+        /// <param name="context">The context.</param>
+        /// <param name="packageId">The package ID to execute. Use the <c>package@version</c> syntax to request a specific version.</param>
+        /// <param name="arguments">The arguments forwarded to the tool.</param>
+        /// <example>
+        /// <code>
+        /// var arguments = new ProcessArgumentBuilder().Append("--version");
+        /// DotNetToolExecute("DPI", arguments);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Tool")]
+        public static void DotNetToolExecute(this ICakeContext context, string packageId, ProcessArgumentBuilder arguments)
+        {
+            context.DotNetToolExecute(packageId, arguments, null);
+        }
+
+        /// <inheritdoc cref="DotNetToolExecute(ICakeContext,string)" />
+        /// <remarks>For more information, see <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-exec">dotnet tool exec</see>.</remarks>
+        /// <param name="context">The context.</param>
+        /// <param name="packageId">The package ID to execute. Use the <c>package@version</c> syntax to request a specific version.</param>
+        /// <param name="arguments">The arguments forwarded to the tool.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// var arguments = new ProcessArgumentBuilder().Append("--version");
+        /// DotNetToolExecute("DPI", arguments, new DotNetToolExecuteSettings
+        /// {
+        ///     WorkingDirectory = "./src"
+        /// });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Tool")]
+        public static void DotNetToolExecute(this ICakeContext context, string packageId, ProcessArgumentBuilder arguments, DotNetToolExecuteSettings settings)
+        {
+            settings ??= new DotNetToolExecuteSettings();
+
+            var dotnetArguments = new ProcessArgumentBuilder().Append("exec");
+            AppendRequiredArgument(dotnetArguments, packageId, nameof(packageId));
+            AppendToolExecuteSettings(dotnetArguments, settings, context.Environment);
+            RunDotNetToolCommandWithForwardedArguments(context, null, dotnetArguments, arguments, settings);
+        }
+
+        /// <inheritdoc cref="DotNetToolExecute(ICakeContext,string)" />
+        /// <remarks>For more information, see <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-exec">dotnet tool exec</see>.</remarks>
+        /// <param name="context">The context.</param>
+        /// <param name="packageId">The package ID to execute. Use the <c>package@version</c> syntax to request a specific version.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// DotNetToolExecute("DPI", new DotNetToolExecuteSettings
+        /// {
+        ///     WorkingDirectory = "./src"
+        /// });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Tool")]
+        public static void DotNetToolExecute(this ICakeContext context, string packageId, DotNetToolExecuteSettings settings)
+        {
+            context.DotNetToolExecute(packageId, (ProcessArgumentBuilder)null, settings);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.Tool.Install.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.Tool.Install.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNet.Tool;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotNet
+{
+    /// <summary>
+    /// <para>Contains functionality related to <see href="https://github.com/dotnet/cli">.NET CLI</see>.</para>
+    /// <para>
+    /// In order to use the commands for this alias, the .NET CLI tools will need to be installed on the machine where
+    /// the Cake script is being executed.  See this <see href="https://www.microsoft.com/net/core">page</see> for information
+    /// on how to install.
+    /// </para>
+    /// </summary>
+    public static partial class DotNetAliases
+    {
+        /// <summary>
+        /// Installs a .NET tool package with <c>dotnet tool install</c>.
+        /// </summary>
+        /// <remarks>For more information, see <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-install">dotnet tool install</see>.</remarks>
+        /// <param name="context">The context.</param>
+        /// <param name="packageId">The package ID to install.</param>
+        /// <example>
+        /// <code>
+        /// DotNetToolInstall("dotnetsay");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Tool")]
+        public static void DotNetToolInstall(this ICakeContext context, string packageId)
+        {
+            context.DotNetToolInstall(packageId, null);
+        }
+
+        /// <inheritdoc cref="DotNetToolInstall(ICakeContext,string)" />
+        /// <remarks>For more information, see <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-install">dotnet tool install</see>.</remarks>
+        /// <param name="context">The context.</param>
+        /// <param name="packageId">The package ID to install.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// DotNetToolInstall("DPI", new DotNetToolInstallSettings
+        /// {
+        ///     WorkingDirectory = "./src"
+        /// });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Tool")]
+        public static void DotNetToolInstall(this ICakeContext context, string packageId, DotNetToolInstallSettings settings)
+        {
+            settings ??= new DotNetToolInstallSettings();
+
+            var arguments = new ProcessArgumentBuilder().Append("install");
+            AppendRequiredArgument(arguments, packageId, nameof(packageId));
+            AppendToolInstallSettings(arguments, settings, context.Configuration, context.Environment);
+            RunDotNetToolCommand(context, null, arguments, settings);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.Tool.List.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.Tool.List.cs
@@ -1,0 +1,107 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNet.Tool;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotNet
+{
+    /// <summary>
+    /// <para>Contains functionality related to <see href="https://github.com/dotnet/cli">.NET CLI</see>.</para>
+    /// <para>
+    /// In order to use the commands for this alias, the .NET CLI tools will need to be installed on the machine where
+    /// the Cake script is being executed.  See this <see href="https://www.microsoft.com/net/core">page</see> for information
+    /// on how to install.
+    /// </para>
+    /// </summary>
+    public static partial class DotNetAliases
+    {
+        /// <summary>
+        /// Lists .NET tools with <c>dotnet tool list</c>.
+        /// </summary>
+        /// <remarks>For more information, see <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-list">dotnet tool list</see>.</remarks>
+        /// <param name="context">The context.</param>
+        /// <example>
+        /// <code>
+        /// DotNetToolList();
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Tool")]
+        public static void DotNetToolList(this ICakeContext context)
+        {
+            context.DotNetToolList(null, null);
+        }
+
+        /// <inheritdoc cref="DotNetToolList(ICakeContext)" />
+        /// <remarks>For more information, see <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-list">dotnet tool list</see>.</remarks>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// DotNetToolList(new DotNetToolListSettings
+        /// {
+        ///     InstallationScope = DotNetToolInstallationScope.Local,
+        ///     WorkingDirectory = "./src"
+        /// });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Tool")]
+        public static void DotNetToolList(this ICakeContext context, DotNetToolListSettings settings)
+        {
+            context.DotNetToolList(null, settings);
+        }
+
+        /// <summary>
+        /// Lists a .NET tool package with <c>dotnet tool list</c>.
+        /// </summary>
+        /// <remarks>For more information, see <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-list">dotnet tool list</see>.</remarks>
+        /// <param name="context">The context.</param>
+        /// <param name="packageId">The package ID to list.</param>
+        /// <example>
+        /// <code>
+        /// DotNetToolList("dotnetsay");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Tool")]
+        public static void DotNetToolList(this ICakeContext context, string packageId)
+        {
+            context.DotNetToolList(packageId, null);
+        }
+
+        /// <inheritdoc cref="DotNetToolList(ICakeContext,string)" />
+        /// <remarks>For more information, see <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-list">dotnet tool list</see>.</remarks>
+        /// <param name="context">The context.</param>
+        /// <param name="packageId">The package ID to list.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// DotNetToolList("DPI", new DotNetToolListSettings
+        /// {
+        ///     InstallationScope = DotNetToolInstallationScope.Local,
+        ///     WorkingDirectory = "./src"
+        /// });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Tool")]
+        public static void DotNetToolList(this ICakeContext context, string packageId, DotNetToolListSettings settings)
+        {
+            settings ??= new DotNetToolListSettings();
+
+            var arguments = new ProcessArgumentBuilder().Append("list");
+            AppendOptionalArgument(arguments, packageId);
+            AppendToolListSettings(arguments, settings, context.Configuration, context.Environment);
+            RunDotNetToolCommandWithoutVerbosity(context, null, arguments, settings);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.Tool.Restore.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.Tool.Restore.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNet.Tool;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotNet
+{
+    /// <summary>
+    /// <para>Contains functionality related to <see href="https://github.com/dotnet/cli">.NET CLI</see>.</para>
+    /// <para>
+    /// In order to use the commands for this alias, the .NET CLI tools will need to be installed on the machine where
+    /// the Cake script is being executed.  See this <see href="https://www.microsoft.com/net/core">page</see> for information
+    /// on how to install.
+    /// </para>
+    /// </summary>
+    public static partial class DotNetAliases
+    {
+        /// <summary>
+        /// Restores .NET tools with <c>dotnet tool restore</c>.
+        /// </summary>
+        /// <remarks>For more information, see <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-restore">dotnet tool restore</see>.</remarks>
+        /// <param name="context">The context.</param>
+        /// <example>
+        /// <code>
+        /// DotNetToolRestore();
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Tool")]
+        public static void DotNetToolRestore(this ICakeContext context)
+        {
+            context.DotNetToolRestore(null);
+        }
+
+        /// <inheritdoc cref="DotNetToolRestore(ICakeContext)" />
+        /// <remarks>For more information, see <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-restore">dotnet tool restore</see>.</remarks>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// DotNetToolRestore(new DotNetToolRestoreSettings
+        /// {
+        ///     WorkingDirectory = "./src"
+        /// });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Tool")]
+        public static void DotNetToolRestore(this ICakeContext context, DotNetToolRestoreSettings settings)
+        {
+            settings ??= new DotNetToolRestoreSettings();
+
+            var arguments = new ProcessArgumentBuilder().Append("restore");
+            AppendToolRestoreSettings(arguments, settings, context.Environment);
+            RunDotNetToolCommand(context, null, arguments, settings);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.Tool.Run.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.Tool.Run.cs
@@ -1,0 +1,108 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNet.Tool;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotNet
+{
+    /// <summary>
+    /// <para>Contains functionality related to <see href="https://github.com/dotnet/cli">.NET CLI</see>.</para>
+    /// <para>
+    /// In order to use the commands for this alias, the .NET CLI tools will need to be installed on the machine where
+    /// the Cake script is being executed.  See this <see href="https://www.microsoft.com/net/core">page</see> for information
+    /// on how to install.
+    /// </para>
+    /// </summary>
+    public static partial class DotNetAliases
+    {
+        /// <summary>
+        /// Runs a local .NET tool with <c>dotnet tool run</c>.
+        /// </summary>
+        /// <remarks>For more information, see <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-run">dotnet tool run</see>.</remarks>
+        /// <param name="context">The context.</param>
+        /// <param name="commandName">The tool command name to run.</param>
+        /// <example>
+        /// <code>
+        /// DotNetToolRun("dotnetsay");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Tool")]
+        public static void DotNetToolRun(this ICakeContext context, string commandName)
+        {
+            context.DotNetToolRun(commandName, null, null);
+        }
+
+        /// <inheritdoc cref="DotNetToolRun(ICakeContext,string)" />
+        /// <remarks>For more information, see <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-run">dotnet tool run</see>.</remarks>
+        /// <param name="context">The context.</param>
+        /// <param name="commandName">The tool command name to run.</param>
+        /// <param name="arguments">The arguments forwarded to the tool.</param>
+        /// <example>
+        /// <code>
+        /// var arguments = new ProcessArgumentBuilder().Append("--version");
+        /// DotNetToolRun("DPI", arguments);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Tool")]
+        public static void DotNetToolRun(this ICakeContext context, string commandName, ProcessArgumentBuilder arguments)
+        {
+            context.DotNetToolRun(commandName, arguments, null);
+        }
+
+        /// <inheritdoc cref="DotNetToolRun(ICakeContext,string)" />
+        /// <remarks>For more information, see <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-run">dotnet tool run</see>.</remarks>
+        /// <param name="context">The context.</param>
+        /// <param name="commandName">The tool command name to run.</param>
+        /// <param name="arguments">The arguments forwarded to the tool.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// DotNetToolRun("DPI", "--version", new DotNetToolRunSettings
+        /// {
+        ///     WorkingDirectory = "./src"
+        /// });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Tool")]
+        public static void DotNetToolRun(this ICakeContext context, string commandName, ProcessArgumentBuilder arguments, DotNetToolRunSettings settings)
+        {
+            settings ??= new DotNetToolRunSettings();
+
+            var dotnetArguments = new ProcessArgumentBuilder().Append("run");
+            AppendRequiredArgument(dotnetArguments, commandName, nameof(commandName));
+            AppendToolRunSettings(dotnetArguments, settings);
+            RunDotNetToolCommandWithForwardedArgumentsWithoutVerbosity(context, null, dotnetArguments, arguments, settings);
+        }
+
+        /// <inheritdoc cref="DotNetToolRun(ICakeContext,string)" />
+        /// <remarks>For more information, see <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-run">dotnet tool run</see>.</remarks>
+        /// <param name="context">The context.</param>
+        /// <param name="commandName">The tool command name to run.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// DotNetToolRun("DPI", new DotNetToolRunSettings
+        /// {
+        ///     WorkingDirectory = "./src"
+        /// });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Tool")]
+        public static void DotNetToolRun(this ICakeContext context, string commandName, DotNetToolRunSettings settings)
+        {
+            context.DotNetToolRun(commandName, null, settings);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.Tool.Search.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.Tool.Search.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNet.Tool;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotNet
+{
+    /// <summary>
+    /// <para>Contains functionality related to <see href="https://github.com/dotnet/cli">.NET CLI</see>.</para>
+    /// <para>
+    /// In order to use the commands for this alias, the .NET CLI tools will need to be installed on the machine where
+    /// the Cake script is being executed.  See this <see href="https://www.microsoft.com/net/core">page</see> for information
+    /// on how to install.
+    /// </para>
+    /// </summary>
+    public static partial class DotNetAliases
+    {
+        /// <summary>
+        /// Searches for .NET tool packages with <c>dotnet tool search</c>.
+        /// </summary>
+        /// <remarks>For more information, see <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-search">dotnet tool search</see>.</remarks>
+        /// <param name="context">The context.</param>
+        /// <param name="searchTerm">The search term.</param>
+        /// <example>
+        /// <code>
+        /// DotNetToolSearch("cake");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Tool")]
+        public static void DotNetToolSearch(this ICakeContext context, string searchTerm)
+        {
+            context.DotNetToolSearch(searchTerm, null);
+        }
+
+        /// <inheritdoc cref="DotNetToolSearch(ICakeContext,string)" />
+        /// <remarks>For more information, see <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-search">dotnet tool search</see>.</remarks>
+        /// <param name="context">The context.</param>
+        /// <param name="searchTerm">The search term.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// DotNetToolSearch("DPI", new DotNetToolSearchSettings
+        /// {
+        ///     WorkingDirectory = "./src"
+        /// });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Tool")]
+        public static void DotNetToolSearch(this ICakeContext context, string searchTerm, DotNetToolSearchSettings settings)
+        {
+            settings ??= new DotNetToolSearchSettings();
+
+            var arguments = new ProcessArgumentBuilder().Append("search");
+            AppendRequiredArgument(arguments, searchTerm, nameof(searchTerm));
+            AppendToolSearchSettings(arguments, settings);
+            RunDotNetToolCommandWithoutVerbosity(context, null, arguments, settings);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.Tool.Uninstall.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.Tool.Uninstall.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNet.Tool;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotNet
+{
+    /// <summary>
+    /// <para>Contains functionality related to <see href="https://github.com/dotnet/cli">.NET CLI</see>.</para>
+    /// <para>
+    /// In order to use the commands for this alias, the .NET CLI tools will need to be installed on the machine where
+    /// the Cake script is being executed.  See this <see href="https://www.microsoft.com/net/core">page</see> for information
+    /// on how to install.
+    /// </para>
+    /// </summary>
+    public static partial class DotNetAliases
+    {
+        /// <summary>
+        /// Uninstalls a .NET tool package with <c>dotnet tool uninstall</c>.
+        /// </summary>
+        /// <remarks>For more information, see <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-uninstall">dotnet tool uninstall</see>.</remarks>
+        /// <param name="context">The context.</param>
+        /// <param name="packageId">The package ID to uninstall.</param>
+        /// <example>
+        /// <code>
+        /// DotNetToolUninstall("dotnetsay");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Tool")]
+        public static void DotNetToolUninstall(this ICakeContext context, string packageId)
+        {
+            context.DotNetToolUninstall(packageId, null);
+        }
+
+        /// <inheritdoc cref="DotNetToolUninstall(ICakeContext,string)" />
+        /// <remarks>For more information, see <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-uninstall">dotnet tool uninstall</see>.</remarks>
+        /// <param name="context">The context.</param>
+        /// <param name="packageId">The package ID to uninstall.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// DotNetToolUninstall("DPI", new DotNetToolUninstallSettings
+        /// {
+        ///     WorkingDirectory = "./src"
+        /// });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Tool")]
+        public static void DotNetToolUninstall(this ICakeContext context, string packageId, DotNetToolUninstallSettings settings)
+        {
+            settings ??= new DotNetToolUninstallSettings();
+
+            var arguments = new ProcessArgumentBuilder().Append("uninstall");
+            AppendRequiredArgument(arguments, packageId, nameof(packageId));
+            AppendToolUninstallSettings(arguments, settings, context.Configuration, context.Environment);
+            RunDotNetToolCommandWithoutVerbosity(context, null, arguments, settings);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/DotNetAliases.Tool.Update.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetAliases.Tool.Update.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.DotNet.Tool;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotNet
+{
+    /// <summary>
+    /// <para>Contains functionality related to <see href="https://github.com/dotnet/cli">.NET CLI</see>.</para>
+    /// <para>
+    /// In order to use the commands for this alias, the .NET CLI tools will need to be installed on the machine where
+    /// the Cake script is being executed.  See this <see href="https://www.microsoft.com/net/core">page</see> for information
+    /// on how to install.
+    /// </para>
+    /// </summary>
+    public static partial class DotNetAliases
+    {
+        /// <summary>
+        /// Updates .NET tool packages with <c>dotnet tool update</c>.
+        /// </summary>
+        /// <remarks>For more information, see <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-update">dotnet tool update</see>.</remarks>
+        /// <param name="context">The context.</param>
+        /// <example>
+        /// <code>
+        /// DotNetToolUpdate();
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Tool")]
+        public static void DotNetToolUpdate(this ICakeContext context)
+        {
+            context.DotNetToolUpdate(null, null);
+        }
+
+        /// <inheritdoc cref="DotNetToolUpdate(ICakeContext)" />
+        /// <remarks>For more information, see <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-update">dotnet tool update</see>.</remarks>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Tool")]
+        public static void DotNetToolUpdate(this ICakeContext context, DotNetToolUpdateSettings settings)
+        {
+            context.DotNetToolUpdate(null, settings);
+        }
+
+        /// <summary>
+        /// Updates a .NET tool package with <c>dotnet tool update</c>.
+        /// </summary>
+        /// <remarks>For more information, see <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-update">dotnet tool update</see>.</remarks>
+        /// <param name="context">The context.</param>
+        /// <param name="packageId">The package ID to update.</param>
+        /// <example>
+        /// <code>
+        /// DotNetToolUpdate("dotnetsay");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Tool")]
+        public static void DotNetToolUpdate(this ICakeContext context, string packageId)
+        {
+            context.DotNetToolUpdate(packageId, null);
+        }
+
+        /// <inheritdoc cref="DotNetToolUpdate(ICakeContext,string)" />
+        /// <remarks>For more information, see <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-update">dotnet tool update</see>.</remarks>
+        /// <param name="context">The context.</param>
+        /// <param name="packageId">The package ID to update.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// DotNetToolUpdate("DPI", new DotNetToolUpdateSettings
+        /// {
+        ///     WorkingDirectory = "./src"
+        /// });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Tool")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotNet.Tool")]
+        public static void DotNetToolUpdate(this ICakeContext context, string packageId, DotNetToolUpdateSettings settings)
+        {
+            settings ??= new DotNetToolUpdateSettings();
+
+            var arguments = new ProcessArgumentBuilder().Append("update");
+            AppendOptionalArgument(arguments, packageId);
+            AppendToolUpdateSettings(arguments, settings, context.Configuration, context.Environment);
+            RunDotNetToolCommand(context, null, arguments, settings);
+        }
+    }
+}

--- a/src/Cake.Common/Tools/DotNet/Tool/DotNetToolCommandSettings.cs
+++ b/src/Cake.Common/Tools/DotNet/Tool/DotNetToolCommandSettings.cs
@@ -1,0 +1,399 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Cake.Core.IO;
+
+namespace Cake.Common.Tools.DotNet.Tool
+{
+    /// <summary>
+    /// The installation scope for <c>dotnet tool</c> commands that support global, local, or tool-path installation.
+    /// </summary>
+    public enum DotNetToolInstallationScope
+    {
+        /// <summary>
+        /// Maps to <c>--tool-path</c>. Uses <see cref="DotNetToolInstallSettings.ToolInstallationPath"/> when set;
+        /// otherwise falls back to the Cake tools directory (same as the <c>#tool</c> directive).
+        /// </summary>
+        ToolPath,
+
+        /// <summary>
+        /// Maps to <c>--global</c>.
+        /// </summary>
+        Global,
+
+        /// <summary>
+        /// Maps to <c>--local</c>. Use <see cref="DotNetToolInstallSettings.ToolManifest"/> to target a specific manifest.
+        /// </summary>
+        Local,
+    }
+
+    /// <summary>
+    /// The output format for <c>dotnet tool list</c>.
+    /// </summary>
+    public enum DotNetToolListFormat
+    {
+        /// <summary>
+        /// Outputs the result as a table.
+        /// </summary>
+        Table,
+
+        /// <summary>
+        /// Outputs the result as JSON.
+        /// </summary>
+        Json
+    }
+
+    /// <summary>
+    /// Contains settings used by <c>dotnet tool exec</c>.
+    /// </summary>
+    public sealed class DotNetToolExecuteSettings : DotNetToolSettings
+    {
+        /// <summary>
+        /// Gets or sets the tool package version to execute.
+        /// </summary>
+        public string Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow a .NET tool to roll forward to newer versions of the .NET runtime.
+        /// </summary>
+        public bool AllowRollForward { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include prerelease packages.
+        /// </summary>
+        public bool Prerelease { get; set; }
+
+        /// <summary>
+        /// Gets or sets the NuGet configuration file to use.
+        /// </summary>
+        public FilePath ConfigFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the package sources to use instead of configured NuGet package sources.
+        /// </summary>
+        public ICollection<string> Source { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets additional package sources to use during installation.
+        /// </summary>
+        public ICollection<string> AddSource { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to prevent restoring multiple projects in parallel.
+        /// </summary>
+        public bool DisableParallel { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to treat package source failures as warnings.
+        /// </summary>
+        public bool IgnoreFailedSources { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to not cache packages and HTTP requests.
+        /// </summary>
+        public bool NoHttpCache { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow the command to stop and wait for user input or action.
+        /// </summary>
+        public bool Interactive { get; set; }
+    }
+
+    /// <summary>
+    /// Contains settings used by <c>dotnet tool install</c>.
+    /// </summary>
+    public sealed class DotNetToolInstallSettings : DotNetToolSettings
+    {
+        /// <summary>
+        /// Gets or sets the installation scope for the tool.
+        /// </summary>
+        public DotNetToolInstallationScope InstallationScope { get; set; }
+
+        /// <summary>
+        /// Gets or sets the directory where the tool will be installed when <see cref="InstallationScope"/> is <see cref="DotNetToolInstallationScope.ToolPath"/>.
+        /// When not set, the Cake tools directory is used.
+        /// </summary>
+        public DirectoryPath ToolInstallationPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tool package version to install.
+        /// </summary>
+        public string Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets the NuGet configuration file to use.
+        /// </summary>
+        public FilePath ConfigFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the local tool manifest file.
+        /// </summary>
+        public FilePath ToolManifest { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional package sources to use during installation.
+        /// </summary>
+        public ICollection<string> AddSource { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets the package sources to use instead of configured NuGet package sources.
+        /// </summary>
+        public ICollection<string> Source { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets the target framework to install the tool for.
+        /// </summary>
+        public string Framework { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include prerelease packages.
+        /// </summary>
+        public bool Prerelease { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to prevent restoring multiple projects in parallel.
+        /// </summary>
+        public bool DisableParallel { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to treat package source failures as warnings.
+        /// </summary>
+        public bool IgnoreFailedSources { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to not cache packages and HTTP requests.
+        /// </summary>
+        public bool NoHttpCache { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow the command to stop and wait for user input or action.
+        /// </summary>
+        public bool Interactive { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow package downgrade when installing a .NET tool package.
+        /// </summary>
+        public bool AllowDowngrade { get; set; }
+
+        /// <summary>
+        /// Gets or sets the target architecture.
+        /// </summary>
+        public string Architecture { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to create a tool manifest if one is not found.
+        /// </summary>
+        public bool CreateManifestIfNeeded { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow a .NET tool to roll forward to newer versions of the .NET runtime.
+        /// </summary>
+        public bool AllowRollForward { get; set; }
+    }
+
+    /// <summary>
+    /// Contains settings used by <c>dotnet tool list</c>.
+    /// </summary>
+    public sealed class DotNetToolListSettings : DotNetToolSettings
+    {
+        /// <summary>
+        /// Gets or sets the installation scope for listing tools.
+        /// </summary>
+        public DotNetToolInstallationScope InstallationScope { get; set; }
+
+        /// <summary>
+        /// Gets or sets the directory containing the tools to list when <see cref="InstallationScope"/> is <see cref="DotNetToolInstallationScope.ToolPath"/>.
+        /// When not set, the Cake tools directory is used.
+        /// </summary>
+        public DirectoryPath ToolInstallationPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the output format.
+        /// </summary>
+        public DotNetToolListFormat? Format { get; set; }
+    }
+
+    /// <summary>
+    /// Contains settings used by <c>dotnet tool restore</c>.
+    /// </summary>
+    public sealed class DotNetToolRestoreSettings : DotNetToolSettings
+    {
+        /// <summary>
+        /// Gets or sets the NuGet configuration file to use.
+        /// </summary>
+        public FilePath ConfigFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional package sources to use during installation.
+        /// </summary>
+        public ICollection<string> AddSource { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets the path to the local tool manifest file.
+        /// </summary>
+        public FilePath ToolManifest { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to prevent restoring multiple projects in parallel.
+        /// </summary>
+        public bool DisableParallel { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to treat package source failures as warnings.
+        /// </summary>
+        public bool IgnoreFailedSources { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to not cache packages and HTTP requests.
+        /// </summary>
+        public bool NoHttpCache { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow the command to stop and wait for user input or action.
+        /// </summary>
+        public bool Interactive { get; set; }
+    }
+
+    /// <summary>
+    /// Contains settings used by <c>dotnet tool run</c>.
+    /// </summary>
+    public sealed class DotNetToolRunSettings : DotNetToolSettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow a .NET tool to roll forward to newer versions of the .NET runtime.
+        /// </summary>
+        public bool AllowRollForward { get; set; }
+    }
+
+    /// <summary>
+    /// Contains settings used by <c>dotnet tool search</c>.
+    /// </summary>
+    public sealed class DotNetToolSearchSettings : DotNetToolSettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to show detailed query results.
+        /// </summary>
+        public bool Detail { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of results to skip for pagination.
+        /// </summary>
+        public int? Skip { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of results to return for pagination.
+        /// </summary>
+        public int? Take { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include prerelease packages.
+        /// </summary>
+        public bool Prerelease { get; set; }
+    }
+
+    /// <summary>
+    /// Contains settings used by <c>dotnet tool uninstall</c>.
+    /// </summary>
+    public sealed class DotNetToolUninstallSettings : DotNetToolSettings
+    {
+        /// <summary>
+        /// Gets or sets the installation scope for uninstalling the tool.
+        /// </summary>
+        public DotNetToolInstallationScope InstallationScope { get; set; }
+
+        /// <summary>
+        /// Gets or sets the directory containing the tool to uninstall when <see cref="InstallationScope"/> is <see cref="DotNetToolInstallationScope.ToolPath"/>.
+        /// When not set, the Cake tools directory is used.
+        /// </summary>
+        public DirectoryPath ToolInstallationPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the local tool manifest file.
+        /// </summary>
+        public FilePath ToolManifest { get; set; }
+    }
+
+    /// <summary>
+    /// Contains settings used by <c>dotnet tool update</c>.
+    /// </summary>
+    public sealed class DotNetToolUpdateSettings : DotNetToolSettings
+    {
+        /// <summary>
+        /// Gets or sets the installation scope for updating the tool.
+        /// </summary>
+        public DotNetToolInstallationScope InstallationScope { get; set; }
+
+        /// <summary>
+        /// Gets or sets the directory where the tool is installed when <see cref="InstallationScope"/> is <see cref="DotNetToolInstallationScope.ToolPath"/>.
+        /// When not set, the Cake tools directory is used.
+        /// </summary>
+        public DirectoryPath ToolInstallationPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tool package version to update to.
+        /// </summary>
+        public string Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets the NuGet configuration file to use.
+        /// </summary>
+        public FilePath ConfigFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the local tool manifest file.
+        /// </summary>
+        public FilePath ToolManifest { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional package sources to use during installation.
+        /// </summary>
+        public ICollection<string> AddSource { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets the package sources to use instead of configured NuGet package sources.
+        /// </summary>
+        public ICollection<string> Source { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets the target framework to install the tool for.
+        /// </summary>
+        public string Framework { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include prerelease packages.
+        /// </summary>
+        public bool Prerelease { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to prevent restoring multiple projects in parallel.
+        /// </summary>
+        public bool DisableParallel { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to treat package source failures as warnings.
+        /// </summary>
+        public bool IgnoreFailedSources { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to not cache packages and HTTP requests.
+        /// </summary>
+        public bool NoHttpCache { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow the command to stop and wait for user input or action.
+        /// </summary>
+        public bool Interactive { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow package downgrade when updating a .NET tool package.
+        /// </summary>
+        public bool AllowDowngrade { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to update all tools.
+        /// </summary>
+        public bool All { get; set; }
+    }
+}

--- a/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
+++ b/tests/integration/Cake.Common/Tools/DotNet/DotNetAliases.cake
@@ -16,449 +16,6 @@ Task("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
     CopyDirectory(sourcePath, targetPath);
 });
 
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRestore")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
-    .Does(() =>
-{
-    // Given
-    var root = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-
-    // When
-    DotNetRestore(root.FullPath, new DotNetRestoreSettings { Verbosity = DotNetVerbosity.Minimal });
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetBuild")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRestore")
-    .Does(() =>
-{
-    // Given
-    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
-    var assembly = path.CombineWithFilePath("hwapp/bin/Debug/net10.0/hwapp.dll");
-
-    // When
-    DotNetBuild(project.FullPath);
-
-    // Then
-    Assert.True(System.IO.File.Exists(assembly.FullPath));
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTest")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetBuild")
-    .Does(() =>
-{
-    // Given
-    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-    var project = path.CombineWithFilePath("hwapp.tests/hwapp.tests.csproj");
-
-    // When
-    DotNetTest(project.FullPath, new DotNetTestSettings { PathType = DotNetTestPathType.Project });
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetVSTest")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetBuild")
-    .Does(() =>
-{
-    // Given
-    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-    var assembly = path.CombineWithFilePath("hwapp.tests/bin/Debug/net10.0/hwapp.tests.dll");
-
-    // When
-    DotNetVSTest(assembly.FullPath);
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTool")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetBuild")
-    .Does(() =>
-{
-    // When
-    DotNetTool("--info");
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRun")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTest")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetVSTest")
-    .Does(() =>
-{
-    // Given
-    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
-
-    // When
-    DotNetRun(project.FullPath);
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetPack")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTest")
-    .Does(() =>
-{
-    // Given
-    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
-    var outputPath = path.Combine("DotNetPack");
-    var nuget = outputPath.CombineWithFilePath("hwapp.1.0.0.nupkg");
-    var nugetSymbols = outputPath.CombineWithFilePath("hwapp.1.0.0.symbols.nupkg");
-    EnsureDirectoryExist(outputPath);
-
-    // When
-    DotNetPack(project.FullPath, new DotNetPackSettings { OutputDirectory = outputPath, IncludeSymbols = true });
-
-    // Then
-    Assert.True(System.IO.File.Exists(nuget.FullPath), "Path:" + nuget.FullPath);
-    Assert.True(System.IO.File.Exists(nugetSymbols.FullPath), "Path:" + nugetSymbols.FullPath);
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetNuGetPush")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetPack")
-    .Does(() =>
-{
-    // Given
-    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-    var outputPath = path.Combine("DotNetPack");
-    var nugetServerPath = path.Combine("DotNetPush");
-    var nugetSource = outputPath.CombineWithFilePath("hwapp.1.0.0.nupkg");
-    var nugetDestination = nugetServerPath.CombineWithFilePath("hwapp.1.0.0.nupkg");
-
-    EnsureDirectoryExist(outputPath);
-    EnsureDirectoryExist(nugetServerPath);
-    Assert.True(System.IO.File.Exists(nugetSource.FullPath), "Path:" + nugetSource.FullPath);
-
-    // When
-    DotNetNuGetPush(nugetSource.FullPath, new DotNetNuGetPushSettings { Source = nugetServerPath.FullPath });
-
-    // Then
-    Assert.True(System.IO.File.Exists(nugetDestination.FullPath), "Path:" + nugetDestination.FullPath);
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetNuGetDelete")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetNuGetPush")
-    .Does(() =>
-{
-    // Given
-    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-    var nugetServerPath = path.Combine("DotNetPush");
-    var nugetDestination = nugetServerPath.CombineWithFilePath("hwapp.1.0.0.nupkg");
-
-    EnsureDirectoryExist(nugetServerPath);
-    Assert.True(System.IO.File.Exists(nugetDestination.FullPath), "Path:" + nugetDestination.FullPath);
-
-    // When
-    DotNetNuGetDelete("hwapp", "1.0.0", new DotNetNuGetDeleteSettings { Source = nugetServerPath.FullPath, NonInteractive = true });
-
-    // Then
-    Assert.False(System.IO.File.Exists(nugetDestination.FullPath), "Path:" + nugetDestination.FullPath);
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetPublish")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTest")
-    .Does(() =>
-{
-    // Given
-    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
-    var outputPath = path.Combine("DotNetPublish");
-    var publishFiles = new [] {
-        outputPath.CombineWithFilePath("hwapp.common.dll"),
-        outputPath.CombineWithFilePath("hwapp.common.pdb"),
-        outputPath.CombineWithFilePath("hwapp.deps.json"),
-        outputPath.CombineWithFilePath("hwapp.dll"),
-        outputPath.CombineWithFilePath("hwapp.pdb"),
-        outputPath.CombineWithFilePath("hwapp.runtimeconfig.json")
-    };
-
-    EnsureDirectoryExist(outputPath);
-
-    // When
-    DotNetPublish(project.FullPath, new DotNetPublishSettings { OutputDirectory = outputPath });
-
-    // Then
-    foreach (var file in publishFiles)
-    {
-        Assert.True(System.IO.File.Exists(file.FullPath), "Path:" + file.FullPath);
-    }
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetExecute")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTest")
-    .Does(() =>
-{
-    // Given
-    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-    var assembly = path.CombineWithFilePath("hwapp/bin/Debug/net10.0/hwapp.dll");
-
-    // When
-    DotNetExecute(assembly);
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetClean")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetBuild")
-    .Does(() =>
-{
-    // Given
-    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
-    var assembly = path.CombineWithFilePath("hwapp/bin/Debug/net10.0/hwapp.dll");
-    Assert.True(System.IO.File.Exists(assembly.FullPath));
-
-    // When
-    DotNetClean(project.FullPath);
-
-    // Then
-    Assert.False(System.IO.File.Exists(assembly.FullPath));
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetMSBuild")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetClean")
-    .Does(() =>
-{
-    // Given
-    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
-    var assembly = path.CombineWithFilePath("hwapp/bin/Debug/net10.0/hwapp.dll");
-
-    // When (Verbosity.Quiet exercises MSBuild /verbosity, not dotnet --verbosity; see https://github.com/cake-build/cake/issues/4456)
-    DotNetMSBuild(project.FullPath, new DotNetMSBuildSettings { Verbosity = DotNetVerbosity.Quiet });
-
-    // Then
-    Assert.True(System.IO.File.Exists(assembly.FullPath));
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetMSBuild.Results")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRestore")
-    .Does(() =>
-{
-    // Given
-    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
-    var settings = new DotNetMSBuildSettings
-    {
-        GetProperties = { "Version", "TargetFramework", },
-        GetItems = { "ProjectReference", },
-        GetTargetResults = { "Build", "Compile", },
-    };
-
-    System.Text.Json.JsonDocument result = null;
-
-    // When
-    DotNetMSBuild(project.FullPath, settings, output => result = System.Text.Json.JsonDocument.Parse(output.SelectMany(x => x).ToArray()));
-
-    // Then
-    Assert.NotNull(result);
-    Assert.Equal("1.0.0", result.RootElement.GetProperty("Properties").GetProperty("Version").GetString());
-    Assert.Equal("net10.0", result.RootElement.GetProperty("Properties").GetProperty("TargetFramework").GetString());
-    Assert.Equal(1, result.RootElement.GetProperty("Items").GetProperty("ProjectReference").GetArrayLength());
-    Assert.Equal("Success", result.RootElement.GetProperty("TargetResults").GetProperty("Build").GetProperty("Result").GetString());
-    Assert.Equal("Success", result.RootElement.GetProperty("TargetResults").GetProperty("Compile").GetProperty("Result").GetString());
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetMSBuildEmptyParametersAllowed")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetClean")
-    .Does(() =>
-{
-    // Given
-    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
-    var assembly = path.CombineWithFilePath("hwapp/bin/Debug/net10.0/hwapp.dll");
-
-    // When - empty string property value is allowed
-    DotNetMSBuild(project.FullPath, new DotNetMSBuildSettings()
-        .WithProperty("APropertyIWantTobeBlank", ""));
-
-    // Then
-    Assert.True(System.IO.File.Exists(assembly.FullPath));
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTest.Fail")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTest")
-    .Does(() =>
-{
-    // Given
-    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-    var project = path.CombineWithFilePath("hwapp.tests/hwapp.tests.csproj");
-
-    // When
-    var exception = Record.Exception(()=>DotNetTest(project.FullPath,
-        new DotNetTestSettings { EnvironmentVariables = new Dictionary<string, string> {{ "hwapp_fail_test", "true" }}
-        }));
-
-    // Then
-    Assert.NotNull(exception);
-    Assert.IsType<CakeException>(exception);
-    Assert.Equal(".NET CLI: Process returned an error (exit code 2).",exception.Message);
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetFormat")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
-    .Does(() =>
-{
-    // Given
-    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
-
-    // When
-    DotNetFormat(project.FullPath);
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSDKCheck")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
-    .Does(() =>
-{
-    // When
-    DotNetSDKCheck();
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetWorkloadSearch")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
-    .Does(() =>
-{
-    // Given
-    var searchString = "maui";
-
-    // When
-    var workloads = DotNetWorkloadSearch(searchString);
-
-    // Then
-    foreach (var workload in workloads)
-    {
-        Assert.Contains("maui", workload.Id);
-        Assert.Contains(".NET MAUI SDK", workload.Description);
-    }
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetWorkloadRepair")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
-    .OnError(exception => { Console.WriteLine(exception); })
-    .Does(() =>
-{
-    // When
-    DotNetWorkloadRepair();
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetWorkloadUpdate")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
-    .Does(() =>
-{
-    // When
-    DotNetWorkloadUpdate();
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetWorkloadRestore")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
-    .Does(() =>
-{
-    // Given
-    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
-
-    // When
-    DotNetWorkloadRestore(project.FullPath);
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetAddPackage")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
-    .Does(() =>
-{
-    // Given
-    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
-    var package = "Cake.Core";
-
-    // When
-    DotNetAddPackage(package, project.FullPath);
-
-    var value = XmlPeek(
-        project.FullPath,
-        $"/Project/ItemGroup/PackageReference[@Include='{package}']/@Include"
-    );
-
-    // Then
-    Assert.Equal(package, value);
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRemovePackage")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetAddPackage")
-    .Does(() =>
-{
-    // Given
-    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
-    var package = "Cake.Core";
-    var value = XmlPeek(
-        project.FullPath,
-        $"/Project/ItemGroup/PackageReference[@Include='{package}']/@Include"
-    );
-    Assert.Equal(package, value);
-
-    // When
-
-    DotNetRemovePackage(
-        package, project.GetFilename().FullPath,
-        // Workaround for SDK regression https://github.com/NuGet/Home/issues/14801
-        new DotNetPackageRemoveSettings { 
-            WorkingDirectory = project.GetDirectory().FullPath
-         });
-
-    value = XmlPeek(
-        project.FullPath,
-        $"/Project/ItemGroup/PackageReference[@Include='{package}']/@Include"
-    );
-
-    // Then
-    Assert.Null(value);
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetAddReference")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
-    .Does(() =>
-{
-    // Given
-    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-    var project = path.CombineWithFilePath("hwapp.tests/hwapp.tests.csproj");
-    var projectReferencePath = path.CombineWithFilePath("hwapp/hwapp.csproj");
-    var projectReference = "..\\hwapp\\hwapp.csproj";
-    // When
-    DotNetAddReference(project.FullPath, new[] { (FilePath)projectReferencePath.FullPath});
-    var value = XmlPeek(
-        project.FullPath,
-        $"/Project/ItemGroup/ProjectReference[@Include='{projectReference}']/@Include"
-    );
-    // Then
-    Assert.Equal(projectReference, value);
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetListReference")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
-    .Does(() =>
-{
-    // Given
-    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
-    var projectReference = FilePath.FromString("../hwapp.common/hwapp.common.csproj");
-    // When
-    var result = DotNetListReference(project.FullPath);
-    // Then
-    Assert.Contains(result, item => FilePath.FromString(item) == projectReference);
-});
-
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRemoveReference")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
-    .Does(() =>
-{
-    // Given
-    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-    var project = path.CombineWithFilePath("hwapp.tests/hwapp.tests.csproj");
-    var projectReferencePath = path.CombineWithFilePath("hwapp/hwapp.csproj");
-    var projectReference = "..\\hwapp\\hwapp.csproj";
-    // When
-    DotNetRemoveReference(project.FullPath, new[] { (FilePath)projectReferencePath.FullPath});
-    var value = XmlPeek(
-        project.FullPath,
-        $"/Project/ItemGroup/ProjectReference[@Include='{projectReference}']/@Include"
-    );
-    // Then
-    Assert.Null(value);
-});
-
 Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSearchPackage")
     .Does(() =>
 {
@@ -494,19 +51,259 @@ Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSearchPackage.ExactMatch")
     }
 });
 
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetListPackage")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRestore")
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetToolExecute")
+    .Does(() =>
+{
+    var workingDirectory = Paths.Temp.Combine("./Cake.Common/Tools/DotNet/DotNetToolExecute");
+    EnsureDirectoryExist(workingDirectory);
+
+    DotNetToolExecute("DPI", "--version", new DotNetToolExecuteSettings
+    {
+        WorkingDirectory = workingDirectory,
+    });
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetToolInstallListRunUninstallLocal")
+    .Does(() =>
+{
+    var package = "DPI";
+    var workingDirectory = Paths.Temp.Combine("./Cake.Common/Tools/DotNet/DotNetToolInstallListRunUninstallLocal");
+    var toolManifest = workingDirectory.CombineWithFilePath("dotnet-tools.json");
+    EnsureDirectoryExist(workingDirectory);
+
+    // dotnet tool --local walks up the directory tree for an existing manifest.
+    // The Cake repo has .config/dotnet-tools.json at the root, so create an isolated manifest here first.
+    System.IO.File.WriteAllText(
+        toolManifest.FullPath,
+        """
+        {
+          "version": 1,
+          "isRoot": true,
+          "tools": {}
+        }
+        """);
+
+    DotNetToolInstall(package, new DotNetToolInstallSettings
+    {
+        InstallationScope = DotNetToolInstallationScope.Local,
+        WorkingDirectory = workingDirectory
+    });
+
+    DotNetToolList(package, new DotNetToolListSettings
+    {
+        InstallationScope = DotNetToolInstallationScope.Local,
+        WorkingDirectory = workingDirectory
+    });
+
+    DotNetToolRun(package, "--version", new DotNetToolRunSettings
+    {
+        WorkingDirectory = workingDirectory,
+    });
+
+    DotNetToolUninstall(package, new DotNetToolUninstallSettings
+    {
+        InstallationScope = DotNetToolInstallationScope.Local,
+        WorkingDirectory = workingDirectory,
+    });
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetToolInstallListRunUninstallLocalToolManifest")
+    .Does(() =>
+{
+    var package = "DPI";
+    var workingDirectory = Paths.Temp.Combine("./Cake.Common/Tools/DotNet/DotNetToolInstallListRunUninstallLocalToolManifest");
+    var toolManifest = workingDirectory.CombineWithFilePath("dotnet-tools.json");
+    EnsureDirectoryExist(workingDirectory);
+
+    // Use an isolated manifest path so local tool commands do not walk up to the Cake repo manifest.
+    System.IO.File.WriteAllText(
+        toolManifest.FullPath,
+        """
+        {
+          "version": 1,
+          "isRoot": true,
+          "tools": {}
+        }
+        """);
+
+    DotNetToolInstall(package, new DotNetToolInstallSettings
+    {
+        InstallationScope = DotNetToolInstallationScope.Local,
+        ToolManifest = toolManifest,
+    });
+
+    DotNetToolList(package, new DotNetToolListSettings
+    {
+        InstallationScope = DotNetToolInstallationScope.Local,
+        WorkingDirectory = workingDirectory
+    });
+
+    DotNetToolRun(package, "--version", new DotNetToolRunSettings
+    {
+        WorkingDirectory = workingDirectory
+    });
+
+    DotNetToolUninstall(package, new DotNetToolUninstallSettings
+    {
+        InstallationScope = DotNetToolInstallationScope.Local,
+        ToolManifest = toolManifest,
+    });
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetToolInstallListRunUninstallToolPath")
+    .Does(() =>
+{
+    var package = "DPI";
+    var workingDirectory = Paths.Temp.Combine("./Cake.Common/Tools/DotNet/DotNetToolInstallListRunUninstallToolPath");
+    var toolInstallationPath = workingDirectory.Combine("./tools");
+    EnsureDirectoryExist(workingDirectory);
+    EnsureDirectoryExist(toolInstallationPath);
+
+    DotNetToolInstall(package, new DotNetToolInstallSettings
+    {
+        InstallationScope = DotNetToolInstallationScope.ToolPath,
+        ToolInstallationPath = toolInstallationPath,
+        WorkingDirectory = workingDirectory,
+    });
+
+    DotNetToolList(package, new DotNetToolListSettings
+    {
+        InstallationScope = DotNetToolInstallationScope.ToolPath,
+        ToolInstallationPath = toolInstallationPath,
+        WorkingDirectory = workingDirectory,
+    });
+
+    // dotnet tool run applies to local manifest tools; --tool-path installs are invoked directly.
+    var toolExecutable = toolInstallationPath.CombineWithFilePath(Context.IsRunningOnUnix() ? "dpi" : "dpi.exe");
+    Assert.True(FileExists(toolExecutable));
+    StartProcess(toolExecutable, new ProcessSettings
+    {
+        Arguments = "--version",
+        WorkingDirectory = workingDirectory,
+    });
+
+    DotNetToolUninstall(package, new DotNetToolUninstallSettings
+    {
+        InstallationScope = DotNetToolInstallationScope.ToolPath,
+        ToolInstallationPath = toolInstallationPath,
+        WorkingDirectory = workingDirectory,
+    });
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetAddPackage")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
     .Does(() =>
 {
     // Given
     var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
     var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
+    var package = "Cake.Core";
+
     // When
-    DotNetRestore(project.FullPath);
-    var result = DotNetListPackage(project.FullPath);
+    DotNetAddPackage(package, project.FullPath);
+
+    var value = XmlPeek(
+        project.FullPath,
+        $"/Project/ItemGroup/PackageReference[@Include='{package}']/@Include"
+    );
+
     // Then
-    Assert.Equal(1, result.Version);
-    Assert.Contains(result.Projects, item => item.Path == project);
+    Assert.Equal(package, value);
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetAddReference")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+    var project = path.CombineWithFilePath("hwapp.tests/hwapp.tests.csproj");
+    var projectReferencePath = path.CombineWithFilePath("hwapp/hwapp.csproj");
+    var projectReference = "..\\hwapp\\hwapp.csproj";
+    // When
+    DotNetAddReference(project.FullPath, new[] { (FilePath)projectReferencePath.FullPath});
+    var value = XmlPeek(
+        project.FullPath,
+        $"/Project/ItemGroup/ProjectReference[@Include='{projectReference}']/@Include"
+    );
+    // Then
+    Assert.Equal(projectReference, value);
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetFormat")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
+
+    // When
+    DotNetFormat(project.FullPath);
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetListReference")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
+    var projectReference = FilePath.FromString("../hwapp.common/hwapp.common.csproj");
+    // When
+    var result = DotNetListReference(project.FullPath);
+    // Then
+    Assert.Contains(result, item => FilePath.FromString(item) == projectReference);
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRemoveReference")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+    var project = path.CombineWithFilePath("hwapp.tests/hwapp.tests.csproj");
+    var projectReferencePath = path.CombineWithFilePath("hwapp/hwapp.csproj");
+    var projectReference = "..\\hwapp\\hwapp.csproj";
+    // When
+    DotNetRemoveReference(project.FullPath, new[] { (FilePath)projectReferencePath.FullPath});
+    var value = XmlPeek(
+        project.FullPath,
+        $"/Project/ItemGroup/ProjectReference[@Include='{projectReference}']/@Include"
+    );
+    // Then
+    Assert.Null(value);
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRestore")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
+    .Does(() =>
+{
+    // Given
+    var root = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+
+    // When
+    DotNetRestore(root.FullPath, new DotNetRestoreSettings { Verbosity = DotNetVerbosity.Minimal });
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSDKCheck")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
+    .Does(() =>
+{
+    // When
+    DotNetSDKCheck();
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSlnAdd")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+    var solution = path.CombineWithFilePath("hwapp.sln");
+    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
+    // When
+    DotNetSlnAdd(solution.FullPath, new[] { (FilePath)project.FullPath});
 });
 
 Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSlnList")
@@ -523,18 +320,6 @@ Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSlnList")
     Assert.Contains(result, item => item == project);
 });
 
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSlnAdd")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
-    .Does(() =>
-{
-    // Given
-    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
-    var solution = path.CombineWithFilePath("hwapp.sln");
-    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
-    // When
-    DotNetSlnAdd(solution.FullPath, new[] { (FilePath)project.FullPath});
-});
-
 Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSlnRemove")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
     .Does(() =>
@@ -547,44 +332,404 @@ Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSlnRemove")
     DotNetSlnRemove(solution.FullPath, new[] { (FilePath)project.FullPath});
 });
 
-Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetBuildServerShutdown")
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetWorkloadRepair")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
+    .OnError(exception => { Console.WriteLine(exception); })
+    .Does(() =>
+{
+    // When
+    DotNetWorkloadRepair();
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetWorkloadRestore")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
+
+    // When
+    DotNetWorkloadRestore(project.FullPath);
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetWorkloadSearch")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
+    .Does(() =>
+{
+    // Given
+    var searchString = "maui";
+
+    // When
+    var workloads = DotNetWorkloadSearch(searchString);
+
+    // Then
+    foreach (var workload in workloads)
+    {
+        Assert.Contains("maui", workload.Id);
+        Assert.Contains(".NET MAUI SDK", workload.Description);
+    }
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetWorkloadUpdate")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.Setup")
+    .Does(() =>
+{
+    // When
+    DotNetWorkloadUpdate();
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetBuild")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRestore")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
+    var assembly = path.CombineWithFilePath("hwapp/bin/Debug/net10.0/hwapp.dll");
+
+    // When
+    DotNetBuild(project.FullPath);
+
+    // Then
+    Assert.True(System.IO.File.Exists(assembly.FullPath));
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetListPackage")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRestore")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
+    // When
+    DotNetRestore(project.FullPath);
+    var result = DotNetListPackage(project.FullPath);
+    // Then
+    Assert.Equal(1, result.Version);
+    Assert.Contains(result.Projects, item => item.Path == project);
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetMSBuild.Results")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRestore")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
+    var settings = new DotNetMSBuildSettings
+    {
+        GetProperties = { "Version", "TargetFramework", },
+        GetItems = { "ProjectReference", },
+        GetTargetResults = { "Build", "Compile", },
+    };
+
+    System.Text.Json.JsonDocument result = null;
+
+    // When
+    DotNetMSBuild(project.FullPath, settings, output => result = System.Text.Json.JsonDocument.Parse(output.SelectMany(x => x).ToArray()));
+
+    // Then
+    Assert.NotNull(result);
+    Assert.Equal("1.0.0", result.RootElement.GetProperty("Properties").GetProperty("Version").GetString());
+    Assert.Equal("net10.0", result.RootElement.GetProperty("Properties").GetProperty("TargetFramework").GetString());
+    Assert.Equal(1, result.RootElement.GetProperty("Items").GetProperty("ProjectReference").GetArrayLength());
+    Assert.Equal("Success", result.RootElement.GetProperty("TargetResults").GetProperty("Build").GetProperty("Result").GetString());
+    Assert.Equal("Success", result.RootElement.GetProperty("TargetResults").GetProperty("Compile").GetProperty("Result").GetString());
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetClean")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetBuild")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetExecute")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
+    var assembly = path.CombineWithFilePath("hwapp/bin/Debug/net10.0/hwapp.dll");
+    Assert.True(System.IO.File.Exists(assembly.FullPath));
+
+    // When
+    DotNetClean(project.FullPath);
+
+    // Then
+    Assert.False(System.IO.File.Exists(assembly.FullPath));
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTest")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetBuild")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+    var project = path.CombineWithFilePath("hwapp.tests/hwapp.tests.csproj");
+
+    // When
+    DotNetTest(project.FullPath, new DotNetTestSettings { PathType = DotNetTestPathType.Project });
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTool")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetBuild")
+    .Does(() =>
+{
+    // When
+    DotNetTool("--info");
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetVSTest")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetBuild")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+    var assembly = path.CombineWithFilePath("hwapp.tests/bin/Debug/net10.0/hwapp.tests.dll");
+
+    // When
+    DotNetVSTest(assembly.FullPath);
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetExecute")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTest")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+    var assembly = path.CombineWithFilePath("hwapp/bin/Debug/net10.0/hwapp.dll");
+    Assert.True(System.IO.File.Exists(assembly.FullPath));
+
+    // When
+    DotNetExecute(assembly);
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetMSBuild")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetClean")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
+    var assembly = path.CombineWithFilePath("hwapp/bin/Debug/net10.0/hwapp.dll");
+
+    // When (Verbosity.Quiet exercises MSBuild /verbosity, not dotnet --verbosity; see https://github.com/cake-build/cake/issues/4456)
+    DotNetMSBuild(project.FullPath, new DotNetMSBuildSettings { Verbosity = DotNetVerbosity.Quiet });
+
+    // Then
+    Assert.True(System.IO.File.Exists(assembly.FullPath));
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetMSBuildEmptyParametersAllowed")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetClean")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
+    var assembly = path.CombineWithFilePath("hwapp/bin/Debug/net10.0/hwapp.dll");
+
+    // When - empty string property value is allowed
+    DotNetMSBuild(project.FullPath, new DotNetMSBuildSettings()
+        .WithProperty("APropertyIWantTobeBlank", ""));
+
+    // Then
+    Assert.True(System.IO.File.Exists(assembly.FullPath));
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetPack")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTest")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
+    var outputPath = path.Combine("DotNetPack");
+    var nuget = outputPath.CombineWithFilePath("hwapp.1.0.0.nupkg");
+    var nugetSymbols = outputPath.CombineWithFilePath("hwapp.1.0.0.symbols.nupkg");
+    EnsureDirectoryExist(outputPath);
+
+    // When
+    DotNetPack(project.FullPath, new DotNetPackSettings { OutputDirectory = outputPath, IncludeSymbols = true });
+
+    // Then
+    Assert.True(System.IO.File.Exists(nuget.FullPath), "Path:" + nuget.FullPath);
+    Assert.True(System.IO.File.Exists(nugetSymbols.FullPath), "Path:" + nugetSymbols.FullPath);
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetPublish")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTest")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
+    var outputPath = path.Combine("DotNetPublish");
+    var publishFiles = new [] {
+        outputPath.CombineWithFilePath("hwapp.common.dll"),
+        outputPath.CombineWithFilePath("hwapp.common.pdb"),
+        outputPath.CombineWithFilePath("hwapp.deps.json"),
+        outputPath.CombineWithFilePath("hwapp.dll"),
+        outputPath.CombineWithFilePath("hwapp.pdb"),
+        outputPath.CombineWithFilePath("hwapp.runtimeconfig.json")
+    };
+
+    EnsureDirectoryExist(outputPath);
+
+    // When
+    DotNetPublish(project.FullPath, new DotNetPublishSettings { OutputDirectory = outputPath });
+
+    // Then
+    foreach (var file in publishFiles)
+    {
+        Assert.True(System.IO.File.Exists(file.FullPath), "Path:" + file.FullPath);
+    }
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRemovePackage")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetAddPackage")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
+    var package = "Cake.Core";
+    var value = XmlPeek(
+        project.FullPath,
+        $"/Project/ItemGroup/PackageReference[@Include='{package}']/@Include"
+    );
+    Assert.Equal(package, value);
+
+    // When
+
+    DotNetRemovePackage(
+        package, project.GetFilename().FullPath,
+        // Workaround for SDK regression https://github.com/NuGet/Home/issues/14801
+        new DotNetPackageRemoveSettings { 
+            WorkingDirectory = project.GetDirectory().FullPath
+         });
+
+    value = XmlPeek(
+        project.FullPath,
+        $"/Project/ItemGroup/PackageReference[@Include='{package}']/@Include"
+    );
+
+    // Then
+    Assert.Null(value);
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTest.Fail")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTest")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+    var project = path.CombineWithFilePath("hwapp.tests/hwapp.tests.csproj");
+
+    // When
+    var exception = Record.Exception(()=>DotNetTest(project.FullPath,
+        new DotNetTestSettings { EnvironmentVariables = new Dictionary<string, string> {{ "hwapp_fail_test", "true" }}
+        }));
+
+    // Then
+    Assert.NotNull(exception);
+    Assert.IsType<CakeException>(exception);
+    Assert.Equal(".NET CLI: Process returned an error (exit code 2).",exception.Message);
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetNuGetPush")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetPack")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+    var outputPath = path.Combine("DotNetPack");
+    var nugetServerPath = path.Combine("DotNetPush");
+    var nugetSource = outputPath.CombineWithFilePath("hwapp.1.0.0.nupkg");
+    var nugetDestination = nugetServerPath.CombineWithFilePath("hwapp.1.0.0.nupkg");
+
+    EnsureDirectoryExist(outputPath);
+    EnsureDirectoryExist(nugetServerPath);
+    Assert.True(System.IO.File.Exists(nugetSource.FullPath), "Path:" + nugetSource.FullPath);
+
+    // When
+    DotNetNuGetPush(nugetSource.FullPath, new DotNetNuGetPushSettings { Source = nugetServerPath.FullPath });
+
+    // Then
+    Assert.True(System.IO.File.Exists(nugetDestination.FullPath), "Path:" + nugetDestination.FullPath);
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRun")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTest")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetVSTest")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTool")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRun")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetPack")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+    var project = path.CombineWithFilePath("hwapp/hwapp.csproj");
+
+    // When
+    DotNetRun(project.FullPath);
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetNuGetDelete")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetNuGetPush")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetNuGetDelete")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetPublish")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetExecute")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetClean")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetMSBuild")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetMSBuild.Results")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTest.Fail")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetFormat")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSDKCheck")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetWorkloadSearch")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetWorkloadRepair")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetWorkloadUpdate")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetWorkloadRestore")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetAddPackage")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRemovePackage")
+    .Does(() =>
+{
+    // Given
+    var path = Paths.Temp.Combine("./Cake.Common/Tools/DotNet");
+    var nugetServerPath = path.Combine("DotNetPush");
+    var nugetDestination = nugetServerPath.CombineWithFilePath("hwapp.1.0.0.nupkg");
+
+    EnsureDirectoryExist(nugetServerPath);
+    Assert.True(System.IO.File.Exists(nugetDestination.FullPath), "Path:" + nugetDestination.FullPath);
+
+    // When
+    DotNetNuGetDelete("hwapp", "1.0.0", new DotNetNuGetDeleteSettings { Source = nugetServerPath.FullPath, NonInteractive = true });
+
+    // Then
+    Assert.False(System.IO.File.Exists(nugetDestination.FullPath), "Path:" + nugetDestination.FullPath);
+});
+
+Task("Cake.Common.Tools.DotNet.DotNetAliases.DotNetBuildServerShutdown")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSearchPackage")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSearchPackage.ExactMatch")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetListPackage")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetToolExecute")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetToolInstallListRunUninstallLocal")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetToolInstallListRunUninstallLocalToolManifest")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetToolInstallListRunUninstallToolPath")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetAddPackage")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetAddReference")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRemoveReference")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetFormat")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetListReference")
-    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSlnList")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRemoveReference")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRestore")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSDKCheck")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSlnAdd")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSlnList")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetSlnRemove")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetWorkloadRepair")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetWorkloadRestore")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetWorkloadSearch")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetWorkloadUpdate")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetBuild")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetListPackage")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetMSBuild.Results")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetClean")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTest")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTool")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetVSTest")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetExecute")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetMSBuild")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetPack")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetPublish")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRemovePackage")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetTest.Fail")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetNuGetPush")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetRun")
+    .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetNuGetDelete")
     .Does(() =>
 {
     // When
     DotNetBuildServerShutdown();
-});;
+});
 
 Task("Cake.Common.Tools.DotNet.DotNetAliases")
     .IsDependentOn("Cake.Common.Tools.DotNet.DotNetAliases.DotNetBuildServerShutdown");


### PR DESCRIPTION
## Summary

Adds first-class Cake aliases for the `dotnet tool` command family, covering the requested subcommands from discussion #4843:

- `DotNetToolExecute`
- `DotNetToolInstall`
- `DotNetToolList`
- `DotNetToolRestore`
- `DotNetToolRun`
- `DotNetToolSearch`
- `DotNetToolUninstall`
- `DotNetToolUpdate`

## Details

This introduces command-specific settings types for each supported `dotnet tool` subcommand, matching the existing DotNet alias style in Cake instead of using a generic shared settings/arguments shape.

Forwarded tool arguments are only supported where the underlying CLI executes a tool:

- `DotNetToolExecute(..., ProcessArgumentBuilder arguments, ...)`
- `DotNetToolRun(..., ProcessArgumentBuilder arguments, ...)`

Those forwarded arguments are kept out of the settings classes and are appended after `--`, consistent with existing aliases like `DotNetRun` and `DotNetTest`.

The aliases also include XML documentation links to the corresponding Microsoft `dotnet tool` command documentation.

## Testing

Added unit coverage for:

- all new alias overloads
- command-specific settings rendering
- forwarded tool arguments for execute/run
- required argument validation
- working directory behavior from project paths
- process start and non-zero exit failure handling
- argument customization preservation
