### PR TITLE
GH4977: Fix CS8632 for aliases from nullable enabled addins

### DIFF
--- a/src/Cake.Common.Tests/Fixtures/Tools/CakeRunnerCoreFixture.cs
+++ b/src/Cake.Common.Tests/Fixtures/Tools/CakeRunnerCoreFixture.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Common.Tools.Cake;
+using Cake.Core.IO;
+using Cake.Testing;
+using Cake.Testing.Fixtures;
+
+namespace Cake.Common.Tests.Fixtures.Tools
+{
+    /// <summary>
+    /// Runs the Cake tool through the .NET host, which is what happens when the
+    /// resolved tool path is Cake.dll instead of a Cake executable.
+    /// </summary>
+    internal sealed class CakeRunnerCoreFixture : ToolFixture<CakeSettings>
+    {
+        public FilePath ScriptPath { get; set; }
+
+        public CakeRunnerCoreFixture()
+            : base("dotnet.exe")
+        {
+            ScriptPath = new FilePath("./build.cake");
+            FileSystem.CreateFile(ScriptPath.MakeAbsolute(Environment));
+
+            Settings.ToolPath = new FilePath("./tools/Cake.dll");
+            this.GivenSettingsToolPathExist();
+        }
+
+        protected override void RunTool()
+        {
+            var runner = new CakeRunner(FileSystem, Environment, Globber, ProcessRunner, Tools);
+            runner.ExecuteScript(ScriptPath, Settings);
+        }
+    }
+}

--- a/src/Cake.Common.Tests/Unit/Tools/Cake/CakeRunnerTests.cs
+++ b/src/Cake.Common.Tests/Unit/Tools/Cake/CakeRunnerTests.cs
@@ -139,5 +139,105 @@ namespace Cake.Common.Tests.Unit.Tools.Cake
                              "--configuration=\"Debug\"", result.Args);
             }
         }
+
+        public sealed class TheExecuteScriptMethodViaTheDotNetHost
+        {
+            [Fact]
+            public void Should_Execute_Cake_Dll_Through_The_DotNet_Host()
+            {
+                // Given
+                var fixture = new CakeRunnerCoreFixture();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("/Working/tools/dotnet.exe", result.Path.FullPath);
+                Assert.Equal("\"/Working/tools/Cake.dll\" \"/Working/build.cake\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Call_Settings_PostAction()
+            {
+                // Given
+                var called = false;
+                var fixture = new CakeRunnerCoreFixture
+                {
+                    Settings = { PostAction = _ => called = true }
+                };
+
+                // When
+                fixture.Run();
+
+                // Then
+                Assert.True(called, "Settings PostAction not called");
+            }
+
+            [Fact]
+            public void Should_Use_Settings_HandleExitCode()
+            {
+                // Given
+                const int expectedExitCode = 1337;
+                var handledExitCode = 0;
+                var fixture = new CakeRunnerCoreFixture
+                {
+                    Settings = { HandleExitCode = exitCode => (handledExitCode = exitCode) == expectedExitCode }
+                };
+                fixture.ProcessRunner.Process.SetExitCode(expectedExitCode);
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                Assert.Null(result);
+                Assert.Equal(expectedExitCode, handledExitCode);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Exit_Code_Is_Not_Handled()
+            {
+                // Given
+                var fixture = new CakeRunnerCoreFixture();
+                fixture.ProcessRunner.Process.SetExitCode(1337);
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                AssertEx.IsCakeException(result, ".NET CLI: Process returned an error (exit code 1337).");
+            }
+
+            [Fact]
+            public void Should_Call_Settings_SetupProcessSettings()
+            {
+                // Given
+                var fixture = new CakeRunnerCoreFixture
+                {
+                    Settings = { SetupProcessSettings = process => process.RedirectStandardOutput = true }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.True(result.Process.RedirectStandardOutput, "Settings SetupProcessSettings not called");
+            }
+
+            [Fact]
+            public void Should_Use_Settings_NoWorkingDirectory()
+            {
+                // Given
+                var fixture = new CakeRunnerCoreFixture
+                {
+                    Settings = { NoWorkingDirectory = true }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.True(result.Process.NoWorkingDirectory);
+            }
+        }
     }
 }

--- a/src/Cake.Common/Tools/Cake/CakeRunner.cs
+++ b/src/Cake.Common/Tools/Cake/CakeRunner.cs
@@ -84,6 +84,10 @@ namespace Cake.Common.Tools.Cake
                     {
                         ArgumentCustomization = settings.ArgumentCustomization,
                         EnvironmentVariables = settings.EnvironmentVariables,
+                        HandleExitCode = settings.HandleExitCode,
+                        NoWorkingDirectory = settings.NoWorkingDirectory,
+                        PostAction = settings.PostAction,
+                        SetupProcessSettings = settings.SetupProcessSettings,
                         ToolTimeout = settings.ToolTimeout,
                         WorkingDirectory = settings.WorkingDirectory
                     });

--- a/src/Cake.Core.Tests/Data/MethodAliasGeneratorData.cs
+++ b/src/Cake.Core.Tests/Data/MethodAliasGeneratorData.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Cake.Core.Annotations;
 
 namespace Cake.Core.Tests.Data
@@ -258,6 +259,175 @@ namespace Cake.Core.Tests.Data
         [CakeMethodAlias]
 #nullable enable
         public static string? NonGeneric_ExtensionMethodWithNullableReturnValue(this ICakeContext context)
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static string NonGeneric_ExtensionMethodWithNotNullReturnValue(this ICakeContext context)
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static void NonGeneric_ExtensionMethodWithNotNullParameter(this ICakeContext context, string parameter)
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static void NonGeneric_ExtensionMethodWithNotNullAndNullableParameters(this ICakeContext context, string notNull, string? nullable)
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+        public static void NonGeneric_ExtensionMethodWithNotNullParameterInDisabledContext(
+            this ICakeContext context,
+#nullable enable
+            string parameter)
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static void NonGeneric_ExtensionMethodWithNullableArrayElements(this ICakeContext context, string?[] values)
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+#pragma warning disable SA1011
+        public static void NonGeneric_ExtensionMethodWithNullableArray(this ICakeContext context, string[]? values)
+#pragma warning restore SA1011
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+#pragma warning disable SA1011
+        public static void NonGeneric_ExtensionMethodWithNullableArrayAndElements(this ICakeContext context, string?[]? values)
+#pragma warning restore SA1011
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static void NonGeneric_ExtensionMethodWithNullableGenericArgument(this ICakeContext context, IList<string?> values)
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static void NonGeneric_ExtensionMethodWithNullableGenericType(this ICakeContext context, IList<string>? values)
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static IList<string?> NonGeneric_ExtensionMethodWithNullableGenericReturn(this ICakeContext context)
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static void NonGeneric_ExtensionMethodWithNullableTaskResult(this ICakeContext context, Task<string?> task)
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static void NonGeneric_ExtensionMethodWithNullableDictionaryValues(this ICakeContext context, Dictionary<string, string?> values)
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static void NonGeneric_ExtensionMethodWithNullableParamsArray(this ICakeContext context, params string?[] values)
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static void Generic_ExtensionMethodWithUnconstrainedTypeParameter<TTest>(this ICakeContext context, TTest value)
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static TTest Generic_ExtensionMethodWithUnconstrainedTypeParameterReturn<TTest>(this ICakeContext context, TTest value)
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static void Generic_ExtensionMethodWithNullableTypeParameter<TTest>(this ICakeContext context, TTest? value)
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static void Generic_ExtensionMethodWithNullableClassConstraint<TTest>(this ICakeContext context, TTest value)
+            where TTest : class?
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static void Generic_ExtensionMethodWithNotNullAndNewConstraints<TTest>(this ICakeContext context, TTest value)
+            where TTest : notnull, new()
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static void Generic_ExtensionMethodWithNullableTypeParameterArgument<TTest>(this ICakeContext context, IList<TTest?> values)
+            where TTest : class
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static void Generic_ExtensionMethodWithUnconstrainedTypeParameterArgument<TTest>(this ICakeContext context, IList<TTest> values)
 #nullable disable
         {
             throw new NotImplementedException();

--- a/src/Cake.Core.Tests/Data/PropertyAliasGeneratorData.cs
+++ b/src/Cake.Core.Tests/Data/PropertyAliasGeneratorData.cs
@@ -131,5 +131,13 @@ namespace Cake.Core.Tests.Data
         {
             throw new NotImplementedException();
         }
+
+        [CakePropertyAlias]
+#nullable enable
+        public static string NonCached_NotNull_Type(this ICakeContext context)
+#nullable disable
+        {
+            return "Hello World";
+        }
     }
 }

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Generic_Methods_name=Generic_ExtensionMethodWithNotNullAndNewConstraints.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Generic_Methods_name=Generic_ExtensionMethodWithNotNullAndNewConstraints.verified.cake
@@ -1,0 +1,7 @@
+﻿#nullable enable
+[System.Diagnostics.DebuggerStepThrough]
+public void Generic_ExtensionMethodWithNotNullAndNewConstraints<TTest>(TTest value)
+where TTest : notnull, new()
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.Generic_ExtensionMethodWithNotNullAndNewConstraints<TTest>(Context, value);
+
+#nullable restore

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Generic_Methods_name=Generic_ExtensionMethodWithNullableClassConstraint.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Generic_Methods_name=Generic_ExtensionMethodWithNullableClassConstraint.verified.cake
@@ -1,0 +1,7 @@
+﻿#nullable enable
+[System.Diagnostics.DebuggerStepThrough]
+public void Generic_ExtensionMethodWithNullableClassConstraint<TTest>(TTest value)
+where TTest : class?
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.Generic_ExtensionMethodWithNullableClassConstraint<TTest>(Context, value);
+
+#nullable restore

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Generic_Methods_name=Generic_ExtensionMethodWithNullableTypeParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Generic_Methods_name=Generic_ExtensionMethodWithNullableTypeParameter.verified.cake
@@ -1,0 +1,6 @@
+﻿#nullable enable
+[System.Diagnostics.DebuggerStepThrough]
+public void Generic_ExtensionMethodWithNullableTypeParameter<TTest>(TTest? value)
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.Generic_ExtensionMethodWithNullableTypeParameter<TTest>(Context, value);
+
+#nullable restore

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Generic_Methods_name=Generic_ExtensionMethodWithNullableTypeParameterArgument.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Generic_Methods_name=Generic_ExtensionMethodWithNullableTypeParameterArgument.verified.cake
@@ -1,0 +1,7 @@
+﻿#nullable enable
+[System.Diagnostics.DebuggerStepThrough]
+public void Generic_ExtensionMethodWithNullableTypeParameterArgument<TTest>(System.Collections.Generic.IList<TTest?> values)
+where TTest : class
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.Generic_ExtensionMethodWithNullableTypeParameterArgument<TTest>(Context, values);
+
+#nullable restore

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Generic_Methods_name=Generic_ExtensionMethodWithUnconstrainedTypeParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Generic_Methods_name=Generic_ExtensionMethodWithUnconstrainedTypeParameter.verified.cake
@@ -1,0 +1,3 @@
+﻿[System.Diagnostics.DebuggerStepThrough]
+public void Generic_ExtensionMethodWithUnconstrainedTypeParameter<TTest>(TTest value)
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.Generic_ExtensionMethodWithUnconstrainedTypeParameter<TTest>(Context, value);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Generic_Methods_name=Generic_ExtensionMethodWithUnconstrainedTypeParameterArgument.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Generic_Methods_name=Generic_ExtensionMethodWithUnconstrainedTypeParameterArgument.verified.cake
@@ -1,0 +1,3 @@
+﻿[System.Diagnostics.DebuggerStepThrough]
+public void Generic_ExtensionMethodWithUnconstrainedTypeParameterArgument<TTest>(System.Collections.Generic.IList<TTest> values)
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.Generic_ExtensionMethodWithUnconstrainedTypeParameterArgument<TTest>(Context, values);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Generic_Methods_name=Generic_ExtensionMethodWithUnconstrainedTypeParameterReturn.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Generic_Methods_name=Generic_ExtensionMethodWithUnconstrainedTypeParameterReturn.verified.cake
@@ -1,0 +1,3 @@
+﻿[System.Diagnostics.DebuggerStepThrough]
+public TTest Generic_ExtensionMethodWithUnconstrainedTypeParameterReturn<TTest>(TTest value)
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.Generic_ExtensionMethodWithUnconstrainedTypeParameterReturn<TTest>(Context, value);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNotNullAndNullableParameters.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNotNullAndNullableParameters.verified.cake
@@ -1,0 +1,6 @@
+﻿#nullable enable
+[System.Diagnostics.DebuggerStepThrough]
+public void NonGeneric_ExtensionMethodWithNotNullAndNullableParameters(System.String notNull, System.String? nullable)
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNotNullAndNullableParameters(Context, notNull, nullable);
+
+#nullable restore

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNotNullParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNotNullParameter.verified.cake
@@ -1,0 +1,3 @@
+﻿[System.Diagnostics.DebuggerStepThrough]
+public void NonGeneric_ExtensionMethodWithNotNullParameter(System.String parameter)
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNotNullParameter(Context, parameter);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNotNullParameterInDisabledContext.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNotNullParameterInDisabledContext.verified.cake
@@ -1,0 +1,3 @@
+﻿[System.Diagnostics.DebuggerStepThrough]
+public void NonGeneric_ExtensionMethodWithNotNullParameterInDisabledContext(System.String parameter)
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNotNullParameterInDisabledContext(Context, parameter);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNotNullReturnValue.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNotNullReturnValue.verified.cake
@@ -1,0 +1,3 @@
+﻿[System.Diagnostics.DebuggerStepThrough]
+public System.String NonGeneric_ExtensionMethodWithNotNullReturnValue()
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNotNullReturnValue(Context);

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableArray.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableArray.verified.cake
@@ -1,0 +1,6 @@
+﻿#nullable enable
+[System.Diagnostics.DebuggerStepThrough]
+public void NonGeneric_ExtensionMethodWithNullableArray(System.String[]? values)
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableArray(Context, values);
+
+#nullable restore

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableArrayAndElements.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableArrayAndElements.verified.cake
@@ -1,0 +1,6 @@
+﻿#nullable enable
+[System.Diagnostics.DebuggerStepThrough]
+public void NonGeneric_ExtensionMethodWithNullableArrayAndElements(System.String?[]? values)
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableArrayAndElements(Context, values);
+
+#nullable restore

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableArrayElements.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableArrayElements.verified.cake
@@ -1,0 +1,6 @@
+﻿#nullable enable
+[System.Diagnostics.DebuggerStepThrough]
+public void NonGeneric_ExtensionMethodWithNullableArrayElements(System.String?[] values)
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableArrayElements(Context, values);
+
+#nullable restore

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableDictionaryValues.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableDictionaryValues.verified.cake
@@ -1,0 +1,6 @@
+﻿#nullable enable
+[System.Diagnostics.DebuggerStepThrough]
+public void NonGeneric_ExtensionMethodWithNullableDictionaryValues(System.Collections.Generic.Dictionary<System.String, System.String?> values)
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableDictionaryValues(Context, values);
+
+#nullable restore

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableGenericArgument.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableGenericArgument.verified.cake
@@ -1,0 +1,6 @@
+﻿#nullable enable
+[System.Diagnostics.DebuggerStepThrough]
+public void NonGeneric_ExtensionMethodWithNullableGenericArgument(System.Collections.Generic.IList<System.String?> values)
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableGenericArgument(Context, values);
+
+#nullable restore

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableGenericReturn.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableGenericReturn.verified.cake
@@ -1,0 +1,6 @@
+﻿#nullable enable
+[System.Diagnostics.DebuggerStepThrough]
+public System.Collections.Generic.IList<System.String?> NonGeneric_ExtensionMethodWithNullableGenericReturn()
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableGenericReturn(Context);
+
+#nullable restore

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableGenericType.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableGenericType.verified.cake
@@ -1,0 +1,6 @@
+﻿#nullable enable
+[System.Diagnostics.DebuggerStepThrough]
+public void NonGeneric_ExtensionMethodWithNullableGenericType(System.Collections.Generic.IList<System.String>? values)
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableGenericType(Context, values);
+
+#nullable restore

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableParameter.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableParameter.verified.cake
@@ -1,3 +1,6 @@
-﻿[System.Diagnostics.DebuggerStepThrough]
+﻿#nullable enable
+[System.Diagnostics.DebuggerStepThrough]
 public void NonGeneric_ExtensionMethodWithNullableParameter(System.String? parameter)
     => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableParameter(Context, parameter);
+
+#nullable restore

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableParamsArray.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableParamsArray.verified.cake
@@ -1,0 +1,6 @@
+﻿#nullable enable
+[System.Diagnostics.DebuggerStepThrough]
+public void NonGeneric_ExtensionMethodWithNullableParamsArray(params System.String?[] values)
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableParamsArray(Context, values);
+
+#nullable restore

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableReturnValue.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableReturnValue.verified.cake
@@ -1,3 +1,6 @@
-﻿[System.Diagnostics.DebuggerStepThrough]
+﻿#nullable enable
+[System.Diagnostics.DebuggerStepThrough]
 public System.String? NonGeneric_ExtensionMethodWithNullableReturnValue()
     => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableReturnValue(Context);
+
+#nullable restore

--- a/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableTaskResult.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/MethodAliasGeneratorTests.TheGeneratorMethod.Should_Return_Correct_Generated_Code_For_Non_Generic_Methods_name=ExtensionMethodWithNullableTaskResult.verified.cake
@@ -1,0 +1,6 @@
+﻿#nullable enable
+[System.Diagnostics.DebuggerStepThrough]
+public void NonGeneric_ExtensionMethodWithNullableTaskResult(System.Threading.Tasks.Task<System.String?> task)
+    => Cake.Core.Tests.Data.MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableTaskResult(Context, task);
+
+#nullable restore

--- a/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Cached_Properties_name=Cached_Nullable_Type.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Cached_Properties_name=Cached_Nullable_Type.verified.cake
@@ -1,3 +1,5 @@
-﻿private System.String? _Cached_Nullable_Type;
+﻿#nullable enable
+private System.String? _Cached_Nullable_Type;
 public System.String? Cached_Nullable_Type
     => _Cached_Nullable_Type ??= Cake.Core.Tests.Data.PropertyAliasGeneratorData.Cached_Nullable_Type(Context);
+#nullable restore

--- a/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Non_Cached_Properties_name=NonCached_NotNull_Type.verified.cake
+++ b/src/Cake.Core.Tests/Expectations/PropertyAliasGeneratorTests.TheGenerateMethod.Should_Return_Correct_Generated_Code_For_Non_Cached_Properties_name=NonCached_NotNull_Type.verified.cake
@@ -1,0 +1,2 @@
+﻿public System.String NonCached_NotNull_Type
+    => Cake.Core.Tests.Data.PropertyAliasGeneratorData.NonCached_NotNull_Type(Context);

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/GenericParameterConstraintEmitterTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/GenericParameterConstraintEmitterTests.cs
@@ -101,6 +101,55 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
             {
                 throw new NotImplementedException();
             }
+
+#nullable enable
+            public static void Test_TIn_TIn_Is_notnull<TIn>(TIn obj)
+                where TIn : notnull
+            {
+                throw new NotImplementedException();
+            }
+
+            public static void Test_TIn_TIn_Is_nullable_class<TIn>(TIn obj)
+                where TIn : class?
+            {
+                throw new NotImplementedException();
+            }
+
+            public static void Test_TIn_TIn_Is_class_In_Enabled_Context<TIn>(TIn obj)
+                where TIn : class
+            {
+                throw new NotImplementedException();
+            }
+
+            public static void Test_TIn_TIn_Is_Unconstrained_In_Enabled_Context<TIn>(TIn obj)
+            {
+                throw new NotImplementedException();
+            }
+
+            public static void Test_TIn_TIn_Is_IFakeInterface_In_Enabled_Context<TIn>(TIn obj)
+                where TIn : IFakeInterface
+            {
+                throw new NotImplementedException();
+            }
+
+            public static void Test_TIn_TIn_Is_notnull_and_DefaultCtor<TIn>(TIn obj)
+                where TIn : notnull, new()
+            {
+                throw new NotImplementedException();
+            }
+
+            public static void Test_TIn_TIn_Is_notnull_and_IFakeInterface<TIn>(TIn obj)
+                where TIn : notnull, IFakeInterface
+            {
+                throw new NotImplementedException();
+            }
+
+            public static void Test_TIn_TIn_Is_notnull_and_FakeClass_and_DefaultCtor<TIn>(TIn obj)
+                where TIn : notnull, FakeClass, new()
+            {
+                throw new NotImplementedException();
+            }
+#nullable disable
         }
 
         [Theory]
@@ -118,6 +167,18 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
         [InlineData("Test_TOut_TIn_TIn_is_FakeClass_and_IFakeInterface_and_TOut_IsIFakeInterface", "where TIn : Cake.Core.Tests.Unit.Scripting.CodeGen.GenericParameterConstraintEmitterTests.FakeClass, Cake.Core.Tests.Unit.Scripting.CodeGen.GenericParameterConstraintEmitterTests.IFakeInterface\r\nwhere TOut : Cake.Core.Tests.Unit.Scripting.CodeGen.GenericParameterConstraintEmitterTests.IFakeInterface")]
         [InlineData("Test_TIn_TIn_is_NestedFakeClass_and_NestedFakeInterface", "where TIn : Cake.Core.Tests.Unit.Scripting.CodeGen.GenericConstraintFakes.FakeClass, Cake.Core.Tests.Unit.Scripting.CodeGen.GenericConstraintFakes.IFakeInterface")]
         [InlineData("Test_TIn_TIn_Is_IEnumerable_int", "where TIn : System.Collections.Generic.IEnumerable<System.Int32>")]
+        [InlineData("Test_TIn_TIn_Is_notnull", "where TIn : notnull")]
+        [InlineData("Test_TIn_TIn_Is_nullable_class", "where TIn : class?")]
+        [InlineData("Test_TIn_TIn_Is_class_In_Enabled_Context", "where TIn : class")]
+        [InlineData("Test_TIn_TIn_Is_Unconstrained_In_Enabled_Context", "")]
+        [InlineData("Test_TIn_TIn_Is_IFakeInterface_In_Enabled_Context", "where TIn : Cake.Core.Tests.Unit.Scripting.CodeGen.GenericParameterConstraintEmitterTests.IFakeInterface")]
+
+        // `new()` doesn't imply non-nullability, so `notnull` has to be emitted alongside it
+        [InlineData("Test_TIn_TIn_Is_notnull_and_DefaultCtor", "where TIn : notnull, new()")]
+
+        // a type constraint does imply non-nullability, so `notnull` is redundant
+        [InlineData("Test_TIn_TIn_Is_notnull_and_IFakeInterface", "where TIn : Cake.Core.Tests.Unit.Scripting.CodeGen.GenericParameterConstraintEmitterTests.IFakeInterface")]
+        [InlineData("Test_TIn_TIn_Is_notnull_and_FakeClass_and_DefaultCtor", "where TIn : Cake.Core.Tests.Unit.Scripting.CodeGen.GenericParameterConstraintEmitterTests.FakeClass, new()")]
         public void Should_Return_Correct_Generated_Code_For_Generic_Method_Parameter_Constraints(string methodName, string expected)
         {
             // Given

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/MethodAliasGeneratorTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/MethodAliasGeneratorTests.cs
@@ -61,6 +61,19 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
             [InlineData("ExtensionMethodWithDynamicReturnValue")]
             [InlineData("ExtensionMethodWithNullableParameter")]
             [InlineData("ExtensionMethodWithNullableReturnValue")]
+            [InlineData("ExtensionMethodWithNotNullReturnValue")]
+            [InlineData("ExtensionMethodWithNotNullParameter")]
+            [InlineData("ExtensionMethodWithNotNullAndNullableParameters")]
+            [InlineData("ExtensionMethodWithNotNullParameterInDisabledContext")]
+            [InlineData("ExtensionMethodWithNullableArrayElements")]
+            [InlineData("ExtensionMethodWithNullableArray")]
+            [InlineData("ExtensionMethodWithNullableArrayAndElements")]
+            [InlineData("ExtensionMethodWithNullableGenericArgument")]
+            [InlineData("ExtensionMethodWithNullableGenericType")]
+            [InlineData("ExtensionMethodWithNullableGenericReturn")]
+            [InlineData("ExtensionMethodWithNullableTaskResult")]
+            [InlineData("ExtensionMethodWithNullableDictionaryValues")]
+            [InlineData("ExtensionMethodWithNullableParamsArray")]
             public Task Should_Return_Correct_Generated_Code_For_Non_Generic_Methods(string name)
             {
                 // Given / When
@@ -76,6 +89,13 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
             [InlineData("Generic_ExtensionMethodWithParameter")]
             [InlineData("Generic_ExtensionMethodWithGenericReturnValue")]
             [InlineData("Generic_ExtensionMethodWithGenericReturnValueAndTypeParamConstraints")]
+            [InlineData("Generic_ExtensionMethodWithUnconstrainedTypeParameter")]
+            [InlineData("Generic_ExtensionMethodWithUnconstrainedTypeParameterReturn")]
+            [InlineData("Generic_ExtensionMethodWithNullableTypeParameter")]
+            [InlineData("Generic_ExtensionMethodWithNullableClassConstraint")]
+            [InlineData("Generic_ExtensionMethodWithNotNullAndNewConstraints")]
+            [InlineData("Generic_ExtensionMethodWithNullableTypeParameterArgument")]
+            [InlineData("Generic_ExtensionMethodWithUnconstrainedTypeParameterArgument")]
             public Task Should_Return_Correct_Generated_Code_For_Generic_Methods(string name)
             {
                 // Given / When

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/NullableAnnotationContextTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/NullableAnnotationContextTests.cs
@@ -1,0 +1,264 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using Cake.Core.Scripting.CodeGen;
+using Cake.Core.Tests.Data;
+using Xunit;
+
+namespace Cake.Core.Tests.Unit.Scripting.CodeGen
+{
+    public sealed class NullableAnnotationContextTests
+    {
+        public sealed class TheGetNullableFlagMethod
+        {
+            [Theory]
+            [InlineData(nameof(ConstraintFixture.NotNull), NullableAnnotationContext.NotAnnotated)]
+            [InlineData(nameof(ConstraintFixture.NullableClass), NullableAnnotationContext.Annotated)]
+            [InlineData(nameof(ConstraintFixture.NotNullClass), NullableAnnotationContext.NotAnnotated)]
+            [InlineData(nameof(ConstraintFixture.UnconstrainedInDisabledContext), NullableAnnotationContext.Oblivious)]
+            public void Should_Read_Flag_Of_Generic_Parameter(string name, byte expected)
+            {
+                // Given
+                var argument = GetGenericArgument(name);
+
+                // When
+                var result = NullableAnnotationContext.GetNullableFlag(argument);
+
+                // Then
+                Assert.Equal(expected, result);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Generic_Parameter_Is_Null()
+            {
+                // Given, When
+                var result = Record.Exception(() => NullableAnnotationContext.GetNullableFlag(null));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "genericParameter");
+            }
+        }
+
+        public sealed class TheRequiresMethod
+        {
+            [Fact]
+            public void Should_Return_False_For_Oblivious_Alias()
+            {
+                // Given
+                var method = GetMethod(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNoParameters));
+
+                // When
+                var result = NullableAnnotationContext.Requires(method);
+
+                // Then
+                Assert.False(result);
+            }
+
+            [Theory]
+            [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableParameter))]
+            [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableReturnValue))]
+            [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNotNullAndNullableParameters))]
+            [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableGenericArgument))]
+            [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableArrayElements))]
+            [InlineData(nameof(MethodAliasGeneratorData.Generic_ExtensionMethodWithNullableTypeParameter))]
+            [InlineData(nameof(MethodAliasGeneratorData.Generic_ExtensionMethodWithNullableClassConstraint))]
+            [InlineData(nameof(MethodAliasGeneratorData.Generic_ExtensionMethodWithNotNullAndNewConstraints))]
+            [InlineData(nameof(MethodAliasGeneratorData.Generic_ExtensionMethodWithNullableTypeParameterArgument))]
+            public void Should_Return_True_For_Nullable_Aware_Alias(string name)
+            {
+                // Given
+                var method = GetMethod(name);
+
+                // When
+                var result = NullableAnnotationContext.Requires(method);
+
+                // Then
+                Assert.True(result);
+            }
+
+            [Theory]
+            [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNotNullReturnValue))]
+            [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNotNullParameter))]
+            [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNotNullParameterInDisabledContext))]
+
+            // an unconstrained type parameter may be a nullable reference type, but that's not the
+            // same as the alias author annotating it, and annotating it anyway breaks the call forward
+            [InlineData(nameof(MethodAliasGeneratorData.Generic_ExtensionMethodWithUnconstrainedTypeParameter))]
+            [InlineData(nameof(MethodAliasGeneratorData.Generic_ExtensionMethodWithUnconstrainedTypeParameterReturn))]
+            [InlineData(nameof(MethodAliasGeneratorData.Generic_ExtensionMethodWithUnconstrainedTypeParameterArgument))]
+            public void Should_Return_False_For_Alias_Without_Annotations(string name)
+            {
+                // Given
+                var method = GetMethod(name);
+
+                // When
+                var result = NullableAnnotationContext.Requires(method);
+
+                // Then
+                Assert.False(result);
+            }
+
+            [Theory]
+            [InlineData(nameof(ConstraintFixture.NotNull), true)]
+            [InlineData(nameof(ConstraintFixture.NullableClass), true)]
+            [InlineData(nameof(ConstraintFixture.NotNullClass), false)]
+            [InlineData(nameof(ConstraintFixture.UnconstrainedInEnabledContext), false)]
+            [InlineData(nameof(ConstraintFixture.UnconstrainedInDisabledContext), false)]
+            public void Should_Consider_Nullable_Aware_Generic_Constraints(string name, bool expected)
+            {
+                // Given
+                var method = GetFixtureMethod(name);
+
+                // When
+                var result = NullableAnnotationContext.Requires(method);
+
+                // Then
+                Assert.Equal(expected, result);
+            }
+
+            [Fact]
+            public void Should_Throw_If_Method_Is_Null()
+            {
+                // Given, When
+                var result = Record.Exception(() => NullableAnnotationContext.Requires(null));
+
+                // Then
+                AssertEx.IsArgumentNullException(result, "method");
+            }
+        }
+
+        public sealed class TheFormatMethod
+        {
+            [Theory]
+            [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableParameter), "System.String?")]
+            [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNotNullParameter), "System.String")]
+            [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableArrayElements), "System.String?[]")]
+            [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableArray), "System.String[]?")]
+            [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableArrayAndElements), "System.String?[]?")]
+            [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableGenericArgument), "System.Collections.Generic.IList<System.String?>")]
+            [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableGenericType), "System.Collections.Generic.IList<System.String>?")]
+            [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableTaskResult), "System.Threading.Tasks.Task<System.String?>")]
+            [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableDictionaryValues), "System.Collections.Generic.Dictionary<System.String, System.String?>")]
+            [InlineData(nameof(MethodAliasGeneratorData.Generic_ExtensionMethodWithUnconstrainedTypeParameter), "TTest")]
+            [InlineData(nameof(MethodAliasGeneratorData.Generic_ExtensionMethodWithNullableTypeParameter), "TTest?")]
+            [InlineData(nameof(MethodAliasGeneratorData.Generic_ExtensionMethodWithNullableClassConstraint), "TTest")]
+            [InlineData(nameof(MethodAliasGeneratorData.Generic_ExtensionMethodWithNotNullAndNewConstraints), "TTest")]
+            [InlineData(nameof(MethodAliasGeneratorData.Generic_ExtensionMethodWithNullableTypeParameterArgument), "System.Collections.Generic.IList<TTest?>")]
+            [InlineData(nameof(MethodAliasGeneratorData.Generic_ExtensionMethodWithUnconstrainedTypeParameterArgument), "System.Collections.Generic.IList<TTest>")]
+            public void Should_Format_Parameter_With_Inner_Annotations(string name, string expected)
+            {
+                // Given
+                var method = GetMethod(name);
+                var parameter = method.GetParameters()[1];
+
+                // When
+                var result = NullableAnnotationContext.Format(parameter);
+
+                // Then
+                Assert.Equal(expected, result);
+            }
+
+            [Theory]
+            [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableReturnValue), "System.String?")]
+            [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNotNullReturnValue), "System.String")]
+            [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableGenericReturn), "System.Collections.Generic.IList<System.String?>")]
+            [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithDynamicReturnValue), "dynamic")]
+            [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNoParameters), "void")]
+            [InlineData(nameof(MethodAliasGeneratorData.Generic_ExtensionMethodWithUnconstrainedTypeParameterReturn), "TTest")]
+            public void Should_Format_Return_With_Inner_Annotations(string name, string expected)
+            {
+                // Given
+                var method = GetMethod(name);
+
+                // When
+                var result = NullableAnnotationContext.FormatReturn(method);
+
+                // Then
+                Assert.Equal(expected, result);
+            }
+        }
+
+        public sealed class TheWrapMethod
+        {
+            [Fact]
+            public void Should_Lead_With_Enable_And_End_With_Restore()
+            {
+                // Given
+                const string code = "public void Foo() { }";
+
+                // When
+                var result = NullableAnnotationContext.Wrap(code).NormalizeGeneratedCode();
+
+                // Then
+                Assert.Equal(
+                    "#nullable enable\r\npublic void Foo() { }\r\n#nullable restore".NormalizeLineEndings(),
+                    result.NormalizeLineEndings());
+            }
+
+            [Fact]
+            public void Should_Not_Wrap_Oblivious_Alias()
+            {
+                // Given
+                var method = GetMethod(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNoParameters));
+
+                // When
+                var result = NullableAnnotationContext.WrapIfRequired(method, "public void Foo() { }");
+
+                // Then
+                Assert.Equal("public void Foo() { }", result);
+            }
+        }
+
+        private static MethodInfo GetMethod(string name)
+        {
+            return typeof(MethodAliasGeneratorData).GetMethods().Single(method => method.Name == name);
+        }
+
+        private static MethodInfo GetFixtureMethod(string name)
+        {
+            return typeof(ConstraintFixture).GetMethods().Single(method => method.Name == name);
+        }
+
+        private static Type GetGenericArgument(string name)
+        {
+            return GetFixtureMethod(name).GetGenericArguments()[0];
+        }
+
+        private static class ConstraintFixture
+        {
+            public static void UnconstrainedInDisabledContext<T>(T value)
+            {
+                throw new NotImplementedException();
+            }
+
+#nullable enable
+            public static void NotNull<T>(T value)
+                where T : notnull
+            {
+                throw new NotImplementedException();
+            }
+
+            public static void NullableClass<T>(T value)
+                where T : class?
+            {
+                throw new NotImplementedException();
+            }
+
+            public static void NotNullClass<T>(T value)
+                where T : class
+            {
+                throw new NotImplementedException();
+            }
+
+            public static void UnconstrainedInEnabledContext<T>(T value)
+            {
+                throw new NotImplementedException();
+            }
+#nullable disable
+        }
+    }
+}

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/ParameterEmitterTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/ParameterEmitterTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Cake.Core.Scripting.CodeGen;
+using Cake.Core.Tests.Data;
 using Xunit;
 // ReSharper disable UnusedMember.Local
 // ReSharper disable UnusedParameter.Local
@@ -543,6 +544,70 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
 
             // Then
             Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Should_Emit_Question_Mark_For_Nullable_Reference_Parameter()
+        {
+            // Given
+            var method = typeof(MethodAliasGeneratorData).GetMethod(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableParameter));
+            var parameter = method.GetParameters()[1];
+
+            // When
+            var result = ParameterEmitter.Emit(parameter, true);
+
+            // Then
+            Assert.Equal("System.String? parameter", result);
+        }
+
+        [Fact]
+        public void Should_Not_Emit_Question_Mark_For_NotNull_Reference_Parameter()
+        {
+            // Given
+            var method = typeof(MethodAliasGeneratorData).GetMethod(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNotNullParameter));
+            var parameter = method.GetParameters()[1];
+
+            // When
+            var result = ParameterEmitter.Emit(parameter, true);
+
+            // Then
+            Assert.Equal("System.String parameter", result);
+        }
+
+        [Theory]
+        [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableArrayElements), "System.String?[] values")]
+        [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableArray), "System.String[]? values")]
+        [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableArrayAndElements), "System.String?[]? values")]
+        [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableGenericArgument), "System.Collections.Generic.IList<System.String?> values")]
+        [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableGenericType), "System.Collections.Generic.IList<System.String>? values")]
+        [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableTaskResult), "System.Threading.Tasks.Task<System.String?> task")]
+        [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableDictionaryValues), "System.Collections.Generic.Dictionary<System.String, System.String?> values")]
+        [InlineData(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNullableParamsArray), "params System.String?[] values")]
+        public void Should_Emit_Inner_Nullable_Reference_Annotations(string methodName, string expected)
+        {
+            // Given
+            var method = typeof(MethodAliasGeneratorData).GetMethod(methodName);
+            var parameter = method.GetParameters()[1];
+
+            // When
+            var result = ParameterEmitter.Emit(parameter, true);
+
+            // Then
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Should_Not_Emit_Question_Mark_For_NotNull_Parameter_In_Disabled_Context()
+        {
+            // Given
+            var method = typeof(MethodAliasGeneratorData).GetMethod(nameof(MethodAliasGeneratorData.NonGeneric_ExtensionMethodWithNotNullParameterInDisabledContext));
+            var parameter = method.GetParameters()[1];
+
+            // When
+            var result = ParameterEmitter.Emit(parameter, true);
+
+            // Then
+            Assert.Equal("System.String parameter", result);
         }
     }
 }

--- a/src/Cake.Core.Tests/Unit/Scripting/CodeGen/PropertyAliasGeneratorTests.cs
+++ b/src/Cake.Core.Tests/Unit/Scripting/CodeGen/PropertyAliasGeneratorTests.cs
@@ -116,6 +116,7 @@ namespace Cake.Core.Tests.Unit.Scripting.CodeGen
             [Theory]
             [InlineData("NonCached_Value_Type")]
             [InlineData("NonCached_Dynamic_Type")]
+            [InlineData("NonCached_NotNull_Type")]
             public Task Should_Return_Correct_Generated_Code_For_Non_Cached_Properties(string name)
             {
                 // Given / When

--- a/src/Cake.Core/Scripting/CodeGen/GenericParameterConstraintEmitter.cs
+++ b/src/Cake.Core/Scripting/CodeGen/GenericParameterConstraintEmitter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
@@ -13,6 +14,10 @@ namespace Cake.Core.Scripting.CodeGen
     /// </summary>
     internal sealed class GenericParameterConstraintEmitter
     {
+        private const string ClassConstraint = "class";
+        private const string NullableClassConstraint = "class?";
+        private const string NotNullConstraint = "notnull";
+
         internal static string Emit(MethodInfo method)
         {
             var builder = new StringBuilder();
@@ -27,10 +32,53 @@ namespace Cake.Core.Scripting.CodeGen
                 return;
             }
 
+            foreach (var argument in method.GetGenericMethodDefinition().GetGenericArguments())
+            {
+                var tokens = BuildConstraintTokens(argument);
+
+                if (tokens.Count > 0)
+                {
+                    builder.AppendLine();
+                    builder.AppendFormat("where {0} : {1}", argument.Name, string.Join(", ", tokens));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> when any emitted constraint of <paramref name="method"/>
+        /// only compiles inside a nullable annotations context.
+        /// </summary>
+        /// <param name="method">The alias method.</param>
+        /// <returns><c>true</c> if <c>notnull</c> or <c>class?</c> will be emitted.</returns>
+        internal static bool HasNullableAwareConstraint(MethodInfo method)
+        {
+            if (!method.IsGenericMethod)
+            {
+                return false;
+            }
+
+            foreach (var argument in method.GetGenericMethodDefinition().GetGenericArguments())
+            {
+                foreach (var token in BuildConstraintTokens(argument))
+                {
+                    if (token is NullableClassConstraint or NotNullConstraint)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static List<string> BuildConstraintTokens(Type argument)
+        {
             /*
              Possible permutations:
              T : class
+             T : class?
              T : class, new(),
+             T : notnull
              T : SomeClass
              T : ISomeInterface
              T : SomeClass, ISomeInterface
@@ -42,57 +90,64 @@ namespace Cake.Core.Scripting.CodeGen
              Cannot specify `struct, new()`
              */
 
-            foreach (var argument in method.GetGenericMethodDefinition().GetGenericArguments())
+            var paramAttributes = argument.GetTypeInfo().GenericParameterAttributes;
+            var tokens = new List<string>();
+
+            if (paramAttributes.HasFlag(GenericParameterAttributes.NotNullableValueTypeConstraint))
             {
-                var paramAttributes = argument.GetTypeInfo().GenericParameterAttributes;
-                var tokens = new List<string>();
+                tokens.Add("struct");
 
-                if (paramAttributes.HasFlag(GenericParameterAttributes.NotNullableValueTypeConstraint))
+                // iterate type constraints; it's possible that you can have ` where T : struct, ISomeInterface`
+                foreach (var constraint in argument.GetTypeInfo().GetGenericParameterConstraints())
                 {
-                    tokens.Add("struct");
-
-                    // iterate type constraints; it's possible that you can have ` where T : struct, ISomeInterface`
-                    foreach (var constraint in argument.GetTypeInfo().GetGenericParameterConstraints())
+                    // however, the struct constraint will return System.ValueType.
+                    // it's not necessarily to emit that as syntax in a generated method
+                    if (constraint == typeof(System.ValueType))
                     {
-                        // however, the struct constraint will return System.ValueType.
-                        // it's not necessarily to emit that as syntax in a generated method
-                        if (constraint == typeof(System.ValueType))
-                        {
-                            continue;
-                        }
-
-                        tokens.Add(constraint.GetFullName());
-                    }
-                }
-                else
-                {
-                    // if it's declared a struct, we can't use any other constraints (inherits/implements or default ctor)
-
-                    // special considerations? reference/value
-                    if (paramAttributes.HasFlag(GenericParameterAttributes.ReferenceTypeConstraint))
-                    {
-                        tokens.Add("class");
+                        continue;
                     }
 
-                    // iterate type constraints
-                    foreach (var constraint in argument.GetTypeInfo().GetGenericParameterConstraints())
-                    {
-                        tokens.Add(constraint.GetFullName());
-                    }
-
-                    // default constructor has to come last, can't be used in conjunction w/ struct
-                    if (paramAttributes.HasFlag(GenericParameterAttributes.DefaultConstructorConstraint))
-                    {
-                        tokens.Add("new()");
-                    }
-                }
-
-                if (tokens.Count > 0)
-                {
-                    builder.AppendLine();
-                    builder.AppendFormat("where {0} : {1}", argument.Name, string.Join(", ", tokens));
+                    tokens.Add(constraint.GetFullName());
                 }
             }
+            else
+            {
+                // if it's declared a struct, we can't use any other constraints (inherits/implements or default ctor)
+
+                // special considerations? reference/value
+                var hasTypeConstraint = paramAttributes.HasFlag(GenericParameterAttributes.ReferenceTypeConstraint);
+                if (hasTypeConstraint)
+                {
+                    // `class?` and `class` only differ by the nullable metadata of the type parameter
+                    tokens.Add(NullableAnnotationContext.GetNullableFlag(argument) == NullableAnnotationContext.Annotated
+                        ? NullableClassConstraint
+                        : ClassConstraint);
+                }
+
+                // iterate type constraints
+                foreach (var constraint in argument.GetTypeInfo().GetGenericParameterConstraints())
+                {
+                    hasTypeConstraint = true;
+                    tokens.Add(constraint.GetFullName());
+                }
+
+                // default constructor has to come last, can't be used in conjunction w/ struct
+                if (paramAttributes.HasFlag(GenericParameterAttributes.DefaultConstructorConstraint))
+                {
+                    tokens.Add("new()");
+                }
+
+                // `notnull` leaves no trace other than the nullable metadata of the type parameter,
+                // and is only needed when no type constraint already implies it. It's a primary
+                // constraint, so it has to come before `new()`.
+                if (!hasTypeConstraint &&
+                    NullableAnnotationContext.GetNullableFlag(argument) == NullableAnnotationContext.NotAnnotated)
+                {
+                    tokens.Insert(0, NotNullConstraint);
+                }
+            }
+
+            return tokens;
         }
     }
 }

--- a/src/Cake.Core/Scripting/CodeGen/MethodAliasGenerator.cs
+++ b/src/Cake.Core/Scripting/CodeGen/MethodAliasGenerator.cs
@@ -5,9 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Text;
 using Cake.Core.Annotations;
 
@@ -95,7 +93,7 @@ namespace Cake.Core.Scripting.CodeGen
 
                     // End method.
                     builder.AppendLine();
-                    return builder.ToString();
+                    return NullableAnnotationContext.WrapIfRequired(method, builder.ToString());
                 }
             }
 
@@ -120,21 +118,12 @@ namespace Cake.Core.Scripting.CodeGen
             // End method.
             builder.AppendLine();
 
-            return builder.ToString();
+            return NullableAnnotationContext.WrapIfRequired(method, builder.ToString());
         }
 
         private static string GetReturnType(MethodInfo method)
         {
-            if (method.ReturnType == typeof(void))
-            {
-                return "void";
-            }
-
-            var isDynamic = method.ReturnTypeCustomAttributes.GetCustomAttributes(typeof(DynamicAttribute), true).Any();
-            var isNullable = method.ReturnTypeCustomAttributes.GetCustomAttributes(true).Any(attr => attr.GetType().FullName == "System.Runtime.CompilerServices.NullableAttribute");
-            return string.Concat(
-                isDynamic ? "dynamic" : method.ReturnType.GetFullName(),
-                isNullable ? "?" : string.Empty);
+            return NullableAnnotationContext.FormatReturn(method);
         }
 
         private static IEnumerable<string> GetProxyParameters(IEnumerable<ParameterInfo> parameters, bool includeType)

--- a/src/Cake.Core/Scripting/CodeGen/NullableAnnotationContext.cs
+++ b/src/Cake.Core/Scripting/CodeGen/NullableAnnotationContext.cs
@@ -1,0 +1,422 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace Cake.Core.Scripting.CodeGen
+{
+    /// <summary>
+    /// Parses compiler-embedded nullable metadata and wraps generated alias members
+    /// that need a nullable annotations context.
+    /// </summary>
+    internal static class NullableAnnotationContext
+    {
+        internal const byte Oblivious = 0;
+        internal const byte NotAnnotated = 1;
+        internal const byte Annotated = 2;
+
+        private const string NullableAttributeName = "System.Runtime.CompilerServices.NullableAttribute";
+        private const string NullableContextAttributeName = "System.Runtime.CompilerServices.NullableContextAttribute";
+
+        /// <summary>
+        /// Gets the nullable flag of a generic type parameter, falling back to the
+        /// nullable context of the declaring method, type or module.
+        /// </summary>
+        /// <param name="genericParameter">The generic type parameter.</param>
+        /// <returns><see cref="Oblivious"/>, <see cref="NotAnnotated"/> or <see cref="Annotated"/>.</returns>
+        internal static byte GetNullableFlag(Type genericParameter)
+        {
+            ArgumentNullException.ThrowIfNull(genericParameter);
+
+            foreach (var attribute in genericParameter.GetCustomAttributesData())
+            {
+                if (TryGetNullableFlags(attribute, out var flags) && flags.Length > 0)
+                {
+                    return flags[0];
+                }
+            }
+
+            return GetNullableContextFlag(genericParameter);
+        }
+
+        /// <summary>
+        /// Formats a parameter type including inner nullable reference annotations.
+        /// </summary>
+        /// <param name="parameter">The parameter to format.</param>
+        /// <returns>The generated type name.</returns>
+        internal static string Format(ParameterInfo parameter)
+        {
+            ArgumentNullException.ThrowIfNull(parameter);
+
+            var type = parameter.ParameterType;
+            var info = new NullabilityInfoContext().Create(parameter);
+            if (type.IsByRef)
+            {
+                type = type.GetElementType();
+                info = info.ElementType ?? info;
+            }
+
+            return Format(type, info, GetPositionFlag(parameter));
+        }
+
+        /// <summary>
+        /// Formats a method return type including inner nullable reference annotations.
+        /// </summary>
+        /// <param name="method">The method whose return type to format.</param>
+        /// <returns>The generated type name.</returns>
+        internal static string FormatReturn(MethodInfo method)
+        {
+            ArgumentNullException.ThrowIfNull(method);
+
+            if (method.ReturnType == typeof(void))
+            {
+                return "void";
+            }
+
+            if (method.ReturnTypeCustomAttributes.GetCustomAttributes(typeof(System.Runtime.CompilerServices.DynamicAttribute), true).Any())
+            {
+                return "dynamic";
+            }
+
+            return Format(
+                method.ReturnType,
+                new NullabilityInfoContext().Create(method.ReturnParameter),
+                GetPositionFlag(method.ReturnParameter));
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> when generated alias source for <paramref name="method"/>
+        /// needs a nullable annotations context.
+        /// </summary>
+        /// <param name="method">The alias method.</param>
+        /// <returns><c>true</c> if the generated member should be wrapped.</returns>
+        internal static bool Requires(MethodInfo method)
+        {
+            ArgumentNullException.ThrowIfNull(method);
+
+            return HasNullableReferenceAnnotation(method)
+                   || GenericParameterConstraintEmitter.HasNullableAwareConstraint(method);
+        }
+
+        /// <summary>
+        /// Wraps generated alias source with <c>#nullable enable</c> / <c>#nullable restore</c>
+        /// when <paramref name="method"/> requires a nullable annotations context.
+        /// </summary>
+        /// <param name="method">The alias method.</param>
+        /// <param name="code">The generated member source.</param>
+        /// <returns>The original or wrapped source.</returns>
+        internal static string WrapIfRequired(MethodInfo method, string code)
+        {
+            return Requires(method) ? Wrap(code) : code;
+        }
+
+        /// <summary>
+        /// Wraps generated alias source with <c>#nullable enable</c> / <c>#nullable restore</c>.
+        /// </summary>
+        /// <param name="code">The generated member source.</param>
+        /// <returns>The wrapped source.</returns>
+        internal static string Wrap(string code)
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine("#nullable enable");
+            builder.Append(code);
+            if (code.Length == 0 || code[code.Length - 1] != '\n')
+            {
+                builder.AppendLine();
+            }
+            builder.AppendLine("#nullable restore");
+            return builder.ToString();
+        }
+
+        private static bool TryGetNullableFlags(CustomAttributeData attribute, out byte[] flags)
+        {
+            flags = null;
+            if (attribute?.AttributeType.FullName != NullableAttributeName)
+            {
+                return false;
+            }
+
+            if (attribute.ConstructorArguments.Count != 1)
+            {
+                return false;
+            }
+
+            return TryReadFlags(attribute.ConstructorArguments[0].Value, out flags);
+        }
+
+        private static bool HasNullableReferenceAnnotation(MethodInfo method)
+        {
+            var context = new NullabilityInfoContext();
+
+            if (method.ReturnType != typeof(void) &&
+                HasNullableReference(method.ReturnType, context.Create(method.ReturnParameter), GetPositionFlag(method.ReturnParameter)))
+            {
+                return true;
+            }
+
+            foreach (var parameter in method.GetParameters().Skip(1))
+            {
+                var type = parameter.ParameterType;
+                var info = context.Create(parameter);
+                if (type.IsByRef)
+                {
+                    type = type.GetElementType();
+                    info = info.ElementType ?? info;
+                }
+
+                if (HasNullableReference(type, info, GetPositionFlag(parameter)))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool HasNullableReference(Type type, NullabilityInfo info, byte? positionFlag)
+        {
+            if (type == null || info == null)
+            {
+                return false;
+            }
+
+            if (IsAnnotated(type, info, positionFlag))
+            {
+                return true;
+            }
+
+            if (type.IsArray && info.ElementType != null)
+            {
+                return HasNullableReference(type.GetElementType(), info.ElementType, null);
+            }
+
+            if (type.IsGenericType && info.GenericTypeArguments is { Length: > 0 })
+            {
+                var arguments = type.GetGenericArguments();
+                var length = Math.Min(arguments.Length, info.GenericTypeArguments.Length);
+                for (var i = 0; i < length; i++)
+                {
+                    if (HasNullableReference(arguments[i], info.GenericTypeArguments[i], null))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static string Format(Type type, NullabilityInfo info, byte? positionFlag)
+        {
+            if (type.IsGenericParameter)
+            {
+                return type.Name + NullableSuffix(type, info, positionFlag);
+            }
+
+            if (type.IsArray)
+            {
+                var elementType = type.GetElementType();
+                var element = info.ElementType != null
+                    ? Format(elementType, info.ElementType, null)
+                    : elementType.GetFullName();
+                return element + GetArrayBrackets(type) + NullableSuffix(type, info, positionFlag);
+            }
+
+            if (type.GetTypeInfo().IsGenericType)
+            {
+                return FormatGenericType(type, info, positionFlag);
+            }
+
+            var name = (type.FullName ?? type.Name).Replace('+', '.');
+            return name + NullableSuffix(type, info, positionFlag);
+        }
+
+        private static string FormatGenericType(Type type, NullabilityInfo info, byte? positionFlag)
+        {
+            var builder = new StringBuilder();
+            if (!string.IsNullOrEmpty(type.Namespace))
+            {
+                builder.Append(type.Namespace);
+                builder.Append('.');
+            }
+
+            var name = type.Name;
+            var arity = name.IndexOf('`');
+            builder.Append(arity >= 0 ? name[..arity] : name);
+            builder.Append('<');
+
+            var arguments = type.GenericTypeArguments;
+            var argumentInfos = info.GenericTypeArguments;
+            for (var i = 0; i < arguments.Length; i++)
+            {
+                if (i > 0)
+                {
+                    builder.Append(", ");
+                }
+
+                builder.Append(i < argumentInfos.Length
+                    ? Format(arguments[i], argumentInfos[i], null)
+                    : arguments[i].GetFullName());
+            }
+
+            builder.Append('>');
+            builder.Append(NullableSuffix(type, info, positionFlag));
+            return builder.ToString();
+        }
+
+        private static string GetArrayBrackets(Type type)
+        {
+            var rank = type.GetArrayRank();
+            return rank == 1 ? "[]" : "[" + new string(',', rank - 1) + "]";
+        }
+
+        private static string NullableSuffix(Type type, NullabilityInfo info, byte? positionFlag)
+        {
+            return IsAnnotated(type, info, positionFlag) ? "?" : string.Empty;
+        }
+
+        private static bool IsAnnotated(Type type, NullabilityInfo info, byte? positionFlag)
+        {
+            if (type.IsValueType)
+            {
+                return false;
+            }
+
+            // A type parameter that may itself be a nullable reference type is reported as nullable
+            // by NullabilityInfoContext wherever it's used, so `T` can't be told apart from `T?` that
+            // way. The nullable flag of the position decides instead, which is only known for the
+            // outermost type; nested usages such as `IList<T>` are treated as not annotated.
+            if (type.IsGenericParameter && GetNullableFlag(type) == Annotated)
+            {
+                return positionFlag == Annotated;
+            }
+
+            return IsNullableState(info);
+        }
+
+        private static bool IsNullableState(NullabilityInfo info)
+        {
+            return info.ReadState == NullabilityState.Nullable ||
+                   info.WriteState == NullabilityState.Nullable;
+        }
+
+        private static byte GetPositionFlag(ParameterInfo parameter)
+        {
+            foreach (var attribute in parameter.GetCustomAttributesData())
+            {
+                if (TryGetNullableFlags(attribute, out var flags) && flags.Length > 0)
+                {
+                    return flags[0];
+                }
+            }
+
+            return parameter.Member != null
+                ? GetScopeContextFlag(parameter.Member)
+                : Oblivious;
+        }
+
+        private static byte GetNullableContextFlag(Type genericParameter)
+        {
+            var scope = (MemberInfo)genericParameter.DeclaringMethod ?? genericParameter.DeclaringType;
+            return scope != null
+                ? GetScopeContextFlag(scope)
+                : Oblivious;
+        }
+
+        private static byte GetScopeContextFlag(MemberInfo member)
+        {
+            for (var scope = member; scope != null; scope = scope.DeclaringType)
+            {
+                if (TryGetContextFlag(scope.GetCustomAttributesData(), out var flag))
+                {
+                    return flag;
+                }
+            }
+
+            return TryGetContextFlag(CustomAttributeData.GetCustomAttributes(member.Module), out var moduleFlag)
+                ? moduleFlag
+                : Oblivious;
+        }
+
+        private static bool TryGetContextFlag(IList<CustomAttributeData> attributes, out byte flag)
+        {
+            foreach (var attribute in attributes)
+            {
+                if (attribute.AttributeType.FullName == NullableContextAttributeName &&
+                    TryGetContextFlag(attribute, out flag))
+                {
+                    return true;
+                }
+            }
+
+            flag = Oblivious;
+            return false;
+        }
+
+        private static bool TryGetContextFlag(CustomAttributeData attribute, out byte flag)
+        {
+            flag = Oblivious;
+            if (attribute.ConstructorArguments.Count != 1)
+            {
+                return false;
+            }
+
+            var value = attribute.ConstructorArguments[0].Value;
+            if (value is byte b)
+            {
+                flag = b;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryReadFlags(object value, out byte[] flags)
+        {
+            flags = null;
+            if (TryReadFlag(value, out var flag))
+            {
+                flags = new[] { flag };
+                return true;
+            }
+
+            if (value is IList<CustomAttributeTypedArgument> list)
+            {
+                flags = new byte[list.Count];
+                for (var i = 0; i < list.Count; i++)
+                {
+                    if (!TryReadFlag(list[i].Value, out flags[i]))
+                    {
+                        flags = null;
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryReadFlag(object value, out byte flag)
+        {
+            switch (value)
+            {
+                case byte b:
+                    flag = b;
+                    return true;
+                case int i when i >= byte.MinValue && i <= byte.MaxValue:
+                    flag = (byte)i;
+                    return true;
+                default:
+                    flag = Oblivious;
+                    return false;
+            }
+        }
+    }
+}

--- a/src/Cake.Core/Scripting/CodeGen/ParameterEmitter.cs
+++ b/src/Cake.Core/Scripting/CodeGen/ParameterEmitter.cs
@@ -45,7 +45,6 @@ namespace Cake.Core.Scripting.CodeGen
             }
             if (includeType)
             {
-                var isNullable = false;
                 if (parameter.IsDefined(typeof(ParamArrayAttribute)))
                 {
                     yield return "params ";
@@ -60,7 +59,6 @@ namespace Cake.Core.Scripting.CodeGen
                         var attributeType = item.AttributeType.GetFullName();
                         if (item.AttributeType.FullName == "System.Runtime.CompilerServices.NullableAttribute")
                         {
-                            isNullable = true;
                             continue;
                         }
                         if (item.AttributeType.Name.EndsWith("Attribute", StringComparison.OrdinalIgnoreCase))
@@ -97,21 +95,7 @@ namespace Cake.Core.Scripting.CodeGen
                     }
                 }
 
-                // if the parameter is 'out' (or implicitly, by ref),
-                // use GetElementType to get the correct value for codegen (instead of IDisposable& or similar)
-                if (parameter.ParameterType.IsByRef)
-                {
-                    yield return parameter.ParameterType.GetElementType().GetFullName();
-                }
-                else
-                {
-                    yield return parameter.ParameterType.GetFullName();
-                }
-
-                if (isNullable)
-                {
-                    yield return "?";
-                }
+                yield return NullableAnnotationContext.Format(parameter);
                 yield return " ";
             }
 

--- a/src/Cake.Core/Scripting/CodeGen/PropertyAliasGenerator.cs
+++ b/src/Cake.Core/Scripting/CodeGen/PropertyAliasGenerator.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -49,9 +48,10 @@ namespace Cake.Core.Scripting.CodeGen
             var attribute = method.GetCustomAttribute<CakePropertyAliasAttribute>();
 
             // Generate code.
-            return attribute.Cache
+            var code = attribute.Cache
                 ? GenerateCachedCode(method, out hash)
                     : GenerateCode(method, out hash);
+            return NullableAnnotationContext.WrapIfRequired(method, code);
         }
 
         private static void ValidateMethod(MethodInfo method)
@@ -218,11 +218,7 @@ namespace Cake.Core.Scripting.CodeGen
 
         private static string GetReturnType(MethodInfo method)
         {
-            var isDynamic = method.ReturnTypeCustomAttributes.GetCustomAttributes(typeof(DynamicAttribute), true).Any();
-            var isNullable = method.ReturnTypeCustomAttributes.GetCustomAttributes(true).Any(attr => attr.GetType().FullName == "System.Runtime.CompilerServices.NullableAttribute");
-            return string.Concat(
-                isDynamic ? "dynamic" : method.ReturnType.GetFullName(),
-                isNullable ? "?" : string.Empty);
+            return NullableAnnotationContext.FormatReturn(method);
         }
     }
 }

--- a/src/Cake.Tests/Cake.Tests.csproj
+++ b/src/Cake.Tests/Cake.Tests.csproj
@@ -10,6 +10,7 @@
   <Import Project="..\Shared.msbuild" />
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />

--- a/src/Cake.Tests/Infrastructure/Scripting/RoslynCodeGeneratorTests.cs
+++ b/src/Cake.Tests/Infrastructure/Scripting/RoslynCodeGeneratorTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.Scripting;
+using Cake.Infrastructure.Scripting;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Scripting;
+using Microsoft.CodeAnalysis.Scripting;
+using Xunit;
+
+namespace Cake.Tests.Infrastructure.Scripting
+{
+    public sealed class RoslynCodeGeneratorTests
+    {
+        [Theory]
+        [InlineData(nameof(NullableAliasCompileGuardData.ExtensionMethodWithNullableParameter), true, "public void ExtensionMethodWithNullableParameter(System.String? parameter)")]
+        [InlineData(nameof(NullableAliasCompileGuardData.ExtensionMethodWithNotNullConstraint), true, "where T : notnull")]
+        [InlineData(nameof(NullableAliasCompileGuardData.ExtensionMethodWithNotNullAndNewConstraints), true, "where T : notnull, new()")]
+        [InlineData(nameof(NullableAliasCompileGuardData.ExtensionMethodWithNullableTypeParameter), true, "public void ExtensionMethodWithNullableTypeParameter<T>(T? value)")]
+        [InlineData(nameof(NullableAliasCompileGuardData.ExtensionMethodWithNullableTypeParameterArgument), true, "(System.Collections.Generic.IList<T?> values)")]
+        [InlineData(nameof(NullableAliasCompileGuardData.ExtensionMethodWithUnconstrainedTypeParameter), false, "public void ExtensionMethodWithUnconstrainedTypeParameter<T>(T value)")]
+        [InlineData(nameof(NullableAliasCompileGuardData.ExtensionMethodWithUnconstrainedTypeParameterArgument), false, "(System.Collections.Generic.IList<T> values)")]
+        public void Should_Generate_Alias_Which_Compiles_Without_Diagnostics(string aliasName, bool expectNullableContext, string expectedSignature)
+        {
+            // Given / When
+            var (code, diagnostics) = Compile(aliasName);
+
+            // Then
+            Assert.Contains(expectedSignature, code);
+            Assert.Equal(expectNullableContext, code.Contains("#nullable enable"));
+
+            // any warning at all, not just CS8632/CS8714, means the generated alias doesn't match
+            // the nullability of the aliased method
+            Assert.Empty(diagnostics
+                .Where(diagnostic => diagnostic.Severity >= DiagnosticSeverity.Warning)
+                .Select(diagnostic => $"{diagnostic.Id}: {diagnostic.GetMessage()}"));
+        }
+
+        private static (string Code, IEnumerable<Diagnostic> Diagnostics) Compile(string aliasName)
+        {
+            var method = typeof(NullableAliasCompileGuardData).GetMethod(aliasName);
+            var alias = new ScriptAlias(method, ScriptAliasType.Method, new HashSet<string>());
+            var script = new Cake.Core.Scripting.Script(
+                Array.Empty<string>(),
+                new[] { "var compiled = true;" },
+                new[] { alias },
+                Array.Empty<string>(),
+                Array.Empty<string>(),
+                Array.Empty<string>());
+            var generator = new RoslynCodeGenerator();
+            var code = generator.Generate(script);
+
+            var options = ScriptOptions.Default
+                .AddReferences(typeof(ICakeContext).Assembly)
+                .AddReferences(typeof(NullableAliasCompileGuardData).Assembly);
+            var roslynScript = CSharpScript.Create(code, options, typeof(NullableAliasScriptHost));
+
+            return (code, roslynScript.GetCompilation().GetDiagnostics(TestContext.Current.CancellationToken));
+        }
+
+        public sealed class NullableAliasScriptHost
+        {
+            public ICakeContext Context { get; set; }
+        }
+    }
+
+    public static class NullableAliasCompileGuardData
+    {
+        [CakeMethodAlias]
+#nullable enable
+        public static void ExtensionMethodWithNullableParameter(this ICakeContext context, string? parameter)
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static void ExtensionMethodWithNotNullConstraint<T>(this ICakeContext context, T value)
+            where T : notnull
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static void ExtensionMethodWithNotNullAndNewConstraints<T>(this ICakeContext context, T value)
+            where T : notnull, new()
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static void ExtensionMethodWithNullableTypeParameter<T>(this ICakeContext context, T? value)
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static void ExtensionMethodWithNullableTypeParameterArgument<T>(this ICakeContext context, IList<T?> values)
+            where T : class
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static void ExtensionMethodWithUnconstrainedTypeParameter<T>(this ICakeContext context, T value)
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+
+        [CakeMethodAlias]
+#nullable enable
+        public static void ExtensionMethodWithUnconstrainedTypeParameterArgument<T>(this ICakeContext context, IList<T> values)
+#nullable disable
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/tests/integration/Cake.Core/Scripting/AddinDirective.cake
+++ b/tests/integration/Cake.Core/Scripting/AddinDirective.cake
@@ -1,9 +1,9 @@
 #addin nuget:?package=Cake.Kudu.Client&version=2.0.0
 #load "./../../utilities/paths.cake"
+#load "./../../utilities/xunit.cake"
+using System.Reflection;
 
-
-Task("Cake.Core.Scripting.AddinDirective.LoadTargetedAddin")
-    .Does(() =>
+(FilePath Cake, string Version) PackScriptingTestAddin()
 {
     CleanDirectories($"{Paths.Resources}/Cake.Core/Scripting/addin/{{bin,obj}}");
 
@@ -35,25 +35,124 @@ Task("Cake.Core.Scripting.AddinDirective.LoadTargetedAddin")
             MSBuildSettings = msBuildSettings
         });
 
-    var script = $@"#addin nuget:{Paths.Resources}/Cake.Core/Scripting/addin/bin/Release?package=addin&version={msBuildSettings.Version}
-        Information(""Magic number: {0}"", GetMagicNumber(false));
-        Information(""The answer to life: {0}"", TheAnswerToLife);
-        Information(""Get Dynamic Magic Number: {0}"", GetDynamicMagicNumber(false).MagicNumber);
-        Information(""Dynamic Magic Number: {0}"", TheDynamicAnswerToLife.TheAnswerToLife);
-    ";
+    return (cake, msBuildSettings.Version);
+}
 
-    CakeExecuteExpression(script,
-        new CakeSettings {
-            EnvironmentVariables = new Dictionary<string, string>{
-                {"CAKE_PATHS_ADDINS", $"{Paths.Temp}/tools/Addins"},
-                {"CAKE_PATHS_TOOLS", $"{Paths.Temp}/tools"},
-                {"CAKE_PATHS_MODULES", $"{Paths.Temp}/tools/Modules"},
-                {"NUGET_PACKAGES", $"{Paths.Temp}/nuget/Packages"},
-                {"NUGET_HTTP_CACHE_PATH ", $"{Paths.Temp}/nuget/Cache"}
-            },
-            ToolPath = cake,
-            Verbosity = Context.Log.Verbosity
+CakeSettings CreateNestedCakeSettings(FilePath cake, string addinsFolder, Action<ProcessSettings> setupProcessSettings = null)
+{
+    return new CakeSettings {
+        EnvironmentVariables = new Dictionary<string, string>{
+            {"CAKE_PATHS_ADDINS", $"{Paths.Temp}/{addinsFolder}/Addins"},
+            {"CAKE_PATHS_TOOLS", $"{Paths.Temp}/{addinsFolder}"},
+            {"CAKE_PATHS_MODULES", $"{Paths.Temp}/{addinsFolder}/Modules"},
+            {"NUGET_PACKAGES", $"{Paths.Temp}/nuget/Packages"},
+            {"NUGET_HTTP_CACHE_PATH ", $"{Paths.Temp}/nuget/Cache"}
+        },
+        SetupProcessSettings = setupProcessSettings,
+        ToolPath = cake,
+        Verbosity = Context.Log.Verbosity
+    };
+}
+
+Task("Cake.Core.Scripting.AddinDirective.LoadTargetedAddin")
+    .Does(() =>
+{
+    var (cake, version) = PackScriptingTestAddin();
+
+    var script = 
+        $$"""
+        {{"#"}}addin nuget:{{Paths.Resources}}/Cake.Core/Scripting/addin/bin/Release?package=addin&version={{version}}
+        Information("Magic number: {0}", GetMagicNumber(false));
+        Information("The answer to life: {0}", TheAnswerToLife);
+        Information("Get Dynamic Magic Number: {0}", GetDynamicMagicNumber(false).MagicNumber);
+        Information("Dynamic Magic Number: {0}", TheDynamicAnswerToLife.TheAnswerToLife);
+        """;
+
+    CakeExecuteExpression(script, CreateNestedCakeSettings(cake, "tools"));
+});
+
+Task("Cake.Core.Scripting.AddinDirective.LoadNullableAddin")
+    .Does(() =>
+{
+    var (cake, version) = PackScriptingTestAddin();
+    var output = new List<string>();
+    var error = new List<string>();
+
+    var script = 
+        $$"""
+        {{"#"}}addin nuget:{{Paths.Resources}}/Cake.Core/Scripting/addin/bin/Release?package=addin&version={{version}}
+        {{"#"}}nullable disable
+        Information("Nullable label: {0}", GetNullableLabel(null));
+        Information("Nullable answer: {0}", TheNullableAnswerToLife);
+        Information("Nullable labels: {0}", CountNullableLabels(new[] { "a", (string)null }));
+        Information("Not null value: {0}", GetNotNullValue("cake"));
+        Information("Unconstrained value: {0}", GetUnconstrainedValue("cake"));
+        Information("Unconstrained values: {0}", CountUnconstrainedValues(new[] { "a", "b" }));
+        Information("Created value: {0}", CreateNotNullValue<System.Text.StringBuilder>().Append("cake"));
+        """;
+
+    var settings = CreateNestedCakeSettings(
+        cake,
+        "nullable-tools",
+        processSettings =>
+        {
+            processSettings.RedirectStandardOutput = true;
+            processSettings.RedirectStandardError = true;
+            processSettings.RedirectedStandardOutputHandler = line =>
+            {
+                if (!string.IsNullOrEmpty(line))
+                {
+                    output.Add(line);
+                }
+
+                return line;
+            };
+            processSettings.RedirectedStandardErrorHandler = line =>
+            {
+                if (!string.IsNullOrEmpty(line))
+                {
+                    error.Add(line);
+                }
+
+                return line;
+            };
         });
+
+    // the integration tests run at quiet verbosity, which hides both the script output and the
+    // compiler warnings asserted on below
+    settings.Verbosity = Verbosity.Diagnostic;
+
+    // CI build servers support ANSI, and the escape codes Cake then emits around each logged
+    // argument would break up the messages asserted on below
+    settings.EnvironmentVariables["NO_COLOR"] = "1";
+
+    CakeExecuteExpression(script, settings);
+
+    var diagnostics = output.Concat(error).ToArray();
+
+    if (Context.Log.Verbosity == Verbosity.Diagnostic)
+    {
+        foreach (var line in diagnostics)
+        {
+            Verbose(line);
+        }
+    }
+
+    Assert.Contains(diagnostics, line => line.Contains("Nullable label: none"));
+    Assert.Contains(diagnostics, line => line.Contains("Nullable answer: 42"));
+    Assert.Contains(diagnostics, line => line.Contains("Nullable labels: 1"));
+    Assert.Contains(diagnostics, line => line.Contains("Not null value: cake"));
+    Assert.Contains(diagnostics, line => line.Contains("Unconstrained value: cake"));
+    Assert.Contains(diagnostics, line => line.Contains("Unconstrained values: 2"));
+    Assert.Contains(diagnostics, line => line.Contains("Created value: cake"));
+
+    // CS8632 nullable annotation outside a nullable context, CS8714 nullability of type argument
+    // doesn't match the notnull constraint, CS8604 possible null reference argument,
+    // CS8620 argument can't be used due to differences in nullability
+    foreach (var id in new[] { "CS8632", "CS8714", "CS8604", "CS8620" })
+    {
+        Assert.DoesNotContain(diagnostics, line => line.Contains(id));
+    }
 });
 
 Task("Cake.Core.Scripting.AddinDirective.CallDuplicatedMethod")
@@ -68,11 +167,14 @@ Task("Cake.Core.Scripting.AddinDirective.LoadNativeAssemblies")
 {
     FilePath cakeCore = typeof(ICakeContext).GetTypeInfo().Assembly.Location;
     FilePath cake = cakeCore.GetDirectory().CombineWithFilePath("Cake.dll");
-    var script = @"#addin nuget:?package=Cake.Git&version=5.0.1
+    var script =
+        $$"""
+        {{"#"}}addin nuget:?package=Cake.Git&version=5.0.1
 
-var repoRoot = GitFindRootFromPath(Context.EnvironmentVariable(""CAKE_TEST_DIR""));
+        var repoRoot = GitFindRootFromPath(Context.EnvironmentVariable("CAKE_TEST_DIR"));
 
-var hasUncommittedChanges = GitHasUncommitedChanges(repoRoot);";
+        var hasUncommittedChanges = GitHasUncommitedChanges(repoRoot);
+        """;
 
     CakeExecuteExpression(script,
         new CakeSettings {
@@ -93,5 +195,6 @@ var hasUncommittedChanges = GitHasUncommitedChanges(repoRoot);";
 
 Task("Cake.Core.Scripting.AddinDirective")
     .IsDependentOn("Cake.Core.Scripting.AddinDirective.LoadTargetedAddin")
+    .IsDependentOn("Cake.Core.Scripting.AddinDirective.LoadNullableAddin")
     .IsDependentOn("Cake.Core.Scripting.AddinDirective.CallDuplicatedMethod")
     .IsDependentOn("Cake.Core.Scripting.AddinDirective.LoadNativeAssemblies");

--- a/tests/integration/resources/Cake.Core/Scripting/addin/MyCakeExtension.cs
+++ b/tests/integration/resources/Cake.Core/Scripting/addin/MyCakeExtension.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Dynamic;
 using Cake.Core;
 using Cake.Core.Annotations;
@@ -43,4 +44,59 @@ public static class MyCakeExtension
         result.MagicNumber = context.GetMagicNumber(value);
         return result;
     }
+
+#nullable enable
+    [CakeMethodAlias]
+    public static string GetNullableLabel(this ICakeContext context, string? value)
+    {
+        return value ?? "none";
+    }
+
+    [CakePropertyAlias]
+    public static string? TheNullableAnswerToLife(this ICakeContext context)
+    {
+        return "42";
+    }
+
+    [CakeMethodAlias]
+    public static int CountNullableLabels(this ICakeContext context, IList<string?> values)
+    {
+        var count = 0;
+        foreach (var value in values)
+        {
+            if (value != null)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    [CakeMethodAlias]
+    public static T GetNotNullValue<T>(this ICakeContext context, T value)
+        where T : notnull
+    {
+        return value;
+    }
+
+    [CakeMethodAlias]
+    public static T GetUnconstrainedValue<T>(this ICakeContext context, T value)
+    {
+        return value;
+    }
+
+    [CakeMethodAlias]
+    public static int CountUnconstrainedValues<T>(this ICakeContext context, IList<T> values)
+    {
+        return values.Count;
+    }
+
+    [CakeMethodAlias]
+    public static T CreateNotNullValue<T>(this ICakeContext context)
+        where T : notnull, new()
+    {
+        return new T();
+    }
+#nullable restore
 }


### PR DESCRIPTION
Cake.Tool emits CS8632 for addins compiled with nullable reference types enabled, and
`#nullable disable` in the `.cake` file doesn't help, because aliases are generated above the user
script in a compilation where annotations are disabled.

### Nullable aware alias generation (#4977)

* Only aliases that actually carry a nullable annotation are wrapped in `#nullable enable` /
  `#nullable restore`. CS8632 is not suppressed anywhere, and scripts keep the oblivious context
  they have today.
* `?` is emitted from `NullableAttribute` / `NullableContextAttribute` flag `2`, including inner
  generic arguments and array elements, so `IList<string?>`, `string?[]?` and `Task<string?>` all
  round trip.
* Unconstrained type parameters stay unannotated. `NullabilityInfoContext` reports every usage of
  such a parameter as nullable, so it can't tell `T` from `T?`; for those positions the nullable
  flag of the parameter or return position decides instead.
* Generic parameter constraints keep their nullability: `class?` is emitted as `class?`, and
  `notnull` is emitted whenever no other constraint implies it, including alongside `new()`.

### Dropped CakeSettings on the Cake.dll path (#4985)

`CakeRunner.ExecuteScript` hand-copies settings onto `DotNetExecuteSettings` when the resolved tool
path is `Cake.dll`, which is the default whenever the outer build runs on Cake.Tool.
`HandleExitCode`, `NoWorkingDirectory`, `PostAction` and `SetupProcessSettings` were missing from
that copy and silently dropped. They're now propagated, which is also what lets the new integration
test capture the nested script's compiler output.

- fixes #4977
- fixes #4985