### PR TITLE
fix(DotNetReferenceRemove): resolve paths relative to WorkingDirectory

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Reference/Remove/DotNetReferenceRemoverTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Reference/Remove/DotNetReferenceRemoverTests.cs
@@ -92,6 +92,22 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Reference.Remove
             }
 
             [Fact]
+            public void Should_Resolve_ReferenceRemove_Paths_Relative_To_WorkingDirectory()
+            {
+                // Given
+                var fixture = new DotNetReferenceRemoverFixture();
+                fixture.Project = "./ToDo.csproj";
+                fixture.ProjectReferences = new[] { (FilePath)"./lib1.csproj", (FilePath)"./lib2/lib2.csproj" };
+                fixture.Settings.WorkingDirectory = "./source/MyProject";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("remove \"/Working/source/MyProject/ToDo.csproj\" reference \"/Working/source/MyProject/lib1.csproj\" \"/Working/source/MyProject/lib2/lib2.csproj\"", result.Args);
+            }
+
+            [Fact]
             public void Should_Not_Add_Project_Argument()
             {
                 // Given

--- a/src/Cake.Common/Tools/DotNet/DotNetTool.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetTool.cs
@@ -127,5 +127,46 @@ namespace Cake.Common.Tools.DotNet
 
             return builder;
         }
+        /// <summary>
+        /// Resolves a relative directory path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteDirectoryPath(DirectoryPath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).Combine(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative file path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static FilePath GetAbsoluteFilePath(FilePath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).CombineWithFilePath(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative output directory against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteOutputDirectory(DirectoryPath outputDirectory, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            return GetAbsoluteDirectoryPath(outputDirectory, settings, environment);
+        }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Reference/Remove/DotNetReferenceRemover.cs
+++ b/src/Cake.Common/Tools/DotNet/Reference/Remove/DotNetReferenceRemover.cs
@@ -60,14 +60,24 @@ namespace Cake.Common.Tools.DotNet.Reference.Remove
             // Project path
             if (!string.IsNullOrWhiteSpace(project))
             {
-                builder.AppendQuoted(project);
+                var projectPath = new FilePath(project);
+                if (settings.WorkingDirectory != null && projectPath.IsRelative)
+                {
+                    projectPath = GetAbsoluteFilePath(projectPath, settings, _environment);
+                    builder.AppendQuoted(projectPath.MakeAbsolute(_environment).FullPath);
+                }
+                else
+                {
+                    builder.AppendQuoted(project);
+                }
             }
 
             // References
             builder.Append("reference");
             foreach (var reference in projectReferences)
             {
-                builder.AppendQuoted(reference.MakeAbsolute(_environment).FullPath);
+                var referencePath = GetAbsoluteFilePath(reference, settings, _environment);
+                builder.AppendQuoted(referencePath.MakeAbsolute(_environment).FullPath);
             }
 
             // Framework


### PR DESCRIPTION
## Summary

Fixes #1917 for `dotnet remove reference`.

When `DotNetReferenceRemoveSettings.WorkingDirectory` is set, relative paths for the target project and project references are now resolved against the working directory instead of the Cake script directory.

## Changes

- Add shared `GetAbsoluteFilePath` / `GetAbsoluteDirectoryPath` helpers on `DotNetTool` (consistent with other #1917 fixes).
- Use them in `DotNetReferenceRemover` for project and reference paths.
- Add unit test `Should_Resolve_ReferenceRemove_Paths_Relative_To_WorkingDirectory`.

## Test plan

- [x] Added unit test for WorkingDirectory-relative project and reference paths
- [ ] CI (no local .NET SDK in contributor environment; relying on GitHub Actions)


Made with [Cursor](https://cursor.com)