### PR TITLE
fix(DotNetSlnList): resolve solution path relative to WorkingDirectory

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Sln/List/DotNetSlnListerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Sln/List/DotNetSlnListerTests.cs
@@ -57,6 +57,21 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Sln.List
             }
 
             [Fact]
+            public void Should_Resolve_SlnList_Solution_Path_Relative_To_WorkingDirectory()
+            {
+                // Given
+                var fixture = new DotNetSlnListerFixture();
+                fixture.Solution = "./ToDo.sln";
+                fixture.Settings.WorkingDirectory = "./source/MyProject";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("sln \"/Working/source/MyProject/ToDo.sln\" list", result.Args);
+            }
+
+            [Fact]
             public void Should_Not_Add_Solution_Argument()
             {
                 // Given

--- a/src/Cake.Common/Tools/DotNet/DotNetTool.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetTool.cs
@@ -127,5 +127,46 @@ namespace Cake.Common.Tools.DotNet
 
             return builder;
         }
+        /// <summary>
+        /// Resolves a relative directory path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteDirectoryPath(DirectoryPath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).Combine(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative file path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static FilePath GetAbsoluteFilePath(FilePath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).CombineWithFilePath(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative output directory against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteOutputDirectory(DirectoryPath outputDirectory, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            return GetAbsoluteDirectoryPath(outputDirectory, settings, environment);
+        }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Sln/List/DotNetSlnLister.cs
+++ b/src/Cake.Common/Tools/DotNet/Sln/List/DotNetSlnLister.cs
@@ -69,7 +69,8 @@ namespace Cake.Common.Tools.DotNet.Sln.List
             // Solution path
             if (solution != null)
             {
-                builder.AppendQuoted(solution.MakeAbsolute(_environment).FullPath);
+                var solutionPath = GetAbsoluteFilePath(solution, settings, _environment);
+                builder.AppendQuoted(solutionPath.MakeAbsolute(_environment).FullPath);
             }
 
             builder.Append("list");


### PR DESCRIPTION
## Summary

Fixes #1917 for `dotnet sln list`.

When `DotNetSlnListSettings.WorkingDirectory` is set, a relative solution file path is now resolved against the working directory instead of the Cake script directory.

## Changes

- Add shared `GetAbsoluteFilePath` / `GetAbsoluteDirectoryPath` helpers on `DotNetTool` (consistent with other #1917 fixes).
- Use `GetAbsoluteFilePath` in `DotNetSlnLister` for the solution path.
- Add unit test `Should_Resolve_SlnList_Solution_Path_Relative_To_WorkingDirectory`.

## Test plan

- [x] Added unit test for WorkingDirectory-relative solution path
- [ ] CI (no local .NET SDK in contributor environment; relying on GitHub Actions)


Made with [Cursor](https://cursor.com)