### PR TITLE
GH4904: Update Basic.Reference.Assemblies.* to 1.8.9

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,9 +6,9 @@
   <ItemGroup>
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
     <PackageVersion Include="Autofac" Version="9.3.0" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.8" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.8" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.8" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.9" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.9" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.9" />
     <PackageVersion Include="Cake.Frosting" Version="3.1.0.0" />
     <PackageVersion Include="Castle.Core" Version="5.2.1" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />


### PR DESCRIPTION
* fixes #4904