### PR TITLE
GH4880: Update .NET SDK to 10.0.301

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -84,9 +84,9 @@ if ($IsMacOS -or $IsLinux) {
         Write-Host "Installing .NET 9.0 SDK..."
         & bash $ScriptPath --channel 9.0 --install-dir "$InstallPath" --no-path --skip-non-versioned-files
         
-        # Install .NET 10.0 SDK (preview quality)
-        Write-Host "Installing .NET 10.0 SDK (preview)..."
-        & bash $ScriptPath --channel 10.0 --quality preview --install-dir "$InstallPath" --no-path --skip-non-versioned-files
+        # Future Install .NET 11.0 SDK (preview quality)
+        # Write-Host "Installing .NET 11.0 SDK (preview)..."
+        # & bash $ScriptPath --channel 11.0 --quality preview --install-dir "$InstallPath" --no-path --skip-non-versioned-files
     }
     
     # Install SDK from global.json

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
         "src"
     ],
     "sdk": {
-        "version": "10.0.300",
+        "version": "10.0.301",
         "rollForward": "latestFeature"
     },
     "test": {


### PR DESCRIPTION
* Update .NET SDK to 10.0.301
* Skip installing .NET 10 preview (resume when  .NET 11 work starts)
* fixes #4880