### PR TITLE
Fix timed process waits killing running processes

### DIFF
--- a/src/Cake.Common.Tests/Unit/ProcessAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/ProcessAliasesTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Cake.Common.Tests.Fixtures;
 using Cake.Core;
 using Cake.Core.IO;
@@ -228,6 +229,27 @@ namespace Cake.Common.Tests.Unit
 
                     // Then
                     Assert.Equal(12, result);
+                }
+
+                [Fact]
+                public void Should_Kill_Process_And_Throw_If_Timeout_Expires()
+                {
+                    // Given
+                    var fixture = new ProcessFixture();
+                    const string fileName = "hello.exe";
+                    var settings = new ProcessSettings
+                    {
+                        Timeout = 1
+                    };
+
+                    fixture.Process.WaitForExit(settings.Timeout.Value).Returns(false);
+
+                    // When
+                    var result = Record.Exception(() => fixture.Start(fileName, settings));
+
+                    // Then
+                    Assert.IsType<TimeoutException>(result);
+                    fixture.Process.Received(1).Kill();
                 }
             }
 

--- a/src/Cake.Common/ProcessAliases.cs
+++ b/src/Cake.Common/ProcessAliases.cs
@@ -110,23 +110,7 @@ namespace Cake.Common
         {
             var process = StartAndReturnProcess(context, fileName, settings);
 
-            // Wait for the process to stop.
-            if (settings.Timeout.HasValue)
-            {
-                if (!process.WaitForExit(settings.Timeout.Value))
-                {
-                    throw new TimeoutException(
-                        string.Format(
-                            CultureInfo.InvariantCulture,
-                            "Process TimeOut ({0}): {1}",
-                            settings.Timeout.Value,
-                            fileName));
-                }
-            }
-            else
-            {
-                process.WaitForExit();
-            }
+            WaitForExit(process, fileName, settings);
 
             redirectedStandardOutput = settings.RedirectStandardOutput
                 ? process.GetStandardOutput()
@@ -189,23 +173,7 @@ namespace Cake.Common
         {
             var process = StartAndReturnProcess(context, fileName, settings);
 
-            // Wait for the process to stop.
-            if (settings.Timeout.HasValue)
-            {
-                if (!process.WaitForExit(settings.Timeout.Value))
-                {
-                    throw new TimeoutException(
-                        string.Format(
-                            CultureInfo.InvariantCulture,
-                            "Process TimeOut ({0}): {1}",
-                            settings.Timeout.Value,
-                            fileName));
-                }
-            }
-            else
-            {
-                process.WaitForExit();
-            }
+            WaitForExit(process, fileName, settings);
 
             redirectedStandardOutput = settings.RedirectStandardOutput
                 ? process.GetStandardOutput()
@@ -282,6 +250,28 @@ namespace Cake.Common
         public static IProcess StartAndReturnProcess(this ICakeContext context, FilePath fileName)
         {
             return StartAndReturnProcess(context, fileName, new ProcessSettings());
+        }
+
+        private static void WaitForExit(IProcess process, FilePath fileName, ProcessSettings settings)
+        {
+            if (!settings.Timeout.HasValue)
+            {
+                process.WaitForExit();
+                return;
+            }
+
+            if (process.WaitForExit(settings.Timeout.Value))
+            {
+                return;
+            }
+
+            process.Kill();
+            throw new TimeoutException(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Process TimeOut ({0}): {1}",
+                    settings.Timeout.Value,
+                    fileName));
         }
     }
 }

--- a/src/Cake.Core.Tests/Unit/IO/ProcessWrapperTests.cs
+++ b/src/Cake.Core.Tests/Unit/IO/ProcessWrapperTests.cs
@@ -9,6 +9,35 @@ namespace Cake.Core.Tests.Unit.IO
 {
     public sealed class ProcessWrapperTests
     {
+        public sealed class The_WaitForExit_Method
+        {
+            [Fact]
+            public void Should_Not_Kill_Process_If_Timed_Wait_Expires()
+            {
+                // Given
+                var fixture = new ProcessWrapperFixture
+                {
+                    Process = StartLongRunningProcess()
+                };
+                var wrapper = fixture.CreateProcessWrapper();
+
+                try
+                {
+                    // When
+                    var result = wrapper.WaitForExit(1);
+
+                    // Then
+                    fixture.Process.Refresh();
+                    Assert.False(result);
+                    Assert.False(fixture.Process.HasExited);
+                }
+                finally
+                {
+                    StopProcess(fixture.Process);
+                }
+            }
+        }
+
         public sealed class The_StandardOutputReceived_Method
         {
             [Fact]
@@ -45,6 +74,29 @@ namespace Cake.Core.Tests.Unit.IO
                 // Then
                 Assert.Equal("message", receivedMessage);
             }
+        }
+
+        private static Process StartLongRunningProcess()
+        {
+            var startInfo = System.OperatingSystem.IsWindows()
+                ? new ProcessStartInfo("powershell.exe", "-NoProfile -Command Start-Sleep -Seconds 30")
+                : new ProcessStartInfo("/bin/sleep", "30");
+
+            startInfo.CreateNoWindow = true;
+            startInfo.UseShellExecute = false;
+
+            return Process.Start(startInfo);
+        }
+
+        private static void StopProcess(Process process)
+        {
+            if (process.HasExited)
+            {
+                return;
+            }
+
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit(5000);
         }
     }
 }

--- a/src/Cake.Core/IO/IProcess.cs
+++ b/src/Cake.Core/IO/IProcess.cs
@@ -18,7 +18,7 @@ namespace Cake.Core.IO
         void WaitForExit();
 
         /// <summary>
-        /// Waits for the process to exit with possible timeout for command.
+        /// Waits for the process to exit.
         /// </summary>
         /// <param name="milliseconds">The amount of time, in milliseconds, to wait for the associated process to exit. The maximum is the largest possible value of a 32-bit integer, which represents infinity to the operating system.</param>
         /// <returns>true if the associated process has exited; otherwise, false.</returns>

--- a/src/Cake.Core/IO/ProcessSettings.cs
+++ b/src/Cake.Core/IO/ProcessSettings.cs
@@ -53,7 +53,7 @@ namespace Cake.Core.IO
         public Func<string, string> RedirectedStandardOutputHandler { get; set; }
 
         /// <summary>
-        /// Gets or sets optional timeout, in milliseconds, to wait for the associated process to exit. The maximum is the largest possible value of a 32-bit integer, which represents infinity to the operating system.
+        /// Gets or sets optional timeout, in milliseconds, to wait for the associated process to exit before the process is stopped. The maximum is the largest possible value of a 32-bit integer, which represents infinity to the operating system.
         /// </summary>
         public int? Timeout { get; set; }
 

--- a/src/Cake.Core/IO/ProcessWrapper.cs
+++ b/src/Cake.Core/IO/ProcessWrapper.cs
@@ -41,16 +41,7 @@ namespace Cake.Core.IO
 
         public bool WaitForExit(int milliseconds)
         {
-            if (_process.WaitForExit(milliseconds))
-            {
-                return true;
-            }
-            _process.Refresh();
-            if (!_process.HasExited)
-            {
-                _process.Kill();
-            }
-            return false;
+            return _process.WaitForExit(milliseconds);
         }
 
         public int GetExitCode()
@@ -108,7 +99,11 @@ namespace Cake.Core.IO
 
         public void Kill()
         {
-            _process.Kill();
+            _process.Refresh();
+            if (!_process.HasExited)
+            {
+                _process.Kill();
+            }
             _process.WaitForExit();
         }
 


### PR DESCRIPTION
## Summary

- Make `ProcessWrapper.WaitForExit(int)` observe the process exit state without killing the process when the timed wait expires.
- Keep `StartProcess(..., ProcessSettings.Timeout)` timeout behavior by explicitly calling `Kill()` before throwing `TimeoutException`.
- Update the `IProcess`/`ProcessSettings` docs and add regression coverage for both contracts.

## Validation

- Red regression before fix: `Cake.Core.Tests.Unit.IO.ProcessWrapperTests+The_WaitForExit_Method.Should_Not_Kill_Process_If_Timed_Wait_Expires` failed because the process was killed.
- `C:\hades\.dotnet-10.0.300\dotnet.exe test src\Cake.Core.Tests\Cake.Core.Tests.csproj --framework net10.0 -- --filter-class "Cake.Core.Tests.Unit.IO.ProcessWrapperTests+The_WaitForExit_Method"`
- `C:\hades\.dotnet-10.0.300\dotnet.exe test src\Cake.Common.Tests\Cake.Common.Tests.csproj --framework net10.0 -- --filter-class "Cake.Common.Tests.Unit.ProcessAliasesTests+TheStartProcessMethod+WithSettings"`
- `C:\hades\.dotnet-10.0.300\dotnet.exe test src\Cake.Core.Tests\Cake.Core.Tests.csproj --framework net10.0` passed: 1845 passed, 4 skipped.
- `C:\hades\.dotnet-10.0.300\dotnet.exe test src\Cake.Common.Tests\Cake.Common.Tests.csproj --framework net10.0` passed: 6076 passed.
- `C:\hades\.dotnet-10.0.300\dotnet.exe build src\Cake.Core\Cake.Core.csproj --configuration Release`
- `C:\hades\.dotnet-10.0.300\dotnet.exe build src\Cake.Common\Cake.Common.csproj --configuration Release`
- `git diff --check HEAD~1 HEAD`

Fixes #4321

---

AI-assisted contribution disclosure: I used Codex to inspect the issue, implement the patch, and run the validation above. I reviewed the code and test results before submitting.