### PR TITLE
GH2102: Fix CopyFiles glob folder structure

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/IO/FileCopierFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/IO/FileCopierFixture.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tests.Fixtures;
@@ -26,7 +26,7 @@ namespace Cake.Common.Tests.Fixtures.IO
         public bool ExistsFile(FilePath path)
         {
             var file = _fileSystem.GetFile(path.MakeAbsolute(Context.Environment));
-            return file != null;
+            return file.Exists;
         }
 
         public FilePath MakeAbsolute(FilePath inputPath)

--- a/src/Cake.Common.Tests/Unit/IO/FileCopierTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/FileCopierTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Cake.Common.IO;
@@ -144,6 +144,32 @@ namespace Cake.Common.Tests.Unit.IO
                 // Then
                 Assert.True(fixture.ExistsFile($"{dstPath}/a/a.txt"));
                 Assert.True(fixture.ExistsFile($"{dstPath}/b/b.txt"));
+            }
+
+            [Fact]
+            public void Should_Copy_Glob_Matches_In_Subdirectory_With_Folder_Structure()
+            {
+                const string dstPath = "./dst";
+
+                // Given
+                var fixture = new FileCopierFixture();
+                fixture.EnsureFileExists("./src/file.txt");
+                fixture.EnsureFileExists("./src/sub/file1.dat");
+                fixture.EnsureFileExists("./src/sub/file2.dat");
+                fixture.EnsureDirectoryExists(dstPath);
+
+                // When
+                FileCopier.CopyFiles(
+                    fixture.Context,
+                    "./src/**/*.dat",
+                    new DirectoryPath(dstPath),
+                    true);
+
+                // Then
+                Assert.True(fixture.ExistsFile($"{dstPath}/sub/file1.dat"));
+                Assert.True(fixture.ExistsFile($"{dstPath}/sub/file2.dat"));
+                Assert.False(fixture.ExistsFile($"{dstPath}/file1.dat"));
+                Assert.False(fixture.ExistsFile($"{dstPath}/file2.dat"));
             }
 
             [Fact]

--- a/src/Cake.Common/IO/FileCopier.cs
+++ b/src/Cake.Common/IO/FileCopier.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -54,10 +54,18 @@ namespace Cake.Common.IO
                 return;
             }
 
-            CopyFiles(context, files, targetDirectoryPath, preserverFolderStructure);
+            var commonPath = preserverFolderStructure
+                ? GetGlobBaseDirectory(context, pattern).FullPath
+                : null;
+            CopyFiles(context, files, targetDirectoryPath, preserverFolderStructure, commonPath);
         }
 
         public static void CopyFiles(ICakeContext context, IEnumerable<FilePath> filePaths, DirectoryPath targetDirectoryPath, bool preserverFolderStructure)
+        {
+            CopyFiles(context, filePaths, targetDirectoryPath, preserverFolderStructure, null);
+        }
+
+        private static void CopyFiles(ICakeContext context, IEnumerable<FilePath> filePaths, DirectoryPath targetDirectoryPath, bool preserverFolderStructure, string commonPath)
         {
             ArgumentNullException.ThrowIfNull(context);
             ArgumentNullException.ThrowIfNull(filePaths);
@@ -78,42 +86,45 @@ namespace Cake.Common.IO
 
             if (preserverFolderStructure)
             {
-                var commonPath = string.Empty;
-                var separatedPath = absoluteFilePaths
-                    .First(str => str.ToString().Length == absoluteFilePaths.Max(st2 => st2.ToString().Length)).ToString()
-                    .Split(new[] { "/" }, StringSplitOptions.RemoveEmptyEntries)
-                    .ToList();
-
-                foreach (string pathSegment in separatedPath)
+                if (commonPath == null)
                 {
-                    if (commonPath.Length == 0 && absoluteFilePaths.All(str => str.ToString().StartsWith(pathSegment)))
-                    {
-                        commonPath = pathSegment;
-                    }
-                    else if (absoluteFilePaths.All(str => str.ToString().StartsWith(commonPath + "/" + pathSegment)))
-                    {
-                        commonPath += "/" + pathSegment;
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }
+                    commonPath = string.Empty;
+                    var separatedPath = absoluteFilePaths
+                        .First(str => str.ToString().Length == absoluteFilePaths.Max(st2 => st2.ToString().Length)).ToString()
+                        .Split(new[] { "/" }, StringSplitOptions.RemoveEmptyEntries)
+                        .ToList();
 
-                if (absoluteFilePaths.Count == 1 && absoluteFilePaths.First().FullPath.Contains(context.Environment.WorkingDirectory.FullPath))
-                {
-                    var relativePath = absoluteFilePaths.First().FullPath.Remove(0, context.Environment.WorkingDirectory.FullPath.Length + 1);
-                    var relativePathParts = relativePath.Split('/').ToList();
-
-                    if (relativePathParts.Count > 2)
+                    foreach (string pathSegment in separatedPath)
                     {
-                        relativePathParts.RemoveAt(0);
-                        var workdirRelativeStructurePath = string.Join("/", relativePathParts.ToArray());
+                        if (commonPath.Length == 0 && absoluteFilePaths.All(str => str.ToString().StartsWith(pathSegment)))
+                        {
+                            commonPath = pathSegment;
+                        }
+                        else if (absoluteFilePaths.All(str => str.ToString().StartsWith(commonPath + "/" + pathSegment)))
+                        {
+                            commonPath += "/" + pathSegment;
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
 
-                        var index = commonPath.IndexOf(workdirRelativeStructurePath, StringComparison.Ordinal);
-                        commonPath = index < 0
-                            ? commonPath
-                            : commonPath.Remove(index, workdirRelativeStructurePath.Length);
+                    if (absoluteFilePaths.Count == 1 && absoluteFilePaths.First().FullPath.Contains(context.Environment.WorkingDirectory.FullPath))
+                    {
+                        var relativePath = absoluteFilePaths.First().FullPath.Remove(0, context.Environment.WorkingDirectory.FullPath.Length + 1);
+                        var relativePathParts = relativePath.Split('/').ToList();
+
+                        if (relativePathParts.Count > 2)
+                        {
+                            relativePathParts.RemoveAt(0);
+                            var workdirRelativeStructurePath = string.Join("/", relativePathParts.ToArray());
+
+                            var index = commonPath.IndexOf(workdirRelativeStructurePath, StringComparison.Ordinal);
+                            commonPath = index < 0
+                                ? commonPath
+                                : commonPath.Remove(index, workdirRelativeStructurePath.Length);
+                        }
                     }
                 }
 
@@ -139,6 +150,27 @@ namespace Cake.Common.IO
             }
         }
 
+        private static DirectoryPath GetGlobBaseDirectory(ICakeContext context, GlobPattern pattern)
+        {
+            var wildcardIndex = pattern.Pattern.IndexOfAny(new[] { '*', '?', '[', '{' });
+            if (wildcardIndex < 0)
+            {
+                return new FilePath(pattern.Pattern).GetDirectory().MakeAbsolute(context.Environment);
+            }
+
+            var prefix = pattern.Pattern.Substring(0, wildcardIndex);
+            var separatorIndex = prefix.LastIndexOfAny(new[] { '/', '\\' });
+            if (separatorIndex < 0)
+            {
+                return context.Environment.WorkingDirectory;
+            }
+
+            var directory = separatorIndex == 0
+                ? prefix.Substring(0, 1)
+                : prefix.Substring(0, separatorIndex);
+            return new DirectoryPath(directory).MakeAbsolute(context.Environment);
+        }
+
         private static void CopyFileCore(ICakeContext context, FilePath filePath, FilePath targetFilePath, string commonPath)
         {
             var absoluteFilePath = filePath.MakeAbsolute(context.Environment);
@@ -159,7 +191,9 @@ namespace Cake.Common.IO
             {
                 // Get the parent folder structure and create it.
                 var newRelativeFolderPath = context.Directory(commonPath).Path.GetRelativePath(filePath.GetDirectory());
-                var newTargetPath = targetFilePath.GetDirectory().Combine(newRelativeFolderPath);
+                var newTargetPath = newRelativeFolderPath.FullPath == "."
+                    ? targetFilePath.GetDirectory()
+                    : targetFilePath.GetDirectory().Combine(newRelativeFolderPath);
                 var newAbsoluteTargetPath = newTargetPath.CombineWithFilePath(filePath.GetFilename());
                 context.Log.Verbose("Copying file {0} to {1}", absoluteFilePath.GetFilename(), newAbsoluteTargetPath);
 


### PR DESCRIPTION
Fixes #2102.

## What changed

`CopyFiles(pattern, target, preserveFolderStructure: true)` now preserves paths relative to the static base directory of the glob pattern instead of inferring the base only from the matched files.

This matters when a pattern such as `./src/**/*.dat` matches multiple files under the same subdirectory. Previously the common path became that subdirectory, so files were copied to `dest/file.dat` instead of `dest/sub/file.dat`.

I also tightened the test fixture's `ExistsFile` helper so it checks `FakeFile.Exists`; `FakeFileSystem.GetFile()` returns a placeholder object for missing files, so `file != null` was not a real existence assertion.

## Verification

- Red before fix: `dotnet test src/Cake.Common.Tests/Cake.Common.Tests.csproj --framework net10.0 --no-restore -v minimal -- --filter-method '*Should_Copy_Glob_Matches_In_Subdirectory_With_Folder_Structure'` failed on the new regression test.
- After fix: same targeted test passed.
- `dotnet test src/Cake.Common.Tests/Cake.Common.Tests.csproj --framework net10.0 --no-build -v minimal -- --filter-class 'Cake.Common.Tests.Unit.IO.FileCopierTests*'` passed: 10 tests.
- `dotnet test src/Cake.Common.Tests/Cake.Common.Tests.csproj --framework net10.0 --no-build -v minimal -- --filter-class 'Cake.Common.Tests.Unit.IO.FileAliasesTests+TheCopyFilesMethod*'` passed: 21 tests.
- `dotnet test src/Cake.Common.Tests/Cake.Common.Tests.csproj --framework net10.0 --no-build -v minimal` passed: 6076 tests.
- `git diff --check` passed.

Local note: this machine currently has the .NET 10 runtime available, so I verified the `net10.0` target locally; CI should cover the full target matrix.