### PR TITLE
fix(DotNetSlnRemove): resolve paths relative to WorkingDirectory

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Sln/Remove/DotNetSlnRemoverTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Sln/Remove/DotNetSlnRemoverTests.cs
@@ -88,6 +88,22 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Sln.Remove
             }
 
             [Fact]
+            public void Should_Resolve_SlnRemove_Paths_Relative_To_WorkingDirectory()
+            {
+                // Given
+                var fixture = new DotNetSlnRemoverFixture();
+                fixture.Solution = (FilePath)"./test.sln";
+                fixture.ProjectPath = new[] { (FilePath)"./lib1.csproj", (FilePath)"./lib2.csproj" };
+                fixture.Settings.WorkingDirectory = "./source/MyProject";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("sln \"/Working/source/MyProject/test.sln\" remove \"/Working/source/MyProject/lib1.csproj\" \"/Working/source/MyProject/lib2.csproj\"", result.Args);
+            }
+
+            [Fact]
             public void Should_Add_Solution_Argument()
             {
                 // Given

--- a/src/Cake.Common/Tools/DotNet/DotNetTool.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetTool.cs
@@ -127,5 +127,46 @@ namespace Cake.Common.Tools.DotNet
 
             return builder;
         }
+        /// <summary>
+        /// Resolves a relative directory path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteDirectoryPath(DirectoryPath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).Combine(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative file path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static FilePath GetAbsoluteFilePath(FilePath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).CombineWithFilePath(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative output directory against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteOutputDirectory(DirectoryPath outputDirectory, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            return GetAbsoluteDirectoryPath(outputDirectory, settings, environment);
+        }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Sln/Remove/DotNetSlnRemover.cs
+++ b/src/Cake.Common/Tools/DotNet/Sln/Remove/DotNetSlnRemover.cs
@@ -60,7 +60,8 @@ namespace Cake.Common.Tools.DotNet.Sln.Remove
             // Solution path
             if (solution != null)
             {
-                builder.AppendQuoted(solution.MakeAbsolute(_environment).FullPath);
+                var solutionPath = GetAbsoluteFilePath(solution, settings, _environment);
+                builder.AppendQuoted(solutionPath.MakeAbsolute(_environment).FullPath);
             }
 
             builder.Append("remove");
@@ -68,7 +69,8 @@ namespace Cake.Common.Tools.DotNet.Sln.Remove
             // Project path
             foreach (var project in projectPath)
             {
-                builder.AppendQuoted(project.MakeAbsolute(_environment).FullPath);
+                var projectFile = GetAbsoluteFilePath(project, settings, _environment);
+                builder.AppendQuoted(projectFile.MakeAbsolute(_environment).FullPath);
             }
 
             return builder;


### PR DESCRIPTION
## Summary

Fixes #1917 for `dotnet sln remove`.

When `DotNetSlnRemoveSettings.WorkingDirectory` is set, relative paths for the solution file and project files are now resolved against the working directory instead of the Cake script directory.

## Changes

- Add shared `GetAbsoluteFilePath` / `GetAbsoluteDirectoryPath` helpers on `DotNetTool` (consistent with other #1917 fixes).
- Use them in `DotNetSlnRemover` for solution and project paths.
- Add unit test covering both path types with `WorkingDirectory` set.

## Test plan

- [x] Added `Should_Resolve_SlnRemove_Paths_Relative_To_WorkingDirectory` unit test
- [ ] CI (no local .NET SDK in contributor environment; relying on GitHub Actions)


Made with [Cursor](https://cursor.com)