### PR TITLE
fix(DotNetReferenceList): resolve project path relative to WorkingDirectory

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Reference/List/DotNetReferenceListerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Reference/List/DotNetReferenceListerTests.cs
@@ -57,6 +57,21 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Reference.List
             }
 
             [Fact]
+            public void Should_Resolve_Project_Path_Relative_To_WorkingDirectory()
+            {
+                // Given
+                var fixture = new DotNetReferenceListerFixture();
+                fixture.Project = "./ToDo.csproj";
+                fixture.Settings.WorkingDirectory = "./source/MyProject";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("list \"/Working/source/MyProject/ToDo.csproj\" reference", result.Args);
+            }
+
+            [Fact]
             public void Should_Not_Add_Project_Argument()
             {
                 // Given

--- a/src/Cake.Common/Tools/DotNet/DotNetTool.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetTool.cs
@@ -127,5 +127,46 @@ namespace Cake.Common.Tools.DotNet
 
             return builder;
         }
+        /// <summary>
+        /// Resolves a relative directory path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteDirectoryPath(DirectoryPath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).Combine(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative file path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static FilePath GetAbsoluteFilePath(FilePath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).CombineWithFilePath(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative output directory against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteOutputDirectory(DirectoryPath outputDirectory, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            return GetAbsoluteDirectoryPath(outputDirectory, settings, environment);
+        }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Reference/List/DotNetReferenceLister.cs
+++ b/src/Cake.Common/Tools/DotNet/Reference/List/DotNetReferenceLister.cs
@@ -65,7 +65,16 @@ namespace Cake.Common.Tools.DotNet.Reference.List
             // Project path
             if (!string.IsNullOrWhiteSpace(project))
             {
-                builder.AppendQuoted(project);
+                var projectPath = new FilePath(project);
+                if (settings.WorkingDirectory != null && projectPath.IsRelative)
+                {
+                    projectPath = GetAbsoluteFilePath(projectPath, settings, _environment);
+                    builder.AppendQuoted(projectPath.MakeAbsolute(_environment).FullPath);
+                }
+                else
+                {
+                    builder.AppendQuoted(project);
+                }
             }
 
             builder.Append("reference");


### PR DESCRIPTION
## Summary

Fixes #1917 for `dotnet list reference`.

When `DotNetReferenceListSettings.WorkingDirectory` is set, a relative target project path is now resolved against the working directory instead of being passed through unchanged.

## Changes

- Add shared `GetAbsoluteFilePath` / `GetAbsoluteDirectoryPath` helpers on `DotNetTool` (consistent with other #1917 fixes).
- Use them in `DotNetReferenceLister` for the project path.
- Add unit test `Should_Resolve_Project_Path_Relative_To_WorkingDirectory`.

## Test plan

- [x] Added unit test for WorkingDirectory-relative project path
- [ ] CI (no local .NET SDK in contributor environment; relying on GitHub Actions)


Made with [Cursor](https://cursor.com)