### PR TITLE
fix(DotNetExecute): resolve assembly path relative to WorkingDirectory

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Execute/DotNetExecutorTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Execute/DotNetExecutorTests.cs
@@ -65,6 +65,24 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Execute
             }
 
             [Fact]
+            public void Should_Resolve_Assembly_Path_Relative_To_WorkingDirectory()
+            {
+                // Given
+                var fixture = new DotNetExecutorFixture();
+                fixture.AssemblyPath = "./bin/Debug/app.dll";
+                fixture.Settings = new DotNetExecuteSettings
+                {
+                    WorkingDirectory = "./source/MyProject"
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("\"/Working/source/MyProject/bin/Debug/app.dll\"", result.Args);
+            }
+
+            [Fact]
             public void Should_Add_Mandatory_Arguments()
             {
                 // Given

--- a/src/Cake.Common/Tools/DotNet/DotNetTool.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetTool.cs
@@ -127,5 +127,46 @@ namespace Cake.Common.Tools.DotNet
 
             return builder;
         }
+        /// <summary>
+        /// Resolves a relative directory path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteDirectoryPath(DirectoryPath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).Combine(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative file path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static FilePath GetAbsoluteFilePath(FilePath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).CombineWithFilePath(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative output directory against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteOutputDirectory(DirectoryPath outputDirectory, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            return GetAbsoluteDirectoryPath(outputDirectory, settings, environment);
+        }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Execute/DotNetExecutor.cs
+++ b/src/Cake.Common/Tools/DotNet/Execute/DotNetExecutor.cs
@@ -56,7 +56,7 @@ namespace Cake.Common.Tools.DotNet.Execute
                 builder.Append(settings.FrameworkVersion);
             }
 
-            builder.AppendQuoted(assemblyPath.MakeAbsolute(_environment).FullPath);
+            builder.AppendQuoted(GetAbsoluteFilePath(assemblyPath, settings, _environment).MakeAbsolute(_environment).FullPath);
 
             if (!arguments.IsNullOrEmpty())
             {


### PR DESCRIPTION
## Summary

Fixes #1917 for `dotnet exec`.

When `DotNetExecuteSettings.WorkingDirectory` is set, a relative assembly path is now resolved against the working directory instead of the Cake script directory.

## Changes

- Add shared `GetAbsoluteFilePath` / `GetAbsoluteDirectoryPath` helpers on `DotNetTool` (consistent with other #1917 fixes).
- Use `GetAbsoluteFilePath` in `DotNetExecutor` for the assembly path.
- Add unit test `Should_Resolve_Assembly_Path_Relative_To_WorkingDirectory`.

## Test plan

- [x] Added unit test for WorkingDirectory-relative assembly path
- [ ] CI (no local .NET SDK in contributor environment; relying on GitHub Actions)


Made with [Cursor](https://cursor.com)