### PR TITLE
GH4882: Update Microsoft.Extensions.DependencyInjection to 9.0.17 (net9.0) & 10.0.9 (net10.0)

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -42,12 +42,12 @@
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.3" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <!-- Pin nuget transitive packages vulnerability issues NuGet.Packaging -->
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.8" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.17" />
     <!-- Pin nuget transitive packages vulnerability issues NuGet.Packaging -->
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.16" />
   </ItemGroup>


### PR DESCRIPTION
* fixes #4882
