### PR TITLE
fix(dotnet): resolve workload paths from WorkingDirectory (#1917)

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Workload/Install/DotNetWorkloadInstallTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Workload/Install/DotNetWorkloadInstallTests.cs
@@ -101,6 +101,23 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Workload.Install
             }
 
             [Fact]
+            public void Should_Resolve_Workload_Paths_Relative_To_WorkingDirectory()
+            {
+                // Given
+                var fixture = new DotNetWorkloadInstallerFixture();
+                fixture.WorkloadIds = new string[] { "maui" };
+                fixture.Settings.WorkingDirectory = "./source/MyProject";
+                fixture.Settings.ConfigFile = "./NuGet.config";
+                fixture.Settings.TempDir = "./temp/workload";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("workload install maui --configfile \"/Working/source/MyProject/NuGet.config\" --temp-dir \"/Working/source/MyProject/temp/workload\"", result.Args);
+            }
+
+            [Fact]
             public void Should_Add_Additional_Arguments()
             {
                 // Given

--- a/src/Cake.Common/Tools/DotNet/DotNetTool.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetTool.cs
@@ -127,5 +127,46 @@ namespace Cake.Common.Tools.DotNet
 
             return builder;
         }
+        /// <summary>
+        /// Resolves a relative directory path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteDirectoryPath(DirectoryPath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).Combine(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative file path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static FilePath GetAbsoluteFilePath(FilePath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).CombineWithFilePath(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative output directory against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteOutputDirectory(DirectoryPath outputDirectory, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            return GetAbsoluteDirectoryPath(outputDirectory, settings, environment);
+        }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Workload/Install/DotNetWorkloadInstaller.cs
+++ b/src/Cake.Common/Tools/DotNet/Workload/Install/DotNetWorkloadInstaller.cs
@@ -65,7 +65,8 @@ namespace Cake.Common.Tools.DotNet.Workload.Install
             // Config File
             if (settings.ConfigFile != null)
             {
-                builder.AppendSwitchQuoted("--configfile", settings.ConfigFile.MakeAbsolute(_environment).FullPath);
+                var configFile = GetAbsoluteFilePath(settings.ConfigFile, settings, _environment);
+                builder.AppendSwitchQuoted("--configfile", configFile.MakeAbsolute(_environment).FullPath);
             }
 
             // Disable Parallel
@@ -116,7 +117,8 @@ namespace Cake.Common.Tools.DotNet.Workload.Install
             // Temp Dir
             if (settings.TempDir != null)
             {
-                builder.AppendSwitchQuoted("--temp-dir", settings.TempDir.MakeAbsolute(_environment).FullPath);
+                var tempDir = GetAbsoluteDirectoryPath(settings.TempDir, settings, _environment);
+                builder.AppendSwitchQuoted("--temp-dir", tempDir.MakeAbsolute(_environment).FullPath);
             }
 
             return builder;

--- a/src/Cake.Common/Tools/DotNet/Workload/Repair/DotNetWorkloadRepairer.cs
+++ b/src/Cake.Common/Tools/DotNet/Workload/Repair/DotNetWorkloadRepairer.cs
@@ -53,7 +53,8 @@ namespace Cake.Common.Tools.DotNet.Workload.Repair
             // Config File
             if (settings.ConfigFile != null)
             {
-                builder.AppendSwitchQuoted("--configfile", settings.ConfigFile.MakeAbsolute(_environment).FullPath);
+                var configFile = GetAbsoluteFilePath(settings.ConfigFile, settings, _environment);
+                builder.AppendSwitchQuoted("--configfile", configFile.MakeAbsolute(_environment).FullPath);
             }
 
             // Disable Parallel
@@ -98,7 +99,8 @@ namespace Cake.Common.Tools.DotNet.Workload.Repair
             // Temp Dir
             if (settings.TempDir != null)
             {
-                builder.AppendSwitchQuoted("--temp-dir", settings.TempDir.MakeAbsolute(_environment).FullPath);
+                var tempDir = GetAbsoluteDirectoryPath(settings.TempDir, settings, _environment);
+                builder.AppendSwitchQuoted("--temp-dir", tempDir.MakeAbsolute(_environment).FullPath);
             }
 
             return builder;

--- a/src/Cake.Common/Tools/DotNet/Workload/Restore/DotNetWorkloadRestorer.cs
+++ b/src/Cake.Common/Tools/DotNet/Workload/Restore/DotNetWorkloadRestorer.cs
@@ -61,7 +61,8 @@ namespace Cake.Common.Tools.DotNet.Workload.Restore
             // Config File
             if (settings.ConfigFile != null)
             {
-                builder.AppendSwitchQuoted("--configfile", settings.ConfigFile.MakeAbsolute(_environment).FullPath);
+                var configFile = GetAbsoluteFilePath(settings.ConfigFile, settings, _environment);
+                builder.AppendSwitchQuoted("--configfile", configFile.MakeAbsolute(_environment).FullPath);
             }
 
             // Disable Parallel
@@ -112,7 +113,8 @@ namespace Cake.Common.Tools.DotNet.Workload.Restore
             // Temp Dir
             if (settings.TempDir != null)
             {
-                builder.AppendSwitchQuoted("--temp-dir", settings.TempDir.MakeAbsolute(_environment).FullPath);
+                var tempDir = GetAbsoluteDirectoryPath(settings.TempDir, settings, _environment);
+                builder.AppendSwitchQuoted("--temp-dir", tempDir.MakeAbsolute(_environment).FullPath);
             }
 
             return builder;

--- a/src/Cake.Common/Tools/DotNet/Workload/Update/DotNetWorkloadUpdater.cs
+++ b/src/Cake.Common/Tools/DotNet/Workload/Update/DotNetWorkloadUpdater.cs
@@ -59,7 +59,8 @@ namespace Cake.Common.Tools.DotNet.Workload.Update
             // Config File
             if (settings.ConfigFile != null)
             {
-                builder.AppendSwitchQuoted("--configfile", settings.ConfigFile.MakeAbsolute(_environment).FullPath);
+                var configFile = GetAbsoluteFilePath(settings.ConfigFile, settings, _environment);
+                builder.AppendSwitchQuoted("--configfile", configFile.MakeAbsolute(_environment).FullPath);
             }
 
             // Disable Parallel
@@ -110,7 +111,8 @@ namespace Cake.Common.Tools.DotNet.Workload.Update
             // Temp Dir
             if (settings.TempDir != null)
             {
-                builder.AppendSwitchQuoted("--temp-dir", settings.TempDir.MakeAbsolute(_environment).FullPath);
+                var tempDir = GetAbsoluteDirectoryPath(settings.TempDir, settings, _environment);
+                builder.AppendSwitchQuoted("--temp-dir", tempDir.MakeAbsolute(_environment).FullPath);
             }
 
             return builder;


### PR DESCRIPTION
## Summary

Related to #1917.

When workload settings specify `WorkingDirectory`, relative `ConfigFile` and `TempDir` were still resolved against the Cake script directory. They are now resolved against `WorkingDirectory` for:

- `dotnet workload install`
- `dotnet workload restore`
- `dotnet workload repair`
- `dotnet workload update`

Adds shared `GetAbsoluteDirectoryPath` / `GetAbsoluteFilePath` helpers on `DotNetTool`.

Complements #4810–#4817.

## Test plan

- [x] Added unit test `Should_Resolve_Workload_Paths_Relative_To_WorkingDirectory`
- [ ] CI: `Cake.Common.Tests` (no local .NET SDK; relying on GitHub Actions)


Made with [Cursor](https://cursor.com)