### PR TITLE
fix(DotNetPackageRemove): resolve project path relative to WorkingDirectory

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/DotNet/Package/Remove/DotNetPackageRemoverFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/DotNet/Package/Remove/DotNetPackageRemoverFixture.cs
@@ -15,7 +15,7 @@ namespace Cake.Common.Tests.Fixtures.Tools.DotNet.Package.Remove
         protected override void RunTool()
         {
             var tool = new DotNetPackageRemover(FileSystem, Environment, ProcessRunner, Tools);
-            tool.Remove(PackageName, Project);
+            tool.Remove(PackageName, Project, Settings);
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/DotNet/Package/Remove/DotNetPackageRemoverTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotNet/Package/Remove/DotNetPackageRemoverTests.cs
@@ -59,6 +59,22 @@ namespace Cake.Common.Tests.Unit.Tools.DotNet.Package.Remove
             }
 
             [Fact]
+            public void Should_Resolve_Project_Path_Relative_To_WorkingDirectory()
+            {
+                // Given
+                var fixture = new DotNetPackageRemoverFixture();
+                fixture.PackageName = "Microsoft.AspNetCore.StaticFiles";
+                fixture.Project = "./ToDo.csproj";
+                fixture.Settings.WorkingDirectory = "./source/MyProject";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("remove \"/Working/source/MyProject/ToDo.csproj\" package Microsoft.AspNetCore.StaticFiles", result.Args);
+            }
+
+            [Fact]
             public void Should_Add_Project_Argument()
             {
                 // Given

--- a/src/Cake.Common/Tools/DotNet/DotNetTool.cs
+++ b/src/Cake.Common/Tools/DotNet/DotNetTool.cs
@@ -127,5 +127,46 @@ namespace Cake.Common.Tools.DotNet
 
             return builder;
         }
+        /// <summary>
+        /// Resolves a relative directory path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteDirectoryPath(DirectoryPath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).Combine(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative file path against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static FilePath GetAbsoluteFilePath(FilePath path, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            if (settings.WorkingDirectory != null && path.IsRelative)
+            {
+                return settings.WorkingDirectory.MakeAbsolute(environment).CombineWithFilePath(path);
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves a relative output directory against <see cref="ToolSettings.WorkingDirectory"/> when set.
+        /// </summary>
+        protected static DirectoryPath GetAbsoluteOutputDirectory(DirectoryPath outputDirectory, DotNetSettings settings, ICakeEnvironment environment)
+        {
+            return GetAbsoluteDirectoryPath(outputDirectory, settings, environment);
+        }
     }
 }

--- a/src/Cake.Common/Tools/DotNet/Package/Remove/DotNetPackageRemover.cs
+++ b/src/Cake.Common/Tools/DotNet/Package/Remove/DotNetPackageRemover.cs
@@ -57,7 +57,16 @@ namespace Cake.Common.Tools.DotNet.Package.Remove
             // Project path
             if (project != null)
             {
-                builder.AppendQuoted(project);
+                var projectPath = new FilePath(project);
+                if (settings.WorkingDirectory != null && projectPath.IsRelative)
+                {
+                    projectPath = GetAbsoluteFilePath(projectPath, settings, environment);
+                    builder.AppendQuoted(projectPath.MakeAbsolute(environment).FullPath);
+                }
+                else
+                {
+                    builder.AppendQuoted(project);
+                }
             }
 
             // Package Name


### PR DESCRIPTION
## Summary

Fixes #1917 for `dotnet remove package`.

When `DotNetPackageRemoveSettings.WorkingDirectory` is set, a relative target project path is now resolved against the working directory instead of being passed through unchanged.

## Changes

- Add shared `GetAbsoluteFilePath` / `GetAbsoluteDirectoryPath` helpers on `DotNetTool` (consistent with other #1917 fixes).
- Use them in `DotNetPackageRemover` for the project path.
- Fix `DotNetPackageRemoverFixture` to pass `Settings` to `Remove()` (matches `DotNetPackageAdderFixture`).
- Add unit test `Should_Resolve_Project_Path_Relative_To_WorkingDirectory`.

## Test plan

- [x] Added unit test for WorkingDirectory-relative project path
- [ ] CI (no local .NET SDK in contributor environment; relying on GitHub Actions)


Made with [Cursor](https://cursor.com)