### PR TITLE
GH4916: Add support for the Command formatting command

### DIFF
--- a/src/Cake.Common.Tests/Unit/Build/AzurePipelines/AzurePipelinesCommandTests.cs
+++ b/src/Cake.Common.Tests/Unit/Build/AzurePipelines/AzurePipelinesCommandTests.cs
@@ -156,6 +156,20 @@ namespace Cake.Common.Tests.Unit.Build.AzurePipelines
             }
 
             [Fact]
+            public void Should_Command_With_CommandLine()
+            {
+                // Given
+                var fixture = new AzurePipelinesFixture();
+                var service = fixture.CreateAzurePipelinesService();
+
+                // When
+                service.Commands.Command("Example Command");
+
+                // Then
+                Assert.Contains(fixture.Writer.Entries, m => m == $"##[command]Example Command");
+            }
+
+            [Fact]
             public void Should_Section_With_Name()
             {
                 // Given

--- a/src/Cake.Common/Build/AzurePipelines/AzurePipelinesCommands.cs
+++ b/src/Cake.Common/Build/AzurePipelines/AzurePipelinesCommands.cs
@@ -82,6 +82,12 @@ namespace Cake.Common.Build.AzurePipelines
         }
 
         /// <inheritdoc/>
+        public void Command(string commandLine)
+        {
+            WriteFormatCommand("command", commandLine);
+        }
+
+        /// <inheritdoc/>
         public void Section(string name)
         {
             WriteFormatCommand("section", name);

--- a/src/Cake.Common/Build/AzurePipelines/IAzurePipelinesCommands.cs
+++ b/src/Cake.Common/Build/AzurePipelines/IAzurePipelinesCommands.cs
@@ -51,6 +51,12 @@ namespace Cake.Common.Build.AzurePipelines
         public void EndGroup();
 
         /// <summary>
+        /// Log command.
+        /// </summary>
+        /// <param name="commandLine">The command-line being run.</param>
+        public void Command(string commandLine);
+
+        /// <summary>
         /// Log section.
         /// </summary>
         /// <param name="name">The name of the section.</param>


### PR DESCRIPTION
Adds support for emitting the `##[command]` formatting command in Azure DevOps, covering the only remaining formatting command not previously supported.

#4914 