### PR TITLE
fix(DotNetSlnAdd): resolve paths relative to WorkingDirectory

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Sln/Add/DotNetSlnAdderTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Sln/Add/DotNetSlnAdderTests.cs
@@ -184,6 +184,23 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Sln.Add
             }
 
             [Fact]
+            public void Should_Resolve_SlnAdd_Paths_Relative_To_WorkingDirectory()
+            {
+                // Given
+                var fixture = new DotNetSlnAdderFixture();
+                fixture.Solution = (FilePath)"./test.sln";
+                fixture.ProjectPath = new[] { (FilePath)"./lib1.csproj" };
+                fixture.Settings.WorkingDirectory = "./source/MyProject";
+                fixture.Settings.SolutionFolder = "./folders/mylibs";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("sln \"/Working/source/MyProject/test.sln\" add --solution-folder \"/Working/source/MyProject/folders/mylibs\" \"/Working/source/MyProject/lib1.csproj\"", result.Args);
+            }
+
+            [Fact]
             public void Should_Add_SolutionFolder_Argument()
             {
                 // Given

--- a/src/Cake.Common/Tools/DotNet/DotNetTool.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetTool.cs
@@ -127,5 +127,46 @@ namespace Cake.Common.Tools.DotNet
 
             return builder;
         }
+        /// <summary>
+        /// Resolves a relative directory path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteDirectoryPath(DirectoryPath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).Combine(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative file path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static FilePath GetAbsoluteFilePath(FilePath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).CombineWithFilePath(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative output directory against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteOutputDirectory(DirectoryPath outputDirectory, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            return GetAbsoluteDirectoryPath(outputDirectory, settings, environment);
+        }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Sln/Add/DotNetSlnAdder.cs
+++ b/src/Cake.Common/Tools/DotNet/Sln/Add/DotNetSlnAdder.cs
@@ -64,7 +64,8 @@ namespace Cake.Common.Tools.DotNet.Sln.Add
             // Solution path
             if (solution != null)
             {
-                builder.AppendQuoted(solution.MakeAbsolute(_environment).FullPath);
+                var solutionPath = GetAbsoluteFilePath(solution, settings, _environment);
+                builder.AppendQuoted(solutionPath.MakeAbsolute(_environment).FullPath);
             }
 
             builder.Append("add");
@@ -72,7 +73,8 @@ namespace Cake.Common.Tools.DotNet.Sln.Add
             // Solution folder
             if (settings.SolutionFolder != null)
             {
-                builder.AppendSwitchQuoted("--solution-folder", settings.SolutionFolder.MakeAbsolute(_environment).FullPath);
+                var solutionFolder = GetAbsoluteDirectoryPath(settings.SolutionFolder, settings, _environment);
+                builder.AppendSwitchQuoted("--solution-folder", solutionFolder.MakeAbsolute(_environment).FullPath);
             }
 
             // In root
@@ -84,7 +86,8 @@ namespace Cake.Common.Tools.DotNet.Sln.Add
             // Project path
             foreach (var project in projectPath)
             {
-                builder.AppendQuoted(project.MakeAbsolute(_environment).FullPath);
+                var projectFile = GetAbsoluteFilePath(project, settings, _environment);
+                builder.AppendQuoted(projectFile.MakeAbsolute(_environment).FullPath);
             }
 
             return builder;


### PR DESCRIPTION
## Summary

Fixes #1917 for `dotnet sln add`.

When `DotNetSlnAddSettings.WorkingDirectory` is set, relative paths for the solution file, project files, and `--solution-folder` are now resolved against the working directory instead of the Cake script directory.

## Changes

- Add shared `GetAbsoluteFilePath` / `GetAbsoluteDirectoryPath` helpers on `DotNetTool` (consistent with other #1917 fixes).
- Use them in `DotNetSlnAdder` for solution, project, and solution-folder paths.
- Add unit test covering all three path types with `WorkingDirectory` set.

## Test plan

- [x] Added `Should_Resolve_SlnAdd_Paths_Relative_To_WorkingDirectory` unit test
- [ ] CI (no local .NET SDK in contributor environment; relying on GitHub Actions)


Made with [Cursor](https://cursor.com)