### PR TITLE
GH4943: Update NSubstitute to 6.0.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="18.8.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="NSubstitute" Version="6.0.0" />
     <PackageVersion Include="NuGet.Common" Version="7.6.0" />
     <PackageVersion Include="NuGet.Frameworks" Version="7.6.0" />
     <PackageVersion Include="NuGet.Packaging" Version="7.6.0" />


### PR DESCRIPTION
* fixes #4943