### PR TITLE
GH4970: Update Microsoft.Testing.Extensions.CodeCoverage to 18.11.2

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -38,7 +38,7 @@
     <PackageVersion Include="xunit.v3.assert" Version="4.0.0" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="4.0.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.11.2" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">


### PR DESCRIPTION
* fixes #4970