### PR TITLE
GH4865: Update Verify.DiffPlex to 3.2.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -31,7 +31,7 @@
     <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
     <PackageVersion Include="Spectre.Console.Testing" Version="0.55.2" />
     <PackageVersion Include="Spectre.Verify.Extensions" Version="28.16.0" />
-    <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
+    <PackageVersion Include="Verify.DiffPlex" Version="3.2.0" />
     <PackageVersion Include="Verify.XunitV3" Version="31.19.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />


### PR DESCRIPTION
* fixes #4865