### PR TITLE
Fix task tree output for dependee edges

### DIFF
--- a/src/Cake.Cli.Tests/Unit/TreeScriptHostTests.cs
+++ b/src/Cake.Cli.Tests/Unit/TreeScriptHostTests.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core;
+using Cake.Testing;
+using NSubstitute;
+
+namespace Cake.Cli.Tests.Unit;
+
+public sealed class TreeScriptHostTests
+{
+    public sealed class TheRunTargetAsyncMethod
+    {
+        [Fact]
+        public async Task Should_Show_Dependee_Tasks_In_Dependency_Tree()
+        {
+            // Given
+            var engine = new CakeEngine(Substitute.For<ICakeDataService>(), new FakeLog());
+            var console = new FakeConsole();
+            var host = new TreeScriptHost(engine, Substitute.For<ICakeContext>(), console);
+
+            host.Task("A");
+            host.Task("B").IsDependeeOf("A");
+
+            // When
+            await host.RunTargetAsync("A");
+
+            // Then
+            Assert.Contains("A", console.Messages);
+            Assert.Contains("\u2514\u2500B", console.Messages);
+        }
+    }
+}

--- a/src/Cake.Cli/Hosts/TreeScriptHost.cs
+++ b/src/Cake.Cli/Hosts/TreeScriptHost.cs
@@ -53,20 +53,20 @@ namespace Cake.Cli
 
         private void PrintTaskTree()
         {
-            var topLevelTasks = GetTopLevelTasks();
+            var graph = CakeGraphBuilder.Build(Tasks);
+            var topLevelTasks = GetTopLevelTasks(graph);
             _console.WriteLine();
 
             foreach (ICakeTaskInfo task in topLevelTasks)
             {
-                PrintTask(task, string.Empty, false, 0);
+                PrintTask(task, graph, string.Empty, false, 0);
                 _console.WriteLine();
             }
         }
 
-        private List<ICakeTaskInfo> GetTopLevelTasks()
+        private List<ICakeTaskInfo> GetTopLevelTasks(CakeGraph graph)
         {
             // Display "Default" first, then alphabetical
-            var graph = CakeGraphBuilder.Build(Tasks);
             return Tasks.Where(task => !graph.Edges.Any(
                 edge => edge.Start.Equals(task.Name, StringComparison.OrdinalIgnoreCase)))
                 .OrderByDescending(task => task.Name.Equals("Default", StringComparison.OrdinalIgnoreCase))
@@ -74,7 +74,7 @@ namespace Cake.Cli
                 .ToList();
         }
 
-        private void PrintTask(ICakeTaskInfo task, string indent, bool isLast, int depth)
+        private void PrintTask(ICakeTaskInfo task, CakeGraph graph, string indent, bool isLast, int depth)
         {
             // Builds ASCII graph
             _console.Write(indent);
@@ -96,15 +96,39 @@ namespace Cake.Cli
                 return;
             }
 
-            for (var i = 0; i < task.Dependencies.Count; i++)
+            var dependencies = GetDependencies(task, graph);
+            for (var i = 0; i < dependencies.Count; i++)
             {
-                // First() is safe as CakeGraphBuilder has already validated graph is valid
-                var childTask = Tasks
-                    .Where(x => x.Name.Equals(task.Dependencies[i].Name, StringComparison.OrdinalIgnoreCase))
-                    .First();
-
-                PrintTask(childTask, indent, i == (task.Dependencies.Count - 1), depth + 1);
+                PrintTask(dependencies[i], graph, indent, i == (dependencies.Count - 1), depth + 1);
             }
+        }
+
+        private List<ICakeTaskInfo> GetDependencies(ICakeTaskInfo task, CakeGraph graph)
+        {
+            var dependencies = new List<ICakeTaskInfo>();
+
+            foreach (var dependency in task.Dependencies)
+            {
+                if (graph.Edges.Any(edge =>
+                    edge.Start.Equals(dependency.Name, StringComparison.OrdinalIgnoreCase) &&
+                    edge.End.Equals(task.Name, StringComparison.OrdinalIgnoreCase)))
+                {
+                    dependencies.Add(Tasks.First(x =>
+                        x.Name.Equals(dependency.Name, StringComparison.OrdinalIgnoreCase)));
+                }
+            }
+
+            foreach (var edge in graph.Edges.Where(edge =>
+                edge.End.Equals(task.Name, StringComparison.OrdinalIgnoreCase)))
+            {
+                if (!dependencies.Any(dependency => dependency.Name.Equals(edge.Start, StringComparison.OrdinalIgnoreCase)))
+                {
+                    dependencies.Add(Tasks.First(x =>
+                        x.Name.Equals(edge.Start, StringComparison.OrdinalIgnoreCase)));
+                }
+            }
+
+            return dependencies;
         }
 
         private void PrintName(ICakeTaskInfo task, int depth)


### PR DESCRIPTION
## Summary
- build the task tree from Cake's normalized dependency graph instead of only `ICakeTaskInfo.Dependencies`
- preserve the existing explicit dependency order, then append dependency edges contributed by `IsDependeeOf`
- add a CLI regression test proving a task declared with `IsDependeeOf` is shown under its depender in `--tree`

Fixes cake-build/cake#4474.

## Tests
- `dotnet test src\Cake.Cli.Tests\Cake.Cli.Tests.csproj --framework net10.0 -- --filter-class "Cake.Cli.Tests.Unit.TreeScriptHostTests+TheRunTargetAsyncMethod"`
- `dotnet test src\Cake.Cli.Tests\Cake.Cli.Tests.csproj --framework net10.0`
- `dotnet test src\Cake.Tests\Cake.Tests.csproj --framework net10.0 -- --filter-class "Cake.Tests.Unit.ProgramTests"`
- `git diff --check`

---
Written by an agent (OpenAI Codex, GPT-5).