### PR TITLE
GH4900: Add Inno Setup 7 support

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/InnoSetupFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/InnoSetupFixture.cs
@@ -29,10 +29,10 @@ namespace Cake.Common.Tests.Fixtures.Tools
             Registry.LocalMachine.Returns(hklm);
         }
 
-        public void GivenToolIsInstalled(bool is64Bit, InnoSetupVersion version)
+        public void GivenToolIsInstalled(bool is64BitPlatform, bool is64Bit, InnoSetupVersion version)
         {
-            Environment.Platform.Is64Bit = is64Bit;
-            ConfigureInstalledLocation(is64Bit, version);
+            Environment.Platform.Is64Bit = is64BitPlatform;
+            ConfigureInstalledLocation(is64BitPlatform, is64Bit, version);
         }
 
         protected override void RunTool()
@@ -41,10 +41,12 @@ namespace Cake.Common.Tests.Fixtures.Tools
             tool.Run(ScriptPath, Settings);
         }
 
-        private void ConfigureInstalledLocation(bool is64Bit, InnoSetupVersion version)
+        private void ConfigureInstalledLocation(bool is64BitPlatform, bool is64Bit, InnoSetupVersion version)
         {
-            var registryKeyPath = GetRegistryKeyPath(is64Bit, version);
-            var installLocation = GetInstallLocation(is64Bit, version);
+            var useWow6432 = is64BitPlatform && !is64Bit;
+
+            var registryKeyPath = GetRegistryKeyPathForVersion(useWow6432, is64Bit, version);
+            var installLocation = GetInstallLocation(useWow6432, version);
 
             var installedToolPath = installLocation.CombineWithFilePath("iscc.exe");
             InstalledToolPaths.Add(version, installLocation.CombineWithFilePath("iscc.exe"));
@@ -58,25 +60,37 @@ namespace Cake.Common.Tests.Fixtures.Tools
             FileSystem.CreateFile(installedToolPath);
         }
 
-        private static string GetRegistryKeyPath(bool is64Bit, InnoSetupVersion version)
+        private static string GetRegistryKeyPathForVersion(bool useWow6432, bool is64Bit, InnoSetupVersion version)
         {
-            var softwareKeyPath = is64Bit ? @"SOFTWARE\Wow6432Node\" : @"SOFTWARE\";
             switch (version)
             {
+                case InnoSetupVersion.InnoSetup7 when !is64Bit:
+                    return GetRegistryKeyPath(useWow6432, "Inno Setup 7 (32-bit)_is1");
+                case InnoSetupVersion.InnoSetup7:
+                    return GetRegistryKeyPath(useWow6432, "Inno Setup 7_is1");
                 case InnoSetupVersion.InnoSetup6:
-                    return $@"{softwareKeyPath}Microsoft\Windows\CurrentVersion\Uninstall\Inno Setup 6_is1";
+                    return GetRegistryKeyPath(useWow6432, "Inno Setup 6_is1");
                 case InnoSetupVersion.InnoSetup5:
-                    return $@"{softwareKeyPath}Microsoft\Windows\CurrentVersion\Uninstall\Inno Setup 5_is1";
+                    return GetRegistryKeyPath(useWow6432, "Inno Setup 5_is1");
                 default:
                     return null;
             }
         }
 
-        private static DirectoryPath GetInstallLocation(bool is64Bit, InnoSetupVersion version)
+        private static string GetRegistryKeyPath(bool useWow6432, string relativePath)
         {
-            var programFiles = is64Bit ? "/Program Files (x86)/" : "/Program Files/";
+            // On 64-bit Windows, the registry key for Inno Setup (32-bit) will be accessible under Wow6432Node
+            var softwareKeyPath = useWow6432 ? @"SOFTWARE\Wow6432Node\" : @"SOFTWARE\";
+            return $@"{softwareKeyPath}Microsoft\Windows\CurrentVersion\Uninstall\{relativePath}";
+        }
+
+        private static DirectoryPath GetInstallLocation(bool useWow6432, InnoSetupVersion version)
+        {
+            var programFiles = useWow6432 ? "/Program Files (x86)/" : "/Program Files/";
             switch (version)
             {
+                case InnoSetupVersion.InnoSetup7:
+                    return $@"{programFiles}Inno Setup 7";
                 case InnoSetupVersion.InnoSetup6:
                     return $@"{programFiles}Inno Setup 6";
                 case InnoSetupVersion.InnoSetup5:

--- a/src/Cake.Common.Tests/Unit/Tools/InnoSetup/InnoSetupRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/InnoSetup/InnoSetupRunnerTests.cs
@@ -106,16 +106,19 @@ namespace Cake.Common.Tests.Unit.Tools.InnoSetup
             }
 
             [WindowsTheory]
-            [InlineData(true, InnoSetupVersion.InnoSetup5)]
-            [InlineData(true, InnoSetupVersion.InnoSetup6)]
-            [InlineData(false, InnoSetupVersion.InnoSetup5)]
-            [InlineData(false, InnoSetupVersion.InnoSetup6)]
-            public void Should_Find_InnoSetup_Runner_In_Installation_Path_If_Tool_Path_Not_Provided(bool is64Bit, InnoSetupVersion version)
+            [InlineData(true, true, InnoSetupVersion.InnoSetup7)]
+            [InlineData(false, false, InnoSetupVersion.InnoSetup5)]
+            [InlineData(false, false, InnoSetupVersion.InnoSetup6)]
+            [InlineData(false, false, InnoSetupVersion.InnoSetup7)]
+            [InlineData(true, false, InnoSetupVersion.InnoSetup5)]
+            [InlineData(true, false, InnoSetupVersion.InnoSetup6)]
+            [InlineData(true, false, InnoSetupVersion.InnoSetup7)]
+            public void Should_Find_InnoSetup_Runner_In_Installation_Path_If_Tool_Path_Not_Provided(bool is64BitPlatform, bool is64Bit, InnoSetupVersion version)
             {
                 // Given
                 var fixture = new InnoSetupFixture();
                 fixture.GivenDefaultToolDoNotExist();
-                fixture.GivenToolIsInstalled(is64Bit, version);
+                fixture.GivenToolIsInstalled(is64BitPlatform, is64Bit, version);
 
                 // When
                 var result = fixture.Run();
@@ -125,35 +128,41 @@ namespace Cake.Common.Tests.Unit.Tools.InnoSetup
             }
 
             [WindowsTheory]
-            [InlineData(true)]
-            [InlineData(false)]
-            public void Should_Use_Newest_InnoSetup_Version_If_Version_And_Tool_Path_Are_Not_Provided(bool is64Bit)
+            [InlineData(true, true)]
+            [InlineData(false, false)]
+            [InlineData(true, false)]
+            public void Should_Use_Newest_InnoSetup_Version_If_Version_And_Tool_Path_Are_Not_Provided(bool is64BitPlatform, bool is64Bit)
             {
                 // Given
                 var fixture = new InnoSetupFixture();
                 fixture.GivenDefaultToolDoNotExist();
-                fixture.GivenToolIsInstalled(is64Bit, InnoSetupVersion.InnoSetup5);
-                fixture.GivenToolIsInstalled(is64Bit, InnoSetupVersion.InnoSetup6);
+                fixture.GivenToolIsInstalled(is64BitPlatform, is64Bit, InnoSetupVersion.InnoSetup5);
+                fixture.GivenToolIsInstalled(is64BitPlatform, is64Bit, InnoSetupVersion.InnoSetup6);
+                fixture.GivenToolIsInstalled(is64BitPlatform, is64Bit, InnoSetupVersion.InnoSetup7);
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal(fixture.InstalledToolPaths[InnoSetupVersion.InnoSetup6].FullPath, result.Path.FullPath);
+                Assert.Equal(fixture.InstalledToolPaths[InnoSetupVersion.InnoSetup7].FullPath, result.Path.FullPath);
             }
 
             [WindowsTheory]
-            [InlineData(true, InnoSetupVersion.InnoSetup5)]
-            [InlineData(true, InnoSetupVersion.InnoSetup6)]
-            [InlineData(false, InnoSetupVersion.InnoSetup5)]
-            [InlineData(false, InnoSetupVersion.InnoSetup6)]
-            public void Should_Use_Provided_InnoSetup_Version_When_Tool_Path_Is_Not_Provided(bool is64Bit, InnoSetupVersion version)
+            [InlineData(true, true, InnoSetupVersion.InnoSetup7)]
+            [InlineData(false, false, InnoSetupVersion.InnoSetup5)]
+            [InlineData(false, false, InnoSetupVersion.InnoSetup6)]
+            [InlineData(false, false, InnoSetupVersion.InnoSetup7)]
+            [InlineData(true, false, InnoSetupVersion.InnoSetup5)]
+            [InlineData(true, false, InnoSetupVersion.InnoSetup6)]
+            [InlineData(true, false, InnoSetupVersion.InnoSetup7)]
+            public void Should_Use_Provided_InnoSetup_Version_When_Tool_Path_Is_Not_Provided(bool is64BitPlatform, bool is64Bit, InnoSetupVersion version)
             {
                 // Given
                 var fixture = new InnoSetupFixture();
                 fixture.GivenDefaultToolDoNotExist();
-                fixture.GivenToolIsInstalled(is64Bit, InnoSetupVersion.InnoSetup5);
-                fixture.GivenToolIsInstalled(is64Bit, InnoSetupVersion.InnoSetup6);
+                fixture.GivenToolIsInstalled(is64BitPlatform, is64Bit, InnoSetupVersion.InnoSetup5);
+                fixture.GivenToolIsInstalled(is64BitPlatform, is64Bit, InnoSetupVersion.InnoSetup6);
+                fixture.GivenToolIsInstalled(is64BitPlatform, is64Bit, InnoSetupVersion.InnoSetup7);
                 fixture.Settings.Version = version;
 
                 // When

--- a/src/Cake.Common/Tools/InnoSetup/InnoSetupRunner.cs
+++ b/src/Cake.Common/Tools/InnoSetup/InnoSetupRunner.cs
@@ -98,30 +98,50 @@ namespace Cake.Common.Tools.InnoSetup
         {
             if (version != null)
             {
-                return new[] { GetRegistryKeyPathForVersion(version.Value) };
+                return GetRegistryKeyPathsForVersion(version.Value);
             }
 
             var versionsToConsider = new[]
             {
+                InnoSetupVersion.InnoSetup7,
                 InnoSetupVersion.InnoSetup6,
                 InnoSetupVersion.InnoSetup5
             };
-            return versionsToConsider.Select(GetRegistryKeyPathForVersion);
+
+            return versionsToConsider.SelectMany(GetRegistryKeyPathsForVersion);
         }
 
-        private string GetRegistryKeyPathForVersion(InnoSetupVersion version)
+        private static IEnumerable<string> GetRegistryKeyPathsForVersion(InnoSetupVersion version)
         {
-            // On 64-bit Windows, the registry key for Inno Setup will be accessible under Wow6432Node
-            var softwareKeyPath = _environment.Platform.Is64Bit ? @"SOFTWARE\Wow6432Node\" : @"SOFTWARE\";
+            foreach (var keyName in GetRegistryKeyNamesForVersion(version))
+            {
+                // Inno Setup (64-bit) on 64-bit Windows and/or Inno Setup (32-bit) on 32-bit Windows.
+                yield return GetRegistryKeyPath(false, keyName);
+                // Inno Setup (32-bit) on 64-bit Windows.
+                yield return GetRegistryKeyPath(true, keyName);
+            }
+        }
+
+        private static string[] GetRegistryKeyNamesForVersion(InnoSetupVersion version)
+        {
             switch (version)
             {
+                case InnoSetupVersion.InnoSetup7:
+                    return new[] { "Inno Setup 7_is1", "Inno Setup 7 (32-bit)_is1", };
                 case InnoSetupVersion.InnoSetup6:
-                    return $@"{softwareKeyPath}Microsoft\Windows\CurrentVersion\Uninstall\Inno Setup 6_is1";
+                    return new[] { "Inno Setup 6_is1", };
                 case InnoSetupVersion.InnoSetup5:
-                    return $@"{softwareKeyPath}Microsoft\Windows\CurrentVersion\Uninstall\Inno Setup 5_is1";
+                    return new[] { "Inno Setup 5_is1", };
                 default:
                     throw new ArgumentOutOfRangeException(nameof(version), version, "Missing switch case");
             }
+        }
+
+        private static string GetRegistryKeyPath(bool useWow6432, string relativePath)
+        {
+            // On 64-bit Windows, the registry key for Inno Setup (32-bit) will be accessible under Wow6432Node
+            var softwareKeyPath = useWow6432 ? @"SOFTWARE\Wow6432Node\" : @"SOFTWARE\";
+            return $@"{softwareKeyPath}Microsoft\Windows\CurrentVersion\Uninstall\{relativePath}";
         }
 
         private ProcessArgumentBuilder GetArguments(FilePath scriptFile, InnoSetupSettings settings)

--- a/src/Cake.Common/Tools/InnoSetup/InnoSetupVersion.cs
+++ b/src/Cake.Common/Tools/InnoSetup/InnoSetupVersion.cs
@@ -13,6 +13,9 @@ namespace Cake.Common.Tools.InnoSetup
         InnoSetup5 = 5,
 
         /// <summary>Version 6.x</summary>
-        InnoSetup6 = 6
+        InnoSetup6 = 6,
+
+        /// <summary>Version 7.x</summary>
+        InnoSetup7 = 7
     }
 }


### PR DESCRIPTION
**Changes (Edited on 2026-06-24):**
- Added Inno Setup 7 support.
- ~~Added support for Inno Setup when installed in user mode.~~ [^1]

**Notes:**
- Inno Setup 7 has both 32-bit and 64-bit editions but the previously supported versions are 32-bit only.
- Inno Setup 7 is currently in beta and it's set to be released in 2026-06-29.
- Fixes: #4900 

[^1]: Since nobody asked for this feature I removed it to make the PR easier to review.