### PR TITLE
GH4912: Add workflow_dispatch trigger to Build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
       - main
       - develop
       - hotfix/*
+  workflow_dispatch:
 jobs:
   prepare:
     name: Prepare integration tests


### PR DESCRIPTION
Enable manual runs of the Build GitHub Actions workflow from the Actions UI.

- Add workflow_dispatch to .github/workflows/build.yml
- fixes #4912
