### PR TITLE
Fix dotCover parameter syntax

### DIFF
--- a/src/Cake.Common.Tests/Unit/Tools/DotCover/Analyse/DotCoverAnalyserTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotCover/Analyse/DotCoverAnalyserTests.cs
@@ -241,6 +241,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Analyse
                 // Given
                 var fixture = new DotCoverAnalyserFixture();
                 fixture.Settings.LogFile = "./logfile.log";
+                fixture.Settings.UseLegacySyntax = true;
 
                 // When
                 var result = fixture.Run();

--- a/src/Cake.Common.Tests/Unit/Tools/DotCover/Cover/DotCoverCovererTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotCover/Cover/DotCoverCovererTests.cs
@@ -90,7 +90,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 AssertEx.IsCakeException(result, "No tool was started.");
             }
 
-            #region New Paramter Syntax
+            #region New Parameter Syntax
 
             [Fact]
             public void Should_Capture_Tool_And_Arguments_From_Action()
@@ -542,7 +542,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
 
             #endregion
 
-            #region Legacy Paramter Syntax
+            #region Legacy Parameter Syntax
 
             [Fact]
             public void Should_Capture_Tool_And_Arguments_From_Action_LegacySyntax()

--- a/src/Cake.Common.Tests/Unit/Tools/DotCover/Cover/DotCoverCovererTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotCover/Cover/DotCoverCovererTests.cs
@@ -87,6 +87,8 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 AssertEx.IsCakeException(result, "No tool was started.");
             }
 
+            #region New Paramter Syntax
+
             [Fact]
             public void Should_Capture_Tool_And_Arguments_From_Action()
             {
@@ -534,6 +536,228 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 Assert.Contains("--exclude-assemblies \"*.Tests\"", result.Args);
                 Assert.Contains("--snapshot-output", result.Args);
             }
+
+            #endregion
+
+            #region Legacy Paramter Syntax
+
+            [Fact]
+            public void Should_Capture_Tool_And_Arguments_From_Action_LegacySyntax()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.WithLegacySyntax();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
+                             "/TargetArguments=\"-argument\" " +
+                             "/Output=\"/Working/result.dcvr\"", result.Args);
+            }
+
+            [Theory]
+            [InlineData("")]
+            [InlineData(null)]
+            public void Should_Not_Capture_Arguments_From_Action_If_Excluded_LegacySyntax(string arguments)
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Action = context =>
+                {
+                    context.ProcessRunner.Start(
+                        new FilePath("/Working/tools/Test.exe"),
+                        new ProcessSettings()
+                        {
+                            Arguments = arguments
+                        });
+                };
+                fixture.Settings.WithLegacySyntax();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
+                             "/Output=\"/Working/result.dcvr\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_TargetWorkingDir_LegacySyntax()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.TargetWorkingDir = new DirectoryPath("/Working");
+                fixture.Settings.WithLegacySyntax();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
+                             "/TargetArguments=\"-argument\" " +
+                             "/Output=\"/Working/result.dcvr\" " +
+                             "/TargetWorkingDir=\"/Working\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_Scope_LegacySyntax()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.WithScope("/Working/*.dll")
+                       .WithScope("/Some/**/Other/*.dll")
+                       .WithLegacySyntax();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
+                             "/TargetArguments=\"-argument\" " +
+                             "/Output=\"/Working/result.dcvr\" " +
+                             "/Scope=\"/Working/*.dll;/Some/**/Other/*.dll\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_Filters_LegacySyntax()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.WithFilter("+:module=Test.*")
+                       .WithFilter("-:myassembly")
+                       .WithLegacySyntax();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
+                             "/TargetArguments=\"-argument\" " +
+                             "/Output=\"/Working/result.dcvr\" " +
+                             "/Filters=\"+:module=Test.*;-:myassembly\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_AttributeFilters_LegacySyntax()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.WithAttributeFilter("filter1")
+                       .WithAttributeFilter("filter2")
+                       .WithLegacySyntax();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
+                             "/TargetArguments=\"-argument\" " +
+                             "/Output=\"/Working/result.dcvr\" " +
+                             "/AttributeFilters=\"filter1;filter2\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_DisableDefaultFilters_LegacySyntax()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.DisableDefaultFilters = true;
+                fixture.Settings.WithLegacySyntax();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
+                             "/TargetArguments=\"-argument\" " +
+                             "/Output=\"/Working/result.dcvr\" " +
+                             "/DisableDefaultFilters", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_ProcessFilters_LegacySyntax()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.WithProcessFilter("+:test.exe")
+                       .WithProcessFilter("-:sqlservr.exe")
+                       .WithLegacySyntax();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("cover /TargetExecutable=\"/Working/tools/Test.exe\" " +
+                             "/TargetArguments=\"-argument\" " +
+                             "/Output=\"/Working/result.dcvr\" " +
+                             "/ProcessFilters=\"+:test.exe;-:sqlservr.exe\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Capture_XUnit_LegacySyntax()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.FileSystem.CreateFile("/Working/tools/xunit.console.exe");
+                fixture.Action = context =>
+                {
+                    context.XUnit2(
+                        new FilePath[] { "./Test.dll" },
+                        new XUnit2Settings { ShadowCopy = false });
+                };
+                fixture.Settings.WithLegacySyntax();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("cover /TargetExecutable=\"/Working/tools/xunit.console.exe\" " +
+                             "/TargetArguments=\"\\\"/Working/Test.dll\\\" -noshadow\" " +
+                             "/Output=\"/Working/result.dcvr\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Capture_NUnit_LegacySyntax()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.FileSystem.CreateFile("/Working/tools/nunit-console.exe");
+                fixture.Action = context =>
+                {
+                    context.NUnit(
+                        new FilePath[] { "./Test.dll" },
+                        new NUnitSettings { ShadowCopy = false });
+                };
+                fixture.Settings.WithLegacySyntax();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("cover /TargetExecutable=\"/Working/tools/nunit-console.exe\" " +
+                             "/TargetArguments=\"\\\"/Working/Test.dll\\\" -noshadow\" " +
+                             "/Output=\"/Working/result.dcvr\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_ConfigurationFile_LegacySyntax()
+            {
+                // Given
+                var fixture = new DotCoverCovererFixture();
+                fixture.Settings.WithConfigFile(new FilePath("./config.xml")).WithLegacySyntax();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("cover \"/Working/config.xml\" /TargetExecutable=\"/Working/tools/Test.exe\" " +
+                             "/TargetArguments=\"-argument\" " +
+                             "/Output=\"/Working/result.dcvr\"", result.Args);
+            }
+
+            #endregion
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/DotCover/Cover/DotCoverCovererTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotCover/Cover/DotCoverCovererTests.cs
@@ -9,7 +9,10 @@ using Cake.Common.Tools.NUnit;
 using Cake.Common.Tools.XUnit;
 using Cake.Core.IO;
 using Cake.Testing;
+using NSubstitute;
 using Xunit;
+using LogLevel = Cake.Core.Diagnostics.LogLevel;
+using Verbosity = Cake.Core.Diagnostics.Verbosity;
 
 namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
 {
@@ -158,6 +161,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 var result = fixture.Run();
 
                 // Then
+                fixture.Context.Log.Received(1).Write(Verbosity.Minimal, LogLevel.Warning, "{0}", "Scope parameter is not supported in new DotCover format");
                 Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
                              "--target-arguments \"-argument\" " +
                              "--snapshot-output \"/Working/result.dcvr\"", result.Args);
@@ -175,6 +179,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 var result = fixture.Run();
 
                 // Then
+                fixture.Context.Log.Received(1).Write(Verbosity.Minimal, LogLevel.Warning, "{0}", "Filters parameter is not supported in new DotCover format");
                 Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
                              "--target-arguments \"-argument\" " +
                              "--snapshot-output \"/Working/result.dcvr\"", result.Args);
@@ -192,6 +197,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 var result = fixture.Run();
 
                 // Then
+                fixture.Context.Log.Received(1).Write(Verbosity.Minimal, LogLevel.Warning, "{0}", "AttributeFilters parameter is not supported in new DotCover format");
                 Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
                              "--target-arguments \"-argument\" " +
                              "--snapshot-output \"/Working/result.dcvr\"", result.Args);
@@ -208,6 +214,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 var result = fixture.Run();
 
                 // Then
+                fixture.Context.Log.Received(1).Write(Verbosity.Minimal, LogLevel.Warning, "{0}", "DisableDefaultFilters parameter is not supported in new DotCover format");
                 Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
                              "--target-arguments \"-argument\" " +
                              "--snapshot-output \"/Working/result.dcvr\"", result.Args);
@@ -225,6 +232,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 var result = fixture.Run();
 
                 // Then
+                fixture.Context.Log.Received(1).Write(Verbosity.Minimal, LogLevel.Warning, "{0}", "ProcessFilters parameter is not supported in new DotCover format");
                 Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
                              "--target-arguments \"-argument\" " +
                              "--snapshot-output \"/Working/result.dcvr\"", result.Args);

--- a/src/Cake.Common.Tests/Unit/Tools/DotCover/Cover/DotCoverCovererTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotCover/Cover/DotCoverCovererTests.cs
@@ -9,7 +9,6 @@ using Cake.Common.Tools.NUnit;
 using Cake.Common.Tools.XUnit;
 using Cake.Core.IO;
 using Cake.Testing;
-using Xunit;
 
 namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
 {
@@ -147,12 +146,12 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
             }
 
             [Fact]
-            public void Should_Append_Scope()
+            public void Should_Not_Append_Scope()
             {
                 // Given
                 var fixture = new DotCoverCovererFixture();
                 fixture.Settings.WithScope("/Working/*.dll")
-                    .WithScope("/Some/**/Other/*.dll");
+                       .WithScope("/Some/**/Other/*.dll");
 
                 // When
                 var result = fixture.Run();
@@ -160,17 +159,16 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 // Then
                 Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
                              "--target-arguments \"-argument\" " +
-                             "--snapshot-output \"/Working/result.dcvr\" " +
-                             "/Scope=\"/Working/*.dll;/Some/**/Other/*.dll\"", result.Args);
+                             "--snapshot-output \"/Working/result.dcvr\"", result.Args);
             }
 
             [Fact]
-            public void Should_Append_Filters()
+            public void Should_Not_Append_Filters()
             {
                 // Given
                 var fixture = new DotCoverCovererFixture();
                 fixture.Settings.WithFilter("+:module=Test.*")
-                    .WithFilter("-:myassembly");
+                       .WithFilter("-:myassembly");
 
                 // When
                 var result = fixture.Run();
@@ -178,17 +176,16 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 // Then
                 Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
                              "--target-arguments \"-argument\" " +
-                             "--snapshot-output \"/Working/result.dcvr\" " +
-                             "/Filters=\"+:module=Test.*;-:myassembly\"", result.Args);
+                             "--snapshot-output \"/Working/result.dcvr\"", result.Args);
             }
 
             [Fact]
-            public void Should_Append_AttributeFilters()
+            public void Should_Not_Append_AttributeFilters()
             {
                 // Given
                 var fixture = new DotCoverCovererFixture();
                 fixture.Settings.WithAttributeFilter("filter1")
-                    .WithAttributeFilter("filter2");
+                       .WithAttributeFilter("filter2");
 
                 // When
                 var result = fixture.Run();
@@ -196,12 +193,11 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 // Then
                 Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
                              "--target-arguments \"-argument\" " +
-                             "--snapshot-output \"/Working/result.dcvr\" " +
-                             "/AttributeFilters=\"filter1;filter2\"", result.Args);
+                             "--snapshot-output \"/Working/result.dcvr\"", result.Args);
             }
 
             [Fact]
-            public void Should_Append_DisableDefaultFilters()
+            public void Should_Not_Append_DisableDefaultFilters()
             {
                 // Given
                 var fixture = new DotCoverCovererFixture();
@@ -213,17 +209,16 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 // Then
                 Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
                              "--target-arguments \"-argument\" " +
-                             "--snapshot-output \"/Working/result.dcvr\" " +
-                             "/DisableDefaultFilters", result.Args);
+                             "--snapshot-output \"/Working/result.dcvr\"", result.Args);
             }
 
             [Fact]
-            public void Should_Append_ProcessFilters()
+            public void Should_Not_Append_ProcessFilters()
             {
                 // Given
                 var fixture = new DotCoverCovererFixture();
                 fixture.Settings.WithProcessFilter("+:test.exe")
-                    .WithProcessFilter("-:sqlservr.exe");
+                       .WithProcessFilter("-:sqlservr.exe");
 
                 // When
                 var result = fixture.Run();
@@ -231,8 +226,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 // Then
                 Assert.Equal("cover --target-executable \"/Working/tools/Test.exe\" " +
                              "--target-arguments \"-argument\" " +
-                             "--snapshot-output \"/Working/result.dcvr\" " +
-                             "/ProcessFilters=\"+:test.exe;-:sqlservr.exe\"", result.Args);
+                             "--snapshot-output \"/Working/result.dcvr\"", result.Args);
             }
 
             [Fact]
@@ -301,7 +295,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 // Given
                 var fixture = new DotCoverCovererFixture();
                 fixture.Settings.WithExcludeAssembly("*.Tests")
-                    .WithExcludeAssembly("Test.*");
+                       .WithExcludeAssembly("Test.*");
 
                 // When
                 var result = fixture.Run();
@@ -319,7 +313,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 // Given
                 var fixture = new DotCoverCovererFixture();
                 fixture.Settings.WithExcludeAttribute("System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute")
-                    .WithExcludeAttribute("Custom.*Attribute");
+                       .WithExcludeAttribute("Custom.*Attribute");
 
                 // When
                 var result = fixture.Run();
@@ -337,7 +331,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 // Given
                 var fixture = new DotCoverCovererFixture();
                 fixture.Settings.WithExcludeProcess("test.exe")
-                    .WithExcludeProcess("*.vshost.exe");
+                       .WithExcludeProcess("*.vshost.exe");
 
                 // When
                 var result = fixture.Run();
@@ -506,8 +500,8 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 // Given
                 var fixture = new DotCoverCovererFixture();
                 fixture.Settings.WithLegacySyntax()
-                    .WithJsonReportOutput(new FilePath("/Working/report.json"))
-                    .WithExcludeAssembly("*.Tests");
+                       .WithJsonReportOutput(new FilePath("/Working/report.json"))
+                       .WithExcludeAssembly("*.Tests");
 
                 // When
                 var result = fixture.Run();
@@ -526,7 +520,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
                 // Given
                 var fixture = new DotCoverCovererFixture();
                 fixture.Settings.WithJsonReportOutput(new FilePath("/Working/report.json"))
-                    .WithExcludeAssembly("*.Tests");
+                       .WithExcludeAssembly("*.Tests");
 
                 // When
                 var result = fixture.Run();

--- a/src/Cake.Common.Tests/Unit/Tools/DotCover/Cover/DotCoverCovererTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotCover/Cover/DotCoverCovererTests.cs
@@ -9,6 +9,7 @@ using Cake.Common.Tools.NUnit;
 using Cake.Common.Tools.XUnit;
 using Cake.Core.IO;
 using Cake.Testing;
+using Xunit;
 
 namespace Cake.Common.Tests.Unit.Tools.DotCover.Cover
 {

--- a/src/Cake.Common.Tests/Unit/Tools/DotCover/Merge/DotCoverMergerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotCover/Merge/DotCoverMergerTests.cs
@@ -2,10 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Cake.Common.Tests.Fixtures.Tools.DotCover.Merge;
 using Cake.Common.Tools.DotCover;
 using Cake.Core.IO;
-
+using Xunit;
 namespace Cake.Common.Tests.Unit.Tools.DotCover.Merge
 {
     public sealed class DotCoverMergerTests

--- a/src/Cake.Common.Tests/Unit/Tools/DotCover/Merge/DotCoverMergerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotCover/Merge/DotCoverMergerTests.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using Cake.Common.Tests.Fixtures.Tools.DotCover.Merge;
 using Cake.Common.Tools.DotCover;
 using Cake.Core.IO;
-using Xunit;
 
 namespace Cake.Common.Tests.Unit.Tools.DotCover.Merge
 {
@@ -70,6 +68,57 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Merge
                 AssertEx.IsArgumentNullException(result, "settings");
             }
 
+            #region New Parameter Syntax
+
+            [Fact]
+            public void Should_Set_Correct_Arguments()
+            {
+                // Given
+                var fixture = new DotCoverMergerFixture();
+                fixture.SourceFiles = new List<FilePath> { new ("/Working/result1.dcvr"), new ("/Working/result2.dcvr") };
+                fixture.OutputFile = new FilePath("/Working/output.dcvr");
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("merge " +
+                             "--snapshot-source \"/Working/result1.dcvr,/Working/result2.dcvr\" " +
+                             "--snapshot-output \"/Working/output.dcvr\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_TemporaryDirectory()
+            {
+                // Given
+                var fixture = new DotCoverMergerFixture();
+                fixture.Settings.TemporaryDirectory = new DirectoryPath("/Working/temp");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("merge " +
+                             "--snapshot-source \"/Working/result1.dcvr,/Working/result2.dcvr\" " +
+                             "--snapshot-output \"/Working/result.dcvr\" " +
+                             "--temporary-directory \"/Working/temp\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Append_Null_TemporaryDirectory()
+            {
+                // Given
+                var fixture = new DotCoverMergerFixture();
+                fixture.Settings.TemporaryDirectory = null;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("merge " +
+                             "--snapshot-source \"/Working/result1.dcvr,/Working/result2.dcvr\" " +
+                             "--snapshot-output \"/Working/result.dcvr\"", result.Args);
+            }
+
             [Fact]
             public void Should_Append_LogFile()
             {
@@ -81,7 +130,29 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Merge
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("Merge " +
+                Assert.Equal("merge " +
+                             "--snapshot-source \"/Working/result1.dcvr,/Working/result2.dcvr\" " +
+                             "--snapshot-output \"/Working/result.dcvr\" " +
+                             "--log-file \"/Working/logfile.log\"", result.Args);
+            }
+
+            #endregion
+
+            #region Legacy Parameter Syntax
+
+            [Fact]
+            public void Should_Append_LogFile_LegacySyntax()
+            {
+                // Given
+                var fixture = new DotCoverMergerFixture();
+                fixture.Settings.LogFile = "./logfile.log";
+                fixture.Settings.UseLegacySyntax = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("merge " +
                              "/Source=\"/Working/result1.dcvr;/Working/result2.dcvr\" " +
                              "/Output=\"/Working/result.dcvr\" " +
                              "/LogFile=\"/Working/logfile.log\"", result.Args);
@@ -93,15 +164,18 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Merge
                 // Given
                 var fixture = new DotCoverMergerFixture();
                 fixture.Settings.WithConfigFile(new FilePath("./config.xml"));
+                fixture.Settings.UseLegacySyntax = true;
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("Merge \"/Working/config.xml\" " +
+                Assert.Equal("merge \"/Working/config.xml\" " +
                              "/Source=\"/Working/result1.dcvr;/Working/result2.dcvr\" " +
                              "/Output=\"/Working/result.dcvr\"", result.Args);
             }
+
+            #endregion
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/DotCover/Merge/DotCoverMergerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotCover/Merge/DotCoverMergerTests.cs
@@ -41,20 +41,6 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Merge
             }
 
             [Fact]
-            public void Should_Throw_If_Output_File_Is_Null()
-            {
-                // Given
-                var fixture = new DotCoverMergerFixture();
-                fixture.OutputFile = null;
-
-                // When
-                var result = Record.Exception(() => fixture.Run());
-
-                // Then
-                AssertEx.IsArgumentNullException(result, "outputFile");
-            }
-
-            [Fact]
             public void Should_Throw_If_Settings_Are_Null()
             {
                 // Given
@@ -69,6 +55,21 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Merge
             }
 
             #region New Parameter Syntax
+
+            [Fact]
+            public void Should_Ignore_Output_If_Not_Set()
+            {
+                // Given
+                var fixture = new DotCoverMergerFixture();
+                fixture.SourceFiles = new List<FilePath> { new ("/Working/result1.dcvr"), new ("/Working/result2.dcvr") };
+                fixture.OutputFile = null;
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("merge " +
+                             "--snapshot-source \"/Working/result1.dcvr,/Working/result2.dcvr\"", result.Args);
+            }
 
             [Fact]
             public void Should_Set_Correct_Arguments()
@@ -159,7 +160,7 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Merge
             }
 
             [Fact]
-            public void Should_Append_ConfigurationFile()
+            public void Should_Append_ConfigurationFile_LegacySyntax()
             {
                 // Given
                 var fixture = new DotCoverMergerFixture();
@@ -173,6 +174,21 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Merge
                 Assert.Equal("merge \"/Working/config.xml\" " +
                              "/Source=\"/Working/result1.dcvr;/Working/result2.dcvr\" " +
                              "/Output=\"/Working/result.dcvr\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Output_File_Is_Null_LegacySyntax()
+            {
+                // Given
+                var fixture = new DotCoverMergerFixture();
+                fixture.OutputFile = null;
+                fixture.Settings.UseLegacySyntax = true;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "outputFile");
             }
 
             #endregion

--- a/src/Cake.Common.Tests/Unit/Tools/DotCover/Report/DotCoverReporterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotCover/Report/DotCoverReporterTests.cs
@@ -59,6 +59,40 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Report
             }
 
             [Fact]
+            public void Should_Not_Ignore_Output_File_With_New_Syntax()
+            {
+                // Given
+                var fixture = new DotCoverReporterFixture();
+                fixture.OutputFile = "myoutputfile.xml";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("report " +
+                             "--snapshot-source \"/Working/result.dcvr\" " +
+                             "--xml-report-output \"/Working/myoutputfile.xml\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Ignore_Output_File_With_New_Syntax_Json()
+            {
+                // Given
+                var fixture = new DotCoverReporterFixture();
+                fixture.OutputFile = "myoutputfile.json";
+                fixture.Settings.ReportType = DotCoverReportType.JSON;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("report " +
+                             "--snapshot-source \"/Working/result.dcvr\" " +
+                             "--json-report-output \"/Working/myoutputfile.json\"", result.Args);
+            }
+
+
+            [Fact]
             public void Should_Append_JsonReportOutput()
             {
                 // Given

--- a/src/Cake.Common.Tests/Unit/Tools/DotCover/Report/DotCoverReporterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotCover/Report/DotCoverReporterTests.cs
@@ -5,7 +5,6 @@
 using Cake.Common.Tests.Fixtures.Tools.DotCover.Report;
 using Cake.Common.Tools.DotCover;
 using Cake.Core.IO;
-using Xunit;
 
 namespace Cake.Common.Tests.Unit.Tools.DotCover.Report
 {
@@ -28,20 +27,6 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Report
             }
 
             [Fact]
-            public void Should_Throw_If_Output_File_Is_Null()
-            {
-                // Given
-                var fixture = new DotCoverReporterFixture();
-                fixture.OutputFile = null;
-
-                // When
-                var result = Record.Exception(() => fixture.Run());
-
-                // Then
-                AssertEx.IsArgumentNullException(result, "outputFile");
-            }
-
-            [Fact]
             public void Should_Throw_If_Settings_Are_Null()
             {
                 // Given
@@ -55,6 +40,125 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Report
                 AssertEx.IsArgumentNullException(result, "settings");
             }
 
+            #region New Parameter Syntax
+
+            [Fact]
+            public void Should_Ignore_Output_File_If_Null()
+            {
+                // Given
+                var fixture = new DotCoverReporterFixture();
+                fixture.OutputFile = null;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("report " +
+                             "--snapshot-source \"/Working/result.dcvr\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Append_JsonReportOutput()
+            {
+                // Given
+                var fixture = new DotCoverReporterFixture();
+                fixture.OutputFile = null;
+                fixture.Settings.JsonReportOutput = new FilePath("/Working/coverage.json");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("report " +
+                             "--snapshot-source \"/Working/result.dcvr\" " +
+                             "--json-report-output \"/Working/coverage.json\"", result.Args);
+            }
+
+            [Theory]
+            [InlineData(DotCoverReportScope.None, "none")]
+            [InlineData(DotCoverReportScope.Assembly, "assembly")]
+            [InlineData(DotCoverReportScope.Type, "type")]
+            [InlineData(DotCoverReportScope.Method, "method")]
+            [InlineData(DotCoverReportScope.Statement, "statement")]
+            public void Should_Append_JsonReportScope(DotCoverReportScope reportScope, string reportScopeString)
+            {
+                // Given
+                var fixture = new DotCoverReporterFixture();
+                fixture.OutputFile = null;
+                fixture.Settings.JsonReportOutput = new FilePath("/Working/coverage.json");
+                fixture.Settings.JsonReportCoveringTestsScope = reportScope;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("report " +
+                             "--snapshot-source \"/Working/result.dcvr\" " +
+                             "--json-report-output \"/Working/coverage.json\" " +
+                             "--json-report-covering-tests-scope \"" + reportScopeString + "\"", result.Args);
+            }
+
+
+            [Fact]
+            public void Should_Append_XmlReportOutput()
+            {
+                // Given
+                var fixture = new DotCoverReporterFixture();
+                fixture.OutputFile = null;
+                fixture.Settings.XmlReportOutput = new FilePath("/Working/coverage.json");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("report " +
+                             "--snapshot-source \"/Working/result.dcvr\" " +
+                             "--xml-report-output \"/Working/coverage.json\"", result.Args);
+            }
+
+            [Theory]
+            [InlineData(DotCoverReportScope.None, "none")]
+            [InlineData(DotCoverReportScope.Assembly, "assembly")]
+            [InlineData(DotCoverReportScope.Type, "type")]
+            [InlineData(DotCoverReportScope.Method, "method")]
+            [InlineData(DotCoverReportScope.Statement, "statement")]
+            public void Should_Append_XmlReportScope(DotCoverReportScope reportScope, string reportScopeString)
+            {
+                // Given
+                var fixture = new DotCoverReporterFixture();
+                fixture.OutputFile = null;
+                fixture.Settings.XmlReportOutput = new FilePath("/Working/coverage.json");
+                fixture.Settings.XmlReportCoveringTestsScope = reportScope;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("report " +
+                             "--snapshot-source \"/Working/result.dcvr\" " +
+                             "--xml-report-output \"/Working/coverage.json\" " +
+                             "--xml-report-covering-tests-scope \"" + reportScopeString + "\"", result.Args);
+            }
+
+            #endregion
+
+            #region Legacy Parameter Syntax
+
+            [Fact]
+            public void Should_Throw_If_Output_File_Is_Null()
+            {
+                // Given
+                var fixture = new DotCoverReporterFixture();
+                fixture.OutputFile = null;
+                fixture.Settings.UseLegacySyntax = true;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "outputFile");
+            }
+
             [Theory]
             [InlineData(DotCoverReportType.DetailedXML, "DetailedXML")]
             [InlineData(DotCoverReportType.HTML, "HTML")]
@@ -65,12 +169,13 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Report
                 // Given
                 var fixture = new DotCoverReporterFixture();
                 fixture.Settings.ReportType = reportType;
+                fixture.Settings.UseLegacySyntax = true;
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("Report " +
+                Assert.Equal("report " +
                              "/Source=\"/Working/result.dcvr\" " +
                              "/Output=\"/Working/result.xml\" " +
                              "/ReportType=" + reportTypeString, result.Args);
@@ -82,12 +187,13 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Report
                 // Given
                 var fixture = new DotCoverReporterFixture();
                 fixture.Settings.LogFile = "./logfile.log";
+                fixture.Settings.UseLegacySyntax = true;
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("Report " +
+                Assert.Equal("report " +
                              "/Source=\"/Working/result.dcvr\" " +
                              "/Output=\"/Working/result.xml\" " +
                              "/LogFile=\"/Working/logfile.log\"", result.Args);
@@ -99,15 +205,18 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Report
                 // Given
                 var fixture = new DotCoverReporterFixture();
                 fixture.Settings.WithConfigFile(new FilePath("./config.xml"));
+                fixture.Settings.UseLegacySyntax = true;
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("Report \"/Working/config.xml\" " +
+                Assert.Equal("report \"/Working/config.xml\" " +
                              "/Source=\"/Working/result.dcvr\" " +
                              "/Output=\"/Working/result.xml\"", result.Args);
             }
+
+            #endregion
         }
     }
 }

--- a/src/Cake.Common.Tests/Unit/Tools/DotCover/Report/DotCoverReporterTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/DotCover/Report/DotCoverReporterTests.cs
@@ -5,6 +5,7 @@
 using Cake.Common.Tests.Fixtures.Tools.DotCover.Report;
 using Cake.Common.Tools.DotCover;
 using Cake.Core.IO;
+using Xunit;
 
 namespace Cake.Common.Tests.Unit.Tools.DotCover.Report
 {
@@ -97,7 +98,6 @@ namespace Cake.Common.Tests.Unit.Tools.DotCover.Report
                              "--json-report-output \"/Working/coverage.json\" " +
                              "--json-report-covering-tests-scope \"" + reportScopeString + "\"", result.Args);
             }
-
 
             [Fact]
             public void Should_Append_XmlReportOutput()

--- a/src/Cake.Common/Tools/DotCover/Cover/DotCoverCoverSettings.cs
+++ b/src/Cake.Common/Tools/DotCover/Cover/DotCoverCoverSettings.cs
@@ -52,13 +52,5 @@ namespace Cake.Common.Tools.DotCover.Cover
         /// This represents the <c>--no-ngen</c> option.
         /// </summary>
         public bool NoNGen { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to use the legacy command syntax.
-        /// When true, uses old format like '/TargetExecutable="/path"'.
-        /// When false, uses new format like '--target-executable "/path"'.
-        /// Default is false (new format).
-        /// </summary>
-        public bool UseLegacySyntax { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotCover/Cover/DotCoverCoverer.cs
+++ b/src/Cake.Common/Tools/DotCover/Cover/DotCoverCoverer.cs
@@ -165,41 +165,6 @@ namespace Cake.Common.Tools.DotCover.Cover
                 builder.AppendSwitch("--exclude-processes", excludeProcesses.Quote());
             }
 
-            // Legacy filtering options (maintain backward compatibility with old format)
-            // Scope
-            if (settings.Scope.Count > 0)
-            {
-                var scope = string.Join(';', settings.Scope);
-                builder.AppendSwitch("/Scope", "=", scope.Quote());
-            }
-
-            // Filters
-            if (settings.Filters.Count > 0)
-            {
-                var filters = string.Join(';', settings.Filters);
-                builder.AppendSwitch("/Filters", "=", filters.Quote());
-            }
-
-            // AttributeFilters
-            if (settings.AttributeFilters.Count > 0)
-            {
-                var attributeFilters = string.Join(';', settings.AttributeFilters);
-                builder.AppendSwitch("/AttributeFilters", "=", attributeFilters.Quote());
-            }
-
-            // ProcessFilters
-            if (settings.ProcessFilters.Count > 0)
-            {
-                var processFilters = string.Join(';', settings.ProcessFilters);
-                builder.AppendSwitch("/ProcessFilters", "=", processFilters.Quote());
-            }
-
-            // DisableDefaultFilters
-            if (settings.DisableDefaultFilters)
-            {
-                builder.Append("/DisableDefaultFilters");
-            }
-
             return builder;
         }
 

--- a/src/Cake.Common/Tools/DotCover/Cover/DotCoverCoverer.cs
+++ b/src/Cake.Common/Tools/DotCover/Cover/DotCoverCoverer.cs
@@ -4,6 +4,7 @@
 
 using System;
 using Cake.Core;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
 
@@ -122,6 +123,31 @@ namespace Cake.Common.Tools.DotCover.Cover
                 if (settings.NoNGen)
                 {
                     builder.Append("--no-ngen");
+                }
+
+                if (settings.Filters is { Count: > 0 })
+                {
+                    context.Log.Warning("Filters parameter is not supported in new DotCover format");
+                }
+
+                if (settings.Scope is { Count: > 0 })
+                {
+                    context.Log.Warning("Scope parameter is not supported in new DotCover format");
+                }
+
+                if (settings.AttributeFilters is { Count: > 0 })
+                {
+                    context.Log.Warning("AttributeFilters parameter is not supported in new DotCover format");
+                }
+
+                if (settings.ProcessFilters is { Count: > 0 })
+                {
+                    context.Log.Warning("ProcessFilters parameter is not supported in new DotCover format");
+                }
+
+                if (settings.DisableDefaultFilters is true)
+                {
+                    context.Log.Warning("DisableDefaultFilters parameter is not supported in new DotCover format");
                 }
 
                 // Get base arguments - new format

--- a/src/Cake.Common/Tools/DotCover/DotCoverAliases.cs
+++ b/src/Cake.Common/Tools/DotCover/DotCoverAliases.cs
@@ -273,5 +273,56 @@ namespace Cake.Common.Tools.DotCover
             // Run DotCover report.
             merger.Merge(sourceFiles, outputFile, settings);
         }
+
+        /// <summary>
+        /// Runs <see href="https://www.jetbrains.com/dotcover/help/dotCover__Console_Runner_Commands.html#merge">DotCover Merge</see>
+        /// for the specified action and settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="sourceFiles">The list of DotCover coverage snapshot files.</param>
+        /// <example>
+        /// <code>
+        /// DotCoverMerge(new[] {
+        ///     new FilePath("./result1.dcvr"),
+        ///     new FilePath("./result2.dcvr")
+        ///   });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Merge")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotCover.Merge")]
+        public static void DotCoverMerge(
+            this ICakeContext context,
+            IEnumerable<FilePath> sourceFiles)
+        {
+            DotCoverMerge(context, sourceFiles, new DotCoverMergeSettings());
+        }
+
+        /// <summary>
+        /// Runs <see href="https://www.jetbrains.com/dotcover/help/dotCover__Console_Runner_Commands.html#merge">DotCover Merge</see>
+        /// for the specified action and settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="sourceFiles">The list of DotCover coverage snapshot files.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// DotCoverMerge(new[] {
+        ///     new FilePath("./result1.dcvr"),
+        ///     new FilePath("./result2.dcvr")
+        ///   },
+        ///   new DotCoverMergeSettings());
+        /// </code>
+        /// </example>
+        public static void DotCoverMerge(
+            this ICakeContext context,
+            IEnumerable<FilePath> sourceFiles,
+            DotCoverMergeSettings settings)
+        {
+            var merger = new DotCoverMerger(
+                context.FileSystem, context.Environment,
+                context.ProcessRunner, context.Tools);
+            merger.Merge(sourceFiles, settings);
+        }
     }
 }

--- a/src/Cake.Common/Tools/DotCover/DotCoverAliases.cs
+++ b/src/Cake.Common/Tools/DotCover/DotCoverAliases.cs
@@ -164,6 +164,45 @@ namespace Cake.Common.Tools.DotCover
         }
 
         /// <summary>
+        /// Runs <see href="https://www.jetbrains.com/dotcover/help/dotCover__Console_Runner_Commands.html#report">DotCover Report</see>
+        /// for the specified action and settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="sourceFile">The DotCover coverage snapshot file name.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        /// <code>
+        /// DotCoverReport(new FilePath("./result.dcvr"),
+        ///   new DotCoverReportSettings {
+        ///     ReportType = DotCoverReportType.HTML
+        ///   });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Report")]
+        [CakeNamespaceImport("Cake.Common.Tools.DotCover.Report")]
+        public static void DotCoverReport(
+            this ICakeContext context,
+            FilePath sourceFile,
+            DotCoverReportSettings settings)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+
+            if (settings == null)
+            {
+                settings = new DotCoverReportSettings();
+            }
+
+            // Create the DotCover reporter.
+            var reporter = new DotCoverReporter(
+                context.FileSystem, context.Environment,
+                context.ProcessRunner, context.Tools);
+
+            // Run DotCover report.
+            reporter.Report(sourceFile, settings);
+        }
+
+        /// <summary>
         /// Runs <see href="https://www.jetbrains.com/dotcover/help/dotCover__Console_Runner_Commands.html#merge">DotCover Merge</see>
         /// for the specified action and settings.
         /// </summary>

--- a/src/Cake.Common/Tools/DotCover/DotCoverAliases.cs
+++ b/src/Cake.Common/Tools/DotCover/DotCoverAliases.cs
@@ -132,9 +132,9 @@ namespace Cake.Common.Tools.DotCover
         /// <example>
         /// <code>
         /// DotCoverReport(new FilePath("./result.dcvr"),
-        ///   new FilePath("./result.html"),
+        ///   new FilePath("./result.xml"),
         ///   new DotCoverReportSettings {
-        ///     ReportType = DotCoverReportType.HTML
+        ///     ReportType = DotCoverReportType.XML
         ///   });
         /// </code>
         /// </example>
@@ -174,7 +174,7 @@ namespace Cake.Common.Tools.DotCover
         /// <code>
         /// DotCoverReport(new FilePath("./result.dcvr"),
         ///   new DotCoverReportSettings {
-        ///     ReportType = DotCoverReportType.HTML
+        ///     ReportType = DotCoverReportType.Xml
         ///   });
         /// </code>
         /// </example>

--- a/src/Cake.Common/Tools/DotCover/DotCoverSettings.cs
+++ b/src/Cake.Common/Tools/DotCover/DotCoverSettings.cs
@@ -24,5 +24,13 @@ namespace Cake.Common.Tools.DotCover
         /// to specifying all parameters in-line or having them in a batch file.
         /// </summary>
         public FilePath ConfigFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use the legacy command syntax.
+        /// When true, uses old format like '/TargetExecutable="/path"'.
+        /// When false, uses new format like '--target-executable "/path"'.
+        /// Default is false (new format).
+        /// </summary>
+        public bool UseLegacySyntax { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotCover/DotCoverTool.cs
+++ b/src/Cake.Common/Tools/DotCover/DotCoverTool.cs
@@ -64,8 +64,16 @@ namespace Cake.Common.Tools.DotCover
             // LogFile
             if (settings.LogFile != null)
             {
-                var logFilePath = settings.LogFile.MakeAbsolute(_environment);
-                builder.AppendSwitch("/LogFile", "=", logFilePath.FullPath.Quote());
+                if (settings.UseLegacySyntax)
+                {
+                    var logFilePath = settings.LogFile.MakeAbsolute(_environment);
+                    builder.AppendSwitch("/LogFile", "=", logFilePath.FullPath.Quote());
+                }
+                else
+                {
+                    var logFilePath = settings.LogFile.MakeAbsolute(_environment);
+                    builder.AppendSwitch("--log-file", logFilePath.FullPath.Quote());
+                }
             }
 
             return builder;

--- a/src/Cake.Common/Tools/DotCover/Merge/DotCoverMergeSettings.cs
+++ b/src/Cake.Common/Tools/DotCover/Merge/DotCoverMergeSettings.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Core.IO;
+
 namespace Cake.Common.Tools.DotCover.Merge
 {
     /// <summary>
@@ -9,5 +11,10 @@ namespace Cake.Common.Tools.DotCover.Merge
     /// </summary>
     public sealed class DotCoverMergeSettings : DotCoverSettings
     {
+        /// <summary>
+        /// Gets or sets the directory for temporary files.
+        /// This represents the <c>--temporary-directory</c> option.
+        /// </summary>
+        public DirectoryPath TemporaryDirectory { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotCover/Merge/DotCoverMerger.cs
+++ b/src/Cake.Common/Tools/DotCover/Merge/DotCoverMerger.cs
@@ -49,8 +49,11 @@ namespace Cake.Common.Tools.DotCover.Merge
             {
                 throw new ArgumentNullException("sourceFiles");
             }
-            ArgumentNullException.ThrowIfNull(outputFile);
             ArgumentNullException.ThrowIfNull(settings);
+            if (settings.UseLegacySyntax)
+            {
+                ArgumentNullException.ThrowIfNull(outputFile);
+            }
 
             // Run the tool.
             Run(settings, GetArguments(sourceFiles, outputFile, settings));
@@ -91,8 +94,11 @@ namespace Cake.Common.Tools.DotCover.Merge
             builder.AppendSwitch("--snapshot-source", source.Quote());
 
             // Set the Output file.
-            outputFile = outputFile.MakeAbsolute(_environment);
-            builder.AppendSwitch("--snapshot-output", outputFile.FullPath.Quote());
+            if (outputFile != null)
+            {
+                outputFile = outputFile.MakeAbsolute(_environment);
+                builder.AppendSwitch("--snapshot-output", outputFile.FullPath.Quote());
+            }
 
             // Set the Temporary directory.
             if (settings.TemporaryDirectory != null)

--- a/src/Cake.Common/Tools/DotCover/Merge/DotCoverMerger.cs
+++ b/src/Cake.Common/Tools/DotCover/Merge/DotCoverMerger.cs
@@ -63,11 +63,47 @@ namespace Cake.Common.Tools.DotCover.Merge
         {
             var builder = new ProcessArgumentBuilder();
 
-            builder.Append("Merge");
+            // Command name - always lowercase 'merge' for both formats
+            builder.Append("merge");
 
             // Set configuration file if exists.
             GetConfigurationFileArgument(settings).CopyTo(builder);
 
+            if (settings.UseLegacySyntax)
+            {
+                BuildLegacyArguments(sourceFiles, outputFile, builder);
+            }
+            else
+            {
+                BuildNewArguments(sourceFiles, outputFile, builder, settings);
+            }
+
+            // Get Global settings
+            GetArguments(settings).CopyTo(builder);
+
+            return builder;
+        }
+
+        private void BuildNewArguments(IEnumerable<FilePath> sourceFiles, FilePath outputFile, ProcessArgumentBuilder builder, DotCoverMergeSettings settings)
+        {
+            // Set the Source files.
+            var source = string.Join(',', sourceFiles.Select(s => s.MakeAbsolute(_environment).FullPath));
+            builder.AppendSwitch("--snapshot-source", source.Quote());
+
+            // Set the Output file.
+            outputFile = outputFile.MakeAbsolute(_environment);
+            builder.AppendSwitch("--snapshot-output", outputFile.FullPath.Quote());
+
+            // Set the Temporary directory.
+            if (settings.TemporaryDirectory != null)
+            {
+                settings.TemporaryDirectory = settings.TemporaryDirectory.MakeAbsolute(_environment);
+                builder.AppendSwitch("--temporary-directory", settings.TemporaryDirectory.FullPath.Quote());
+            }
+        }
+
+        private void BuildLegacyArguments(IEnumerable<FilePath> sourceFiles, FilePath outputFile, ProcessArgumentBuilder builder)
+        {
             // Set the Source files.
             var source = string.Join(';', sourceFiles.Select(s => s.MakeAbsolute(_environment).FullPath));
             builder.AppendSwitch("/Source", "=", source.Quote());
@@ -75,11 +111,6 @@ namespace Cake.Common.Tools.DotCover.Merge
             // Set the Output file.
             outputFile = outputFile.MakeAbsolute(_environment);
             builder.AppendSwitch("/Output", "=", outputFile.FullPath.Quote());
-
-            // Get Global settings
-            GetArguments(settings).CopyTo(builder);
-
-            return builder;
         }
     }
 }

--- a/src/Cake.Common/Tools/DotCover/Merge/DotCoverMerger.cs
+++ b/src/Cake.Common/Tools/DotCover/Merge/DotCoverMerger.cs
@@ -35,6 +35,17 @@ namespace Cake.Common.Tools.DotCover.Merge
         }
 
         /// <summary>
+        /// Runs DotCover Merge with the new parameter Syntax.
+        /// </summary>
+        /// <param name="sourceFiles">The list of DotCover coverage snapshot files.</param>
+        /// <param name="settings">The settings.</param>
+        /// <param name="outputFile">The merged output file (optional).</param>
+        public void Merge(IEnumerable<FilePath> sourceFiles, DotCoverMergeSettings settings, FilePath outputFile = null)
+        {
+            Merge(sourceFiles, outputFile, settings);
+        }
+
+        /// <summary>
         /// Runs DotCover Merge with the specified settings.
         /// </summary>
         /// <param name="sourceFiles">The list of DotCover coverage snapshot files.</param>

--- a/src/Cake.Common/Tools/DotCover/Report/DotCoverReportSettings.cs
+++ b/src/Cake.Common/Tools/DotCover/Report/DotCoverReportSettings.cs
@@ -31,13 +31,13 @@ namespace Cake.Common.Tools.DotCover.Report
         public DotCoverReportScope? JsonReportCoveringTestsScope { get; set; }
 
         /// <summary>
-        /// Gets or sets the path to save a formatted JSON report.
+        /// Gets or sets the path to save a formatted XML report.
         /// This represents the <c>--xml-report-output</c> option.
         /// </summary>
         public FilePath XmlReportOutput { get; set; }
 
         /// <summary>
-        /// Gets or sets granularity for including covering tests in JSON reports: [none|assembly|type|method|statement]
+        /// Gets or sets granularity for including covering tests in XML reports: [none|assembly|type|method|statement]
         /// This represents the <c>--xml-report-covering-tests-scope</c> option.
         /// </summary>
         public DotCoverReportScope? XmlReportCoveringTestsScope { get; set; }

--- a/src/Cake.Common/Tools/DotCover/Report/DotCoverReportSettings.cs
+++ b/src/Cake.Common/Tools/DotCover/Report/DotCoverReportSettings.cs
@@ -19,25 +19,25 @@ namespace Cake.Common.Tools.DotCover.Report
         public DotCoverReportType ReportType { get; set; }
 
         /// <summary>
-        /// Gets the path to save a formatted JSON report.
+        /// Gets or sets the path to save a formatted JSON report.
         /// This represents the <c>--json-report-output</c> option.
         /// </summary>
         public FilePath JsonReportOutput { get; set; }
 
         /// <summary>
-        /// Gets granularity for including covering tests in JSON reports: [none|assembly|type|method|statement]
+        /// Gets or sets granularity for including covering tests in JSON reports: [none|assembly|type|method|statement]
         /// This represents the <c>--json-report-covering-tests-scope</c> option.
         /// </summary>
         public DotCoverReportScope? JsonReportCoveringTestsScope { get; set; }
 
         /// <summary>
-        /// Gets the path to save a formatted JSON report.
+        /// Gets or sets the path to save a formatted JSON report.
         /// This represents the <c>--xml-report-output</c> option.
         /// </summary>
         public FilePath XmlReportOutput { get; set; }
 
         /// <summary>
-        /// Gets granularity for including covering tests in JSON reports: [none|assembly|type|method|statement]
+        /// Gets or sets granularity for including covering tests in JSON reports: [none|assembly|type|method|statement]
         /// This represents the <c>--xml-report-covering-tests-scope</c> option.
         /// </summary>
         public DotCoverReportScope? XmlReportCoveringTestsScope { get; set; }

--- a/src/Cake.Common/Tools/DotCover/Report/DotCoverReportSettings.cs
+++ b/src/Cake.Common/Tools/DotCover/Report/DotCoverReportSettings.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Cake.Core.IO;
+
 namespace Cake.Common.Tools.DotCover.Report
 {
     /// <summary>
@@ -15,5 +17,29 @@ namespace Cake.Common.Tools.DotCover.Report
         /// The Default value is <see cref="DotCoverReportType.XML"/>.
         /// </summary>
         public DotCoverReportType ReportType { get; set; }
+
+        /// <summary>
+        /// Gets the path to save a formatted JSON report.
+        /// This represents the <c>--json-report-output</c> option.
+        /// </summary>
+        public FilePath JsonReportOutput { get; set; }
+
+        /// <summary>
+        /// Gets granularity for including covering tests in JSON reports: [none|assembly|type|method|statement]
+        /// This represents the <c>--json-report-covering-tests-scope</c> option.
+        /// </summary>
+        public DotCoverReportScope? JsonReportCoveringTestsScope { get; set; }
+
+        /// <summary>
+        /// Gets the path to save a formatted JSON report.
+        /// This represents the <c>--xml-report-output</c> option.
+        /// </summary>
+        public FilePath XmlReportOutput { get; set; }
+
+        /// <summary>
+        /// Gets granularity for including covering tests in JSON reports: [none|assembly|type|method|statement]
+        /// This represents the <c>--xml-report-covering-tests-scope</c> option.
+        /// </summary>
+        public DotCoverReportScope? XmlReportCoveringTestsScope { get; set; }
     }
 }

--- a/src/Cake.Common/Tools/DotCover/Report/DotCoverReporter.cs
+++ b/src/Cake.Common/Tools/DotCover/Report/DotCoverReporter.cs
@@ -51,6 +51,23 @@ namespace Cake.Common.Tools.DotCover.Report
                 ArgumentNullException.ThrowIfNull(outputFile);
             }
 
+            if (!settings.UseLegacySyntax && outputFile != null)
+            {
+                // map outputFile to new syntax parameters. Otherwise input is ignored
+                switch (settings.ReportType)
+                {
+                    case DotCoverReportType.XML:
+                        settings.XmlReportOutput = outputFile;
+                        break;
+                    case DotCoverReportType.JSON:
+                        settings.JsonReportOutput = outputFile;
+                        break;
+                    default:
+                        settings.XmlReportOutput = outputFile;
+                        break;
+                }
+            }
+
             // Run the tool.
             Run(settings, GetArguments(sourceFile, settings, outputFile));
         }

--- a/src/Cake.Common/Tools/DotCover/Report/DotCoverReporter.cs
+++ b/src/Cake.Common/Tools/DotCover/Report/DotCoverReporter.cs
@@ -33,7 +33,7 @@ namespace Cake.Common.Tools.DotCover.Report
         }
 
         /// <summary>
-        /// Runs DotCover Cover with the specified settings.
+        /// Runs DotCover Report with the specified settings.
         /// </summary>
         /// <param name="sourceFile">The DotCover coverage snapshot file name.</param>
         /// <param name="outputFile">The DotCover output file.</param>
@@ -73,7 +73,7 @@ namespace Cake.Common.Tools.DotCover.Report
         }
 
         /// <summary>
-        /// Runs DotCover Cover with the specified settings.
+        /// Runs DotCover Report with the specified settings.
         /// </summary>
         /// <param name="sourceFile">The DotCover coverage snapshot file name.</param>
         /// <param name="settings">The settings.</param>

--- a/src/Cake.Common/Tools/DotCover/Report/DotCoverReporter.cs
+++ b/src/Cake.Common/Tools/DotCover/Report/DotCoverReporter.cs
@@ -44,25 +44,91 @@ namespace Cake.Common.Tools.DotCover.Report
             DotCoverReportSettings settings)
         {
             ArgumentNullException.ThrowIfNull(sourceFile);
-            ArgumentNullException.ThrowIfNull(outputFile);
+            ArgumentNullException.ThrowIfNull(settings);
+
+            if (settings.UseLegacySyntax)
+            {
+                ArgumentNullException.ThrowIfNull(outputFile);
+            }
+
+            // Run the tool.
+            Run(settings, GetArguments(sourceFile, settings, outputFile));
+        }
+
+        /// <summary>
+        /// Runs DotCover Cover with the specified settings.
+        /// </summary>
+        /// <param name="sourceFile">The DotCover coverage snapshot file name.</param>
+        /// <param name="settings">The settings.</param>
+        public void Report(
+            FilePath sourceFile,
+            DotCoverReportSettings settings)
+        {
+            ArgumentNullException.ThrowIfNull(sourceFile);
             ArgumentNullException.ThrowIfNull(settings);
 
             // Run the tool.
-            Run(settings, GetArguments(sourceFile, outputFile, settings));
+            Run(settings, GetArguments(sourceFile, settings));
         }
 
         private ProcessArgumentBuilder GetArguments(
             FilePath sourceFile,
-            FilePath outputFile,
-            DotCoverReportSettings settings)
+            DotCoverReportSettings settings, FilePath outputFile = null)
         {
             var builder = new ProcessArgumentBuilder();
 
-            builder.Append("Report");
+            builder.Append("report");
 
             // Set configuration file if exists.
             GetConfigurationFileArgument(settings).CopyTo(builder);
 
+            if (settings.UseLegacySyntax)
+            {
+                GenerateLegacyArguments(sourceFile, outputFile, settings, builder);
+            }
+            else
+            {
+                GenerateArguments(sourceFile, settings, builder);
+            }
+
+            // Get Global settings
+            GetArguments(settings).CopyTo(builder);
+
+            return builder;
+        }
+
+        private void GenerateArguments(FilePath sourceFile, DotCoverReportSettings settings, ProcessArgumentBuilder builder)
+        {
+            // Set the Source file.
+            builder.AppendSwitch("--snapshot-source", sourceFile.MakeAbsolute(_environment).FullPath.Quote());
+
+            // Set Json report output
+            if (settings.JsonReportOutput != null)
+            {
+                builder.AppendSwitch("--json-report-output", settings.JsonReportOutput.MakeAbsolute(_environment).FullPath.Quote());
+            }
+
+            // Set test scope, ignore default value
+            if (settings.JsonReportCoveringTestsScope.HasValue)
+            {
+                builder.AppendSwitch("--json-report-covering-tests-scope", settings.JsonReportCoveringTestsScope.Value.ToString().ToLowerInvariant().Quote());
+            }
+
+            // Set Xml report output
+            if (settings.XmlReportOutput != null)
+            {
+                builder.AppendSwitch("--xml-report-output", settings.XmlReportOutput.MakeAbsolute(_environment).FullPath.Quote());
+            }
+
+            // Set test scope, ignore default value
+            if (settings.XmlReportCoveringTestsScope.HasValue)
+            {
+                builder.AppendSwitch("--xml-report-covering-tests-scope", settings.XmlReportCoveringTestsScope.Value.ToString().ToLowerInvariant().Quote());
+            }
+        }
+
+        private void GenerateLegacyArguments(FilePath sourceFile, FilePath outputFile, DotCoverReportSettings settings, ProcessArgumentBuilder builder)
+        {
             // Set the Source file.
             sourceFile = sourceFile.MakeAbsolute(_environment);
             builder.AppendSwitch("/Source", "=", sourceFile.FullPath.Quote());
@@ -76,11 +142,6 @@ namespace Cake.Common.Tools.DotCover.Report
             {
                 builder.AppendSwitch("/ReportType", "=", settings.ReportType.ToString());
             }
-
-            // Get Global settings
-            GetArguments(settings).CopyTo(builder);
-
-            return builder;
         }
     }
 }


### PR DESCRIPTION
As of dotCover 2025.2 JetBrains made significant changes to the parameter syntax of dotCover. Some changes where already made in #4670. Unfortunately not all commands and parameters have been covered. This pull request adds compatibility for the following commands:
- `merge`
- `report`

`analyse` has not been covered, as it's not a supported command anymore.

For a complete list of the commands and their parameters see https://www.jetbrains.com/help/dotcover/dotCover__Console_Runner_Commands.html#help

This fixes #4096