### PR TITLE
GH4929: Update System.Security.Cryptography.Pkcs to 9.0.18 (net9.0) & 10.0.10 (net10.0)

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -44,12 +44,12 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
     <!-- Pin nuget transitive packages vulnerability issues NuGet.Packaging -->
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.9" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.18" />
     <!-- Pin nuget transitive packages vulnerability issues NuGet.Packaging -->
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.17" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.18" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />


### PR DESCRIPTION
* fixes #4929