### PR TITLE
Fix CleanDirectory handling of directory symlinks

### DIFF
--- a/src/Cake.Common.Tests/Unit/IO/DirectoryAliasesTests.cs
+++ b/src/Cake.Common.Tests/Unit/IO/DirectoryAliasesTests.cs
@@ -146,6 +146,40 @@ namespace Cake.Common.Tests.Unit.IO
                 Assert.Empty(fixture.FileSystem.GetDirectory(directory).GetDirectories("*", SearchScope.Recursive));
             }
 
+            [NonWindowsFact("Requires directory symbolic link support.")]
+            public void Should_Delete_Directory_Symlinks_Without_Cleaning_Target()
+            {
+                // Given
+                var root = System.IO.Directory.CreateTempSubdirectory("cake-clean-symlink-");
+                var cleanDirectoryPath = System.IO.Path.Combine(root.FullName, "clean");
+                var targetDirectoryPath = System.IO.Path.Combine(root.FullName, "target");
+                var linkPath = System.IO.Path.Combine(cleanDirectoryPath, "Current");
+                var targetFilePath = System.IO.Path.Combine(targetDirectoryPath, "payload.txt");
+
+                try
+                {
+                    System.IO.Directory.CreateDirectory(cleanDirectoryPath);
+                    System.IO.Directory.CreateDirectory(targetDirectoryPath);
+                    System.IO.File.WriteAllText(targetFilePath, "keep");
+                    System.IO.Directory.CreateSymbolicLink(linkPath, targetDirectoryPath);
+
+                    var context = Substitute.For<ICakeContext>();
+                    context.FileSystem.Returns(new Cake.Core.IO.FileSystem());
+
+                    // When
+                    DirectoryAliases.CleanDirectory(context, new DirectoryPath(cleanDirectoryPath));
+
+                    // Then
+                    Assert.True(System.IO.Directory.Exists(cleanDirectoryPath));
+                    Assert.False(System.IO.Directory.Exists(linkPath));
+                    Assert.True(System.IO.File.Exists(targetFilePath));
+                }
+                finally
+                {
+                    root.Delete(true);
+                }
+            }
+
             [Fact]
             public void Should_Throw_When_Deleting_Readonly_Files_In_Provided_Directory_If_Not_Forced()
             {

--- a/src/Cake.Core/IO/Directory.cs
+++ b/src/Cake.Core/IO/Directory.cs
@@ -53,6 +53,11 @@ namespace Cake.Core.IO
 
         public IEnumerable<IDirectory> GetDirectories(string filter, SearchScope scope)
         {
+            if (IsReparsePoint())
+            {
+                return Enumerable.Empty<IDirectory>();
+            }
+
             var option = scope == SearchScope.Current ? SearchOption.TopDirectoryOnly : SearchOption.AllDirectories;
             return _directory.EnumerateDirectories(filter, option)
                 .Select(directory => new Directory(directory.FullName));
@@ -60,9 +65,19 @@ namespace Cake.Core.IO
 
         public IEnumerable<IFile> GetFiles(string filter, SearchScope scope)
         {
+            if (IsReparsePoint())
+            {
+                return Enumerable.Empty<IFile>();
+            }
+
             var option = scope == SearchScope.Current ? SearchOption.TopDirectoryOnly : SearchOption.AllDirectories;
             return _directory.EnumerateFiles(filter, option)
                 .Select(file => new File(file.FullName));
+        }
+
+        private bool IsReparsePoint()
+        {
+            return (_directory.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Fixes #2135.

## Summary
- Treat physical directory reparse points as leaf entries when enumerating children.
- This lets `CleanDirectory` remove a directory symlink itself instead of recursively cleaning the symlink target.
- Add a non-Windows regression test that verifies the symlink is removed while the target payload is preserved.

## Verification
- `src\Cake.Common.Tests\bin\Debug\net10.0\Cake.Common.Tests.exe -class "Cake.Common.Tests.Unit.IO.DirectoryAliasesTests+TheCleanMethod" -noLogo -noColor`
- `src\Cake.Common.Tests\bin\Debug\net10.0\Cake.Common.Tests.exe -class "Cake.Common.Tests.Unit.IO.DirectoryAliasesTests*" -noLogo -noColor`
- `dotnet build src\Cake.Core\Cake.Core.csproj -f net10.0 --no-restore`
- `dotnet build src\Cake.Common.Tests\Cake.Common.Tests.csproj -f net10.0 --no-restore`
- `git diff --check`

Notes: the new symlink regression is marked `NonWindowsFact` because this Windows workstation requires elevated privileges for directory symlink creation. The direct net8/net9 local test targets could not run here because the x64 .NET 8/9 runtimes are not installed; net10 build/test coverage passed.

Disclosure: this pull request was prepared with AI assistance and reviewed/tested locally before submission.