### PR TITLE
GH4870: Fix problem with weird border bg color in report table

### DIFF
--- a/src/Cake.Cli/Infrastructure/CakeSpectreReportPrinter.cs
+++ b/src/Cake.Cli/Infrastructure/CakeSpectreReportPrinter.cs
@@ -35,7 +35,7 @@ namespace Cake.Cli
             // Create a table
             var table = new Table().Border(TableBorder.SimpleHeavy);
             table.Width(100);
-            table.BorderStyle(default(Style).Foreground(ConsoleColor.Green));
+            table.BorderStyle(Style.Plain.Foreground(ConsoleColor.Green));
 
             var includeSkippedReasonColumn = report.Any(r => !string.IsNullOrEmpty(r.SkippedMessage));
             var rowStyle = new Style(ConsoleColor.Green);


### PR DESCRIPTION
Fixed a regression where the report table's border background color was incorrectly set to black, breaking rendering in terminals without a #000000 background.