### PR TITLE
fix(dotnet): resolve package list/search config from WorkingDirectory (#1917)

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Package/List/DotNetPackageListerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Package/List/DotNetPackageListerTests.cs
@@ -72,6 +72,22 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Package.List
             }
 
             [Fact]
+            public void Should_Resolve_ConfigFile_Relative_To_WorkingDirectory()
+            {
+                // Given
+                var fixture = new DotNetPackageListerFixture();
+                fixture.Settings.WorkingDirectory = "./source/MyProject";
+                fixture.Settings.ConfigFile = "./NuGet.config";
+                fixture.GivenPackgeListResult();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("list package --config \"/Working/source/MyProject/NuGet.config\" --format json --output-version 1", result.Args);
+            }
+
+            [Fact]
             public void Should_Add_Additional_Arguments()
             {
                 // Given

--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Package/Search/DotNetPackageSearcherTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Package/Search/DotNetPackageSearcherTests.cs
@@ -123,6 +123,23 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Package.Search
             }
 
             [Fact]
+            public void Should_Resolve_ConfigFile_Relative_To_WorkingDirectory()
+            {
+                // Given
+                var fixture = new DotNetPackageSearcherFixture();
+                fixture.SearchTerm = "Cake";
+                fixture.Settings.WorkingDirectory = "./source/MyProject";
+                fixture.Settings.ConfigFile = "./NuGet.config";
+                fixture.GivenNormalPackageResult();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("package search \"Cake\" --configfile \"/Working/source/MyProject/NuGet.config\" --verbosity normal --format json", result.Args);
+            }
+
+            [Fact]
             public void Should_Add_ConfigFile_To_Arguments_If_Set()
             {
                 // Given

--- a/src/Cake.Common/Tools/DotNet/DotNetTool.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetTool.cs
@@ -127,5 +127,46 @@ namespace Cake.Common.Tools.DotNet
 
             return builder;
         }
+        /// <summary>
+        /// Resolves a relative directory path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteDirectoryPath(DirectoryPath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).Combine(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative file path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static FilePath GetAbsoluteFilePath(FilePath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).CombineWithFilePath(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative output directory against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteOutputDirectory(DirectoryPath outputDirectory, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            return GetAbsoluteDirectoryPath(outputDirectory, settings, environment);
+        }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Package/List/DotNetPackageLister.cs
+++ b/src/Cake.Common/Tools/DotNet/Package/List/DotNetPackageLister.cs
@@ -73,7 +73,8 @@ namespace Cake.Common.Tools.DotNet.Package.List
             // Config File
             if (settings.ConfigFile != null)
             {
-                builder.AppendSwitchQuoted("--config", settings.ConfigFile.MakeAbsolute(_environment).FullPath);
+                var configFile = GetAbsoluteFilePath(settings.ConfigFile, settings, _environment);
+                builder.AppendSwitchQuoted("--config", configFile.MakeAbsolute(_environment).FullPath);
             }
 
             // Deprecated

--- a/src/Cake.Common/Tools/DotNet/Package/Search/DotNetPackageSearcher.cs
+++ b/src/Cake.Common/Tools/DotNet/Package/Search/DotNetPackageSearcher.cs
@@ -103,7 +103,8 @@ namespace Cake.Common.Tools.DotNet.Package.Search
             if (settings.ConfigFile != null)
             {
                 builder.Append("--configfile");
-                builder.AppendQuoted(settings.ConfigFile.MakeAbsolute(_environment).FullPath);
+                var configFile = GetAbsoluteFilePath(settings.ConfigFile, settings, _environment);
+                builder.AppendQuoted(configFile.MakeAbsolute(_environment).FullPath);
             }
 
             if (settings.Take is { } take)


### PR DESCRIPTION
## Summary

Related to #1917.

When package list/search settings specify `WorkingDirectory`, relative `ConfigFile` was still resolved against the Cake script directory. It is now resolved against `WorkingDirectory` for:

- `dotnet package list` (`--config`)
- `dotnet package search` (`--configfile`)

Adds shared `GetAbsoluteDirectoryPath` / `GetAbsoluteFilePath` helpers on `DotNetTool`.

Complements #4810–#4847.

## Test plan

- [x] Added unit tests for list and search WorkingDirectory config resolution
- [ ] CI: `Cake.Common.Tests` (no local .NET SDK; relying on GitHub Actions)


Made with [Cursor](https://cursor.com)