### PR TITLE
GH4891: Add missing GitHub Actions environment variables and XML documentation

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Build/GitHubActionsInfoFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Build/GitHubActionsInfoFixture.cs
@@ -33,10 +33,14 @@ namespace Cake.Common.Tests.Fixtures.Build
             Environment.GetEnvironmentVariable("ImageOS").Returns("ubuntu20");
             Environment.GetEnvironmentVariable("ImageVersion").Returns("20211209.3");
             Environment.GetEnvironmentVariable("RUNNER_USER").Returns("runner");
+            Environment.GetEnvironmentVariable("RUNNER_DEBUG").Returns("1");
+            Environment.GetEnvironmentVariable("RUNNER_ENVIRONMENT").Returns("github-hosted");
 
             Environment.GetEnvironmentVariable("GITHUB_ACTION").Returns("run1");
             Environment.GetEnvironmentVariable("GITHUB_ACTION_PATH").Returns("/path/to/action");
+            Environment.GetEnvironmentVariable("GITHUB_ACTION_REPOSITORY").Returns("actions/checkout");
             Environment.GetEnvironmentVariable("GITHUB_ACTOR").Returns("dependabot");
+            Environment.GetEnvironmentVariable("GITHUB_ACTOR_ID").Returns("1234567");
             Environment.GetEnvironmentVariable("GITHUB_API_URL").Returns("https://api.github.com");
             Environment.GetEnvironmentVariable("GITHUB_BASE_REF").Returns("master");
             Environment.GetEnvironmentVariable("GITHUB_EVENT_NAME").Returns("pull_request");
@@ -46,12 +50,18 @@ namespace Cake.Common.Tests.Fixtures.Build
             Environment.GetEnvironmentVariable("GITHUB_JOB").Returns("job");
             Environment.GetEnvironmentVariable("GITHUB_REF").Returns("refs/pull/1/merge");
             Environment.GetEnvironmentVariable("GITHUB_REPOSITORY").Returns("cake-build/cake");
+            Environment.GetEnvironmentVariable("GITHUB_REPOSITORY_ID").Returns("123456789");
             Environment.GetEnvironmentVariable("GITHUB_REPOSITORY_OWNER").Returns("cake-build");
+            Environment.GetEnvironmentVariable("GITHUB_REPOSITORY_OWNER_ID").Returns("9876543");
+            Environment.GetEnvironmentVariable("GITHUB_RETENTION_DAYS").Returns("90");
             Environment.GetEnvironmentVariable("GITHUB_RUN_ID").Returns("34058136");
             Environment.GetEnvironmentVariable("GITHUB_RUN_NUMBER").Returns("60");
             Environment.GetEnvironmentVariable("GITHUB_SERVER_URL").Returns("https://github.com");
             Environment.GetEnvironmentVariable("GITHUB_SHA").Returns("d1e4f990f57349334368c8253382abc63be02d73");
+            Environment.GetEnvironmentVariable("GITHUB_TRIGGERING_ACTOR").Returns("octocat");
             Environment.GetEnvironmentVariable("GITHUB_WORKFLOW").Returns("Build");
+            Environment.GetEnvironmentVariable("GITHUB_WORKFLOW_REF").Returns("cake-build/cake/.github/workflows/build.yml@refs/heads/main");
+            Environment.GetEnvironmentVariable("GITHUB_WORKFLOW_SHA").Returns("a1b2c3d4e5f6789012345678901234567890abcd");
             Environment.GetEnvironmentVariable("GITHUB_WORKSPACE").Returns("/home/runner/work/cake/cake");
             Environment.GetEnvironmentVariable("GITHUB_RUN_ATTEMPT").Returns("2");
             Environment.GetEnvironmentVariable("GITHUB_REF_PROTECTED").Returns("true");
@@ -70,9 +80,11 @@ namespace Cake.Common.Tests.Fixtures.Build
             Environment.Runtime.CakeVersion.Returns(CakeTestVersion);
         }
 
-        public GitHubActionsRunnerInfo CreateRunnerInfo(string architecture = null)
+        public GitHubActionsRunnerInfo CreateRunnerInfo(string architecture = null, string debug = "1", string environment = "github-hosted")
         {
             Environment.GetEnvironmentVariable("RUNNER_ARCH").Returns(architecture);
+            Environment.GetEnvironmentVariable("RUNNER_DEBUG").Returns(debug);
+            Environment.GetEnvironmentVariable("RUNNER_ENVIRONMENT").Returns(environment);
             return new GitHubActionsRunnerInfo(Environment);
         }
 

--- a/src/Cake.Common.Tests/Unit/Build/GitHubActions/Data/GitHubActionsRunnerInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/GitHubActions/Data/GitHubActionsRunnerInfoTests.cs
@@ -159,5 +159,43 @@ namespace Cake.Common.Tests.Unit.Build.GitHubActions.Data
                 Assert.Equal(expected, result);
             }
         }
+
+        public sealed class TheIsDebugProperty
+        {
+            [Theory]
+            [InlineData("1", true)]
+            [InlineData("", false)]
+            [InlineData("true", false)]
+            public void Should_Return_Correct_Value(string value, bool expected)
+            {
+                // Given
+                var info = new GitHubActionsInfoFixture().CreateRunnerInfo(debug: value);
+
+                // When
+                var result = info.IsDebug;
+
+                // Then
+                Assert.Equal(expected, result);
+            }
+        }
+
+        public sealed class TheEnvironmentProperty
+        {
+            [Theory]
+            [InlineData("github-hosted", GitHubActionsRunnerEnvironment.GitHubHosted)]
+            [InlineData("self-hosted", GitHubActionsRunnerEnvironment.SelfHosted)]
+            [InlineData("", GitHubActionsRunnerEnvironment.Unknown)]
+            public void Should_Return_Correct_Value(string value, GitHubActionsRunnerEnvironment expected)
+            {
+                // Given
+                var info = new GitHubActionsInfoFixture().CreateRunnerInfo(environment: value);
+
+                // When
+                var result = info.Environment;
+
+                // Then
+                Assert.Equal(expected, result);
+            }
+        }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Build/GitHubActions/Data/GitHubActionsWorkflowInfoTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/GitHubActions/Data/GitHubActionsWorkflowInfoTests.cs
@@ -42,6 +42,22 @@ namespace Cake.Common.Tests.Unit.Build.GitHubActions.Data
             }
         }
 
+        public sealed class TheActionRepositoryProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitHubActionsInfoFixture().CreateWorkflowInfo();
+
+                // When
+                var result = info.ActionRepository;
+
+                // Then
+                Assert.Equal("actions/checkout", result);
+            }
+        }
+
         public sealed class TheActorProperty
         {
             [Fact]
@@ -55,6 +71,22 @@ namespace Cake.Common.Tests.Unit.Build.GitHubActions.Data
 
                 // Then
                 Assert.Equal("dependabot", result);
+            }
+        }
+
+        public sealed class TheActorIdProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitHubActionsInfoFixture().CreateWorkflowInfo();
+
+                // When
+                var result = info.ActorId;
+
+                // Then
+                Assert.Equal("1234567", result);
             }
         }
 
@@ -202,6 +234,22 @@ namespace Cake.Common.Tests.Unit.Build.GitHubActions.Data
             }
         }
 
+        public sealed class TheRepositoryIdProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitHubActionsInfoFixture().CreateWorkflowInfo();
+
+                // When
+                var result = info.RepositoryId;
+
+                // Then
+                Assert.Equal("123456789", result);
+            }
+        }
+
         public sealed class TheRepositoryOwnerProperty
         {
             [Fact]
@@ -215,6 +263,38 @@ namespace Cake.Common.Tests.Unit.Build.GitHubActions.Data
 
                 // Then
                 Assert.Equal("cake-build", result);
+            }
+        }
+
+        public sealed class TheRepositoryOwnerIdProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitHubActionsInfoFixture().CreateWorkflowInfo();
+
+                // When
+                var result = info.RepositoryOwnerId;
+
+                // Then
+                Assert.Equal("9876543", result);
+            }
+        }
+
+        public sealed class TheRetentionDaysProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitHubActionsInfoFixture().CreateWorkflowInfo();
+
+                // When
+                var result = info.RetentionDays;
+
+                // Then
+                Assert.Equal(90, result);
             }
         }
 
@@ -282,6 +362,22 @@ namespace Cake.Common.Tests.Unit.Build.GitHubActions.Data
             }
         }
 
+        public sealed class TheTriggeringActorProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitHubActionsInfoFixture().CreateWorkflowInfo();
+
+                // When
+                var result = info.TriggeringActor;
+
+                // Then
+                Assert.Equal("octocat", result);
+            }
+        }
+
         public sealed class TheWorkflowProperty
         {
             [Fact]
@@ -295,6 +391,38 @@ namespace Cake.Common.Tests.Unit.Build.GitHubActions.Data
 
                 // Then
                 Assert.Equal("Build", result);
+            }
+        }
+
+        public sealed class TheWorkflowRefProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitHubActionsInfoFixture().CreateWorkflowInfo();
+
+                // When
+                var result = info.WorkflowRef;
+
+                // Then
+                Assert.Equal("cake-build/cake/.github/workflows/build.yml@refs/heads/main", result);
+            }
+        }
+
+        public sealed class TheWorkflowShaProperty
+        {
+            [Fact]
+            public void Should_Return_Correct_Value()
+            {
+                // Given
+                var info = new GitHubActionsInfoFixture().CreateWorkflowInfo();
+
+                // When
+                var result = info.WorkflowSha;
+
+                // Then
+                Assert.Equal("a1b2c3d4e5f6789012345678901234567890abcd", result);
             }
         }
 

--- a/src/Cake.Common/Build/GitHubActions/Commands/GitHubActionsCommands.cs
+++ b/src/Cake.Common/Build/GitHubActions/Commands/GitHubActionsCommands.cs
@@ -54,6 +54,14 @@ namespace Cake.Common.Build.GitHubActions.Commands
         /// Write debug message to the build log.
         /// </summary>
         /// <param name="message">The message.</param>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     GitHubActions.Commands.Debug("This is a debug message");
+        /// }
+        /// </code>
+        /// </example>
         public void Debug(string message)
         {
             WriteCommand("debug", message);
@@ -64,6 +72,14 @@ namespace Cake.Common.Build.GitHubActions.Commands
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="annotation">The annotation.</param>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     GitHubActions.Commands.Notice("This is a notice message");
+        /// }
+        /// </code>
+        /// </example>
         public void Notice(string message, GitHubActionsAnnotation annotation = null)
         {
             WriteCommand("notice", annotation?.GetParameters(), message);
@@ -74,6 +90,14 @@ namespace Cake.Common.Build.GitHubActions.Commands
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="annotation">The annotation.</param>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     GitHubActions.Commands.Warning("This is a warning message");
+        /// }
+        /// </code>
+        /// </example>
         public void Warning(string message, GitHubActionsAnnotation annotation = null)
         {
             WriteCommand("warning", annotation?.GetParameters(), message);
@@ -84,6 +108,14 @@ namespace Cake.Common.Build.GitHubActions.Commands
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="annotation">The annotation.</param>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     GitHubActions.Commands.Error("This is an error message");
+        /// }
+        /// </code>
+        /// </example>
         public void Error(string message, GitHubActionsAnnotation annotation = null)
         {
             WriteCommand("error", annotation?.GetParameters(), message);
@@ -93,6 +125,16 @@ namespace Cake.Common.Build.GitHubActions.Commands
         /// Start a group in the build log.
         /// </summary>
         /// <param name="title">The title.</param>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     GitHubActions.Commands.StartGroup("Cake group");
+        ///     Information("This is inside a group");
+        ///     GitHubActions.Commands.EndGroup();
+        /// }
+        /// </code>
+        /// </example>
         public void StartGroup(string title)
         {
             WriteCommand("group", title);
@@ -101,6 +143,14 @@ namespace Cake.Common.Build.GitHubActions.Commands
         /// <summary>
         /// End a group in the build log.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     GitHubActions.Commands.EndGroup();
+        /// }
+        /// </code>
+        /// </example>
         public void EndGroup()
         {
             WriteCommand("endgroup");
@@ -110,6 +160,14 @@ namespace Cake.Common.Build.GitHubActions.Commands
         /// Registers a secret which will get masked in the build log.
         /// </summary>
         /// <param name="secret">The secret.</param>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     GitHubActions.Commands.SetSecret(Guid.NewGuid().ToString());
+        /// }
+        /// </code>
+        /// </example>
         public void SetSecret(string secret)
         {
             WriteCommand("add-mask", secret);
@@ -119,6 +177,14 @@ namespace Cake.Common.Build.GitHubActions.Commands
         /// Prepends a directory to the system PATH variable and automatically makes it available to all subsequent actions in the current job.
         /// </summary>
         /// <param name="path">The directory path.</param>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     GitHubActions.Commands.AddPath(toolsPath);
+        /// }
+        /// </code>
+        /// </example>
         public void AddPath(DirectoryPath path)
         {
             ArgumentNullException.ThrowIfNull(path);
@@ -139,6 +205,16 @@ namespace Cake.Common.Build.GitHubActions.Commands
         /// </summary>
         /// <param name="key">The key.</param>
         /// <param name="value">The Value.</param>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     GitHubActions.Commands.SetEnvironmentVariable(
+        ///         "CAKE_VERSION",
+        ///         Context.Environment.Runtime.CakeVersion.ToString(3));
+        /// }
+        /// </code>
+        /// </example>
         public void SetEnvironmentVariable(string key, string value)
         {
             if (string.IsNullOrEmpty(key))
@@ -167,6 +243,20 @@ namespace Cake.Common.Build.GitHubActions.Commands
         /// </summary>
         /// <param name="key">The key.</param>
         /// <param name="value">The Value.</param>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     GitHubActions.Commands.SetOutputParameter(
+        ///         "CAKE_VERSION_OS",
+        ///         string.Join(
+        ///             '_',
+        ///             Context.Environment.Runtime.CakeVersion.ToString(3),
+        ///             GitHubActions.Environment.Runner.OS,
+        ///             GitHubActions.Environment.Runner.Architecture));
+        /// }
+        /// </code>
+        /// </example>
         public void SetOutputParameter(string key, string value)
         {
             if (string.IsNullOrEmpty(key))
@@ -193,6 +283,15 @@ namespace Cake.Common.Build.GitHubActions.Commands
         /// Creates or updates the step summary for a GitHub workflow.
         /// </summary>
         /// <param name="summary">The step summary.</param>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     GitHubActions.Commands.SetStepSummary(
+        ///         $"## Cake Version\n{Context.Environment.Runtime.CakeVersion.ToString(3)}");
+        /// }
+        /// </code>
+        /// </example>
         public void SetStepSummary(string summary)
         {
             if (string.IsNullOrEmpty(summary))
@@ -217,6 +316,14 @@ namespace Cake.Common.Build.GitHubActions.Commands
         /// <param name="path">Path to the local file.</param>
         /// <param name="artifactName">The artifact name.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     await GitHubActions.Commands.UploadArtifact(artifactPath, "my-artifact");
+        /// }
+        /// </code>
+        /// </example>
         public async Task UploadArtifact(FilePath path, string artifactName)
         {
             var file = _fileSystem.GetFile(ValidateArtifactParameters(path, artifactName));
@@ -235,6 +342,14 @@ namespace Cake.Common.Build.GitHubActions.Commands
         /// <param name="path">Path to the local directory.</param>
         /// <param name="artifactName">The artifact name.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     await GitHubActions.Commands.UploadArtifact(artifactDirectory, "my-artifact");
+        /// }
+        /// </code>
+        /// </example>
         public async Task UploadArtifact(DirectoryPath path, string artifactName)
         {
             var directory = _fileSystem.GetDirectory(ValidateArtifactParameters(path, artifactName));
@@ -257,6 +372,14 @@ namespace Cake.Common.Build.GitHubActions.Commands
         /// <param name="artifactName">The artifact name.</param>
         /// <param name="path">Path to the local directory.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     await GitHubActions.Commands.DownloadArtifact("cake-integration-tests", targetPath);
+        /// }
+        /// </code>
+        /// </example>
         public async Task DownloadArtifact(string artifactName, DirectoryPath path)
         {
             var directory = _fileSystem.GetDirectory(ValidateArtifactParameters(path, artifactName));

--- a/src/Cake.Common/Build/GitHubActions/Data/GitHubActionsEnvironmentInfo.cs
+++ b/src/Cake.Common/Build/GitHubActions/Data/GitHubActionsEnvironmentInfo.cs
@@ -213,13 +213,43 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <para>Via BuildSystem.</para>
         /// <example>
         /// <code>
-        /// // TODO
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(
+        ///         @"Runtime:
+        ///         IsRuntimeAvailable: {0}
+        ///         OutputPath: {1}
+        ///         StepSummary: {2}",
+        ///         BuildSystem.GitHubActions.Environment.Runtime.IsRuntimeAvailable,
+        ///         BuildSystem.GitHubActions.Environment.Runtime.OutputPath,
+        ///         BuildSystem.GitHubActions.Environment.Runtime.StepSummary
+        ///         );
+        /// }
+        /// else
+        /// {
+        ///     Information("Not running on GitHubActions");
+        /// }
         /// </code>
         /// </example>
         /// <para>Via GitHubActions.</para>
         /// <example>
         /// <code>
-        /// // TODO
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(
+        ///         @"Runtime:
+        ///         IsRuntimeAvailable: {0}
+        ///         OutputPath: {1}
+        ///         StepSummary: {2}",
+        ///         GitHubActions.Environment.Runtime.IsRuntimeAvailable,
+        ///         GitHubActions.Environment.Runtime.OutputPath,
+        ///         GitHubActions.Environment.Runtime.StepSummary
+        ///         );
+        /// }
+        /// else
+        /// {
+        ///     Information("Not running on GitHubActions");
+        /// }
         /// </code>
         /// </example>
         public GitHubActionsRuntimeInfo Runtime { get; }

--- a/src/Cake.Common/Build/GitHubActions/Data/GitHubActionsPullRequestInfo.cs
+++ b/src/Cake.Common/Build/GitHubActions/Data/GitHubActionsPullRequestInfo.cs
@@ -26,6 +26,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         ///   <c>true</c> if the current build was started by a pull request; otherwise, <c>false</c>.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"IsPullRequest: {0}", BuildSystem.GitHubActions.Environment.PullRequest.IsPullRequest);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"IsPullRequest: {0}", GitHubActions.Environment.PullRequest.IsPullRequest);
+        /// }
+        /// </code>
+        /// </example>
         public bool IsPullRequest => GetEnvironmentString("GITHUB_EVENT_NAME") == "pull_request";
     }
 }

--- a/src/Cake.Common/Build/GitHubActions/Data/GitHubActionsRunnerEnvironment.cs
+++ b/src/Cake.Common/Build/GitHubActions/Data/GitHubActionsRunnerEnvironment.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Cake.Common.Build.GitHubActions.Data
+{
+    /// <summary>
+    /// The GitHub Actions runner environment.
+    /// </summary>
+    public enum GitHubActionsRunnerEnvironment
+    {
+        /// <summary>
+        /// Unknown.
+        /// </summary>
+        Unknown,
+
+        /// <summary>
+        /// GitHub-hosted runner provided by GitHub.
+        /// </summary>
+        GitHubHosted,
+
+        /// <summary>
+        /// Self-hosted runner configured by the repository owner.
+        /// </summary>
+        SelfHosted
+    }
+}

--- a/src/Cake.Common/Build/GitHubActions/Data/GitHubActionsRunnerInfo.cs
+++ b/src/Cake.Common/Build/GitHubActions/Data/GitHubActionsRunnerInfo.cs
@@ -27,6 +27,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The name of the runner executing the job.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runner Name: {0}", BuildSystem.GitHubActions.Environment.Runner.Name);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runner Name: {0}", GitHubActions.Environment.Runner.Name);
+        /// }
+        /// </code>
+        /// </example>
         public string Name => GetEnvironmentString("RUNNER_NAME");
 
         /// <summary>
@@ -35,6 +53,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The operating system of the runner executing the job.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runner OS: {0}", BuildSystem.GitHubActions.Environment.Runner.OS);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runner OS: {0}", GitHubActions.Environment.Runner.OS);
+        /// }
+        /// </code>
+        /// </example>
         // ReSharper disable once InconsistentNaming
         public string OS => GetEnvironmentString("RUNNER_OS");
 
@@ -45,6 +81,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// The path of the temporary directory for the runner.
         /// This directory is guaranteed to be empty at the start of each job, even on self-hosted runners.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runner Temp: {0}", BuildSystem.GitHubActions.Environment.Runner.Temp);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runner Temp: {0}", GitHubActions.Environment.Runner.Temp);
+        /// }
+        /// </code>
+        /// </example>
         public DirectoryPath Temp => GetEnvironmentDirectoryPath("RUNNER_TEMP");
 
         /// <summary>
@@ -53,6 +107,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The path of the directory containing some of the pre-installed tools for GitHub-hosted runners.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runner ToolCache: {0}", BuildSystem.GitHubActions.Environment.Runner.ToolCache);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runner ToolCache: {0}", GitHubActions.Environment.Runner.ToolCache);
+        /// }
+        /// </code>
+        /// </example>
         public DirectoryPath ToolCache => GetEnvironmentDirectoryPath("RUNNER_TOOL_CACHE");
 
         /// <summary>
@@ -61,6 +133,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The runner workspace directory path.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runner Workspace: {0}", BuildSystem.GitHubActions.Environment.Runner.Workspace);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runner Workspace: {0}", GitHubActions.Environment.Runner.Workspace);
+        /// }
+        /// </code>
+        /// </example>
         public DirectoryPath Workspace => GetEnvironmentDirectoryPath("RUNNER_WORKSPACE");
 
         /// <summary>
@@ -69,6 +159,28 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The runner image OS on hosted agents.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     var imageOs = BuildSystem.GitHubActions.Environment.Runner.ImageOS
+        ///         ?? BuildSystem.GitHubActions.Environment.Runner.OS;
+        ///     Information(@"Runner ImageOS: {0}", imageOs);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     var imageOs = GitHubActions.Environment.Runner.ImageOS
+        ///         ?? GitHubActions.Environment.Runner.OS;
+        ///     Information(@"Runner ImageOS: {0}", imageOs);
+        /// }
+        /// </code>
+        /// </example>
         public string ImageOS => GetEnvironmentString("ImageOS");
 
         /// <summary>
@@ -77,6 +189,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The runner image version on hosted agents.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runner ImageVersion: {0}", BuildSystem.GitHubActions.Environment.Runner.ImageVersion);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runner ImageVersion: {0}", GitHubActions.Environment.Runner.ImageVersion);
+        /// }
+        /// </code>
+        /// </example>
         public string ImageVersion => GetEnvironmentString("ImageVersion");
 
         /// <summary>
@@ -85,6 +215,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The runner user name.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runner User: {0}", BuildSystem.GitHubActions.Environment.Runner.User);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runner User: {0}", GitHubActions.Environment.Runner.User);
+        /// }
+        /// </code>
+        /// </example>
         public string User => GetEnvironmentString("RUNNER_USER");
 
         /// <summary>
@@ -93,6 +241,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The runner architecture of the runner executing the job. Possible values are X86, X64, ARM, and ARM64.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runner Architecture: {0}", BuildSystem.GitHubActions.Environment.Runner.Architecture);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runner Architecture: {0}", GitHubActions.Environment.Runner.Architecture);
+        /// }
+        /// </code>
+        /// </example>
         public GitHubActionsArchitecture Architecture => GetEnvironmentString("RUNNER_ARCH")
                                                             ?.ToUpperInvariant() switch
                                                             {
@@ -101,6 +267,64 @@ namespace Cake.Common.Build.GitHubActions.Data
                                                                 "ARM" => GitHubActionsArchitecture.ARM,
                                                                 "ARM64" => GitHubActionsArchitecture.ARM64,
                                                                 _ => GitHubActionsArchitecture.Unknown
+                                                            };
+
+        /// <summary>
+        /// Gets a value indicating whether debug logging is enabled for the runner.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if debug logging is enabled; otherwise, <c>false</c>.
+        /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runner Debug: {0}", BuildSystem.GitHubActions.Environment.Runner.IsDebug);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runner Debug: {0}", GitHubActions.Environment.Runner.IsDebug);
+        /// }
+        /// </code>
+        /// </example>
+        public bool IsDebug => GetEnvironmentString("RUNNER_DEBUG") == "1";
+
+        /// <summary>
+        /// Gets the environment of the runner executing the job.
+        /// </summary>
+        /// <value>
+        /// The environment of the runner executing the job.
+        /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runner Environment: {0}", BuildSystem.GitHubActions.Environment.Runner.Environment);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runner Environment: {0}", GitHubActions.Environment.Runner.Environment);
+        /// }
+        /// </code>
+        /// </example>
+        public GitHubActionsRunnerEnvironment Environment => GetEnvironmentString("RUNNER_ENVIRONMENT")
+                                                            ?.ToLowerInvariant() switch
+                                                            {
+                                                                "github-hosted" => GitHubActionsRunnerEnvironment.GitHubHosted,
+                                                                "self-hosted" => GitHubActionsRunnerEnvironment.SelfHosted,
+                                                                _ => GitHubActionsRunnerEnvironment.Unknown
                                                             };
     }
 }

--- a/src/Cake.Common/Build/GitHubActions/Data/GitHubActionsRuntimeInfo.cs
+++ b/src/Cake.Common/Build/GitHubActions/Data/GitHubActionsRuntimeInfo.cs
@@ -27,6 +27,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// <c>true</c> if the GitHub Actions Runtime is available for the current build.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.Environment.Runtime.IsRuntimeAvailable)
+        /// {
+        ///     await BuildSystem.GitHubActions.Commands.UploadArtifact(path, name);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.Environment.Runtime.IsRuntimeAvailable)
+        /// {
+        ///     await GitHubActions.Commands.UploadArtifact(path, name);
+        /// }
+        /// </code>
+        /// </example>
         public bool IsRuntimeAvailable
             => !string.IsNullOrWhiteSpace(Token) && !string.IsNullOrWhiteSpace(Url) && !string.IsNullOrWhiteSpace(ResultsUrl);
 
@@ -36,6 +54,26 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The current runtime API authorization token.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     var hasToken = !string.IsNullOrWhiteSpace(BuildSystem.GitHubActions.Environment.Runtime.Token);
+        ///     Information(@"Runtime token configured: {0}", hasToken);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     var hasToken = !string.IsNullOrWhiteSpace(GitHubActions.Environment.Runtime.Token);
+        ///     Information(@"Runtime token configured: {0}", hasToken);
+        /// }
+        /// </code>
+        /// </example>
         public string Token => GetEnvironmentString("ACTIONS_RUNTIME_TOKEN");
 
         /// <summary>
@@ -44,11 +82,50 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The current runtime API endpoint url.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runtime Url: {0}", BuildSystem.GitHubActions.Environment.Runtime.Url);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runtime Url: {0}", GitHubActions.Environment.Runtime.Url);
+        /// }
+        /// </code>
+        /// </example>
         public string Url => GetEnvironmentString("ACTIONS_RUNTIME_URL");
 
         /// <summary>
         /// Gets the current runtime API endpoint url for the job.
         /// </summary>
+        /// <value>
+        /// The current runtime API endpoint url for the job.
+        /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runtime ResultsUrl: {0}", BuildSystem.GitHubActions.Environment.Runtime.ResultsUrl);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runtime ResultsUrl: {0}", GitHubActions.Environment.Runtime.ResultsUrl);
+        /// }
+        /// </code>
+        /// </example>
         public string ResultsUrl => GetEnvironmentString("ACTIONS_RESULTS_URL");
 
         /// <summary>
@@ -57,6 +134,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The path to environment file to set an environment variable that the following steps in a job can use.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runtime EnvPath: {0}", BuildSystem.GitHubActions.Environment.Runtime.EnvPath);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runtime EnvPath: {0}", GitHubActions.Environment.Runtime.EnvPath);
+        /// }
+        /// </code>
+        /// </example>
         public FilePath EnvPath => GetEnvironmentFilePath("GITHUB_ENV");
 
         /// <summary>
@@ -65,6 +160,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The path to output file to set an output parameter that the following steps in a job can use.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runtime OutputPath: {0}", BuildSystem.GitHubActions.Environment.Runtime.OutputPath);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runtime OutputPath: {0}", GitHubActions.Environment.Runtime.OutputPath);
+        /// }
+        /// </code>
+        /// </example>
         public FilePath OutputPath => GetEnvironmentFilePath("GITHUB_OUTPUT");
 
         /// <summary>
@@ -73,6 +186,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The path to output file to set the step summary.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runtime StepSummary: {0}", BuildSystem.GitHubActions.Environment.Runtime.StepSummary);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runtime StepSummary: {0}", GitHubActions.Environment.Runtime.StepSummary);
+        /// }
+        /// </code>
+        /// </example>
         public FilePath StepSummary => GetEnvironmentFilePath("GITHUB_STEP_SUMMARY");
 
         /// <summary>
@@ -81,6 +212,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The path to path file to add a path to system path that the following steps in a job can use.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runtime SystemPath: {0}", BuildSystem.GitHubActions.Environment.Runtime.SystemPath);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Runtime SystemPath: {0}", GitHubActions.Environment.Runtime.SystemPath);
+        /// }
+        /// </code>
+        /// </example>
         public FilePath SystemPath => GetEnvironmentFilePath("GITHUB_PATH");
     }
 }

--- a/src/Cake.Common/Build/GitHubActions/Data/GitHubActionsWorkflowInfo.cs
+++ b/src/Cake.Common/Build/GitHubActions/Data/GitHubActionsWorkflowInfo.cs
@@ -27,6 +27,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The unique identifier of the action.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow Action: {0}", BuildSystem.GitHubActions.Environment.Workflow.Action);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow Action: {0}", GitHubActions.Environment.Workflow.Action);
+        /// }
+        /// </code>
+        /// </example>
         public string Action => GetEnvironmentString("GITHUB_ACTION");
 
         /// <summary>
@@ -35,7 +53,51 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The path where your action is located. You can use this path to access files located in the same repository as your action. This variable is only supported in composite run steps actions.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow ActionPath: {0}", BuildSystem.GitHubActions.Environment.Workflow.ActionPath);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow ActionPath: {0}", GitHubActions.Environment.Workflow.ActionPath);
+        /// }
+        /// </code>
+        /// </example>
         public DirectoryPath ActionPath => GetEnvironmentDirectoryPath("GITHUB_ACTION_PATH");
+
+        /// <summary>
+        /// Gets the owner and repository name of the action being executed.
+        /// </summary>
+        /// <value>
+        /// The owner and repository name of the action being executed. For example, actions/checkout.
+        /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow ActionRepository: {0}", BuildSystem.GitHubActions.Environment.Workflow.ActionRepository);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow ActionRepository: {0}", GitHubActions.Environment.Workflow.ActionRepository);
+        /// }
+        /// </code>
+        /// </example>
+        public string ActionRepository => GetEnvironmentString("GITHUB_ACTION_REPOSITORY");
 
         /// <summary>
         /// Gets the name of the person or app that initiated the workflow.
@@ -43,7 +105,51 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The name of the person or app that initiated the workflow.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow Actor: {0}", BuildSystem.GitHubActions.Environment.Workflow.Actor);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow Actor: {0}", GitHubActions.Environment.Workflow.Actor);
+        /// }
+        /// </code>
+        /// </example>
         public string Actor => GetEnvironmentString("GITHUB_ACTOR");
+
+        /// <summary>
+        /// Gets the account ID of the person or app that triggered the initial workflow run.
+        /// </summary>
+        /// <value>
+        /// The account ID of the person or app that triggered the initial workflow run.
+        /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow ActorId: {0}", BuildSystem.GitHubActions.Environment.Workflow.ActorId);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow ActorId: {0}", GitHubActions.Environment.Workflow.ActorId);
+        /// }
+        /// </code>
+        /// </example>
+        public string ActorId => GetEnvironmentString("GITHUB_ACTOR_ID");
 
         /// <summary>
         /// Gets the API URL.
@@ -51,6 +157,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The API URL. For example: https://api.github.com.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow ApiUrl: {0}", BuildSystem.GitHubActions.Environment.Workflow.ApiUrl);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow ApiUrl: {0}", GitHubActions.Environment.Workflow.ApiUrl);
+        /// }
+        /// </code>
+        /// </example>
         public string ApiUrl => GetEnvironmentString("GITHUB_API_URL");
 
         /// <summary>
@@ -59,6 +183,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The branch of the base repository. Only set for forked repositories.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow BaseRef: {0}", BuildSystem.GitHubActions.Environment.Workflow.BaseRef);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow BaseRef: {0}", GitHubActions.Environment.Workflow.BaseRef);
+        /// }
+        /// </code>
+        /// </example>
         public string BaseRef => GetEnvironmentString("GITHUB_BASE_REF");
 
         /// <summary>
@@ -67,6 +209,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The name of the webhook event that triggered the workflow.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow EventName: {0}", BuildSystem.GitHubActions.Environment.Workflow.EventName);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow EventName: {0}", GitHubActions.Environment.Workflow.EventName);
+        /// }
+        /// </code>
+        /// </example>
         public string EventName => GetEnvironmentString("GITHUB_EVENT_NAME");
 
         /// <summary>
@@ -75,6 +235,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The path of the file with the complete webhook event payload.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow EventPath: {0}", BuildSystem.GitHubActions.Environment.Workflow.EventPath);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow EventPath: {0}", GitHubActions.Environment.Workflow.EventPath);
+        /// }
+        /// </code>
+        /// </example>
         public FilePath EventPath => GetEnvironmentFilePath("GITHUB_EVENT_PATH");
 
         /// <summary>
@@ -83,6 +261,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The GraphQL API URL. For example: https://api.github.com/graphql.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow GraphQLUrl: {0}", BuildSystem.GitHubActions.Environment.Workflow.GraphQLUrl);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow GraphQLUrl: {0}", GitHubActions.Environment.Workflow.GraphQLUrl);
+        /// }
+        /// </code>
+        /// </example>
         public string GraphQLUrl => GetEnvironmentString("GITHUB_GRAPHQL_URL");
 
         /// <summary>
@@ -91,6 +287,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The branch of the head repository. Only set for forked repositories.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow HeadRef: {0}", BuildSystem.GitHubActions.Environment.Workflow.HeadRef);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow HeadRef: {0}", GitHubActions.Environment.Workflow.HeadRef);
+        /// }
+        /// </code>
+        /// </example>
         public string HeadRef => GetEnvironmentString("GITHUB_HEAD_REF");
 
         /// <summary>
@@ -99,6 +313,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The job name.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow Job: {0}", BuildSystem.GitHubActions.Environment.Workflow.Job);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow Job: {0}", GitHubActions.Environment.Workflow.Job);
+        /// }
+        /// </code>
+        /// </example>
         public string Job => GetEnvironmentString("GITHUB_JOB");
 
         /// <summary>
@@ -107,6 +339,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The branch or tag ref that triggered the workflow.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow Ref: {0}", BuildSystem.GitHubActions.Environment.Workflow.Ref);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow Ref: {0}", GitHubActions.Environment.Workflow.Ref);
+        /// }
+        /// </code>
+        /// </example>
         public string Ref => GetEnvironmentString("GITHUB_REF");
 
         /// <summary>
@@ -115,7 +365,51 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The owner and repository name.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow Repository: {0}", BuildSystem.GitHubActions.Environment.Workflow.Repository);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow Repository: {0}", GitHubActions.Environment.Workflow.Repository);
+        /// }
+        /// </code>
+        /// </example>
         public string Repository => GetEnvironmentString("GITHUB_REPOSITORY");
+
+        /// <summary>
+        /// Gets the ID of the repository.
+        /// </summary>
+        /// <value>
+        /// The ID of the repository.
+        /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow RepositoryId: {0}", BuildSystem.GitHubActions.Environment.Workflow.RepositoryId);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow RepositoryId: {0}", GitHubActions.Environment.Workflow.RepositoryId);
+        /// }
+        /// </code>
+        /// </example>
+        public string RepositoryId => GetEnvironmentString("GITHUB_REPOSITORY_ID");
 
         /// <summary>
         /// Gets the repository owner.
@@ -123,7 +417,77 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The repository owner.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow RepositoryOwner: {0}", BuildSystem.GitHubActions.Environment.Workflow.RepositoryOwner);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow RepositoryOwner: {0}", GitHubActions.Environment.Workflow.RepositoryOwner);
+        /// }
+        /// </code>
+        /// </example>
         public string RepositoryOwner => GetEnvironmentString("GITHUB_REPOSITORY_OWNER");
+
+        /// <summary>
+        /// Gets the account ID of the repository owner.
+        /// </summary>
+        /// <value>
+        /// The account ID of the repository owner.
+        /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow RepositoryOwnerId: {0}", BuildSystem.GitHubActions.Environment.Workflow.RepositoryOwnerId);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow RepositoryOwnerId: {0}", GitHubActions.Environment.Workflow.RepositoryOwnerId);
+        /// }
+        /// </code>
+        /// </example>
+        public string RepositoryOwnerId => GetEnvironmentString("GITHUB_REPOSITORY_OWNER_ID");
+
+        /// <summary>
+        /// Gets the number of days that workflow run logs and artifacts are kept.
+        /// </summary>
+        /// <value>
+        /// The number of days that workflow run logs and artifacts are kept.
+        /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow RetentionDays: {0}", BuildSystem.GitHubActions.Environment.Workflow.RetentionDays);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow RetentionDays: {0}", GitHubActions.Environment.Workflow.RetentionDays);
+        /// }
+        /// </code>
+        /// </example>
+        public int RetentionDays => GetEnvironmentInteger("GITHUB_RETENTION_DAYS");
 
         /// <summary>
         /// Gets the unique number for each run within the repository.
@@ -131,6 +495,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The unique number for each run within the repository.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow RunId: {0}", BuildSystem.GitHubActions.Environment.Workflow.RunId);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow RunId: {0}", GitHubActions.Environment.Workflow.RunId);
+        /// }
+        /// </code>
+        /// </example>
         public string RunId => GetEnvironmentString("GITHUB_RUN_ID");
 
         /// <summary>
@@ -139,6 +521,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The unique number for each run of a particular workflow in the repository.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow RunNumber: {0}", BuildSystem.GitHubActions.Environment.Workflow.RunNumber);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow RunNumber: {0}", GitHubActions.Environment.Workflow.RunNumber);
+        /// }
+        /// </code>
+        /// </example>
         public int RunNumber => GetEnvironmentInteger("GITHUB_RUN_NUMBER");
 
         /// <summary>
@@ -147,6 +547,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The URL of the GitHub server. For example: https://github.com.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow ServerUrl: {0}", BuildSystem.GitHubActions.Environment.Workflow.ServerUrl);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow ServerUrl: {0}", GitHubActions.Environment.Workflow.ServerUrl);
+        /// }
+        /// </code>
+        /// </example>
         public string ServerUrl => GetEnvironmentString("GITHUB_SERVER_URL");
 
         /// <summary>
@@ -155,7 +573,51 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The commit SHA that triggered the workflow.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow Sha: {0}", BuildSystem.GitHubActions.Environment.Workflow.Sha);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow Sha: {0}", GitHubActions.Environment.Workflow.Sha);
+        /// }
+        /// </code>
+        /// </example>
         public string Sha => GetEnvironmentString("GITHUB_SHA");
+
+        /// <summary>
+        /// Gets the username of the user that initiated the workflow run.
+        /// </summary>
+        /// <value>
+        /// The username of the user that initiated the workflow run. On re-runs, this value may differ from <see cref="Actor"/>.
+        /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow TriggeringActor: {0}", BuildSystem.GitHubActions.Environment.Workflow.TriggeringActor);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow TriggeringActor: {0}", GitHubActions.Environment.Workflow.TriggeringActor);
+        /// }
+        /// </code>
+        /// </example>
+        public string TriggeringActor => GetEnvironmentString("GITHUB_TRIGGERING_ACTOR");
 
         /// <summary>
         /// Gets the name of the workflow.
@@ -163,7 +625,77 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The name of the workflow.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow: {0}", BuildSystem.GitHubActions.Environment.Workflow.Workflow);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow: {0}", GitHubActions.Environment.Workflow.Workflow);
+        /// }
+        /// </code>
+        /// </example>
         public string Workflow => GetEnvironmentString("GITHUB_WORKFLOW");
+
+        /// <summary>
+        /// Gets the ref path to the workflow file.
+        /// </summary>
+        /// <value>
+        /// The ref path to the workflow file.
+        /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow WorkflowRef: {0}", BuildSystem.GitHubActions.Environment.Workflow.WorkflowRef);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow WorkflowRef: {0}", GitHubActions.Environment.Workflow.WorkflowRef);
+        /// }
+        /// </code>
+        /// </example>
+        public string WorkflowRef => GetEnvironmentString("GITHUB_WORKFLOW_REF");
+
+        /// <summary>
+        /// Gets the commit SHA for the workflow file.
+        /// </summary>
+        /// <value>
+        /// The commit SHA for the workflow file.
+        /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow WorkflowSha: {0}", BuildSystem.GitHubActions.Environment.Workflow.WorkflowSha);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow WorkflowSha: {0}", GitHubActions.Environment.Workflow.WorkflowSha);
+        /// }
+        /// </code>
+        /// </example>
+        public string WorkflowSha => GetEnvironmentString("GITHUB_WORKFLOW_SHA");
 
         /// <summary>
         /// Gets the GitHub workspace directory path.
@@ -171,6 +703,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The GitHub workspace directory path.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow Workspace: {0}", BuildSystem.GitHubActions.Environment.Workflow.Workspace);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow Workspace: {0}", GitHubActions.Environment.Workflow.Workspace);
+        /// }
+        /// </code>
+        /// </example>
         public DirectoryPath Workspace => GetEnvironmentDirectoryPath("GITHUB_WORKSPACE");
 
         /// <summary>
@@ -179,6 +729,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The attempt number  for current run.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow Attempt: {0}", BuildSystem.GitHubActions.Environment.Workflow.Attempt);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow Attempt: {0}", GitHubActions.Environment.Workflow.Attempt);
+        /// }
+        /// </code>
+        /// </example>
         public int Attempt => GetEnvironmentInteger("GITHUB_RUN_ATTEMPT");
 
         /// <summary>
@@ -187,6 +755,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// Value whether if branch protections are configured for the ref that triggered the workflow run.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow RefProtected: {0}", BuildSystem.GitHubActions.Environment.Workflow.RefProtected);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow RefProtected: {0}", GitHubActions.Environment.Workflow.RefProtected);
+        /// }
+        /// </code>
+        /// </example>
         public bool RefProtected => GetEnvironmentBoolean("GITHUB_REF_PROTECTED");
 
         /// <summary>
@@ -195,6 +781,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The branch or tag name that triggered the workflow run.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow RefName: {0}", BuildSystem.GitHubActions.Environment.Workflow.RefName);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow RefName: {0}", GitHubActions.Environment.Workflow.RefName);
+        /// }
+        /// </code>
+        /// </example>
         public string RefName => GetEnvironmentString("GITHUB_REF_NAME");
 
         /// <summary>
@@ -203,6 +807,24 @@ namespace Cake.Common.Build.GitHubActions.Data
         /// <value>
         /// The type of ref that triggered the workflow run. Valid values are branch or tag.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow RefType: {0}", BuildSystem.GitHubActions.Environment.Workflow.RefType);
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(@"Workflow RefType: {0}", GitHubActions.Environment.Workflow.RefType);
+        /// }
+        /// </code>
+        /// </example>
         public GitHubActionsRefType RefType => GetEnvironmentString("GITHUB_REF_TYPE")
                                                     ?.ToLowerInvariant() switch
                                                     {

--- a/src/Cake.Common/Build/GitHubActions/IGitHubActionsProvider.cs
+++ b/src/Cake.Common/Build/GitHubActions/IGitHubActionsProvider.cs
@@ -18,6 +18,32 @@ namespace Cake.Common.Build.GitHubActions
         /// <value>
         /// <c>true</c> if the current build is running on GitHub Actions; otherwise, <c>false</c>.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information("Running on GitHub Actions");
+        /// }
+        /// else
+        /// {
+        ///     Information("Not running on GitHub Actions");
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     GitHubActions.Commands.Debug("Running on GitHub Actions");
+        /// }
+        /// else
+        /// {
+        ///     Information("Not running on GitHub Actions");
+        /// }
+        /// </code>
+        /// </example>
         bool IsRunningOnGitHubActions { get; }
 
         /// <summary>
@@ -26,6 +52,60 @@ namespace Cake.Common.Build.GitHubActions
         /// <value>
         /// The GitHub Actions environment.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(
+        ///         @"Workflow:
+        ///         Workflow: {0}
+        ///         Repository: {1}
+        ///         Actor: {2}
+        ///         Runner OS: {3}
+        ///         Runner Environment: {4}
+        ///         Runner Architecture: {5}",
+        ///         BuildSystem.GitHubActions.Environment.Workflow.Workflow,
+        ///         BuildSystem.GitHubActions.Environment.Workflow.Repository,
+        ///         BuildSystem.GitHubActions.Environment.Workflow.Actor,
+        ///         BuildSystem.GitHubActions.Environment.Runner.OS,
+        ///         BuildSystem.GitHubActions.Environment.Runner.Environment,
+        ///         BuildSystem.GitHubActions.Environment.Runner.Architecture
+        ///         );
+        /// }
+        /// else
+        /// {
+        ///     Information("Not running on GitHub Actions");
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     Information(
+        ///         @"Workflow:
+        ///         Workflow: {0}
+        ///         Repository: {1}
+        ///         Actor: {2}
+        ///         Runner OS: {3}
+        ///         Runner Environment: {4}
+        ///         Runner Architecture: {5}",
+        ///         GitHubActions.Environment.Workflow.Workflow,
+        ///         GitHubActions.Environment.Workflow.Repository,
+        ///         GitHubActions.Environment.Workflow.Actor,
+        ///         GitHubActions.Environment.Runner.OS,
+        ///         GitHubActions.Environment.Runner.Environment,
+        ///         GitHubActions.Environment.Runner.Architecture
+        ///         );
+        /// }
+        /// else
+        /// {
+        ///     Information("Not running on GitHub Actions");
+        /// }
+        /// </code>
+        /// </example>
         GitHubActionsEnvironmentInfo Environment { get; }
 
         /// <summary>
@@ -34,6 +114,42 @@ namespace Cake.Common.Build.GitHubActions
         /// <value>
         /// The GitHub Actions commands.
         /// </value>
+        /// <para>Via BuildSystem.</para>
+        /// <example>
+        /// <code>
+        /// if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     BuildSystem.GitHubActions.Commands.Notice("Build started");
+        ///     BuildSystem.GitHubActions.Commands.SetOutputParameter(
+        ///         "cake_version",
+        ///         Context.Environment.Runtime.CakeVersion.ToString(3));
+        ///     BuildSystem.GitHubActions.Commands.SetStepSummary("## Cake Version\n" +
+        ///         Context.Environment.Runtime.CakeVersion.ToString(3));
+        /// }
+        /// else
+        /// {
+        ///     Information("Not running on GitHub Actions");
+        /// }
+        /// </code>
+        /// </example>
+        /// <para>Via GitHubActions.</para>
+        /// <example>
+        /// <code>
+        /// if (GitHubActions.IsRunningOnGitHubActions)
+        /// {
+        ///     GitHubActions.Commands.Notice("Build started");
+        ///     GitHubActions.Commands.SetOutputParameter(
+        ///         "cake_version",
+        ///         Context.Environment.Runtime.CakeVersion.ToString(3));
+        ///     GitHubActions.Commands.SetStepSummary("## Cake Version\n" +
+        ///         Context.Environment.Runtime.CakeVersion.ToString(3));
+        /// }
+        /// else
+        /// {
+        ///     Information("Not running on GitHub Actions");
+        /// }
+        /// </code>
+        /// </example>
         public GitHubActionsCommands Commands { get; }
     }
 }

--- a/tests/integration/Cake.Common/Build/GitHubActions/GitHubActionsProvider.cake
+++ b/tests/integration/Cake.Common/Build/GitHubActions/GitHubActionsProvider.cake
@@ -103,7 +103,33 @@ Task("Cake.Common.Build.GitHubActionsProvider.Commands.SetStepSummary")
 {Context.Environment.Runtime.CakeVersion.ToString(3)}
 
 ## Runner OS
-{GitHubActions.Environment.Runner.OS}";
+{GitHubActions.Environment.Runner.OS}
+
+## Runner Environment
+{GitHubActions.Environment.Runner.Environment}
+
+## Runner Architecture
+{GitHubActions.Environment.Runner.Architecture}
+
+## Runner Debug
+{GitHubActions.Environment.Runner.IsDebug}
+
+## Action Repository
+{GitHubActions.Environment.Workflow.ActionRepository}
+
+## Actor / Triggering Actor
+{GitHubActions.Environment.Workflow.Actor} / {GitHubActions.Environment.Workflow.TriggeringActor}
+
+## Repository
+{GitHubActions.Environment.Workflow.Repository} ({GitHubActions.Environment.Workflow.RepositoryId})
+
+## Workflow Ref / SHA
+{GitHubActions.Environment.Workflow.WorkflowRef}
+
+{GitHubActions.Environment.Workflow.WorkflowSha}
+
+## Retention Days
+{GitHubActions.Environment.Workflow.RetentionDays}";
 
         // When
         GitHubActions.Commands.SetStepSummary(summary);


### PR DESCRIPTION
Expose documented GitHub Actions default environment variables that were previously unavailable through the Cake provider, and improve API documentation with integration-inspired XML examples.

- Add workflow properties: ActionRepository, ActorId, RepositoryId, RepositoryOwnerId, RetentionDays, TriggeringActor, WorkflowRef, and WorkflowSha
- Add runner properties: IsDebug and Environment, with new GitHubActionsRunnerEnvironment enum
- Extend GitHubActionsInfoFixture and unit tests for new workflow and runner properties
- Add XML documentation examples to IGitHubActionsProvider, GitHubActionsCommands, GitHubActionsRunnerInfo, GitHubActionsRuntimeInfo, and GitHubActionsPullRequestInfo
- Expand GitHub Actions integration step summary to exercise new environment properties on CI
- fixes #4891
