### PR TITLE
GH2965: Fix duplicate missing load warnings during bootstrap

### DIFF
--- a/src/Cake.Core.Tests/Fixtures/ScriptAnalyzerFixture.cs
+++ b/src/Cake.Core.Tests/Fixtures/ScriptAnalyzerFixture.cs
@@ -46,6 +46,11 @@ namespace Cake.Core.Tests.Fixtures
             return CreateAnalyzer().Analyze(script, new ScriptAnalyzerSettings());
         }
 
+        public ScriptAnalyzerResult AnalyzeModules(FilePath script)
+        {
+            return CreateAnalyzer().Analyze(script, new ScriptAnalyzerSettings { Mode = ScriptAnalyzerMode.Modules });
+        }
+
         public void GivenScriptExist(FilePath path, string content)
         {
             FileSystem.CreateFile(path).SetContent(content);

--- a/src/Cake.Core.Tests/Unit/Scripting/Analysis/ScriptAnalyzerTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/Analysis/ScriptAnalyzerTests.cs
@@ -3,8 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
+using Cake.Core.Diagnostics;
 using Cake.Core.Scripting.Processors.Loading;
 using Cake.Core.Tests.Fixtures;
+using Cake.Testing;
 using Xunit;
 
 namespace Cake.Core.Tests.Unit.Scripting.Analysis
@@ -368,6 +370,57 @@ namespace Cake.Core.Tests.Unit.Scripting.Analysis
                 Assert.Equal("/Working/script2.cake", result.Errors[0].File.FullPath);
                 Assert.Equal(2, result.Errors[0].Line);
                 Assert.Equal("Query string for #load contains more than one parameter 'path'.", result.Errors[0].Message);
+            }
+
+            [Fact]
+            public void Should_Not_Log_Missing_Load_Warning_In_Modules_Mode()
+            {
+                // Given
+                var log = new FakeLog();
+                var fixture = new ScriptAnalyzerFixture { Log = log };
+                fixture.AddFileLoadDirectiveProvider();
+                fixture.GivenScriptExist("/Working/script.cake", "#load \"optional.cake\"");
+
+                // When
+                fixture.AnalyzeModules("/Working/script.cake");
+
+                // Then
+                Assert.DoesNotContain(log.Entries, entry => entry.Level == LogLevel.Warning);
+            }
+
+            [Fact]
+            public void Should_Log_Missing_Load_Warning_In_Default_Mode()
+            {
+                // Given
+                var log = new FakeLog();
+                var fixture = new ScriptAnalyzerFixture { Log = log };
+                fixture.AddFileLoadDirectiveProvider();
+                fixture.GivenScriptExist("/Working/script.cake", "#load \"optional.cake\"");
+
+                // When
+                fixture.Analyze("/Working/script.cake");
+
+                // Then
+                Assert.Contains(log.Entries, entry =>
+                    entry.Level == LogLevel.Warning &&
+                    entry.Message == "No scripts found at /Working/optional.cake.");
+            }
+
+            [Fact]
+            public void Should_Process_Modules_From_Loaded_Scripts_In_Modules_Mode()
+            {
+                // Given
+                var fixture = new ScriptAnalyzerFixture();
+                fixture.AddFileLoadDirectiveProvider();
+                fixture.GivenScriptExist("/Working/script.cake", "#load \"modules.cake\"");
+                fixture.GivenScriptExist("/Working/modules.cake", "#module \"nuget:?package=Cake.Module\"");
+
+                // When
+                var result = fixture.AnalyzeModules("/Working/script.cake");
+
+                // Then
+                Assert.Single(result.Modules);
+                Assert.Equal("nuget:?package=Cake.Module", result.Modules.Single().OriginalString);
             }
 
             [Fact]

--- a/src/Cake.Core/Scripting/Analysis/ScriptAnalyzer.cs
+++ b/src/Cake.Core/Scripting/Analysis/ScriptAnalyzer.cs
@@ -83,7 +83,7 @@ namespace Cake.Core.Scripting.Analysis
             // Create a new context.
             var context = new ScriptAnalyzerContext(
                 _fileSystem, _environment,
-                _log, callback, path);
+                _log, callback, path, settings.Mode);
 
             // Analyze the script.
             context.Analyze(path);
@@ -104,7 +104,7 @@ namespace Cake.Core.Scripting.Analysis
             var lines = ReadLines(context.Current.Path);
             foreach (var line in lines)
             {
-                foreach (var processor in _defaultProcessors)
+                foreach (var processor in _moduleProcessors)
                 {
                     if (processor.Process(context, _environment.ExpandEnvironmentVariables(line), out var _))
                     {

--- a/src/Cake.Core/Scripting/Analysis/ScriptAnalyzerContext.cs
+++ b/src/Cake.Core/Scripting/Analysis/ScriptAnalyzerContext.cs
@@ -28,6 +28,8 @@ namespace Cake.Core.Scripting.Analysis
 
         public IScriptInformation Current => _current;
 
+        public ScriptAnalyzerMode Mode { get; }
+
         public IReadOnlyList<string> Lines => _lines;
 
         public IReadOnlyList<ScriptAnalyzerError> Errors => _errors;
@@ -37,13 +39,15 @@ namespace Cake.Core.Scripting.Analysis
             ICakeEnvironment environment,
             ICakeLog log,
             Action<IScriptAnalyzerContext> callback,
-            FilePath script)
+            FilePath script,
+            ScriptAnalyzerMode mode)
         {
             _fileSystem = fileSystem;
             _environment = environment;
             _log = log;
             _callback = callback;
             _script = script.MakeAbsolute(_environment);
+            Mode = mode;
             _processedScripts = new HashSet<FilePath>(new PathComparer(_environment));
             _stack = new Stack<ScriptInformation>();
             _lines = new List<string>();

--- a/src/Cake.Core/Scripting/Processors/Loading/FileLoadDirectiveProvider.cs
+++ b/src/Cake.Core/Scripting/Processors/Loading/FileLoadDirectiveProvider.cs
@@ -67,7 +67,11 @@ namespace Cake.Core.Scripting.Processors.Loading
             if (files.Length == 0)
             {
                 // No scripts found.
-                _log.Warning("No scripts found at {0}.", path);
+                if (context is not ScriptAnalyzerContext { Mode: ScriptAnalyzerMode.Modules })
+                {
+                    _log.Warning("No scripts found at {0}.", path);
+                }
+
                 return;
             }
 


### PR DESCRIPTION
Fixes #2965.

## Summary
- Use the module-only processor set during bootstrap analysis instead of the full script processor set.
- Carry the analyzer mode through the internal analyzer context so missing optional `#load` warnings are suppressed only during module discovery.
- Keep the normal build analysis warning intact, so users still see one `No scripts found...` warning for a missing optional load.
- Preserve bootstrap discovery of `#module` directives inside existing loaded scripts.

## Verification
- Red check before fix: `Should_Not_Log_Missing_Load_Warning_In_Modules_Mode` failed because module analysis logged `No scripts found at /Working/optional.cake.`
- `dotnet test src\Cake.Core.Tests\Cake.Core.Tests.csproj --framework net10.0 --no-restore -- --filter-method "Cake.Core.Tests.Unit.Scripting.Analysis.ScriptAnalyzerTests+TheProcessMethod.Should_Not_Log_Missing_Load_Warning_In_Modules_Mode"`
- `dotnet test src\Cake.Core.Tests\Cake.Core.Tests.csproj --framework net10.0 --no-restore -- --filter-class "Cake.Core.Tests.Unit.Scripting.Analysis.ScriptAnalyzerTests*"`
- `dotnet test src\Cake.Core.Tests\Cake.Core.Tests.csproj --framework net10.0 --no-restore`
- `dotnet build src\Cake.Core\Cake.Core.csproj --no-restore`
- `dotnet build src\Cake\Cake.csproj -f net10.0`
- End-to-end smoke with the built `Cake.dll`: temporary script containing `#load "optional.cake"` plus a `Default` task exited 0 and emitted `No scripts found at ...optional.cake.` exactly once.
- `git diff --check` and `git diff --cached --check`

Disclosure: this pull request was prepared with AI assistance and reviewed/tested locally before submission.