### PR TITLE
fix(dotnet): resolve nuget source config from WorkingDirectory (#1917)

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/NuGet/Source/DotNetNuGetSourcerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/NuGet/Source/DotNetNuGetSourcerTests.cs
@@ -106,6 +106,25 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.NuGet.Source
             }
 
             [Fact]
+            public void Should_Resolve_ConfigFile_Relative_To_WorkingDirectory()
+            {
+                // Given
+                var fixture = new DotNetNuGetAddSourceFixture();
+                fixture.Settings = new DotNetNuGetSourceSettings
+                {
+                    Source = "source",
+                    WorkingDirectory = "./source/MyProject",
+                    ConfigFile = "./NuGet.config"
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("nuget add source \"source\" --name \"name\" --configfile \"/Working/source/MyProject/NuGet.config\"", result.Args);
+            }
+
+            [Fact]
             public void Should_Add_Additional_Arguments()
             {
                 // Given

--- a/src/Cake.Common/Tools/DotNet/DotNetTool.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetTool.cs
@@ -127,5 +127,46 @@ namespace Cake.Common.Tools.DotNet
 
             return builder;
         }
+        /// <summary>
+        /// Resolves a relative directory path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteDirectoryPath(DirectoryPath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).Combine(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative file path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static FilePath GetAbsoluteFilePath(FilePath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).CombineWithFilePath(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative output directory against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteOutputDirectory(DirectoryPath outputDirectory, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            return GetAbsoluteDirectoryPath(outputDirectory, settings, environment);
+        }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/NuGet/Source/DotNetNuGetSourcer.cs
+++ b/src/Cake.Common/Tools/DotNet/NuGet/Source/DotNetNuGetSourcer.cs
@@ -296,7 +296,8 @@ namespace Cake.Common.Tools.DotNet.NuGet.Source
             if (settings.ConfigFile != null)
             {
                 builder.Append("--configfile");
-                builder.AppendQuoted(settings.ConfigFile.MakeAbsolute(_environment).FullPath);
+                var configFile = GetAbsoluteFilePath(settings.ConfigFile, settings, _environment);
+                builder.AppendQuoted(configFile.MakeAbsolute(_environment).FullPath);
             }
         }
     }


### PR DESCRIPTION
## Summary

Related to #1917.

When `DotNetNuGetSourceSettings.WorkingDirectory` is set, relative `ConfigFile` was still resolved against the Cake script directory. It is now resolved against `WorkingDirectory` for all `dotnet nuget source` subcommands (add, remove, list, etc.) via shared `AddCommonArguments`.

Adds shared `GetAbsoluteDirectoryPath` / `GetAbsoluteFilePath` helpers on `DotNetTool`.

Complements #4810–#4848.

## Test plan

- [x] Added unit test `Should_Resolve_ConfigFile_Relative_To_WorkingDirectory`
- [ ] CI: `Cake.Common.Tests` (no local .NET SDK; relying on GitHub Actions)


Made with [Cursor](https://cursor.com)